### PR TITLE
fix(theme): neutralize neumorphic palette — white light / black dark

### DIFF
--- a/__tests__/theme/tokens.test.ts
+++ b/__tests__/theme/tokens.test.ts
@@ -40,9 +40,23 @@ describe('design constants', () => {
     expect(TYPE).toEqual({ xs: 12, sm: 14, md: 16, lg: 18, xl: 22, '2xl': 28 });
   });
 
-  it('keeps neumorphic surface equal to background (mono-tone rule)', () => {
-    expect(NEUMORPHIC_LIGHT.surface).toBe(NEUMORPHIC_LIGHT.bg);
-    expect(NEUMORPHIC_DARK.surface).toBe(NEUMORPHIC_DARK.bg);
+  it('keeps neumorphic surface and bg slightly distinct so soft shadows still read', () => {
+    expect(NEUMORPHIC_LIGHT.surface).not.toBe(NEUMORPHIC_LIGHT.bg);
+    expect(NEUMORPHIC_DARK.surface).not.toBe(NEUMORPHIC_DARK.bg);
+  });
+
+  it('keeps neumorphic palette neutral (no blue-tinted shadows or surfaces)', () => {
+    // Neutral grays decompose to channels within ±2 of each other.
+    const isNeutral = (hex: string): boolean => {
+      const r = parseInt(hex.slice(1, 3), 16);
+      const g = parseInt(hex.slice(3, 5), 16);
+      const b = parseInt(hex.slice(5, 7), 16);
+      return Math.max(r, g, b) - Math.min(r, g, b) <= 2;
+    };
+    for (const key of ['bg', 'surface', 'highlight', 'shadow', 'border'] as const) {
+      expect(isNeutral(NEUMORPHIC_LIGHT[key])).toBe(true);
+      expect(isNeutral(NEUMORPHIC_DARK[key])).toBe(true);
+    }
   });
 
   it('preserves the existing flat palette colors used today', () => {

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -17,38 +17,41 @@ export interface Palette {
   card: string;
 }
 
+// Neumorphic palette uses a near-pure white (light) / black (dark) surface
+// with a slightly off-shade bg so the soft inner/outer shadows still read.
+// Pure mono-tone (surface === bg) flattens the depth illusion.
 export const NEUMORPHIC_LIGHT: Palette = {
-  bg: '#E0E5EC',
-  surface: '#E0E5EC',
+  bg: '#F2F2F2',
+  surface: '#FFFFFF',
   highlight: '#FFFFFF',
-  shadow: '#A3B1C6',
-  text: '#2D3142',
-  textSecondary: '#6B7280',
+  shadow: '#BFBFBF',
+  text: '#1C1C1E',
+  textSecondary: '#6E6E73',
   accent: '#7B8CDE',
   accentMuted: '#A8B3E5',
   error: '#E07A7A',
-  background: '#E0E5EC',
-  surfaceSecondary: '#D6DCE5',
+  background: '#F2F2F2',
+  surfaceSecondary: '#F5F5F5',
   primary: '#7B8CDE',
-  border: '#C4CBD7',
-  card: '#EAEEF4',
+  border: '#D8D8D8',
+  card: '#FFFFFF',
 };
 
 export const NEUMORPHIC_DARK: Palette = {
-  bg: '#2A2D3A',
-  surface: '#2A2D3A',
-  highlight: '#353945',
-  shadow: '#1F2129',
-  text: '#E4E6EB',
-  textSecondary: '#9097A6',
+  bg: '#0E0E0E',
+  surface: '#000000',
+  highlight: '#1F1F1F',
+  shadow: '#000000',
+  text: '#F2F2F7',
+  textSecondary: '#8E8E93',
   accent: '#8B9BE8',
   accentMuted: '#5A6BB5',
   error: '#E07A7A',
-  background: '#2A2D3A',
-  surfaceSecondary: '#323645',
+  background: '#0E0E0E',
+  surfaceSecondary: '#141414',
   primary: '#8B9BE8',
-  border: '#1F2129',
-  card: '#323645',
+  border: '#262626',
+  card: '#0A0A0A',
 };
 
 export const FLAT_LIGHT: Palette = {


### PR DESCRIPTION
## Summary
The neumorphic palette in \`src/theme/tokens.ts\` was blue-tinted (\`#E0E5EC\` base, \`#A3B1C6\` lavender-blue shadow). Swap to a neutral palette per the issue's spec.

- **Light**: \`surface #FFFFFF\`, \`bg #F2F2F2\`, \`shadow #BFBFBF\`, \`border #D8D8D8\`
- **Dark**: \`surface #000000\`, \`bg #0E0E0E\`, \`highlight #1F1F1F\`, \`shadow #000000\`

Surface and bg deliberately differ by ~5 % so soft inner/outer shadows still read — pure mono-tone flattens the depth illusion (called out in the issue's risks).

\`accent\` / \`primary\` stay lavender (#7B8CDE / #8B9BE8) — the issue lists that as an open question pending owner confirmation, so happy to swap to a non-blue accent in a follow-up if preferred.

## Test changes
- Drop the old \`surface === bg\` mono-tone rule
- Add a neutral-channel rule (max-min RGB delta ≤ 2 across bg/surface/highlight/shadow/border) so future blue-tint regressions fail in CI

\`__tests__/theme/elevation.test.ts\` references palette by name not hex, so it still passes unchanged.

## Test plan
- [ ] \`npm test\` green (52/52)
- [ ] Cold-launch in light + dark, eyeball Home / Notes / Editor / Settings — no blue cast
- [ ] Soft-shadow neumorphic depth still readable on Surface elevation tiers

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)