### PR TITLE
perf: memoize AuthContext + React.memo NoteCard (#270)

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -48,7 +48,7 @@ interface NoteCardProps {
   highlighted?: boolean;
 }
 
-export default function NoteCard({ note, onPress, onLongPress, compact = false, highlighted = false }: NoteCardProps) {
+function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted = false }: NoteCardProps) {
   const { colors, isDark } = useTheme();
   const { isTablet } = useResponsive();
   
@@ -149,6 +149,18 @@ export default function NoteCard({ note, onPress, onLongPress, compact = false, 
     </TouchableOpacity>
   );
 }
+
+const NoteCard = React.memo(NoteCardImpl, (prev, next) => {
+  return (
+    prev.note === next.note &&
+    prev.compact === next.compact &&
+    prev.highlighted === next.highlighted &&
+    prev.onPress === next.onPress &&
+    prev.onLongPress === next.onLongPress
+  );
+});
+
+export default NoteCard;
 
 const styles = StyleSheet.create({
   card: {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react';
 import { AuthService, AuthState } from '../services/AuthService';
 import { GitHubService } from '../services/GitHubService';
 
@@ -24,12 +24,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
   });
   const [isLoading, setIsLoading] = useState(true);
 
-  const refreshAuth = async () => {
+  const refreshAuth = useCallback(async () => {
     const state = await AuthService.checkAuthState();
     setAuthState(state);
-  };
+  }, []);
 
-  const setToken = async (token: string): Promise<boolean> => {
+  const setToken = useCallback(async (token: string): Promise<boolean> => {
     setIsLoading(true);
     const state = await AuthService.setToken(token);
     if (!state.isAuthenticated) {
@@ -51,13 +51,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setAuthState(state);
     setIsLoading(false);
     return true;
-  };
+  }, []);
 
-  const clearToken = async () => {
+  const clearToken = useCallback(async () => {
     await AuthService.clearToken();
     await GitHubService.clearToken();
     setAuthState({ isAuthenticated: false, user: null, token: null });
-  };
+  }, []);
 
   useEffect(() => {
     refreshAuth()
@@ -68,11 +68,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       .finally(() => setIsLoading(false));
   }, []);
 
-  return (
-    <AuthContext.Provider value={{ authState, isLoading, refreshAuth, setToken, clearToken }}>
-      {children}
-    </AuthContext.Provider>
+  const value = useMemo(
+    () => ({ authState, isLoading, refreshAuth, setToken, clearToken }),
+    [authState, isLoading, refreshAuth, setToken, clearToken],
   );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 export function useAuth() {


### PR DESCRIPTION
Closes #270. `useMemo`/`useCallback` on the AuthContext value and a `React.memo` wrapper on NoteCard so list rows skip rerenders when their note hasn't changed.