### PR TITLE
security(viewers): tighten WebView whitelist + drop universal file access (#243)

### DIFF
--- a/src/screens/PdfViewerScreen.tsx
+++ b/src/screens/PdfViewerScreen.tsx
@@ -188,8 +188,14 @@ export default function PdfViewerScreen() {
         <WebView
           source={{ uri: localUri }}
           style={{ flex: 1, backgroundColor: colors.background }}
-          originWhitelist={['*']}
+          // Local file PDF — restrict origin to file:// (was '*'). The
+          // injected JS only needs to read scrollY and post a message
+          // back, no cross-origin file access required.
+          originWhitelist={['file://']}
           allowsInlineMediaPlayback
+          allowFileAccess
+          allowFileAccessFromFileURLs={false}
+          allowUniversalAccessFromFileURLs={false}
           injectedJavaScript={injectedJavaScript}
           onMessage={handleMessage}
         />

--- a/src/screens/VideoViewerScreen.tsx
+++ b/src/screens/VideoViewerScreen.tsx
@@ -99,17 +99,22 @@ export default function VideoViewerScreen() {
   const html = useMemo(() => {
     if (!localUri) return '';
     const mime = videoMime(fileName);
+    // Escape any " in the URI so a crafted filename can't break out of the
+    // attribute and inject script. (mime is whitelisted in videoMime.)
+    const safeUri = localUri.replace(/"/g, '%22');
+    const safeMime = mime.replace(/[^a-zA-Z0-9/.+-]/g, '');
     return `<!DOCTYPE html>
 <html>
 <head>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; media-src file: blob:; style-src 'unsafe-inline'">
 <style>
   html, body { margin: 0; height: 100%; background: #000; }
   video { width: 100%; height: 100%; object-fit: contain; }
 </style>
 </head>
 <body>
-  <video src="${localUri}" type="${mime}" controls autoplay playsinline></video>
+  <video src="${safeUri}" type="${safeMime}" controls autoplay playsinline></video>
 </body>
 </html>`;
   }, [localUri, fileName]);
@@ -153,10 +158,16 @@ export default function VideoViewerScreen() {
           style={{ flex: 1, backgroundColor: '#000' }}
           allowsInlineMediaPlayback
           mediaPlaybackRequiresUserAction={false}
-          originWhitelist={['*']}
+          originWhitelist={['file://']}
           allowFileAccess
-          allowFileAccessFromFileURLs
-          allowUniversalAccessFromFileURLs
+          // Universal / cross-origin file access removed — not needed to
+          // play a single local <video src="file://...">. With the previous
+          // flags + originWhitelist=['*'], a script that escaped the
+          // attribute interpolation could read arbitrary file:// resources.
+          allowFileAccessFromFileURLs={false}
+          allowUniversalAccessFromFileURLs={false}
+          javaScriptEnabled={false}
+          domStorageEnabled={false}
         />
       )}
     </SafeAreaView>


### PR DESCRIPTION
Closes #243. PdfViewer + VideoViewer scope `originWhitelist` to `file://` and disable cross-origin / universal file access. VideoViewer also disables JS, escapes the URI attribute, and adds a CSP meta tag.