### PR TITLE
fix(auth): single /user round-trip + atomic propagation (#262)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -32,12 +32,25 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const setToken = async (token: string): Promise<boolean> => {
     setIsLoading(true);
     const state = await AuthService.setToken(token);
-    setAuthState(state);
-    if (state.isAuthenticated) {
-      await GitHubService.setToken(token);
+    if (!state.isAuthenticated) {
+      // Validation failed — keep prior auth state untouched so a typo
+      // doesn't log the user out.
+      setIsLoading(false);
+      return false;
     }
+    // Pass the user we just validated so GitHubService doesn't re-hit /user.
+    // If the GitHubService write fails, roll AuthService back so the two
+    // services don't disagree about who's logged in.
+    const ghUser = await GitHubService.setToken(token, (state.user as unknown) as Parameters<typeof GitHubService.setToken>[1]);
+    if (!ghUser) {
+      await AuthService.clearToken();
+      setAuthState({ isAuthenticated: false, user: null, token: null });
+      setIsLoading(false);
+      return false;
+    }
+    setAuthState(state);
     setIsLoading(false);
-    return state.isAuthenticated;
+    return true;
   };
 
   const clearToken = async () => {

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -121,17 +121,20 @@ class GitHubServiceClass {
     }
   }
 
-  async setToken(token: string): Promise<GitHubUser | null> {
+  async setToken(token: string, user?: GitHubUser | null): Promise<GitHubUser | null> {
     this.token = token;
-    const user = await this.fetchUser();
-    if (!user) {
+    // If the caller already validated the token + fetched the user
+    // (AuthContext does this via AuthService.setToken), trust it instead
+    // of round-tripping /user a second time.
+    const resolvedUser = user === undefined ? await this.fetchUser() : user;
+    if (!resolvedUser) {
       this.token = null;
       return null;
     }
-    this.user = user;
+    this.user = resolvedUser;
     await AsyncStorage.setItem(TOKEN_KEY, token);
-    await AsyncStorage.setItem(USER_KEY, JSON.stringify(user));
-    return user;
+    await AsyncStorage.setItem(USER_KEY, JSON.stringify(resolvedUser));
+    return resolvedUser;
   }
 
   async clearToken(): Promise<void> {


### PR DESCRIPTION
Closes #262. `GitHubService.setToken` accepts a pre-validated user. AuthContext rolls back on partial failure so both services agree.