### PR TITLE
perf(filter-modal): virtualize folders and tags chip rows

### DIFF
--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -1180,40 +1180,42 @@ export default function NotesListScreen() {
                   >
                     Folder
                   </Text>
-                  <ScrollView
+                  <FlatList
                     horizontal
                     showsHorizontalScrollIndicator={false}
                     style={styles.filterChipRow}
-                  >
-                    <TouchableOpacity
-                      style={[
-                        styles.filterChip,
-                        { borderColor: colors.border },
-                        !selectedFolder && {
-                          borderColor: colors.primary,
-                          backgroundColor: colors.primary + "15",
-                        },
-                      ]}
-                      onPress={() => setSelectedFolder(null)}
-                    >
-                      <Text
+                    data={allFolders}
+                    keyExtractor={(folder) => folder}
+                    ListHeaderComponent={
+                      <TouchableOpacity
                         style={[
-                          styles.filterChipText,
-                          {
-                            color: !selectedFolder
-                              ? colors.primary
-                              : colors.text,
+                          styles.filterChip,
+                          { borderColor: colors.border },
+                          !selectedFolder && {
+                            borderColor: colors.primary,
+                            backgroundColor: colors.primary + "15",
                           },
                         ]}
+                        onPress={() => setSelectedFolder(null)}
                       >
-                        All
-                      </Text>
-                    </TouchableOpacity>
-                    {allFolders.map((folder) => {
+                        <Text
+                          style={[
+                            styles.filterChipText,
+                            {
+                              color: !selectedFolder
+                                ? colors.primary
+                                : colors.text,
+                            },
+                          ]}
+                        >
+                          All
+                        </Text>
+                      </TouchableOpacity>
+                    }
+                    renderItem={({ item: folder }) => {
                       const isSelected = selectedFolder === folder;
                       return (
                         <TouchableOpacity
-                          key={folder}
                           style={[
                             styles.filterChip,
                             { borderColor: colors.border },
@@ -1251,8 +1253,8 @@ export default function NotesListScreen() {
                           </Text>
                         </TouchableOpacity>
                       );
-                    })}
-                  </ScrollView>
+                    }}
+                  />
                 </>
               )}
 
@@ -1267,16 +1269,16 @@ export default function NotesListScreen() {
                   >
                     Tags
                   </Text>
-                  <ScrollView
+                  <FlatList
                     horizontal
                     showsHorizontalScrollIndicator={false}
                     style={styles.filterChipRow}
-                  >
-                    {allTags.map((tag) => {
+                    data={allTags}
+                    keyExtractor={(tag) => tag}
+                    renderItem={({ item: tag }) => {
                       const isSelected = selectedTags.includes(tag);
                       return (
                         <TouchableOpacity
-                          key={tag}
                           style={[
                             styles.filterChip,
                             { borderColor: colors.border },
@@ -1315,8 +1317,8 @@ export default function NotesListScreen() {
                           </Text>
                         </TouchableOpacity>
                       );
-                    })}
-                  </ScrollView>
+                    }}
+                  />
                 </>
               )}
 


### PR DESCRIPTION
## Summary
- Convert the Folders + Tags chip rows in the Notes filter modal from horizontal \`ScrollView\` + \`.map\` to horizontal \`FlatList\` so off-screen chips recycle for power users with hundreds of tags
- Repos stay as a plain map — they live in a vertical-wrap layout, and FlatList can't preserve wrap; count is bounded by linked repos anyway

## Test plan
- [ ] Open filter modal — Folders/Tags rows scroll the same as before
- [ ] Select a folder / a tag — selection state highlights the right chip
- [ ] "All" header chip on Folders still clears the filter

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)