### PR TITLE
security(auth): GitHub PAT → expo-secure-store + migration (#240)

### DIFF
--- a/app.json
+++ b/app.json
@@ -49,7 +49,8 @@
         }
       ],
       "expo-image-picker",
-      "@react-native-community/datetimepicker"
+      "@react-native-community/datetimepicker",
+      "expo-secure-store"
     ],
     "owner": "vidwa",
     "runtimeVersion": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "expo-haptics": "~15.0.8",
         "expo-image-picker": "~17.0.11",
         "expo-notifications": "~0.32.17",
+        "expo-secure-store": "~15.0.8",
         "expo-sharing": "~14.0.8",
         "expo-speech": "~14.0.8",
         "expo-status-bar": "~3.0.9",
@@ -4761,6 +4762,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.8.tgz",
+      "integrity": "sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "expo-haptics": "~15.0.8",
     "expo-image-picker": "~17.0.11",
     "expo-notifications": "~0.32.17",
+    "expo-secure-store": "~15.0.8",
     "expo-sharing": "~14.0.8",
     "expo-speech": "~14.0.8",
     "expo-status-bar": "~3.0.9",

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,6 +1,48 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
 
 const TOKEN_KEY = '@gitnotes:github_token';
+const SECURE_KEY = 'gitnotes_github_token';
+
+async function readToken(): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    return AsyncStorage.getItem(TOKEN_KEY);
+  }
+  try {
+    const secure = await SecureStore.getItemAsync(SECURE_KEY);
+    if (secure) return secure;
+    // One-time migration from legacy AsyncStorage location.
+    const legacy = await AsyncStorage.getItem(TOKEN_KEY);
+    if (legacy) {
+      await SecureStore.setItemAsync(SECURE_KEY, legacy);
+      await AsyncStorage.removeItem(TOKEN_KEY);
+      return legacy;
+    }
+    return null;
+  } catch (err) {
+    console.error('[AuthService] readToken error:', err);
+    return null;
+  }
+}
+
+async function writeToken(token: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.setItem(TOKEN_KEY, token);
+    return;
+  }
+  await SecureStore.setItemAsync(SECURE_KEY, token);
+  await AsyncStorage.removeItem(TOKEN_KEY).catch(() => undefined);
+}
+
+async function deleteToken(): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.removeItem(TOKEN_KEY);
+    return;
+  }
+  await SecureStore.deleteItemAsync(SECURE_KEY).catch(() => undefined);
+  await AsyncStorage.removeItem(TOKEN_KEY).catch(() => undefined);
+}
 
 export interface GitHubUser {
   id: number;
@@ -18,7 +60,7 @@ export interface AuthState {
 
 export class AuthService {
   static async checkAuthState(): Promise<AuthState> {
-    const token = await AsyncStorage.getItem(TOKEN_KEY);
+    const token = await readToken();
     if (!token) return { isAuthenticated: false, user: null, token: null };
     const user = await this.getUser(token);
     return { isAuthenticated: !!user, user, token };
@@ -27,12 +69,12 @@ export class AuthService {
   static async setToken(token: string): Promise<AuthState> {
     const user = await this.getUser(token);
     if (!user) return { isAuthenticated: false, user: null, token: null };
-    await AsyncStorage.setItem(TOKEN_KEY, token);
+    await writeToken(token);
     return { isAuthenticated: true, user, token };
   }
 
   static async clearToken(): Promise<void> {
-    await AsyncStorage.removeItem(TOKEN_KEY);
+    await deleteToken();
   }
 
   static async getUser(token: string): Promise<GitHubUser | null> {


### PR DESCRIPTION
## Summary
- Add \`expo-secure-store\` and route the PAT through it on iOS / Android.
- iOS Keychain / Android Keystore-backed \`EncryptedSharedPreferences\`.
- One-time migration in \`readToken()\`: if a legacy \`AsyncStorage\` token exists, copy it to SecureStore and delete the plaintext. Existing users keep their session.
- Web falls back to AsyncStorage (SecureStore is native-only).

Closes #240

## Why
The PAT was stored in plaintext in AsyncStorage. On Android with the default \`allowBackup=true\` (see #241) this was also extractable via \`adb backup\` without root. On rooted devices it's trivially exposed.

## Test plan
- [ ] Existing user with token in AsyncStorage launches app → token is migrated to SecureStore, AsyncStorage entry gone, session intact
- [ ] Fresh install + Settings → Connect GitHub → token saved, persists across cold start
- [ ] Settings → Disconnect → token removed from both stores
- [ ] Web build still works
- [ ] Tests + ts:check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)