### PR TITLE
test: cover NoteSyncQueueService and Note model helpers

### DIFF
--- a/__tests__/Note.test.ts
+++ b/__tests__/Note.test.ts
@@ -1,0 +1,194 @@
+import {
+  createNote,
+  updateNote,
+  sortNotesByUpdated,
+  sortNotesWithPinnedFirst,
+  filterNotesBySearch,
+  filterNotesByFolder,
+  getNotesInFolderAndSubfolders,
+  getNoteFileExtension,
+  isNeorgNote,
+  getSupportedFileExtensions,
+  isSupportedFileExtension,
+  deriveFolderPath,
+  Note,
+} from '../src/models/Note';
+
+const baseNote = (overrides: Partial<Note> = {}): Note => ({
+  id: 'n1',
+  title: 'T',
+  content: '',
+  createdAt: 0,
+  updatedAt: 0,
+  tags: [],
+  ...overrides,
+});
+
+describe('createNote', () => {
+  test('fills required fields and defaults', () => {
+    const n = createNote({ title: 'A', content: 'body' });
+    expect(n.title).toBe('A');
+    expect(n.content).toBe('body');
+    expect(n.tags).toEqual([]);
+    expect(n.attachments).toEqual([]);
+    expect(n.isPinned).toBe(false);
+    expect(n.format).toBe('markdown');
+    expect(n.id).toMatch(/^\d+-[a-z0-9]+$/);
+    expect(n.createdAt).toBe(n.updatedAt);
+  });
+
+  test('preserves provided overrides', () => {
+    const n = createNote({
+      title: 'A',
+      content: '',
+      tags: ['x'],
+      isPinned: true,
+      format: 'neorg',
+      repo: 'o/r',
+      branch: 'dev',
+    });
+    expect(n.tags).toEqual(['x']);
+    expect(n.isPinned).toBe(true);
+    expect(n.format).toBe('neorg');
+    expect(n.repo).toBe('o/r');
+    expect(n.branch).toBe('dev');
+  });
+});
+
+describe('updateNote', () => {
+  test('overrides only the supplied fields', () => {
+    const original = baseNote({ title: 'old', content: 'oldc', tags: ['a'] });
+    const next = updateNote(original, { title: 'new' });
+    expect(next.title).toBe('new');
+    expect(next.content).toBe('oldc');
+    expect(next.tags).toEqual(['a']);
+  });
+
+  test('always bumps updatedAt', () => {
+    const original = baseNote({ updatedAt: 1 });
+    const next = updateNote(original, {});
+    expect(next.updatedAt).toBeGreaterThanOrEqual(original.updatedAt);
+  });
+});
+
+describe('sort helpers', () => {
+  test('sortNotesByUpdated newest first', () => {
+    const notes = [
+      baseNote({ id: 'a', updatedAt: 1 }),
+      baseNote({ id: 'b', updatedAt: 3 }),
+      baseNote({ id: 'c', updatedAt: 2 }),
+    ];
+    expect(sortNotesByUpdated(notes).map((n) => n.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  test('sortNotesWithPinnedFirst pins float to top, then by updatedAt', () => {
+    const notes = [
+      baseNote({ id: 'old', updatedAt: 1 }),
+      baseNote({ id: 'pinned-old', updatedAt: 1, isPinned: true }),
+      baseNote({ id: 'new', updatedAt: 9 }),
+      baseNote({ id: 'pinned-new', updatedAt: 9, isPinned: true }),
+    ];
+    expect(sortNotesWithPinnedFirst(notes).map((n) => n.id)).toEqual([
+      'pinned-new',
+      'pinned-old',
+      'new',
+      'old',
+    ]);
+  });
+});
+
+describe('filterNotesBySearch', () => {
+  test('returns all when query is blank', () => {
+    const notes = [baseNote({ id: 'a' }), baseNote({ id: 'b' })];
+    expect(filterNotesBySearch(notes, '')).toEqual(notes);
+    expect(filterNotesBySearch(notes, '   ')).toEqual(notes);
+  });
+
+  test('matches title, content, or tag (case-insensitive)', () => {
+    const notes = [
+      baseNote({ id: 'a', title: 'Hello world', content: '' }),
+      baseNote({ id: 'b', title: '', content: 'totally relevant' }),
+      baseNote({ id: 'c', title: '', content: '', tags: ['react'] }),
+      baseNote({ id: 'd', title: 'unrelated', content: 'nope' }),
+    ];
+    expect(filterNotesBySearch(notes, 'WORLD').map((n) => n.id)).toEqual(['a']);
+    expect(filterNotesBySearch(notes, 'relevant').map((n) => n.id)).toEqual(['b']);
+    expect(filterNotesBySearch(notes, 'react').map((n) => n.id)).toEqual(['c']);
+  });
+});
+
+describe('filterNotesByFolder', () => {
+  test('returns all when folderPath is null/undefined', () => {
+    const notes = [baseNote({ id: 'a', folderPath: '/foo' }), baseNote({ id: 'b' })];
+    expect(filterNotesByFolder(notes, null)).toEqual(notes);
+  });
+
+  test('matches normalized paths (leading slash, trailing slash, blanks)', () => {
+    const notes = [
+      baseNote({ id: 'a', folderPath: '/foo' }),
+      baseNote({ id: 'b', folderPath: 'foo/' }),
+      baseNote({ id: 'c', folderPath: '/foo/bar' }),
+      baseNote({ id: 'd' }),
+    ];
+    expect(filterNotesByFolder(notes, 'foo').map((n) => n.id)).toEqual(['a', 'b']);
+    expect(filterNotesByFolder(notes, '/foo/').map((n) => n.id)).toEqual(['a', 'b']);
+  });
+
+  test('skips notes with no folderPath', () => {
+    const notes = [baseNote({ id: 'a' }), baseNote({ id: 'b', folderPath: '/foo' })];
+    expect(filterNotesByFolder(notes, '/foo').map((n) => n.id)).toEqual(['b']);
+  });
+});
+
+describe('getNotesInFolderAndSubfolders', () => {
+  test('matches the folder and any descendants', () => {
+    const notes = [
+      baseNote({ id: 'a', folderPath: '/foo' }),
+      baseNote({ id: 'b', folderPath: '/foo/bar' }),
+      baseNote({ id: 'c', folderPath: '/foobar' }),
+      baseNote({ id: 'd', folderPath: '/other' }),
+    ];
+    expect(getNotesInFolderAndSubfolders(notes, '/foo').map((n) => n.id)).toEqual(['a', 'b']);
+  });
+
+  test('treats notes with no folderPath as root', () => {
+    const notes = [baseNote({ id: 'a' }), baseNote({ id: 'b', folderPath: '/x' })];
+    expect(getNotesInFolderAndSubfolders(notes, '/').map((n) => n.id)).toEqual(['a']);
+  });
+});
+
+describe('format helpers', () => {
+  test('getNoteFileExtension maps formats', () => {
+    expect(getNoteFileExtension('markdown')).toBe('.md');
+    expect(getNoteFileExtension('neorg')).toBe('.norg');
+    expect(getNoteFileExtension('org')).toBe('.org');
+    expect(getNoteFileExtension('pdf')).toBe('.pdf');
+    expect(getNoteFileExtension(undefined)).toBe('.md');
+  });
+
+  test('isNeorgNote', () => {
+    expect(isNeorgNote(baseNote({ format: 'neorg' }))).toBe(true);
+    expect(isNeorgNote(baseNote({ format: 'markdown' }))).toBe(false);
+    expect(isNeorgNote(baseNote())).toBe(false);
+  });
+
+  test('getSupportedFileExtensions / isSupportedFileExtension', () => {
+    expect(getSupportedFileExtensions()).toEqual(['.md', '.norg', '.org', '.pdf']);
+    expect(isSupportedFileExtension('a.md')).toBe(true);
+    expect(isSupportedFileExtension('A.PDF')).toBe(true);
+    expect(isSupportedFileExtension('a.txt')).toBe(false);
+  });
+});
+
+describe('deriveFolderPath', () => {
+  test('returns parent directory of a file path', () => {
+    expect(deriveFolderPath('a/b/c.md')).toBe('a/b');
+  });
+
+  test('returns undefined for top-level files or empty input', () => {
+    expect(deriveFolderPath(undefined)).toBeUndefined();
+    expect(deriveFolderPath('')).toBeUndefined();
+    expect(deriveFolderPath('a.md')).toBeUndefined();
+    expect(deriveFolderPath('/a.md')).toBeUndefined();
+  });
+});

--- a/__tests__/NoteSyncQueueService.test.ts
+++ b/__tests__/NoteSyncQueueService.test.ts
@@ -1,0 +1,260 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  let store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (key: string) => (key in store ? store[key] : null)),
+      setItem: jest.fn(async (key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: jest.fn(async (key: string) => {
+        delete store[key];
+      }),
+      clear: jest.fn(async () => {
+        store = {};
+      }),
+      __reset: () => {
+        store = {};
+      },
+    },
+  };
+});
+
+jest.mock('../src/services/NoteGitHubSyncService', () => ({
+  syncNoteToGitHub: jest.fn(),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { NoteSyncQueueService } from '../src/services/NoteSyncQueueService';
+import { syncNoteToGitHub } from '../src/services/NoteGitHubSyncService';
+
+const QUEUE_KEY = '@gitnotes:sync_queue_v1';
+
+describe('NoteSyncQueueService', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    (AsyncStorage as unknown as { __reset: () => void }).__reset();
+  });
+
+  describe('enqueueNoteUpsert', () => {
+    test('appends a new mutation', async () => {
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'owner/repo',
+        branch: 'main',
+        filePath: 'notes/a.md',
+        title: 'A',
+        content: '...',
+        format: 'markdown',
+      });
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].type).toBe('note.upsert');
+      expect(items[0].attempts).toBe(0);
+      expect(items[0].params.title).toBe('A');
+    });
+
+    test('dedupes by repo + branch + filePath + title (latest wins)', async () => {
+      const base = {
+        repo: 'owner/repo',
+        branch: 'main',
+        filePath: 'notes/a.md',
+        title: 'A',
+        format: 'markdown' as const,
+      };
+      await NoteSyncQueueService.enqueueNoteUpsert({ ...base, content: 'first' });
+      await NoteSyncQueueService.enqueueNoteUpsert({ ...base, content: 'second' });
+      await NoteSyncQueueService.enqueueNoteUpsert({ ...base, content: 'third' });
+
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].params.content).toBe('third');
+    });
+
+    test('treats missing branch as "main" for dedupe', async () => {
+      const base = {
+        repo: 'owner/repo',
+        filePath: 'notes/a.md',
+        title: 'A',
+        format: 'markdown' as const,
+      };
+      await NoteSyncQueueService.enqueueNoteUpsert({ ...base, content: 'one' });
+      await NoteSyncQueueService.enqueueNoteUpsert({ ...base, branch: 'main', content: 'two' });
+
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].params.content).toBe('two');
+    });
+
+    test('keeps separate entries for different files', async () => {
+      const base = {
+        repo: 'owner/repo',
+        branch: 'main',
+        title: 'A',
+        format: 'markdown' as const,
+        content: 'x',
+      };
+      await NoteSyncQueueService.enqueueNoteUpsert({ ...base, filePath: 'a.md' });
+      await NoteSyncQueueService.enqueueNoteUpsert({ ...base, filePath: 'b.md' });
+      const items = await NoteSyncQueueService.getAll();
+      expect(items.map((m) => m.params.filePath)).toEqual(['a.md', 'b.md']);
+    });
+  });
+
+  describe('pendingCount', () => {
+    test('returns 0 for empty queue', async () => {
+      expect(await NoteSyncQueueService.pendingCount()).toBe(0);
+    });
+
+    test('returns the queue length', async () => {
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'b', title: 'B', content: '', format: 'markdown',
+      });
+      expect(await NoteSyncQueueService.pendingCount()).toBe(2);
+    });
+  });
+
+  describe('getAll resilience', () => {
+    test('returns [] for malformed JSON', async () => {
+      await AsyncStorage.setItem(QUEUE_KEY, '{not json');
+      expect(await NoteSyncQueueService.getAll()).toEqual([]);
+    });
+
+    test('returns [] for non-array payload', async () => {
+      await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify({ foo: 'bar' }));
+      expect(await NoteSyncQueueService.getAll()).toEqual([]);
+    });
+  });
+
+  describe('drain', () => {
+    test('removes successfully-synced items', async () => {
+      (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: true });
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'b', title: 'B', content: '', format: 'markdown',
+      });
+
+      const result = await NoteSyncQueueService.drain();
+      expect(result.succeeded).toBe(2);
+      expect(result.failed).toBe(0);
+      expect(result.remaining).toBe(0);
+      expect(await NoteSyncQueueService.pendingCount()).toBe(0);
+    });
+
+    test('keeps failed items and bumps attempts', async () => {
+      (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: false, error: 'network' });
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+
+      const result = await NoteSyncQueueService.drain();
+      expect(result.succeeded).toBe(0);
+      expect(result.failed).toBe(1);
+      expect(result.remaining).toBe(1);
+
+      const items = await NoteSyncQueueService.getAll();
+      expect(items[0].attempts).toBe(1);
+      expect(items[0].lastError).toBe('network');
+    });
+
+    test('drops items after MAX_ATTEMPTS', async () => {
+      (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: false, error: 'fatal' });
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+
+      // 8 failed drains (MAX_ATTEMPTS = 8) → dropped
+      for (let i = 0; i < 8; i++) {
+        await NoteSyncQueueService.drain();
+      }
+      expect(await NoteSyncQueueService.pendingCount()).toBe(0);
+    });
+
+    test('mixes successes and failures', async () => {
+      (syncNoteToGitHub as jest.Mock).mockImplementation(async ({ filePath }: { filePath: string }) =>
+        filePath === 'a' ? { success: true } : { success: false, error: 'nope' },
+      );
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'b', title: 'B', content: '', format: 'markdown',
+      });
+
+      const result = await NoteSyncQueueService.drain();
+      expect(result.succeeded).toBe(1);
+      expect(result.failed).toBe(1);
+      const items = await NoteSyncQueueService.getAll();
+      expect(items.map((m) => m.params.filePath)).toEqual(['b']);
+    });
+
+    test('is reentrancy-guarded', async () => {
+      let resolveSync: (value: { success: boolean }) => void = () => {};
+      (syncNoteToGitHub as jest.Mock).mockImplementation(
+        () => new Promise((res) => { resolveSync = res; }),
+      );
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+
+      const firstDrain = NoteSyncQueueService.drain();
+      const secondDrain = await NoteSyncQueueService.drain();
+      expect(secondDrain.succeeded).toBe(0);
+      expect(secondDrain.remaining).toBe(1);
+
+      resolveSync({ success: true });
+      const first = await firstDrain;
+      expect(first.succeeded).toBe(1);
+    });
+  });
+
+  describe('subscribe', () => {
+    test('notifies on enqueue', async () => {
+      const fn = jest.fn();
+      const unsub = NoteSyncQueueService.subscribe(fn);
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+
+      expect(fn).toHaveBeenCalled();
+      unsub();
+    });
+
+    test('unsubscribe stops notifications', async () => {
+      const fn = jest.fn();
+      const unsub = NoteSyncQueueService.subscribe(fn);
+      unsub();
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    test('listener errors do not break the chain', async () => {
+      const bad = jest.fn(() => { throw new Error('boom'); });
+      const good = jest.fn();
+      const u1 = NoteSyncQueueService.subscribe(bad);
+      const u2 = NoteSyncQueueService.subscribe(good);
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+
+      expect(bad).toHaveBeenCalled();
+      expect(good).toHaveBeenCalled();
+      u1();
+      u2();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 16 tests for \`NoteSyncQueueService\`: enqueue dedupe (across branch/file/title), drain success/failure/mixed batches, \`MAX_ATTEMPTS\` drop, reentrancy guard, subscribe/unsubscribe, listener-error isolation, malformed-storage resilience
- 18 tests for \`Note\` model helpers: \`createNote\`/\`updateNote\`, sort & filter helpers (search, folder, recursive folder), format/extension mapping, \`deriveFolderPath\`

## Coverage delta
- \`NoteSyncQueueService.ts\`: 0 % → **96 %** lines
- \`Note.ts\`: 0 % → **100 %** lines
- Suite total: 51 → **85** passing tests, 5 → 7 suites

## Test plan
- [x] \`npm test\` green locally

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)