### PR TITLE
fix(notes-list): clear pull-refresh timeout (#264)

### DIFF
--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -395,9 +395,10 @@ export default function NotesListScreen() {
     setIsPullRefreshing(true);
     HapticService.light();
 
-    const timeout = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Sync timed out")), 60000),
-    );
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error("Sync timed out")), 60000);
+    });
 
     try {
       await Promise.race([
@@ -413,6 +414,7 @@ export default function NotesListScreen() {
       HapticService.warning();
       console.warn("[Sync] pull-refresh failed:", pullError);
     } finally {
+      if (timeoutId !== null) clearTimeout(timeoutId);
       setIsPullRefreshing(false);
     }
   }, [isPullRefreshing, refreshNotes]);


### PR DESCRIPTION
## Summary
Capture the 60s timeout id in \`handlePullToRefresh\` and \`clearTimeout\` it in the \`finally\` block so it doesn't fire after a successful sync.

Closes #264

## Why
Without the cleanup, the timer keeps running for up to 60s after success and tries to reject an already-resolved promise (swallowed by catch but still wastes CPU and keeps the bridge awake; also races against unmount).

## Test plan
- [ ] Pull to refresh — completes in normal time → no warning
- [ ] Pull to refresh on flaky network — times out, message shown
- [ ] Pull to refresh + immediately navigate away → no setState-on-unmounted warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)