### PR TITLE
fix(pull): preserve updatedAt when remote bytes unchanged (#246)

### DIFF
--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -106,11 +106,19 @@ async function pullNotesFromRepo(
         (n) => n.repo === repoPath && n.filePath === item.path,
       );
       if (existingIdx !== -1) {
-        allNotes[existingIdx] = {
-          ...allNotes[existingIdx],
-          content: item.content,
-          updatedAt: Date.now(),
-        };
+        const existing = allNotes[existingIdx];
+        // Only mutate the local note if the remote content actually differs.
+        // Bumping updatedAt unconditionally clobbered cross-device LWW: a
+        // pure read on device B would defeat a real write on device A whose
+        // pull happened a moment later.
+        if (existing.content !== item.content) {
+          allNotes[existingIdx] = {
+            ...existing,
+            content: item.content,
+            updatedAt: Date.now(),
+          };
+          pulled++;
+        }
       } else {
         allNotes.push(
           createNote({
@@ -122,8 +130,8 @@ async function pullNotesFromRepo(
             format: noteFormatFromExt(ext),
           }),
         );
+        pulled++;
       }
-      pulled++;
     }
 
     await StorageService.saveAllNotes(allNotes);
@@ -162,14 +170,19 @@ async function pullCanvasesFromRepo(
         .replace(/-/g, ' ');
 
       if (existing) {
-        const updated = updateCanvas(existing, { scene });
-        const allCanvases = await StorageService.getAllCanvases();
-        const idx = allCanvases.findIndex((c) => c.id === existing.id);
-        if (idx !== -1) {
-          allCanvases[idx] = updated;
-          await StorageService.saveAllCanvases(allCanvases);
+        // Skip the local mutation if the scene is bytewise unchanged. Avoids
+        // pushing an artificial updatedAt that would clobber cross-device LWW.
+        const sceneChanged = JSON.stringify(existing.scene) !== JSON.stringify(scene);
+        if (sceneChanged) {
+          const updated = updateCanvas(existing, { scene });
+          const allCanvases = await StorageService.getAllCanvases();
+          const idx = allCanvases.findIndex((c) => c.id === existing.id);
+          if (idx !== -1) {
+            allCanvases[idx] = updated;
+            await StorageService.saveAllCanvases(allCanvases);
+          }
+          pulled++;
         }
-        pulled++;
       } else {
         const newCanvas = createCanvas({
           title: titleFromPath,


### PR DESCRIPTION
## Summary
\`pullNotesFromRepo\` and \`pullCanvasesFromRepo\` now compare remote content / scene against the local copy and **only** mutate + bump \`updatedAt\` when the bytes actually differ. The "create new" path is unchanged — that's a real write.

Closes #246

## Why
Pulling unconditionally bumped \`updatedAt\` to \`Date.now()\` even when nothing changed. Two devices syncing through the same GitHub repo would defeat each other's last-write-wins:

\`\`\`
A edits at t=10 → push
B pulls at t=20 → local has updatedAt=20 but content didn't change
A pulls at t=21 → sees no newer remote bytes; B's "newer" timestamp
                  now wins on the next pair-sync direction.
\`\`\`

## Out of scope
- Todo pull (\`applyTodoUpdate\`) has different ownership semantics; left for a separate PR.
- Using GitHub's commit \`committer.date\` as the source of truth is a stretch goal — would require an extra API call per file.

## Test plan
- [ ] Edit note on device A, push, then pull on device B → B's note shows fresh content + new updatedAt
- [ ] Pull on device B again with no remote changes → B's updatedAt unchanged
- [ ] Repeat for canvases

🤖 Generated with [Claude Code](https://claude.com/claude-code)