### PR TITLE
security(android): allowBackup=false (#241)

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,6 +31,7 @@
       },
       "package": "com.gitnotes.app",
       "scheme": "gitnotes",
+      "allowBackup": false,
       "permissions": [
         "android.permission.RECORD_AUDIO"
       ]


### PR DESCRIPTION
## Summary
- \`app.json\` adds \`expo.android.allowBackup: false\`.

Closes #241

## Why
With \`allowBackup=true\` (Android's implicit default), \`adb backup\` extracts the app's private data — \*\*including the GitHub PAT stored in AsyncStorage\*\* — onto a developer machine without root. Disabling it is the standard hardening recommendation.

The token-storage move to expo-secure-store is tracked separately as #240.

## Test plan
- [ ] EAS build for Android prod → AndroidManifest contains \`android:allowBackup="false"\`
- [ ] \`adb backup\` of the app produces no app data (or fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)