### PR TITLE
perf(notes-list): stable FlatList key (#249)

### DIFF
--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -940,7 +940,7 @@ export default function NotesListScreen() {
           data={displayNotes}
           renderItem={getRenderItem()}
           keyExtractor={keyExtractor}
-          key={`${viewMode}-${displayNotes.length}`}
+          key={viewMode}
           onScrollToIndexFailed={handleScrollToIndexFailed}
           {...getListLayout()}
           contentContainerStyle={getListContentStyle()}


### PR DESCRIPTION
Closes #249. Drop `displayNotes.length` from the FlatList key so it doesn't remount on every add/remove/filter.