### PR TITLE
fix(notes): drop file-tree UI from notes page

### DIFF
--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -38,7 +38,6 @@ import ContextMenu from "../components/ContextMenu";
 import NoteCard from "../components/NoteCard";
 import SearchBar from "../components/SearchBar";
 import { NScreenHeader } from "../components/neumorphic";
-import RepoFileBrowser from "../components/RepoFileBrowser";
 import { parseRepoPath } from "../utils/gitPathParser";
 import { HapticService } from "../utils/haptics";
 import {
@@ -160,11 +159,6 @@ export default function NotesListScreen() {
     (selectedFormat ? 1 : 0) +
     (selectedTags.length > 0 ? 1 : 0);
 
-  const repoInfo = useMemo(
-    () => (selectedRepo ? parseRepoPath(selectedRepo.path) : null),
-    [selectedRepo],
-  );
-
   const displayNotes = useMemo(() => {
     let result = filteredNotes;
     if (selectedFolder) {
@@ -267,81 +261,6 @@ export default function NotesListScreen() {
       setShowViewModePicker(false);
     },
     [setViewMode],
-  );
-
-  const handleRepoFilePress = useCallback(
-    async (filePath: string) => {
-      const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
-
-      if (ext === "pdf") {
-        if (!selectedRepo || !repoInfo) return;
-        navigation.navigate("PdfViewer", {
-          owner: repoInfo.owner,
-          repo: repoInfo.repo,
-          branch: selectedBranch ?? undefined,
-          path: filePath,
-          title: filePath.split("/").pop(),
-        });
-        return;
-      }
-
-      const existing = notes.find(
-        (n: Note) => n.repo === selectedRepo?.path && n.filePath === filePath,
-      );
-      if (existing) {
-        navigation.navigate("NoteEditor", { noteId: existing.id });
-        return;
-      }
-      if (!selectedRepo || !repoInfo) return;
-
-      const branch = selectedBranch ?? "main";
-      const content = await GitHubService.getFileContent(
-        repoInfo.owner,
-        repoInfo.repo,
-        filePath,
-        branch,
-      );
-      if (content === null) {
-        Alert.alert("Failed to load", "Could not fetch file from GitHub.");
-        return;
-      }
-
-      const fileExt = ext || "md";
-      const format: NoteFormat =
-        fileExt === "norg" ? "neorg" : fileExt === "org" ? "org" : "markdown";
-      const titleFromPath = filePath
-        .replace(/\.[^.]+$/, "")
-        .split("/")
-        .pop()
-        ?.replace(/[-_]/g, " ") ?? filePath;
-
-      const created = await createNote({
-        title: titleFromPath,
-        content,
-        repo: selectedRepo.path,
-        branch,
-        filePath,
-        format,
-      });
-      if (created) {
-        navigation.navigate("NoteEditor", { noteId: created.id });
-      }
-    },
-    [notes, selectedRepo, selectedBranch, repoInfo, createNote, navigation],
-  );
-
-  const handleCreateNoteInFolder = useCallback(
-    (folderPath: string) => {
-      navigation.navigate("NoteEditor", {
-        format: "markdown",
-        initialTitle: "",
-        initialContent: "",
-        repo: selectedRepo?.path,
-        branch: selectedBranch ?? undefined,
-        folderPath: folderPath || undefined,
-      });
-    },
-    [navigation, selectedRepo, selectedBranch],
   );
 
   const handleDeleteFromSwipe = useCallback(
@@ -792,7 +711,7 @@ export default function NotesListScreen() {
       )}
 
       <Modal
-        visible={showViewModePicker && !selectedRepo}
+        visible={showViewModePicker}
         transparent
         animationType="fade"
         onRequestClose={() => setShowViewModePicker(false)}
@@ -839,7 +758,7 @@ export default function NotesListScreen() {
         </TouchableOpacity>
       </Modal>
 
-      {activeFilterCount > 0 && !selectedRepo && (
+      {activeFilterCount > 0 && (
         <View style={styles.activeFilterWrap}>
           <ScrollView
             horizontal
@@ -922,74 +841,45 @@ export default function NotesListScreen() {
         </View>
       )}
 
-      {selectedRepo ? (
-        repoInfo ? (
-          <RepoFileBrowser
-            owner={repoInfo.owner}
-            repo={repoInfo.repo}
-            branch={selectedBranch ?? undefined}
-            onFilePress={handleRepoFilePress}
-            onCreateNoteInFolder={handleCreateNoteInFolder}
-            key={selectedRepo.id}
+      <FlatList
+        ref={listRef}
+        data={displayNotes}
+        renderItem={getRenderItem()}
+        keyExtractor={keyExtractor}
+        key={viewMode}
+        onScrollToIndexFailed={handleScrollToIndexFailed}
+        {...getListLayout()}
+        contentContainerStyle={getListContentStyle()}
+        refreshControl={
+          <RefreshControl
+            refreshing={isPullRefreshing}
+            onRefresh={handlePullToRefresh}
+            tintColor={colors.primary}
+            colors={[colors.primary]}
           />
-        ) : (
+        }
+        ListEmptyComponent={
           <View style={styles.emptyContainer}>
             <Ionicons
-              name="alert-circle-outline"
+              name="document-text-outline"
               size={48}
               color={colors.textSecondary}
             />
             <Text style={[styles.emptyTitle, { color: colors.text }]}>
-              Invalid Repository
+              {searchQuery || activeFilterCount > 0
+                ? "No matching notes"
+                : "No notes yet"}
             </Text>
             <Text
               style={[styles.emptySubtext, { color: colors.textSecondary }]}
             >
-              Check the repo path in Settings
+              {searchQuery || activeFilterCount > 0
+                ? "Try adjusting your search or filters"
+                : "Create your first note to get started"}
             </Text>
           </View>
-        )
-      ) : (
-        <FlatList
-          ref={listRef}
-          data={displayNotes}
-          renderItem={getRenderItem()}
-          keyExtractor={keyExtractor}
-          key={viewMode}
-          onScrollToIndexFailed={handleScrollToIndexFailed}
-          {...getListLayout()}
-          contentContainerStyle={getListContentStyle()}
-          refreshControl={
-            <RefreshControl
-              refreshing={isPullRefreshing}
-              onRefresh={handlePullToRefresh}
-              tintColor={colors.primary}
-              colors={[colors.primary]}
-            />
-          }
-          ListEmptyComponent={
-            <View style={styles.emptyContainer}>
-              <Ionicons
-                name="document-text-outline"
-                size={48}
-                color={colors.textSecondary}
-              />
-              <Text style={[styles.emptyTitle, { color: colors.text }]}>
-                {searchQuery || activeFilterCount > 0
-                  ? "No matching notes"
-                  : "No notes yet"}
-              </Text>
-              <Text
-                style={[styles.emptySubtext, { color: colors.textSecondary }]}
-              >
-                {searchQuery || activeFilterCount > 0
-                  ? "Try adjusting your search or filters"
-                  : "Create your first note to get started"}
-              </Text>
-            </View>
-          }
-        />
-      )}
+        }
+      />
 
       {/* ── Filter modal ── */}
       <Modal visible={showFilterModal} transparent animationType="slide">


### PR DESCRIPTION
## Summary
- Repo filter now just narrows the notes FlatList instead of swapping the screen for a separate file-tree browser
- Drops `RepoFileBrowser` rendering, the `handleRepoFilePress` / `handleCreateNoteInFolder` callbacks, the unused `repoInfo` memo, and the `!selectedRepo` gates that hid the view-mode picker and active-filter chips
- Keeps `parseRepoPath` (still used in the note-card breadcrumb) and `selectedRepo` filter state

## Test plan
- [ ] Open Notes tab — full FlatList renders
- [ ] Filter to a repo via the filter modal — list narrows, chips visible
- [ ] Filter chips remove repo / format / tags as expected
- [ ] View-mode picker still opens with a repo selected

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)