### PR TITLE
fix: drop `as any` casts on Ionicon and canvas typings

### DIFF
--- a/src/components/CanvasModal.tsx
+++ b/src/components/CanvasModal.tsx
@@ -452,7 +452,7 @@ export default function CanvasModal({ visible, onSave, onClose, editJsonUri }: C
         >
           {canvasSize && (
             <GestureDetector gesture={panGesture}>
-              <SkiaCanvas ref={canvasRef as any} style={{ width: canvasSize.width, height: canvasSize.height }}>
+              <SkiaCanvas ref={canvasRef} style={{ width: canvasSize.width, height: canvasSize.height }}>
                 <Fill color="white" />
                 {elements.map(renderElement)}
               </SkiaCanvas>

--- a/src/components/MoveNoteDialog.tsx
+++ b/src/components/MoveNoteDialog.tsx
@@ -14,6 +14,8 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
+
+type IoniconName = keyof typeof Ionicons.glyphMap;
 import { DraxView, DraxProvider } from 'react-native-drax';
 import { useTheme } from '../contexts/ThemeContext';
 import { GitHubService, GitHubContent } from '../services/GitHubService';
@@ -239,7 +241,7 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
     Keyboard.dismiss();
   }, []);
 
-  const getFileIcon = useCallback((name: string): string => {
+  const getFileIcon = useCallback((name: string): IoniconName => {
     const ext = name.toLowerCase().split('.').pop();
     switch (ext) {
       case 'md': return 'document-text';
@@ -258,7 +260,7 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
 
     const itemContent = (
       <View style={[exploreStyles.item, { borderBottomColor: colors.border + '40' }]}>
-        <Ionicons name={iconName as any} size={22} color={iconColor} style={exploreStyles.itemIcon} />
+        <Ionicons name={iconName} size={22} color={iconColor} style={exploreStyles.itemIcon} />
         <Text style={[exploreStyles.itemName, { color: colors.text }]} numberOfLines={1}>
           {item.name}
         </Text>

--- a/src/components/RepoFileTree.tsx
+++ b/src/components/RepoFileTree.tsx
@@ -49,7 +49,9 @@ interface TreeItemProps {
   onRefresh?: () => void;
 }
 
-const FILE_ICON_MAP: Record<string, string> = {
+type IoniconName = keyof typeof Ionicons.glyphMap;
+
+const FILE_ICON_MAP: Record<string, IoniconName> = {
   md: 'document-text',
   markdown: 'document-text',
   norg: 'document-text',
@@ -71,7 +73,7 @@ const FILE_ICON_MAP: Record<string, string> = {
   toml: 'settings',
 };
 
-function getFileIcon(name: string): string {
+function getFileIcon(name: string): IoniconName {
   const ext = name.toLowerCase().split('.').pop() || '';
   return FILE_ICON_MAP[ext] || 'document';
 }
@@ -494,7 +496,7 @@ function TreeItem({ node, owner, repo, branch, level, onFilePress, onRefresh }: 
             <View style={treeStyles.chevronPlaceholder} />
           )}
         </View>
-        <Ionicons name={iconName as any} size={20} color={iconColor} style={treeStyles.icon} />
+        <Ionicons name={iconName} size={20} color={iconColor} style={treeStyles.icon} />
         <Text style={[treeStyles.name, { color: colors.text }]} numberOfLines={1}>
           {node.name}
         </Text>

--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -31,7 +31,7 @@ const TemplateListItem = ({ item, onSelect, colors }: TemplateListItemProps) => 
   return (
     <TouchableOpacity style={[styles.templateItem, { backgroundColor: colors.card, shadowColor: colors.shadow }]} onPress={onPressItem}>
       <View style={[styles.templateIcon, { backgroundColor: colors.primary + '20' }]}>
-        <Ionicons name={item.icon as any} size={24} color={colors.primary} />
+        <Ionicons name={item.icon} size={24} color={colors.primary} />
       </View>
       <View style={styles.templateInfo}>
         <Text style={[styles.templateName, { color: colors.text }]}>{item.name}</Text>

--- a/src/components/neumorphic/NTabBar.tsx
+++ b/src/components/neumorphic/NTabBar.tsx
@@ -6,7 +6,9 @@ import { Ionicons } from '@expo/vector-icons';
 import { Surface } from './Surface';
 import { useTokens } from '../../contexts/ThemeContext';
 
-const TAB_ICONS: Record<string, { focused: string; outline: string; label: string }> = {
+type IoniconName = keyof typeof Ionicons.glyphMap;
+
+const TAB_ICONS: Record<string, { focused: IoniconName; outline: IoniconName; label: string }> = {
   HomeTab: { focused: 'home', outline: 'home-outline', label: 'Home' },
   NotesTab: { focused: 'document-text', outline: 'document-text-outline', label: 'Notes' },
   ExploreTab: { focused: 'compass', outline: 'compass-outline', label: 'Explore' },
@@ -80,7 +82,7 @@ export function NTabBar({ state, navigation }: BottomTabBarProps) {
                 }}
               >
                 <Ionicons
-                  name={(isFocused ? config.focused : config.outline) as any}
+                  name={isFocused ? config.focused : config.outline}
                   size={22}
                   color={isFocused ? colors.accent : colors.textSecondary}
                 />

--- a/src/models/Canvas.ts
+++ b/src/models/Canvas.ts
@@ -143,7 +143,7 @@ export function canvasIdFromLink(target: string): string {
   return target.slice(CANVAS_LINK_PREFIX.length);
 }
 
-export function canvasToLink(canvas: Canvas): string {
+export function canvasToLink(canvas: Pick<Canvas, 'id'>): string {
   return `${CANVAS_LINK_PREFIX}${canvas.id}`;
 }
 

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -22,7 +22,9 @@ import { NTabBar } from '../components/neumorphic';
 
 const Tab = createBottomTabNavigator<BottomTabParamList>();
 
-const TAB_ICONS: Record<string, { focused: string; outline: string; label: string }> = {
+type IoniconName = keyof typeof Ionicons.glyphMap;
+
+const TAB_ICONS: Record<string, { focused: IoniconName; outline: IoniconName; label: string }> = {
   HomeTab: { focused: 'home', outline: 'home-outline', label: 'Home' },
   NotesTab: { focused: 'document-text', outline: 'document-text-outline', label: 'Notes' },
   ExploreTab: { focused: 'compass', outline: 'compass-outline', label: 'Explore' },
@@ -86,7 +88,7 @@ function TabletRail({ state, navigation }: BottomTabBarProps) {
               activeOpacity={0.7}
             >
               <Ionicons
-                name={(isFocused ? config.focused : config.outline) as any}
+                name={isFocused ? config.focused : config.outline}
                 size={24}
                 color={isFocused ? colors.primary : colors.textSecondary}
               />
@@ -151,7 +153,7 @@ export default function TabNavigator() {
           const config = TAB_ICONS[route.name];
           if (!config) return null;
           const iconName = focused ? config.focused : config.outline;
-          return <Ionicons name={iconName as any} size={size} color={color} />;
+          return <Ionicons name={iconName} size={size} color={color} />;
         },
         tabBarActiveTintColor: '#007AFF',
         tabBarInactiveTintColor: 'gray',

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -446,7 +446,7 @@ export default function NoteEditorScreen() {
   }, [content]);
 
   const handleLinkCanvas = useCallback((canvasId: string, canvasTitle: string) => {
-    const link = canvasToLink({ id: canvasId } as any);
+    const link = canvasToLink({ id: canvasId });
     let linkText: string;
     if (noteFormat === 'neorg') {
       linkText = `\n{${link}}[${canvasTitle}]\n`;

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -572,7 +572,7 @@ export default function NotesListScreen() {
           }}
         >
           <Ionicons
-            name={VIEW_MODE_ICONS[viewMode] as any}
+            name={VIEW_MODE_ICONS[viewMode]}
             size={20}
             color={colors.primary}
           />
@@ -802,7 +802,7 @@ export default function NotesListScreen() {
                   activeOpacity={0.7}
                 >
                   <Ionicons
-                    name={VIEW_MODE_ICONS[mode] as any}
+                    name={VIEW_MODE_ICONS[mode]}
                     size={22}
                     color={viewMode === mode ? colors.primary : colors.textSecondary}
                   />

--- a/src/services/TemplateService.ts
+++ b/src/services/TemplateService.ts
@@ -1,7 +1,11 @@
+import type { Ionicons } from '@expo/vector-icons';
+
+export type NoteTemplateIcon = keyof typeof Ionicons.glyphMap;
+
 export interface NoteTemplate {
   id: string;
   name: string;
-  icon: string;
+  icon: NoteTemplateIcon;
   description: string;
   title?: string;
   content: string;

--- a/src/utils/viewModes.ts
+++ b/src/utils/viewModes.ts
@@ -1,4 +1,8 @@
+import type { Ionicons } from '@expo/vector-icons';
+
 export type ViewMode = 'list' | 'grid' | 'card' | 'journal';
+
+type IoniconName = keyof typeof Ionicons.glyphMap;
 
 export interface ViewModePreference {
   global: ViewMode;
@@ -14,7 +18,7 @@ export const VIEW_MODE_LABELS: Record<ViewMode, string> = {
   journal: 'Journal',
 };
 
-export const VIEW_MODE_ICONS: Record<ViewMode, string> = {
+export const VIEW_MODE_ICONS: Record<ViewMode, IoniconName> = {
   list: 'list',
   grid: 'grid',
   card: 'albums',


### PR DESCRIPTION
## Summary
- Type Ionicon glyph names via \`keyof typeof Ionicons.glyphMap\` in TabNavigator, NTabBar, RepoFileTree, MoveNoteDialog, TemplateSelector, NotesListScreen / viewModes, and NoteTemplate
- \`canvasToLink\` now takes \`Pick<Canvas,'id'>\`, dropping the \`{ id } as any\` cast at the call site
- CanvasModal SkiaCanvas ref no longer needs a cast

11 → 1 in-repo \`as any\`. The remaining one is in GitSyncService, deleted by #238 / PR #316.

## Test plan
- [ ] \`npx tsc --noEmit\` clean
- [ ] App still renders all icons (tab bar, file tree, move dialog, templates, view-mode picker)

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)