### PR TITLE
docs: refresh README with current feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,34 @@ A React Native app built with Expo for managing development notes with Git integ
 
 ## Features
 
-- ✅ Create and organize development notes
+### Notes & content
+- ✅ Create, organize, and tag development notes
 - ✅ Link notes to Git repositories and commits
-- ✅ Tag notes for easy organization
-- ✅ Search and filter functionality
+- ✅ Markdown rendering with code-fence handling
+- ✅ Filter notes by folder
+- ✅ Repo browser with flat "All notes" view
+- ✅ Search and filter across notes
+
+### Editor & canvas
+- ✅ Markdown editor with preview mode
+- ✅ Canvas editor with pinch-zoom and two-finger pan
+- ✅ Neorg-style table rendering
+
+### GitHub integration
+- ✅ Lists private + collaborator repos with pagination
+- ✅ Conflict-aware uploads (retry on 409, skip on existing 422)
+
+### UI / UX
+- ✅ Neumorphic design system (tokens, `Surface`, elevation builder)
+- ✅ Unified `NScreenHeader` + `SearchBar` across tab screens
+- ✅ Floating `NTabBar` pill
 - ✅ Dark mode support
-- ✅ Haptic feedback for enhanced UX
-- ✅ Markdown rendering support
+- ✅ Haptic feedback
+- ✅ Cross-platform primitives (iOS + Android)
+
+### Reliability
 - ✅ Comprehensive error handling
-- ✅ Loading states for async operations
+- ✅ Loading states for async ops
 
 ## Getting Started
 
@@ -52,13 +71,24 @@ gitnotes/
 ├── src/
 │   ├── navigation/            # Navigation configuration
 │   ├── screens/               # Screen components
-│   ├── contexts/             # React contexts
+│   ├── contexts/              # React contexts
 │   ├── components/            # Reusable components
+│   │   └── ui/                # Neumorphic primitives (Surface, NTabBar, etc.)
+│   ├── theme/                 # Design tokens, elevation, useTokens hook
 │   ├── models/                # TypeScript models
-│   ├── services/             # API and storage services
-│   └── utils/                # Utility functions
-└── assets/                   # Images and fonts
+│   ├── services/              # API and storage services
+│   └── utils/                 # Utility functions
+└── assets/                    # Images and fonts
 ```
+
+## Design System
+
+GitNotēs ships a neumorphic design system:
+
+- **Tokens** — `src/theme/` exposes color/elevation/spacing tokens via `useTokens`.
+- **Primitives** — `Surface` (cross-platform soft shadows), `NScreenHeader`, `SearchBar`, `NTabBar`, `NGroup`.
+- **Gallery** — dev-only `NeumorphicGallery` for visual smoke testing.
+- **Style flag** — toggle between flat and neumorphic via theme flag.
 
 ## Development
 
@@ -72,6 +102,8 @@ Built with:
 
 This project addresses the following security vulnerabilities:
 - ✅ **markdown-it (GHSA-6vfc-qv3f-vr6c)**: Fixed by forcing markdown-it v14.1.1 using npm overrides
+
+Open advisories tracked in issues (see #222 for upstream Expo bumps for postcss + uuid CVEs).
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- Rename to **GitNotēs**.
- Reorganise Features into groups (Notes & content, Editor & canvas, GitHub, UI/UX, Reliability).
- Add entries for: folder filter, flat "All notes" view, canvas pinch-zoom, neumorphic design system, unified \`NScreenHeader\` + \`SearchBar\`, floating \`NTabBar\`, private/collaborator repo listing.
- New **Design System** section pointing at tokens, primitives, gallery, style flag.
- Project structure: \`src/components/ui/\` and \`src/theme/\`.
- Security: pointer to advisory tracker (#222).

## Test plan
- [ ] Render README on GitHub — formatting / TOC look right
- [ ] Spelling of GitNotēs renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)