### PR TITLE
fix(pdf-viewer): delete cached PDF on unmount + param change (#248)

### DIFF
--- a/src/screens/PdfViewerScreen.tsx
+++ b/src/screens/PdfViewerScreen.tsx
@@ -36,6 +36,7 @@ export default function PdfViewerScreen() {
   const [localUri, setLocalUri] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const cancelledRef = useRef(false);
+  const downloadedUriRef = useRef<string | null>(null);
   const memoryKey = PositionMemoryService.pdfKey(owner, repo, branch, path);
   const [restoredY, setRestoredY] = useState<number | null>(null);
   const lastYRef = useRef(0);
@@ -103,6 +104,13 @@ export default function PdfViewerScreen() {
     setLocalUri(null);
     setError(null);
 
+    // Drop any prior download from a previous param tuple before starting a new one.
+    const previous = downloadedUriRef.current;
+    if (previous) {
+      downloadedUriRef.current = null;
+      FileSystem.deleteAsync(previous, { idempotent: true }).catch(() => undefined);
+    }
+
     (async () => {
       try {
         const ref = branch || 'main';
@@ -122,12 +130,19 @@ export default function PdfViewerScreen() {
         }
 
         const result = await FileSystem.downloadAsync(url, target, { headers });
-        if (cancelledRef.current) return;
+        if (cancelledRef.current) {
+          // Effect was cancelled while we were downloading. Drop the file.
+          FileSystem.deleteAsync(result.uri, { idempotent: true }).catch(() => undefined);
+          return;
+        }
 
         if (result.status !== 200) {
+          // Failed download — still drop whatever was written.
+          FileSystem.deleteAsync(result.uri, { idempotent: true }).catch(() => undefined);
           setError(`Download failed (HTTP ${result.status})`);
           return;
         }
+        downloadedUriRef.current = result.uri;
         setLocalUri(result.uri);
       } catch (e) {
         if (cancelledRef.current) return;
@@ -139,6 +154,16 @@ export default function PdfViewerScreen() {
       cancelledRef.current = true;
     };
   }, [owner, repo, branch, path, authState.token]);
+
+  useEffect(() => {
+    return () => {
+      const uri = downloadedUriRef.current;
+      if (uri) {
+        downloadedUriRef.current = null;
+        FileSystem.deleteAsync(uri, { idempotent: true }).catch(() => undefined);
+      }
+    };
+  }, []);
 
   const handleOpenExternal = async () => {
     if (!localUri) return;


### PR DESCRIPTION
## Summary
Track the downloaded file uri in a ref. Delete it when:
- The fetch effect re-runs with new params (drops the previous)
- The screen unmounts
- The download is cancelled or returns non-200

Uses \`{ idempotent: true }\` so concurrent navigation doesn't crash on already-deleted files.

Closes #248

## Why
Each effect run wrote \`\${Date.now()}-\${name}\` and never deleted it. iOS doesn't aggressively prune the cache directory; over many sessions this grows unbounded.

## Test plan
- [ ] View a PDF → \`/cache\` contains one file
- [ ] Close screen → file gone
- [ ] Switch to another PDF mid-view → previous file deleted before new download
- [ ] Cancel slow download → no orphan in cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)