### PR TITLE
fix(editor): scope Speech.stop() to owning instance (#263)

### DIFF
--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -610,25 +610,33 @@ export default function NoteEditorScreen() {
       .trim();
   }, [previewContent]);
 
+  const isSpeakingRef = useRef(false);
+
   const handleToggleSpeak = useCallback(async () => {
     if (isSpeaking) {
       await Speech.stop();
+      isSpeakingRef.current = false;
       setIsSpeaking(false);
       return;
     }
     if (!speakableContent) return;
     HapticService.light();
+    isSpeakingRef.current = true;
     setIsSpeaking(true);
     Speech.speak(speakableContent, {
-      onDone: () => setIsSpeaking(false),
-      onStopped: () => setIsSpeaking(false),
-      onError: () => setIsSpeaking(false),
+      onDone: () => { isSpeakingRef.current = false; setIsSpeaking(false); },
+      onStopped: () => { isSpeakingRef.current = false; setIsSpeaking(false); },
+      onError: () => { isSpeakingRef.current = false; setIsSpeaking(false); },
     });
   }, [isSpeaking, speakableContent]);
 
   useEffect(() => {
     return () => {
-      Speech.stop();
+      // Only stop if this screen instance was the one speaking. Otherwise
+      // unmounting one editor would silence speech started by another.
+      if (isSpeakingRef.current) {
+        Speech.stop();
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Summary
Track speech ownership on \`NoteEditorScreen\` with \`isSpeakingRef\`. Cleanup only calls \`Speech.stop()\` when this instance actually started speaking. Same flag updated from \`onDone\`/\`onStopped\`/\`onError\` and the manual toggle.

Closes #263

## Why
\`useEffect(..., [])\` cleanup unconditionally called \`Speech.stop()\`. When a previous editor instance unmounted (e.g. note→note navigation) it silenced speech that another screen — or a freshly-mounted editor — had started.

## Test plan
- [ ] Start speech in note A, tap a different note → A's speech continues for new instance
- [ ] Toggle off → speech stops
- [ ] Speech finishes naturally → button reverts to "play"
- [ ] Force quit during speech → no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)