### PR TITLE
fix(canvas): visible back button + hardware back (#229)

### DIFF
--- a/src/screens/CanvasEditorScreen.tsx
+++ b/src/screens/CanvasEditorScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -10,8 +10,10 @@ import {
   Platform,
   ScrollView,
   Alert,
+  BackHandler,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
@@ -119,6 +121,17 @@ export default function CanvasEditorScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<RouteType>();
   const { canvasId, canvasWidth, canvasTitle } = route.params;
+
+  useEffect(() => {
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (navigation.canGoBack()) {
+        navigation.goBack();
+        return true;
+      }
+      return false;
+    });
+    return () => sub.remove();
+  }, [navigation]);
   const { getCanvasById, createCanvas, updateCanvas } = useCanvases();
 
   const cw = canvasWidth ?? Dimensions.get('window').width;
@@ -585,8 +598,14 @@ export default function CanvasEditorScreen() {
     <GestureHandlerRootView style={styles.container}>
       <SafeAreaView edges={['top', 'bottom']} style={styles.safeArea}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.iconBtn}>
-          <Text style={styles.iconText}>{'‹ Back'}</Text>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          style={styles.backBtn}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+        >
+          <Ionicons name="chevron-back" size={28} color="#007AFF" />
         </TouchableOpacity>
         <TextInput style={styles.titleInput} value={title} onChangeText={setTitle} placeholder="Canvas Title" />
         <TouchableOpacity onPress={saveCanvas} style={styles.saveBtn}>
@@ -718,6 +737,7 @@ const styles = StyleSheet.create({
   },
   iconBtn: { padding: 8 },
   iconText: { fontSize: 15, color: '#007AFF' },
+  backBtn: { paddingVertical: 8, paddingHorizontal: 4, minWidth: 44, minHeight: 44, alignItems: 'center', justifyContent: 'center' },
   titleInput: {
     flex: 1,
     marginHorizontal: 8,


### PR DESCRIPTION
## Summary
- Replace small "‹ Back" text with Ionicons chevron-back (28pt, 44×44 touch target, 12pt hitSlop).
- Add explicit Android \`hardwareBackPress\` handler.

Closes #229

## Why
The text-only back button was small and easy to miss; users reported being unable to leave the canvas screen. \`GestureHandlerRootView\` may also intercept navigator-level back behaviour, so an explicit hardware back listener defends against that.

## Test plan
- [ ] Open a canvas → tap chevron-back → returns to previous screen
- [ ] iOS edge swipe-back works
- [ ] Android hardware back works
- [ ] Touch target reachable even when toolbar/canvas gesture is active
- [ ] Manual UI verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)