### PR TITLE
fix(a11y): drop colors.accent from body text — keep on icons/fills only

### DIFF
--- a/src/components/neumorphic/NButton.tsx
+++ b/src/components/neumorphic/NButton.tsx
@@ -56,7 +56,11 @@ export function NButton(props: NButtonProps) {
     transform: [{ scale: scale.value }],
   }));
 
-  const textColor = variant === 'primary' ? colors.accent : colors.text;
+  // Primary button text uses colors.text, not colors.accent — accent on
+  // a light Surface fails WCAG AA body-text contrast (~3:1). The button's
+  // raised Surface + the accent-colored leading icon carry the "primary"
+  // affordance instead. (See #221.)
+  const textColor = colors.text;
   const isGhost = variant === 'ghost';
 
   const content = (

--- a/src/components/neumorphic/NChip.tsx
+++ b/src/components/neumorphic/NChip.tsx
@@ -36,9 +36,12 @@ export function NChip(props: NChipProps) {
     >
       {leading}
       {label !== undefined && (
+        // Always colors.text — accent on light surfaces fails WCAG AA at
+        // type.sm (14pt). Active state is signaled by inset Surface + the
+        // accent-colored leading icon. (See #221.)
         <Text
           style={{
-            color: active ? colors.accent : colors.text,
+            color: colors.text,
             fontSize: type.sm,
             fontWeight: active ? '600' : '500',
           }}

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -114,7 +114,9 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
               onPress={() => Linking.openURL('https://github.com/settings/tokens/new?scopes=repo,read:user&description=GitNotes')}
               leadingIcon={<Ionicons name="open-outline" size={14} color={colors.accent} />}
               label="Generate token on GitHub"
-              textStyle={{ color: colors.accent, fontSize: 14, fontWeight: '500' }}
+              // colors.text not colors.accent for AA contrast on light bg;
+              // link affordance carried by the leading icon. (See #221.)
+              textStyle={{ color: colors.text, fontSize: 14, fontWeight: '500' }}
               style={{ marginBottom: 16 }}
             />
 


### PR DESCRIPTION
## Summary
Audit of every \`colors.accent\` use against the \`#7B8CDE\` light / \`#8B9BE8\` dark accent. Light-mode contrast on the white surface is ~3:1 — fails WCAG AA (4.5:1) for body text but passes the 3:1 minimum for icons / focus rings / fills.

Three sites used accent **on body text** and need a fix:
- \`NButton\` primary variant: text now \`colors.text\`. Raised Surface + accent leading icon still signal "primary"
- \`NChip\` active state: text now \`colors.text\`. Inset Surface + bold weight signal active
- Onboarding "Generate token on GitHub" link: text now \`colors.text\`, keeping the open-outline icon as accent for the link affordance

All other accent uses (Ionicons, ActivityIndicator, badge/dot/toggle/progress fills, NInput focus border) are non-text and stay accent — the 3:1 minimum already covers them.

## Test plan
- [ ] Open Home and tap "Create New Note" — primary button reads cleanly on light
- [ ] Open the note filter modal active chips — labels readable on inset surface
- [ ] Onboarding token-step "Generate token" link — readable on light, link affordance still there
- [ ] Dark mode on all three — accent at \`#8B9BE8\` on dark already passes AA, no regression
- [ ] \`npx tsc --noEmit\` clean

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)