### PR TITLE
build: worklets plugin + Metro inline-requires (#259)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,8 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    // react-native-worklets/plugin must be the LAST plugin per the
+    // react-native-worklets / Reanimated 4 docs.
+    plugins: ['react-native-worklets/plugin'],
   };
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -3,4 +3,11 @@ const { getDefaultConfig } = require('expo/metro-config');
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(__dirname);
 
+config.transformer.getTransformOptions = async () => ({
+  transform: {
+    experimentalImportSupport: false,
+    inlineRequires: true,
+  },
+});
+
 module.exports = config;


### PR DESCRIPTION
## Summary
- \`babel.config.js\`: add \`react-native-worklets/plugin\` as the last plugin (Reanimated 4 / worklets 0.5 requirement).
- \`metro.config.js\`: enable \`inlineRequires: true\` for cold-start improvements.

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)