### PR TITLE
fix(sync,pull): drain merge + single-write canvas/todo pulls (#260 #245)

### DIFF
--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -94,31 +94,49 @@ class NoteSyncQueueServiceClass {
     let failed = 0;
 
     try {
-      const items = await this.getAll();
-      const remaining: QueuedMutation[] = [];
+      const initial = await this.getAll();
+      // Snapshot the ids we're about to process. After draining we re-read
+      // the live queue and only remove these ids, preserving any new
+      // mutations that arrived during the drain.
+      const processedIds = new Set<string>();
+      const updatedById = new Map<string, QueuedMutation>();
+      const droppedIds = new Set<string>();
 
-      for (const item of items) {
-        if (item.type !== 'note.upsert') {
-          remaining.push(item);
-          continue;
-        }
+      for (const item of initial) {
+        if (item.type !== 'note.upsert') continue;
+        processedIds.add(item.id);
         const result = await syncNoteToGitHub(item.params);
         if (result.success) {
           succeeded++;
+          droppedIds.add(item.id);
           continue;
         }
         const attempts = item.attempts + 1;
         if (attempts >= MAX_ATTEMPTS) {
           console.warn('[NoteSyncQueue] dropped after max attempts:', result.error);
           failed++;
+          droppedIds.add(item.id);
         } else {
-          remaining.push({ ...item, attempts, lastError: result.error });
+          updatedById.set(item.id, { ...item, attempts, lastError: result.error });
           failed++;
         }
       }
 
-      await this.saveAll(remaining);
-      return { succeeded, failed, remaining: remaining.length };
+      // Re-read the queue to pick up anything enqueued during drain. Drop
+      // ids we successfully processed; merge in the updated entries.
+      const live = await this.getAll();
+      const next: QueuedMutation[] = [];
+      for (const m of live) {
+        if (droppedIds.has(m.id)) continue;
+        if (updatedById.has(m.id)) {
+          next.push(updatedById.get(m.id)!);
+          continue;
+        }
+        next.push(m);
+      }
+
+      await this.saveAll(next);
+      return { succeeded, failed, remaining: next.length };
     } finally {
       this.isDraining = false;
     }

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -151,7 +151,13 @@ async function pullCanvasesFromRepo(
   let pulled = 0;
   try {
     const files = await fetchDirectoryFiles(owner, repo, 'canvases', branch);
-    const localCanvases = await StorageService.getAllCanvases();
+    if (files.length === 0) return 0;
+
+    // Single read → mutate in memory → single write. Previous code re-read
+    // and re-wrote inside each iteration which lost interleaved edits when
+    // pulls ran in parallel (Promise.all in pullAllFromRepos).
+    const allCanvases = await StorageService.getAllCanvases();
+    let dirty = false;
 
     for (const file of files) {
       if (!file.path.endsWith('.json')) continue;
@@ -163,39 +169,36 @@ async function pullCanvasesFromRepo(
         continue;
       }
 
-      const existing = localCanvases.find((c) => c.filePath === file.path);
       const titleFromPath = file.path
         .replace(/^canvases\//, '')
         .replace(/\.json$/, '')
         .replace(/-/g, ' ');
 
-      if (existing) {
-        // Skip the local mutation if the scene is bytewise unchanged. Avoids
-        // pushing an artificial updatedAt that would clobber cross-device LWW.
-        const sceneChanged = JSON.stringify(existing.scene) !== JSON.stringify(scene);
-        if (sceneChanged) {
-          const updated = updateCanvas(existing, { scene });
-          const allCanvases = await StorageService.getAllCanvases();
-          const idx = allCanvases.findIndex((c) => c.id === existing.id);
-          if (idx !== -1) {
-            allCanvases[idx] = updated;
-            await StorageService.saveAllCanvases(allCanvases);
-          }
+      const idx = allCanvases.findIndex((c) => c.filePath === file.path);
+      if (idx !== -1) {
+        const existing = allCanvases[idx];
+        if (JSON.stringify(existing.scene) !== JSON.stringify(scene)) {
+          allCanvases[idx] = updateCanvas(existing, { scene });
+          dirty = true;
           pulled++;
         }
       } else {
-        const newCanvas = createCanvas({
-          title: titleFromPath,
-          scene,
-          repo: repoPath,
-          branch,
-          filePath: file.path,
-        });
-        const allCanvases = await StorageService.getAllCanvases();
-        allCanvases.push(newCanvas);
-        await StorageService.saveAllCanvases(allCanvases);
+        allCanvases.push(
+          createCanvas({
+            title: titleFromPath,
+            scene,
+            repo: repoPath,
+            branch,
+            filePath: file.path,
+          }),
+        );
+        dirty = true;
         pulled++;
       }
+    }
+
+    if (dirty) {
+      await StorageService.saveAllCanvases(allCanvases);
     }
   } catch {
     console.warn(`[RepoPullService] Failed to pull canvases from ${owner}/${repo}`);
@@ -212,7 +215,10 @@ async function pullTodosFromRepo(
   let pulled = 0;
   try {
     const files = await fetchDirectoryFiles(owner, repo, 'todos', branch);
-    const localTodos = await StorageService.getAllTodos();
+    if (files.length === 0) return 0;
+
+    const allTodos = await StorageService.getAllTodos();
+    let dirty = false;
 
     for (const file of files) {
       if (!file.path.endsWith('.json')) continue;
@@ -224,13 +230,14 @@ async function pullTodosFromRepo(
         continue;
       }
 
-      const existing = localTodos.find((t) => t.filePath === file.path);
       const titleFromPath = file.path
         .replace(/^todos\//, '')
         .replace(/\.json$/, '')
         .replace(/-/g, ' ');
 
-      if (existing) {
+      const idx = allTodos.findIndex((t) => t.filePath === file.path);
+      if (idx !== -1) {
+        const existing = allTodos[idx];
         const updated = applyTodoUpdate(existing, {
           text: data.text ?? existing.text,
           completed: data.completed ?? existing.completed,
@@ -239,30 +246,30 @@ async function pullTodosFromRepo(
           tags: data.tags ?? existing.tags,
           dueDate: data.dueDate ?? existing.dueDate,
         });
-        const allTodos = await StorageService.getAllTodos();
-        const idx = allTodos.findIndex((t) => t.id === existing.id);
-        if (idx !== -1) {
-          allTodos[idx] = updated;
-          await StorageService.saveAllTodos(allTodos);
-        }
+        allTodos[idx] = updated;
+        dirty = true;
         pulled++;
       } else {
-        const newTodo = createTodoItem({
-          text: data.text ?? titleFromPath,
-          completed: data.completed ?? false,
-          priority: data.priority,
-          notes: data.notes,
-          tags: data.tags,
-          dueDate: data.dueDate,
-          repo: repoPath,
-          branch,
-          filePath: file.path,
-        });
-        const allTodos = await StorageService.getAllTodos();
-        allTodos.push(newTodo);
-        await StorageService.saveAllTodos(allTodos);
+        allTodos.push(
+          createTodoItem({
+            text: data.text ?? titleFromPath,
+            completed: data.completed ?? false,
+            priority: data.priority,
+            notes: data.notes,
+            tags: data.tags,
+            dueDate: data.dueDate,
+            repo: repoPath,
+            branch,
+            filePath: file.path,
+          }),
+        );
+        dirty = true;
         pulled++;
       }
+    }
+
+    if (dirty) {
+      await StorageService.saveAllTodos(allTodos);
     }
   } catch {
     console.warn(`[RepoPullService] Failed to pull todos from ${owner}/${repo}`);


### PR DESCRIPTION
Closes #260 and #245. Sync queue drain now re-reads the live queue and removes only processed ids. Canvas/todo pulls do one read + one write.