### PR TITLE
security(deep-links): drop unverified https:// prefix (#266)

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -20,7 +20,12 @@ import { useTheme } from '../contexts/ThemeContext';
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 const linking: LinkingOptions<RootStackParamList> = {
-  prefixes: ['gitnotes://', 'https://gitnotes.app'],
+  // Only the custom-scheme prefix is accepted until the gitnotes.app domain
+  // hosts an apple-app-site-association / .well-known/assetlinks.json with
+  // matching associatedDomains entitlement (iOS) + android:autoVerify intent
+  // filter (Android). Without that, another app on the same OS can register
+  // the same https:// pattern and hijack the link — see #266.
+  prefixes: ['gitnotes://'],
   config: {
     screens: {
       MainTabs: {


### PR DESCRIPTION
Closes #266. Removes `https://gitnotes.app` from the linking prefixes until the AASA/assetlinks artifacts and entitlements land. Custom-scheme `gitnotes://` is unchanged.