### PR TITLE
fix(contexts): catch unhandled rejections in auth bootstrap (#273)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -49,6 +49,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
   useEffect(() => {
     refreshAuth()
       .then(() => GitHubService.initialize())
+      .catch((err) => {
+        console.warn('[AuthContext] auth bootstrap failed:', err);
+      })
       .finally(() => setIsLoading(false));
   }, []);
 

--- a/src/contexts/GitHubAuthContext.tsx
+++ b/src/contexts/GitHubAuthContext.tsx
@@ -13,10 +13,14 @@ export function GitHubAuthProvider({ children }: { children: ReactNode }) {
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
-    GitHubService.initialize().then(() => {
-      setUser(GitHubService.getUser());
-      setIsReady(true);
-    });
+    GitHubService.initialize()
+      .then(() => {
+        setUser(GitHubService.getUser());
+      })
+      .catch((err) => {
+        console.warn('[GitHubAuthContext] initialize failed:', err);
+      })
+      .finally(() => setIsReady(true));
   }, []);
 
   return (


### PR DESCRIPTION
Closes #273. Adds `.catch` before `.finally` on the AuthContext and GitHubAuthContext init effects.