### PR TITLE
feat(notes): Duplicate + clearer Share/Save (#227)

### DIFF
--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -1364,10 +1364,33 @@ export default function NotesListScreen() {
                     },
                     {
                       icon: "share-outline",
-                      label: "Share",
+                      label: "Share / Save",
                       onPress: async () => {
                         const ok = await ShareService.shareByNoteFormat(longPressedNote);
                         if (!ok) Alert.alert("Error", "Failed to share note");
+                      },
+                    },
+                    {
+                      icon: "copy-outline",
+                      label: "Duplicate",
+                      onPress: async () => {
+                        const src = longPressedNote;
+                        const created = await createNote({
+                          title: `${src.title || 'Untitled'} (copy)`,
+                          content: src.content ?? '',
+                          tags: src.tags ? [...src.tags] : undefined,
+                          repo: src.repo,
+                          branch: src.branch,
+                          folderPath: src.folderPath,
+                          format: src.format,
+                          attachments: src.attachments ? [...src.attachments] : undefined,
+                        });
+                        if (created) {
+                          HapticService.success();
+                        } else {
+                          HapticService.error();
+                          Alert.alert("Error", "Failed to duplicate note");
+                        }
                       },
                     },
                   ],


### PR DESCRIPTION
## Summary
- Long-press context menu: rename **Share** → **Share / Save** (the existing system share sheet already covers "save to device" via Files / Download targets, so this is purely a label fix).
- Add **Duplicate** item that copies title/content/tags/repo/branch/folderPath/format/attachments into a new note titled \`<original> (copy)\`.

Closes #227

## Why
Issue asked for in-app **Copy** + **Download**. Download was already plumbed via \`ShareService.shareByNoteFormat\` → \`expo-sharing\` → system share sheet (Files target). Duplicate (intra-app copy) was missing.

## Out of scope
- Bulk select + zip export (stretch goal in original issue) — separate follow-up.
- Repo file download (the issue mentioned "files / repo blobs"; this PR covers note duplication. RepoFileBrowser-side download is a separate touch).

## Test plan
- [ ] Long-press note → menu shows Share / Save and Duplicate
- [ ] Tap Share / Save → system share sheet (with Save to Files etc.)
- [ ] Tap Duplicate → new note appears titled "X (copy)" with same content/tags/repo
- [ ] Manual UI verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)