### PR TITLE
fix(todo): scroll Remind-me options into view on open

### DIFF
--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useRef } from 'react';
 import {
   View,
   Text,
@@ -54,6 +54,7 @@ export default function TodoListScreen() {
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [showTimePicker, setShowTimePicker] = useState(false);
   const [showReminderPicker, setShowReminderPicker] = useState(false);
+  const modalScrollRef = useRef<ScrollView>(null);
   const [filterCompleted, setFilterCompleted] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [todoRepo, setTodoRepo] = useState<string | undefined>(undefined);
@@ -417,7 +418,7 @@ export default function TodoListScreen() {
               </TouchableOpacity>
             </View>
 
-            <ScrollView style={styles.modalBody}>
+            <ScrollView ref={modalScrollRef} style={styles.modalBody}>
               <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>Todo Text *</Text>
               <TextInput
                 style={[styles.input, { color: colors.text, borderColor: colors.border }]}
@@ -539,7 +540,16 @@ export default function TodoListScreen() {
                   <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>Remind me</Text>
                   <TouchableOpacity
                     style={[styles.reminderPickerButton, { borderColor: colors.border }]}
-                    onPress={() => setShowReminderPicker(!showReminderPicker)}
+                    onPress={() => {
+                      const next = !showReminderPicker;
+                      setShowReminderPicker(next);
+                      if (next) {
+                        // Wait for the options to mount before scrolling.
+                        requestAnimationFrame(() => {
+                          modalScrollRef.current?.scrollToEnd({ animated: true });
+                        });
+                      }
+                    }}
                   >
                     <Ionicons name="notifications-outline" size={16} color="#FF9500" />
                     <Text style={[styles.reminderPickerText, { color: colors.text }]}>


### PR DESCRIPTION
## Summary
The Remind-me dropdown in the new-todo modal expanded below the visible scroll area, so tapping it looked like a no-op. Wire a ref to the modal \`ScrollView\` and call \`scrollToEnd\` on \`requestAnimationFrame\` after the options mount, so the list lands above the fold. Closing the picker doesn't scroll, so there's no jump on dismiss.

## Test plan
- [ ] Add a todo, set a deadline, tap Remind me → options visible without manual scroll
- [ ] Tap Remind me again to close → no scroll jump
- [ ] Pick an option → closes cleanly, value updates

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)