### PR TITLE
fix(preview): selectable text in note preview (#226)

### DIFF
--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -584,6 +584,18 @@ export default function NoteEditorScreen() {
         </Text>
       );
     },
+    text: (node: any, _children: any, _parent: any, styles: any, inheritedStyles: any = {}) => (
+      <Text key={node.key} selectable style={[inheritedStyles, styles.text]}>{node.content}</Text>
+    ),
+    code_inline: (node: any, _children: any, _parent: any, styles: any, inheritedStyles: any = {}) => (
+      <Text key={node.key} selectable style={[inheritedStyles, styles.code_inline]}>{node.content}</Text>
+    ),
+    code_block: (node: any, _children: any, _parent: any, styles: any, inheritedStyles: any = {}) => (
+      <Text key={node.key} selectable style={[inheritedStyles, styles.code_block]}>{node.content}</Text>
+    ),
+    fence: (node: any, _children: any, _parent: any, styles: any, inheritedStyles: any = {}) => (
+      <Text key={node.key} selectable style={[inheritedStyles, styles.fence]}>{node.content}</Text>
+    ),
   }), [colors]);
 
   const previewContent = (() => {


### PR DESCRIPTION
## Summary
- Override \`text\`, \`code_inline\`, \`code_block\`, \`fence\` renderers in markdown preview rules.
- All emit \`<Text selectable>\` so users can long-press to select/copy.

Closes #226

## Why
Notes preview was non-selectable. Long-press did nothing. Users couldn't copy snippets out.

## Scope
- Markdown preview only.
- NeorgRenderer (.norg / .org content) not covered here — separate follow-up if needed.

## Test plan
- [ ] Open a markdown note → switch to preview → long-press paragraph → selection handles appear, Copy works
- [ ] Inline code (\`\`code\`\`) selectable
- [ ] Fenced code block selectable
- [ ] Inline links still tap-able (don't get hijacked by selection)
- [ ] iOS + Android
- [ ] Manual UI verification needed (cannot run simulator from CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)