### PR TITLE
chore(branding): rename user-facing GitNotes → GitNotēs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img width="200" height="200" alt="icon" align="center" src="https://github.com/user-attachments/assets/776e9654-0117-44c5-a85e-5a72e7f4ac9f" />
 </p>
 
-# GitNotes
+# GitNotēs
 
 A React Native app built with Expo for managing development notes with Git integration.
 

--- a/app.json
+++ b/app.json
@@ -19,8 +19,8 @@
       "bundleIdentifier": "com.xaventra.gitnotes",
       "scheme": "gitnotes",
       "infoPlist": {
-        "NSPhotoLibraryUsageDescription": "GitNotes needs access to your photo library to attach images to notes.",
-        "NSMicrophoneUsageDescription": "GitNotes needs access to your microphone for voice-to-text note input.",
+        "NSPhotoLibraryUsageDescription": "GitNotēs needs access to your photo library to attach images to notes.",
+        "NSMicrophoneUsageDescription": "GitNotēs needs access to your microphone for voice-to-text note input.",
         "ITSAppUsesNonExemptEncryption": false
       }
     },

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -142,7 +142,7 @@ export default function HomeScreen() {
 
   return (
     <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: colors.background }]}>
-      <NScreenHeader title="GitNotes" subtitle="Your development notes, organized." />
+      <NScreenHeader title="GitNotēs" subtitle="Your development notes, organized." />
       <ScrollView style={styles.container} contentContainerStyle={[styles.content, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]} showsVerticalScrollIndicator={false}>
       <View style={{ gap: 12, marginBottom: 24 }}>
         <NButton

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -23,7 +23,7 @@ interface OnboardingScreenProps {
 
 const INFO_STEPS = [
   {
-    title: 'Welcome to GitNotes',
+    title: 'Welcome to GitNotēs',
     description: 'Your development notes, perfectly organized with Git integration.',
     icon: 'journal-outline' as const,
   },

--- a/src/services/ShareService.ts
+++ b/src/services/ShareService.ts
@@ -196,7 +196,7 @@ export class ShareService {
       let combinedContent = '';
 
       if (format === 'markdown') {
-        combinedContent += '# GitNotes Export\n\n';
+        combinedContent += '# GitNotēs Export\n\n';
         combinedContent += `Exported ${notes.length} notes on ${new Date().toLocaleDateString()}\n\n`;
         combinedContent += '---\n\n';
       }


### PR DESCRIPTION
## Summary
- HomeScreen header, Onboarding welcome step, ShareService export header, iOS \`NS*UsageDescription\` strings, and README title now use the macron form
- URL query params (\`?description=GitNotes\` for the GitHub PAT-create link) stay ASCII to avoid percent-encoding ugliness; the surrounding in-app copy is unchanged

## Test plan
- [ ] Cold-launch the app — Home header reads "GitNotēs"
- [ ] Trigger onboarding — first card title reads "Welcome to GitNotēs"
- [ ] Export → markdown bundle starts with \`# GitNotēs Export\`
- [ ] First photo / mic permission prompt shows the macron form

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)