### PR TITLE
chore: jest testMatch .tsx + engines.node (#239 #274)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,8 +7,8 @@ module.exports = {
   },
   testEnvironment: 'node',
   testMatch: [
-    '**/__tests__/**/*.ts',
-    '**/?(*.)+(spec|test).ts',
+    '**/__tests__/**/*.{ts,tsx}',
+    '**/?(*.)+(spec|test).{ts,tsx}',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverage: true,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "gitnotes",
   "version": "1.0.0",
   "main": "expo/AppEntry.js",
+  "engines": {
+    "node": ">=20.18"
+  },
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",


### PR DESCRIPTION
## Summary
- \`jest.config.js\` testMatch: \`.ts\` → \`.{ts,tsx}\`. Closes #239.
- \`package.json\` adds \`engines.node: ">=20.18"\`. Closes #274.

## Test plan
- [ ] CI green
- [ ] Component tests authored as \`*.test.tsx\` get picked up
- [ ] \`npm install\` warns on Node < 20.18

🤖 Generated with [Claude Code](https://claude.com/claude-code)