### PR TITLE
chore(deps): drop unused expo-auth-session (#275)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@shopify/react-native-skia": "2.2.12",
         "date-fns": "^4.1.0",
         "expo": "~54.0.34",
-        "expo-auth-session": "~7.0.11",
         "expo-blur": "~15.0.8",
         "expo-crypto": "~15.0.9",
         "expo-device": "~8.0.10",
@@ -52,6 +51,9 @@
         "babel-jest": "^30.3.0",
         "jest": "^30.3.0",
         "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": ">=20.18"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -7208,24 +7210,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-auth-session": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/expo-auth-session/-/expo-auth-session-7.0.11.tgz",
-      "integrity": "sha512-AhWtt/m9rb1Po77X/VBFbeE6UTgbm2vXP2iCblUSRsHCw2qD6lO0ulKUB8Xyxy9FtoI9yrNQ1iwCNgIIgo8VYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "expo-application": "~7.0.8",
-        "expo-constants": "~18.0.13",
-        "expo-crypto": "~15.0.9",
-        "expo-linking": "~8.0.12",
-        "expo-web-browser": "~15.0.11",
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo-blur": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-15.0.8.tgz",
@@ -7363,20 +7347,6 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
-      }
-    },
-    "node_modules/expo-linking": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.12.tgz",
-      "integrity": "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "expo-constants": "~18.0.13",
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@shopify/react-native-skia": "2.2.12",
     "date-fns": "^4.1.0",
     "expo": "~54.0.34",
-    "expo-auth-session": "~7.0.11",
     "expo-blur": "~15.0.8",
     "expo-crypto": "~15.0.9",
     "expo-device": "~8.0.10",


### PR DESCRIPTION
Closes #275. The package was never imported. OAuth Device Flow / PKCE can be re-introduced (and would intersect #233) — add the dep back when that work starts.