### PR TITLE
fix(editor): stop reloading note state on every notes-array update

### DIFF
--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -198,9 +198,17 @@ export default function NoteEditorScreen() {
     return `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`;
   }, []);
 
+  // Keep getNoteById in a ref so the load effect below depends only on
+  // noteId — otherwise external updates to the notes array (background
+  // pulls, other-note edits) re-fire it and clobber unsaved local edits.
+  const getNoteByIdRef = useRef(getNoteById);
+  useEffect(() => {
+    getNoteByIdRef.current = getNoteById;
+  }, [getNoteById]);
+
   useEffect(() => {
     if (noteId) {
-      const existingNote = getNoteById(noteId);
+      const existingNote = getNoteByIdRef.current(noteId);
       if (existingNote) {
         setTitle(existingNote.title);
         setContent(existingNote.content);
@@ -214,7 +222,7 @@ export default function NoteEditorScreen() {
         setAttachments(existingNote.attachments || []);
       }
     }
-  }, [noteId, getNoteById, setContent]);
+  }, [noteId, setContent]);
 
   const handleTitleChange = useCallback((text: string) => {
     setTitle(text);


### PR DESCRIPTION
## Summary
Audit of \`useEffect\` dependency arrays surfaced one real bug:

\`NoteEditorScreen\`'s note-load effect depended on \`getNoteById\`, which is wrapped in \`useCallback([notes])\` inside \`NoteContext\`. So every external mutation of the notes array — a background sync pull, an edit to a different note, a refresh — re-fires the effect and resets the editor's local \`title\` / \`content\` / \`branch\` / \`tags\` / \`attachments\` to whatever's currently in storage, clobbering unsaved typing.

Fix: stash \`getNoteById\` in a ref kept fresh by a tiny separate effect, narrow the load effect's deps to \`[noteId, setContent]\` so it only runs when the user opens a different note.

The rest of the audit looked clean — most other effects already depend only on what they read, and a few \`length\`-based deps in StartupSyncGate / ExploreScreen are already covered by the dedicated #247 work.

## Test plan
- [ ] Open a note, type without saving, then trigger a background pull → typing should persist
- [ ] Open a note, type, then save → no clobbering on save
- [ ] Navigate between notes → each note loads its own state correctly

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)