### PR TITLE
feat(notes): remember note format choice (#232)

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useCallback } from 'react';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import React, { useState, useCallback, useEffect } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -13,6 +13,7 @@ import { parseRepoPath } from '../components/RepoFileBrowser';
 import { HapticService } from '../utils/haptics';
 import TemplateSelector from '../components/TemplateSelector';
 import { NoteTemplate } from '../services/TemplateService';
+import { NoteFormatPreferenceService } from '../services/NoteFormatPreferenceService';
 import { useResponsive } from '../hooks/useResponsive';
 import { NButton, NCard, NModal, NGroup, NGroupRow, NScreenHeader } from '../components/neumorphic';
 
@@ -88,16 +89,42 @@ export default function HomeScreen() {
   const { isTablet, maxContentWidth } = useResponsive();
   const [showFormatPicker, setShowFormatPicker] = useState(false);
   const [showTemplateSelector, setShowTemplateSelector] = useState(false);
+  const [defaultFormat, setDefaultFormat] = useState<EditableNoteFormat | null>(null);
+  const [rememberFormat, setRememberFormat] = useState<boolean>(false);
+  const [pickerRemember, setPickerRemember] = useState<boolean>(false);
+
+  useEffect(() => {
+    (async () => {
+      const fmt = await NoteFormatPreferenceService.getDefaultFormat();
+      const remember = await NoteFormatPreferenceService.getRememberPreference();
+      setDefaultFormat(fmt);
+      setRememberFormat(remember);
+    })();
+  }, []);
 
   const handleCreateNote = useCallback(() => {
     HapticService.medium();
+    if (rememberFormat && defaultFormat) {
+      navigation.navigate('NoteEditor', { format: defaultFormat });
+      return;
+    }
+    setPickerRemember(false);
     setShowFormatPicker(true);
-  }, []);
+  }, [navigation, rememberFormat, defaultFormat]);
 
-  const handleSelectFormat = useCallback((format: EditableNoteFormat) => {
+  const handleSelectFormat = useCallback(async (format: EditableNoteFormat) => {
     setShowFormatPicker(false);
+    if (pickerRemember) {
+      await NoteFormatPreferenceService.setDefaultFormat(format, true);
+      setDefaultFormat(format);
+      setRememberFormat(true);
+    } else {
+      await NoteFormatPreferenceService.setDefaultFormat(format, false);
+      setDefaultFormat(format);
+      setRememberFormat(false);
+    }
     navigation.navigate('NoteEditor', { format });
-  }, [navigation]);
+  }, [navigation, pickerRemember]);
 
   const handleFormatPickerClose = useCallback(() => {
     setShowFormatPicker(false);
@@ -149,6 +176,11 @@ export default function HomeScreen() {
           variant="primary"
           fullWidth
           onPress={handleCreateNote}
+          onLongPress={() => {
+            HapticService.medium();
+            setPickerRemember(false);
+            setShowFormatPicker(true);
+          }}
           leadingIcon={<Ionicons name="add" size={22} color={colors.accent} />}
           label="Create New Note"
         />
@@ -225,6 +257,19 @@ export default function HomeScreen() {
             </NCard>
           ))}
         </View>
+        <TouchableOpacity
+          style={styles.rememberRow}
+          onPress={() => setPickerRemember((v) => !v)}
+          accessibilityRole="checkbox"
+          accessibilityState={{ checked: pickerRemember }}
+        >
+          <Ionicons
+            name={pickerRemember ? 'checkbox' : 'square-outline'}
+            size={22}
+            color={pickerRemember ? colors.accent : colors.textSecondary}
+          />
+          <Text style={[styles.rememberLabel, { color: colors.text }]}>Remember my choice</Text>
+        </TouchableOpacity>
         <View style={{ marginTop: 12 }}>
           <NButton variant="ghost" fullWidth label="Cancel" onPress={handleFormatPickerClose} />
         </View>
@@ -376,5 +421,15 @@ const styles = StyleSheet.create({
   recentNoteTablet: {
     width: '48%',
     marginHorizontal: 0,
+  },
+  rememberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+  },
+  rememberLabel: {
+    fontSize: 14,
   },
 });

--- a/src/services/NoteFormatPreferenceService.ts
+++ b/src/services/NoteFormatPreferenceService.ts
@@ -1,0 +1,29 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { NoteFormat } from '../models/Note';
+
+const DEFAULT_FORMAT_KEY = '@gitnotes:default_note_format';
+const REMEMBER_FORMAT_KEY = '@gitnotes:remember_note_format';
+
+export type EditableNoteFormat = Exclude<NoteFormat, 'pdf'>;
+
+export class NoteFormatPreferenceService {
+  static async getDefaultFormat(): Promise<EditableNoteFormat | null> {
+    const v = await AsyncStorage.getItem(DEFAULT_FORMAT_KEY);
+    if (v === 'markdown' || v === 'org' || v === 'neorg') return v;
+    return null;
+  }
+
+  static async getRememberPreference(): Promise<boolean> {
+    return (await AsyncStorage.getItem(REMEMBER_FORMAT_KEY)) === 'true';
+  }
+
+  static async setDefaultFormat(format: EditableNoteFormat, remember: boolean): Promise<void> {
+    await AsyncStorage.setItem(DEFAULT_FORMAT_KEY, format);
+    await AsyncStorage.setItem(REMEMBER_FORMAT_KEY, remember ? 'true' : 'false');
+  }
+
+  static async clearDefaultFormat(): Promise<void> {
+    await AsyncStorage.removeItem(DEFAULT_FORMAT_KEY);
+    await AsyncStorage.removeItem(REMEMBER_FORMAT_KEY);
+  }
+}


### PR DESCRIPTION
## Summary
- New \`NoteFormatPreferenceService\` persists default format + a "remember" flag in AsyncStorage.
- Format picker shows a "Remember my choice" checkbox.
- If remembered, **Create New Note** skips the picker and opens the editor in the saved format.
- **Long-press** Create New Note → reopens the picker even with a default set (override / change).

Closes #232

## Why
Issue: prompt appeared every time a note was created. Friction.

## Test plan
- [ ] Tap Create New Note (no preference set) → picker shows
- [ ] Pick markdown without checking remember → next tap shows picker again
- [ ] Pick org with remember checked → next tap goes straight to org editor
- [ ] Long-press Create New Note → picker reopens (preserved default)
- [ ] Picker checkbox toggles correctly
- [ ] Manual UI verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)