### PR TITLE
fix(notes): folder filter includes subfolders + parent paths (#223)

### DIFF
--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -140,9 +140,15 @@ export default function NotesListScreen() {
   const allFolders = useMemo(() => {
     const set = new Set<string>();
     notes.forEach((note) => {
-      if (note.folderPath && note.folderPath.trim().length > 0) {
-        set.add(note.folderPath);
+      const fp = note.folderPath?.trim();
+      if (!fp) return;
+      const parts = fp.split('/').filter(Boolean);
+      let acc = '';
+      for (const seg of parts) {
+        acc = acc ? `${acc}/${seg}` : (fp.startsWith('/') ? `/${seg}` : seg);
+        set.add(acc);
       }
+      set.add(fp);
     });
     return Array.from(set).sort();
   }, [notes]);
@@ -160,8 +166,14 @@ export default function NotesListScreen() {
 
   const displayNotes = useMemo(() => {
     let result = filteredNotes;
-    if (selectedFolder)
-      result = result.filter((n: Note) => n.folderPath === selectedFolder);
+    if (selectedFolder) {
+      const sel = selectedFolder;
+      result = result.filter((n: Note) => {
+        const fp = n.folderPath;
+        if (!fp) return false;
+        return fp === sel || fp.startsWith(`${sel}/`);
+      });
+    }
     if (!selectedRepo) {
       if (selectedFormat)
         result = result.filter(


### PR DESCRIPTION
## Summary
- \`allFolders\` now includes intermediate folder paths derived from notes' folderPaths (not just leaves), so parents like \`/projects\` are selectable even when only \`/projects/web\` notes exist.
- Folder filter uses prefix match: selecting \`/projects\` includes notes anywhere under it.

Closes #223

## Why
The filter introduced in 91af39c used strict equality and only listed leaf folders. Users couldn't filter by a parent folder, and selecting one excluded its subfolders.

## Test plan
- [ ] Notes in \`/projects\`, \`/projects/web\`, \`/projects/api\` → filter chip \`/projects\` shows all three
- [ ] Filter chip \`/projects/web\` shows only those
- [ ] Notes with no folder are not included when any folder is selected
- [ ] "All" chip resets filter
- [ ] Manual UI verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)