### PR TITLE
fix(settings): show/hide + paste/copy + keyboard avoid for token (#231)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo": "~54.0.34",
         "expo-auth-session": "~7.0.11",
         "expo-blur": "~15.0.8",
+        "expo-clipboard": "~8.0.8",
         "expo-crypto": "~15.0.9",
         "expo-device": "~8.0.10",
         "expo-file-system": "~19.0.21",
@@ -4565,6 +4566,17 @@
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-15.0.8.tgz",
       "integrity": "sha512-rWyE1NBRZEu9WD+X+5l7gyPRszw7n12cW3IRNAb5i6KFzaBp8cxqT5oeaphJapqURvcqhkOZn2k5EtBSbsuU7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-8.0.8.tgz",
+      "integrity": "sha512-VKoBkHIpZZDJTB0jRO4/PZskHdMNOEz3P/41tmM6fDuODMpqhvyWK053X0ebspkxiawJX9lX33JXHBCvVsTTOA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo": "~54.0.34",
     "expo-auth-session": "~7.0.11",
     "expo-blur": "~15.0.8",
+    "expo-clipboard": "~8.0.8",
     "expo-crypto": "~15.0.9",
     "expo-device": "~8.0.10",
     "expo-file-system": "~19.0.21",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -12,7 +12,10 @@ import {
   ActivityIndicator,
   Linking,
   Dimensions,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import { useNotes } from '../contexts/NoteContext';
@@ -46,6 +49,30 @@ export default function SettingsScreen() {
   const [tokenInput, setTokenInput] = useState('');
   const [isVerifying, setIsVerifying] = useState(false);
   const [tokenError, setTokenError] = useState<string | null>(null);
+  const [tokenVisible, setTokenVisible] = useState(false);
+
+  const handlePasteToken = useCallback(async () => {
+    try {
+      const text = await Clipboard.getStringAsync();
+      if (text.trim()) {
+        setTokenInput(text.trim());
+        setTokenError(null);
+        HapticService.success();
+      }
+    } catch {
+      HapticService.error();
+    }
+  }, []);
+
+  const handleCopyToken = useCallback(async () => {
+    if (!tokenInput.trim()) return;
+    try {
+      await Clipboard.setStringAsync(tokenInput.trim());
+      HapticService.success();
+    } catch {
+      HapticService.error();
+    }
+  }, [tokenInput]);
 
   const [syncingRepo, setSyncingRepo] = useState<string | null>(null);
 
@@ -486,17 +513,24 @@ export default function SettingsScreen() {
 
       {/* GitHub token modal */}
       <Modal visible={showTokenModal} transparent animationType="slide">
-        <View style={styles.modalOverlay}>
+        <KeyboardAvoidingView
+          style={styles.modalOverlay}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        >
           <View style={[styles.modalSheet, { backgroundColor: colors.surface }]}>
             <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
               <Text style={[styles.modalTitle, { color: colors.text }]}>
                 {authState.isAuthenticated ? 'Change Token' : 'Connect GitHub'}
               </Text>
-              <TouchableOpacity onPress={() => setShowTokenModal(false)}>
+              <TouchableOpacity onPress={() => { setShowTokenModal(false); setTokenVisible(false); }}>
                 <Ionicons name="close" size={24} color={colors.textSecondary} />
               </TouchableOpacity>
             </View>
-            <View style={styles.modalBody}>
+            <ScrollView
+              style={styles.modalBody}
+              keyboardShouldPersistTaps="handled"
+              contentContainerStyle={{ paddingBottom: 16 }}
+            >
               <Text style={[styles.modalDesc, { color: colors.textSecondary }]}>
                 Personal Access Token with <Text style={{ fontWeight: '600' }}>repo</Text> and{' '}
                 <Text style={{ fontWeight: '600' }}>read:user</Text> scopes.
@@ -508,16 +542,45 @@ export default function SettingsScreen() {
                 <Ionicons name="open-outline" size={14} color={colors.primary} />
                 <Text style={[styles.generateLinkText, { color: colors.primary }]}>Generate token on GitHub</Text>
               </TouchableOpacity>
-              <TextInput
-                style={[styles.tokenInput, { color: colors.text, borderColor: tokenError ? '#FF3B30' : colors.border, backgroundColor: colors.background }]}
-                placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
-                placeholderTextColor={colors.textSecondary}
-                value={tokenInput}
-                onChangeText={(t) => { setTokenInput(t); setTokenError(null); }}
-                secureTextEntry
-                autoCapitalize="none"
-                autoCorrect={false}
-              />
+              <View style={[styles.tokenInputRow, { borderColor: tokenError ? '#FF3B30' : colors.border, backgroundColor: colors.background }]}>
+                <TextInput
+                  style={[styles.tokenInputInner, { color: colors.text }]}
+                  placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+                  placeholderTextColor={colors.textSecondary}
+                  value={tokenInput}
+                  onChangeText={(t) => { setTokenInput(t); setTokenError(null); }}
+                  secureTextEntry={!tokenVisible}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+                <TouchableOpacity
+                  onPress={() => setTokenVisible((v) => !v)}
+                  style={styles.tokenIconBtn}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  accessibilityLabel={tokenVisible ? 'Hide token' : 'Show token'}
+                >
+                  <Ionicons name={tokenVisible ? 'eye-off-outline' : 'eye-outline'} size={20} color={colors.textSecondary} />
+                </TouchableOpacity>
+              </View>
+              <View style={styles.tokenActionsRow}>
+                <TouchableOpacity
+                  style={[styles.tokenActionBtn, { borderColor: colors.border }]}
+                  onPress={handlePasteToken}
+                  accessibilityLabel="Paste token from clipboard"
+                >
+                  <Ionicons name="clipboard-outline" size={16} color={colors.primary} />
+                  <Text style={[styles.tokenActionLabel, { color: colors.primary }]}>Paste</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.tokenActionBtn, { borderColor: colors.border, opacity: tokenInput.trim() ? 1 : 0.4 }]}
+                  onPress={handleCopyToken}
+                  disabled={!tokenInput.trim()}
+                  accessibilityLabel="Copy token to clipboard"
+                >
+                  <Ionicons name="copy-outline" size={16} color={colors.primary} />
+                  <Text style={[styles.tokenActionLabel, { color: colors.primary }]}>Copy</Text>
+                </TouchableOpacity>
+              </View>
               {tokenError ? <Text style={styles.errorText}>{tokenError}</Text> : null}
               <TouchableOpacity
                 style={[styles.modalButton, { backgroundColor: colors.primary }]}
@@ -529,9 +592,9 @@ export default function SettingsScreen() {
                   : <Text style={styles.modalButtonText}>Save Token</Text>
                 }
               </TouchableOpacity>
-            </View>
+            </ScrollView>
           </View>
-        </View>
+        </KeyboardAvoidingView>
       </Modal>
     </SafeAreaView>
   );
@@ -595,6 +658,12 @@ const styles = StyleSheet.create({
   generateLink: { flexDirection: 'row', alignItems: 'center', gap: 4, marginBottom: 16 },
   generateLinkText: { fontSize: 14, fontWeight: '500' },
   tokenInput: { height: 50, borderWidth: 1, borderRadius: 8, paddingHorizontal: 12, marginBottom: 8, fontSize: 14 },
+  tokenInputRow: { flexDirection: 'row', alignItems: 'center', borderWidth: 1, borderRadius: 8, paddingHorizontal: 12, marginBottom: 8, height: 50 },
+  tokenInputInner: { flex: 1, fontSize: 14, paddingVertical: 0 },
+  tokenIconBtn: { paddingHorizontal: 6, paddingVertical: 6, marginLeft: 4 },
+  tokenActionsRow: { flexDirection: 'row', gap: 8, marginBottom: 8 },
+  tokenActionBtn: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', paddingVertical: 10, paddingHorizontal: 12, borderRadius: 8, borderWidth: 1, flex: 1, gap: 6 },
+  tokenActionLabel: { fontSize: 14, fontWeight: '600' },
   errorText: { color: '#FF3B30', fontSize: 13, marginBottom: 10 },
   modalButton: { paddingVertical: 14, borderRadius: 8, alignItems: 'center', marginTop: 8 },
   modalButtonText: { color: '#fff', fontSize: 16, fontWeight: '600' },


### PR DESCRIPTION
## Summary
- Token modal now wraps a \`KeyboardAvoidingView\` so the field stays visible above the keyboard.
- Eye toggle reveals / hides the token (plain text ↔ \`secureTextEntry\`).
- Dedicated **Paste** button (reads clipboard) and **Copy** button (writes input to clipboard).
- Body scrolls when keyboard cuts space short.
- Haptic feedback on copy/paste.

Adds dep: \`expo-clipboard\`.

Closes #231

## Why
Users couldn't copy/paste tokens reliably — the keyboard obscured the field, the input was \`secureTextEntry\` so they couldn't see what they pasted, and there was no in-app copy action.

## Test plan
- [ ] Settings → Connect GitHub → keyboard appears → field stays visible
- [ ] Tap eye → token visible
- [ ] Tap Paste → fills field from clipboard, success haptic
- [ ] Tap Copy with token in field → clipboard receives it, success haptic
- [ ] Tap Copy with empty field → button disabled
- [ ] Manual UI verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)