### PR TITLE
build(babel): strip console in production (#268)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,20 @@
-module.exports = function(api) {
+module.exports = function (api) {
   api.cache(true);
+
+  const isProduction =
+    process.env.BABEL_ENV === 'production' ||
+    process.env.NODE_ENV === 'production';
+
+  const plugins = [];
+  if (isProduction) {
+    plugins.push(['transform-remove-console', { exclude: ['error', 'warn'] }]);
+  }
+  // react-native-worklets/plugin must be the LAST plugin per the
+  // react-native-worklets / Reanimated 4 docs.
+  plugins.push('react-native-worklets/plugin');
+
   return {
     presets: ['babel-preset-expo'],
-    // react-native-worklets/plugin must be the LAST plugin per the
-    // react-native-worklets / Reanimated 4 docs.
-    plugins: ['react-native-worklets/plugin'],
+    plugins,
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@types/jest": "^30.0.0",
         "@types/react": "~19.1.10",
         "babel-jest": "^30.3.0",
+        "babel-plugin-transform-remove-console": "^6.9.4",
         "jest": "^30.3.0",
         "react-test-renderer": "^19.1.0",
         "typescript": "^5.6.3"
@@ -5810,6 +5811,13 @@
       "dependencies": {
         "@babel/plugin-syntax-flow": "^7.12.1"
       }
+    },
+    "node_modules/babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha512-88blrUrMX3SPiGkT1GnvVY8E/7A+k6oj3MNvUtTIxJflFzXTw1bHkuJ/y039ouhFMp2prRn5cQGzokViYi1dsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/jest": "^30.0.0",
     "@types/react": "~19.1.10",
     "babel-jest": "^30.3.0",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "jest": "^30.3.0",
     "react-test-renderer": "^19.1.0",
     "typescript": "^5.6.3"


### PR DESCRIPTION
## Summary
- Add \`babel-plugin-transform-remove-console\` (dev-dep).
- Babel config conditionally enables it when \`BABEL_ENV=production\` or \`NODE_ENV=production\`.
- \`error\` and \`warn\` are exempted so genuine reporting still works.

Closes #268

## Why
Defense in depth — minimises accidental token / secret leakage to native logs (\`logcat\`, Console.app, Crashlytics) when production code logs unexpectedly.

## Test plan
- [ ] Dev / Expo Go: \`console.log\` still works
- [ ] EAS production build: \`console.log\` calls compiled out (verify with \`eas build --profile production\` + check release JS)
- [ ] Tests still pass
- [ ] Type check still clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)