### PR TITLE
test(neumorphic): add @testing-library/react-native + snapshot tests for primitives

### DIFF
--- a/__tests__/neumorphic/NButton.test.tsx
+++ b/__tests__/neumorphic/NButton.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { NButton } from '../../src/components/neumorphic/NButton';
+import { TestThemeProvider } from './testThemeProvider';
+
+describe('NButton', () => {
+  it('renders the label and fires onPress', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NButton label="Tap me" onPress={onPress} />
+      </TestThemeProvider>,
+    );
+    fireEvent.press(getByText('Tap me'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders all three variants without crashing', () => {
+    for (const variant of ['primary', 'secondary', 'ghost'] as const) {
+      const { getByText } = render(
+        <TestThemeProvider>
+          <NButton label={variant} variant={variant} />
+        </TestThemeProvider>,
+      );
+      expect(getByText(variant)).toBeTruthy();
+    }
+  });
+
+  it('applies disabled state without firing onPress', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NButton label="No-go" onPress={onPress} disabled />
+      </TestThemeProvider>,
+    );
+    fireEvent.press(getByText('No-go'));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('snapshots primary in light + dark', () => {
+    const light = render(
+      <TestThemeProvider mode="light">
+        <NButton label="Save" variant="primary" />
+      </TestThemeProvider>,
+    ).toJSON();
+    expect(light).toMatchSnapshot('primary-light');
+
+    const dark = render(
+      <TestThemeProvider mode="dark">
+        <NButton label="Save" variant="primary" />
+      </TestThemeProvider>,
+    ).toJSON();
+    expect(dark).toMatchSnapshot('primary-dark');
+  });
+});

--- a/__tests__/neumorphic/NCard.test.tsx
+++ b/__tests__/neumorphic/NCard.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import { NCard } from '../../src/components/neumorphic/NCard';
+import { TestThemeProvider } from './testThemeProvider';
+
+describe('NCard', () => {
+  it('renders children', () => {
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NCard>
+          <Text>card body</Text>
+        </NCard>
+      </TestThemeProvider>,
+    );
+    expect(getByText('card body')).toBeTruthy();
+  });
+
+  it('fires onPress when interactive', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NCard onPress={onPress}>
+          <Text>tap</Text>
+        </NCard>
+      </TestThemeProvider>,
+    );
+    fireEvent.press(getByText('tap'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks onPress when disabled', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NCard onPress={onPress} disabled>
+          <Text>nope</Text>
+        </NCard>
+      </TestThemeProvider>,
+    );
+    fireEvent.press(getByText('nope'));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('snapshots non-interactive light', () => {
+    const tree = render(
+      <TestThemeProvider>
+        <NCard>
+          <Text>snap</Text>
+        </NCard>
+      </TestThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/__tests__/neumorphic/NChip.test.tsx
+++ b/__tests__/neumorphic/NChip.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import { NChip } from '../../src/components/neumorphic/NChip';
+import { TestThemeProvider } from './testThemeProvider';
+
+describe('NChip', () => {
+  it('renders a label', () => {
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NChip label="React Native" />
+      </TestThemeProvider>,
+    );
+    expect(getByText('React Native')).toBeTruthy();
+  });
+
+  it('fires onPress when pressable', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NChip label="press" onPress={onPress} />
+      </TestThemeProvider>,
+    );
+    fireEvent.press(getByText('press'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the active state without crashing', () => {
+    const { getByText } = render(
+      <TestThemeProvider mode="light">
+        <NChip label="active" active />
+      </TestThemeProvider>,
+    );
+    expect(getByText('active')).toBeTruthy();
+  });
+
+  it('snapshots inactive + active', () => {
+    const inactive = render(
+      <TestThemeProvider>
+        <NChip label="tag" />
+      </TestThemeProvider>,
+    ).toJSON();
+    expect(inactive).toMatchSnapshot('chip-inactive');
+
+    const active = render(
+      <TestThemeProvider>
+        <NChip label="tag" active />
+      </TestThemeProvider>,
+    ).toJSON();
+    expect(active).toMatchSnapshot('chip-active');
+  });
+
+  it('renders children alongside the label', () => {
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NChip label="parent">
+          <Text>child</Text>
+        </NChip>
+      </TestThemeProvider>,
+    );
+    expect(getByText('parent')).toBeTruthy();
+    expect(getByText('child')).toBeTruthy();
+  });
+});

--- a/__tests__/neumorphic/NGroup.test.tsx
+++ b/__tests__/neumorphic/NGroup.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import { NGroup, NGroupRow } from '../../src/components/neumorphic/NGroup';
+import { TestThemeProvider } from './testThemeProvider';
+
+describe('NGroup', () => {
+  it('renders title + children inside a single Surface', () => {
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NGroup title="Settings">
+          <NGroupRow>
+            <Text>Theme</Text>
+          </NGroupRow>
+          <NGroupRow>
+            <Text>Account</Text>
+          </NGroupRow>
+        </NGroup>
+      </TestThemeProvider>,
+    );
+    expect(getByText('Settings')).toBeTruthy();
+    expect(getByText('Theme')).toBeTruthy();
+    expect(getByText('Account')).toBeTruthy();
+  });
+
+  it('renders footer below the surface', () => {
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NGroup title="A" footer="below">
+          <NGroupRow>
+            <Text>row</Text>
+          </NGroupRow>
+        </NGroup>
+      </TestThemeProvider>,
+    );
+    expect(getByText('below')).toBeTruthy();
+  });
+
+  it('NGroupRow fires onPress when interactive', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <TestThemeProvider>
+        <NGroup>
+          <NGroupRow onPress={onPress}>
+            <Text>press</Text>
+          </NGroupRow>
+        </NGroup>
+      </TestThemeProvider>,
+    );
+    fireEvent.press(getByText('press'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('snapshots a 2-row group', () => {
+    const tree = render(
+      <TestThemeProvider>
+        <NGroup title="A">
+          <NGroupRow>
+            <Text>one</Text>
+          </NGroupRow>
+          <NGroupRow>
+            <Text>two</Text>
+          </NGroupRow>
+        </NGroup>
+      </TestThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/__tests__/neumorphic/NToggle.test.tsx
+++ b/__tests__/neumorphic/NToggle.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { NToggle } from '../../src/components/neumorphic/NToggle';
+import { TestThemeProvider } from './testThemeProvider';
+
+describe('NToggle', () => {
+  it('fires onValueChange when pressed', () => {
+    const onValueChange = jest.fn();
+    const { getByTestId } = render(
+      <TestThemeProvider>
+        <NToggle value={false} onValueChange={onValueChange} testID="toggle" />
+      </TestThemeProvider>,
+    );
+    fireEvent.press(getByTestId('toggle'));
+    expect(onValueChange).toHaveBeenCalledWith(true);
+  });
+
+  it('inverts on each press', () => {
+    const onValueChange = jest.fn();
+    const { getByTestId } = render(
+      <TestThemeProvider>
+        <NToggle value={true} onValueChange={onValueChange} testID="toggle" />
+      </TestThemeProvider>,
+    );
+    fireEvent.press(getByTestId('toggle'));
+    expect(onValueChange).toHaveBeenCalledWith(false);
+  });
+
+  it('snapshots both states', () => {
+    expect(
+      render(
+        <TestThemeProvider>
+          <NToggle value={false} onValueChange={() => undefined} />
+        </TestThemeProvider>,
+      ).toJSON(),
+    ).toMatchSnapshot('toggle-off');
+
+    expect(
+      render(
+        <TestThemeProvider>
+          <NToggle value={true} onValueChange={() => undefined} />
+        </TestThemeProvider>,
+      ).toJSON(),
+    ).toMatchSnapshot('toggle-on');
+  });
+});

--- a/__tests__/neumorphic/Surface.test.tsx
+++ b/__tests__/neumorphic/Surface.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { Surface } from '../../src/components/neumorphic/Surface';
+import { TestThemeProvider } from './testThemeProvider';
+
+describe('Surface', () => {
+  it('renders children inside a neumorphic light frame', () => {
+    const { getByText } = render(
+      <TestThemeProvider style="neumorphic" mode="light">
+        <Surface>
+          <Text>hello</Text>
+        </Surface>
+      </TestThemeProvider>,
+    );
+    expect(getByText('hello')).toBeTruthy();
+  });
+
+  it('renders children inside a neumorphic dark frame', () => {
+    const { getByText } = render(
+      <TestThemeProvider style="neumorphic" mode="dark">
+        <Surface>
+          <Text>dark</Text>
+        </Surface>
+      </TestThemeProvider>,
+    );
+    expect(getByText('dark')).toBeTruthy();
+  });
+
+  it('honors style="flat" by emitting zero outer shadow', () => {
+    const { getByTestId } = render(
+      <TestThemeProvider style="flat" mode="light">
+        <Surface testID="flat-surface">
+          <Text>flat</Text>
+        </Surface>
+      </TestThemeProvider>,
+    );
+    const surface = getByTestId('flat-surface');
+    // The outer style merges StyleSheet.flatten — check no shadow props leaked.
+    const flat = (Array.isArray(surface.props.style)
+      ? Object.assign({}, ...surface.props.style.filter(Boolean))
+      : surface.props.style) as Record<string, unknown>;
+    expect(flat.shadowOpacity).toBeUndefined();
+    expect(flat.shadowRadius).toBeUndefined();
+  });
+
+  it('snapshots a raised neumorphic Surface with a Text child', () => {
+    const tree = render(
+      <TestThemeProvider style="neumorphic" mode="light">
+        <Surface elevation="raised" radius="md" testID="raised">
+          <Text>snap</Text>
+        </Surface>
+      </TestThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/__tests__/neumorphic/__snapshots__/NButton.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/NButton.test.tsx.snap
@@ -1,0 +1,269 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`NButton snapshots primary in light + dark: primary-dark 1`] = `
+<View
+  style={
+    [
+      {
+        "alignSelf": "auto",
+        "opacity": 1,
+      },
+      {
+        "transform": [
+          {
+            "scale": 1,
+          },
+        ],
+      },
+    ]
+  }
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#2A2D3A",
+            "borderRadius": 18,
+          },
+          {
+            "shadowColor": "#1F2129",
+            "shadowOffset": {
+              "height": 4,
+              "width": 4,
+            },
+            "shadowOpacity": 1,
+            "shadowRadius": 8,
+          },
+          [
+            {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "minHeight": 44,
+              "paddingHorizontal": 20,
+              "paddingVertical": 12,
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      <View
+        pointerEvents="none"
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "borderRadius": 18,
+            },
+            {
+              "shadowColor": "#353945",
+              "shadowOffset": {
+                "height": -4,
+                "width": -4,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 8,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 8,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "color": "#8B9BE8",
+                "fontSize": 16,
+                "fontWeight": "600",
+              },
+              undefined,
+            ]
+          }
+        >
+          Save
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`NButton snapshots primary in light + dark: primary-light 1`] = `
+<View
+  style={
+    [
+      {
+        "alignSelf": "auto",
+        "opacity": 1,
+      },
+      {
+        "transform": [
+          {
+            "scale": 1,
+          },
+        ],
+      },
+    ]
+  }
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#E0E5EC",
+            "borderRadius": 18,
+          },
+          {
+            "shadowColor": "#A3B1C6",
+            "shadowOffset": {
+              "height": 4,
+              "width": 4,
+            },
+            "shadowOpacity": 1,
+            "shadowRadius": 8,
+          },
+          [
+            {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "minHeight": 44,
+              "paddingHorizontal": 20,
+              "paddingVertical": 12,
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      <View
+        pointerEvents="none"
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "borderRadius": 18,
+            },
+            {
+              "shadowColor": "#FFFFFF",
+              "shadowOffset": {
+                "height": -4,
+                "width": -4,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 8,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 8,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "color": "#7B8CDE",
+                "fontSize": 16,
+                "fontWeight": "600",
+              },
+              undefined,
+            ]
+          }
+        >
+          Save
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/__tests__/neumorphic/__snapshots__/NCard.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/NCard.test.tsx.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`NCard snapshots non-interactive light 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#E0E5EC",
+        "borderRadius": 24,
+      },
+      {
+        "shadowColor": "#A3B1C6",
+        "shadowOffset": {
+          "height": 4,
+          "width": 4,
+        },
+        "shadowOpacity": 1,
+        "shadowRadius": 8,
+      },
+      [
+        {
+          "padding": 16,
+        },
+        undefined,
+      ],
+    ]
+  }
+>
+  <View
+    pointerEvents="none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "borderRadius": 24,
+        },
+        {
+          "shadowColor": "#FFFFFF",
+          "shadowOffset": {
+            "height": -4,
+            "width": -4,
+          },
+          "shadowOpacity": 1,
+          "shadowRadius": 8,
+        },
+      ]
+    }
+  />
+  <Text>
+    snap
+  </Text>
+</View>
+`;

--- a/__tests__/neumorphic/__snapshots__/NChip.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/NChip.test.tsx.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`NChip snapshots inactive + active: chip-active 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#E0E5EC",
+        "borderRadius": 999,
+      },
+      {
+        "shadowColor": "#FFFFFF",
+        "shadowOffset": {
+          "height": 2,
+          "width": 2,
+        },
+        "shadowOpacity": 1,
+        "shadowRadius": 4,
+      },
+      [
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 4,
+          "paddingHorizontal": 12,
+          "paddingVertical": 6,
+        },
+        undefined,
+      ],
+    ]
+  }
+>
+  <View
+    pointerEvents="none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "borderRadius": 999,
+        },
+        {
+          "shadowColor": "#A3B1C6",
+          "shadowOffset": {
+            "height": -2,
+            "width": -2,
+          },
+          "shadowOpacity": 1,
+          "shadowRadius": 4,
+        },
+      ]
+    }
+  />
+  <Text
+    style={
+      {
+        "color": "#7B8CDE",
+        "fontSize": 14,
+        "fontWeight": "600",
+      }
+    }
+  >
+    tag
+  </Text>
+</View>
+`;
+
+exports[`NChip snapshots inactive + active: chip-inactive 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#E0E5EC",
+        "borderRadius": 999,
+      },
+      {
+        "shadowColor": "#A3B1C6",
+        "shadowOffset": {
+          "height": 2,
+          "width": 2,
+        },
+        "shadowOpacity": 1,
+        "shadowRadius": 4,
+      },
+      [
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 4,
+          "paddingHorizontal": 12,
+          "paddingVertical": 6,
+        },
+        undefined,
+      ],
+    ]
+  }
+>
+  <View
+    pointerEvents="none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "borderRadius": 999,
+        },
+        {
+          "shadowColor": "#FFFFFF",
+          "shadowOffset": {
+            "height": -2,
+            "width": -2,
+          },
+          "shadowOpacity": 1,
+          "shadowRadius": 4,
+        },
+      ]
+    }
+  />
+  <Text
+    style={
+      {
+        "color": "#2D3142",
+        "fontSize": 14,
+        "fontWeight": "500",
+      }
+    }
+  >
+    tag
+  </Text>
+</View>
+`;

--- a/__tests__/neumorphic/__snapshots__/NGroup.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/NGroup.test.tsx.snap
@@ -1,0 +1,144 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`NGroup snapshots a 2-row group 1`] = `
+<View
+  style={
+    [
+      {
+        "gap": 8,
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    style={
+      {
+        "color": "#6B7280",
+        "fontSize": 14,
+        "fontWeight": "600",
+        "letterSpacing": 0.6,
+        "marginLeft": 12,
+        "textTransform": "uppercase",
+      }
+    }
+  >
+    A
+  </Text>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "#E0E5EC",
+          "borderRadius": 24,
+        },
+        {
+          "shadowColor": "#A3B1C6",
+          "shadowOffset": {
+            "height": 4,
+            "width": 4,
+          },
+          "shadowOpacity": 1,
+          "shadowRadius": 8,
+        },
+        {
+          "overflow": "hidden",
+        },
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "borderRadius": 24,
+          },
+          {
+            "shadowColor": "#FFFFFF",
+            "shadowOffset": {
+              "height": -4,
+              "width": -4,
+            },
+            "shadowOpacity": 1,
+            "shadowRadius": 8,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "minHeight": 48,
+            "opacity": 1,
+            "paddingHorizontal": 16,
+            "paddingVertical": 12,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <Text>
+          one
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "backgroundColor": "#A3B1C6",
+          "height": 1,
+          "marginLeft": 16,
+          "opacity": 0.18,
+        }
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "minHeight": 48,
+            "opacity": 1,
+            "paddingHorizontal": 16,
+            "paddingVertical": 12,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <Text>
+          two
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/__tests__/neumorphic/__snapshots__/NToggle.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/NToggle.test.tsx.snap
@@ -1,0 +1,285 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`NToggle snapshots both states: toggle-off 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  hitSlop={8}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "opacity": 1,
+    }
+  }
+>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "#E0E5EC",
+          "borderRadius": 999,
+        },
+        {
+          "shadowColor": "#FFFFFF",
+          "shadowOffset": {
+            "height": 2,
+            "width": 2,
+          },
+          "shadowOpacity": 1,
+          "shadowRadius": 4,
+        },
+        {
+          "height": 30,
+          "justifyContent": "center",
+          "padding": 4,
+          "width": 52,
+        },
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "borderRadius": 999,
+          },
+          {
+            "shadowColor": "#A3B1C6",
+            "shadowOffset": {
+              "height": -2,
+              "width": -2,
+            },
+            "shadowOpacity": 1,
+            "shadowRadius": 4,
+          },
+        ]
+      }
+    />
+    <View
+      pointerEvents="none"
+      style={
+        [
+          {
+            "backgroundColor": "#7B8CDE",
+            "borderRadius": 999,
+            "bottom": 4,
+            "left": 4,
+            "position": "absolute",
+            "right": 4,
+            "top": 4,
+          },
+          {
+            "opacity": 0,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        {
+          "transform": [
+            {
+              "translateX": 0,
+            },
+          ],
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "backgroundColor": "#E0E5EC",
+            "borderRadius": 11,
+            "elevation": 2,
+            "height": 22,
+            "shadowColor": "#A3B1C6",
+            "shadowOffset": {
+              "height": 1,
+              "width": 1,
+            },
+            "shadowOpacity": 0.6,
+            "shadowRadius": 2,
+            "width": 22,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`NToggle snapshots both states: toggle-on 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  hitSlop={8}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "opacity": 1,
+    }
+  }
+>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "#E0E5EC",
+          "borderRadius": 999,
+        },
+        {
+          "shadowColor": "#FFFFFF",
+          "shadowOffset": {
+            "height": 2,
+            "width": 2,
+          },
+          "shadowOpacity": 1,
+          "shadowRadius": 4,
+        },
+        {
+          "height": 30,
+          "justifyContent": "center",
+          "padding": 4,
+          "width": 52,
+        },
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "borderRadius": 999,
+          },
+          {
+            "shadowColor": "#A3B1C6",
+            "shadowOffset": {
+              "height": -2,
+              "width": -2,
+            },
+            "shadowOpacity": 1,
+            "shadowRadius": 4,
+          },
+        ]
+      }
+    />
+    <View
+      pointerEvents="none"
+      style={
+        [
+          {
+            "backgroundColor": "#7B8CDE",
+            "borderRadius": 999,
+            "bottom": 4,
+            "left": 4,
+            "position": "absolute",
+            "right": 4,
+            "top": 4,
+          },
+          {
+            "opacity": 1,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        {
+          "transform": [
+            {
+              "translateX": 22,
+            },
+          ],
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "backgroundColor": "#E0E5EC",
+            "borderRadius": 11,
+            "elevation": 2,
+            "height": 22,
+            "shadowColor": "#A3B1C6",
+            "shadowOffset": {
+              "height": 1,
+              "width": 1,
+            },
+            "shadowOpacity": 0.6,
+            "shadowRadius": 2,
+            "width": 22,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;

--- a/__tests__/neumorphic/__snapshots__/Surface.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/Surface.test.tsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Surface snapshots a raised neumorphic Surface with a Text child 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#E0E5EC",
+        "borderRadius": 18,
+      },
+      {
+        "shadowColor": "#A3B1C6",
+        "shadowOffset": {
+          "height": 4,
+          "width": 4,
+        },
+        "shadowOpacity": 1,
+        "shadowRadius": 8,
+      },
+      undefined,
+    ]
+  }
+  testID="raised"
+>
+  <View
+    pointerEvents="none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "borderRadius": 18,
+        },
+        {
+          "shadowColor": "#FFFFFF",
+          "shadowOffset": {
+            "height": -4,
+            "width": -4,
+          },
+          "shadowOpacity": 1,
+          "shadowRadius": 8,
+        },
+      ]
+    }
+  />
+  <Text>
+    snap
+  </Text>
+</View>
+`;

--- a/__tests__/neumorphic/testThemeProvider.tsx
+++ b/__tests__/neumorphic/testThemeProvider.tsx
@@ -1,0 +1,44 @@
+import React, { ReactNode } from 'react';
+import { ThemeContext } from '../../src/contexts/ThemeContext';
+import {
+  NEUMORPHIC_LIGHT,
+  NEUMORPHIC_DARK,
+  FLAT_LIGHT,
+  FLAT_DARK,
+  RADII,
+  SPACING,
+  TYPE,
+  type Palette,
+  type ThemeStyle,
+} from '../../src/theme/tokens';
+
+type Mode = 'light' | 'dark';
+
+interface TestThemeProviderProps {
+  children: ReactNode;
+  style?: ThemeStyle;
+  mode?: Mode;
+}
+
+const palette = (style: ThemeStyle, mode: Mode): Palette => {
+  if (style === 'flat') return mode === 'dark' ? FLAT_DARK : FLAT_LIGHT;
+  return mode === 'dark' ? NEUMORPHIC_DARK : NEUMORPHIC_LIGHT;
+};
+
+export function TestThemeProvider({
+  children,
+  style = 'neumorphic',
+  mode = 'light',
+}: TestThemeProviderProps) {
+  const colors = palette(style, mode);
+  const value = {
+    theme: mode,
+    isDark: mode === 'dark',
+    style,
+    setTheme: () => undefined,
+    setStyle: () => undefined,
+    colors,
+    tokens: { colors, radii: RADII, spacing: SPACING, type: TYPE },
+  };
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,10 +7,14 @@ module.exports = {
   },
   testEnvironment: 'node',
   testMatch: [
-    '**/__tests__/**/*.{ts,tsx}',
+    '**/__tests__/**/*.test.{ts,tsx}',
     '**/?(*.)+(spec|test).{ts,tsx}',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  setupFiles: ['<rootDir>/jest.setup.ts'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native|@react-navigation|expo|@expo|react-native-reanimated|@shopify)/)',
+  ],
   collectCoverage: true,
   coveragePathIgnorePatterns: [
     '/node_modules/',

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,43 @@
+// Mocks for the @testing-library/react-native render path.
+
+// Minimal reanimated stub — official mock pulls in TS source that the
+// jest transform pipeline can't load. We only need the surface area used
+// by neumorphic primitives (useSharedValue, useAnimatedStyle, withSpring,
+// Animated.View).
+jest.mock('react-native-reanimated', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const View = require('react-native').View;
+  return {
+    __esModule: true,
+    default: { View, createAnimatedComponent: (c: unknown) => c },
+    View,
+    useSharedValue: (initial: unknown) => ({ value: initial }),
+    useAnimatedStyle: (cb: () => Record<string, unknown>) => cb(),
+    withSpring: (v: unknown) => v,
+    withTiming: (v: unknown) => v,
+    runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+  };
+});
+
+// expo-haptics: noop the native calls.
+jest.mock('expo-haptics', () => ({
+  selectionAsync: jest.fn(() => Promise.resolve()),
+  impactAsync: jest.fn(() => Promise.resolve()),
+  notificationAsync: jest.fn(() => Promise.resolve()),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+  NotificationFeedbackType: { Success: 'success', Warning: 'warning', Error: 'error' },
+}));
+
+// AsyncStorage in-memory mock so providers using it for hydration don't crash.
+jest.mock('@react-native-async-storage/async-storage', () => {
+  let store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (k: string) => (k in store ? store[k] : null)),
+      setItem: jest.fn(async (k: string, v: string) => { store[k] = v; }),
+      removeItem: jest.fn(async (k: string) => { delete store[k]; }),
+      clear: jest.fn(async () => { store = {}; }),
+    },
+  };
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,11 +47,17 @@
       "devDependencies": {
         "@babel/preset-env": "^7.29.3",
         "@babel/preset-typescript": "^7.28.5",
+        "@testing-library/jest-native": "^5.4.3",
+        "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^30.0.0",
         "@types/react": "~19.1.10",
         "babel-jest": "^30.3.0",
         "jest": "^30.3.0",
+        "react-test-renderer": "^19.1.0",
         "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": ">=20.18"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -4808,6 +4814,140 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@testing-library/jest-native": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.3.tgz",
+      "integrity": "sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==",
+      "deprecated": "DEPRECATED: This package is no longer maintained.\nPlease use the built-in Jest matchers available in @testing-library/react-native v12.4+.\n\nSee migration guide: https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "jest-diff": "^29.0.1",
+        "jest-matcher-utils": "^29.0.1",
+        "pretty-format": "^29.0.3",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.3.3.tgz",
+      "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.0.5",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.0.5",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -6647,6 +6787,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/diff3": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
@@ -8133,6 +8283,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -12122,6 +12282,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -13610,6 +13780,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.1.0",
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -13624,6 +13808,20 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regenerate": {
@@ -14481,6 +14679,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -53,10 +53,13 @@
   "devDependencies": {
     "@babel/preset-env": "^7.29.3",
     "@babel/preset-typescript": "^7.28.5",
+    "@testing-library/jest-native": "^5.4.3",
+    "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
     "@types/react": "~19.1.10",
     "babel-jest": "^30.3.0",
     "jest": "^30.3.0",
+    "react-test-renderer": "^19.1.0",
     "typescript": "^5.6.3"
   },
   "resolutions": {


### PR DESCRIPTION
## Summary
Pulls in the missing dev infra called out in #220 and uses it to lock the neumorphic primitives' rendering with snapshots.

### Dev deps
- \`@testing-library/react-native@13.3.3\`
- \`@testing-library/jest-native@5.4.3\`
- \`react-test-renderer@19.1.0\` (pinned to match \`react@19.1.0\`)

### Test infra
- \`jest.setup.ts\` mocks: \`react-native-reanimated\` (minimal stub: \`useSharedValue\`/\`useAnimatedStyle\`/\`withSpring\`/\`runOnJS\`), \`expo-haptics\` (noop), \`@react-native-async-storage/async-storage\` (in-memory)
- \`jest.config.js\`: register \`setupFiles\`, expand \`transformIgnorePatterns\` for RN / Expo / reanimated / Shopify scope, tighten \`testMatch\` to \`*.test.{ts,tsx}\` so the helper file isn't picked up as a suite
- \`TestThemeProvider\` helper hand-builds the \`ThemeContext\` value with selectable \`style\` + \`mode\`, skipping AsyncStorage hydration

### Tests added (24)
Surface / NButton / NChip / NCard / NToggle / NGroup — render, press handlers, disabled gating, all three NButton variants, NToggle invert, NGroup title/footer/divider, plus per-primitive snapshots in light + dark / inactive + active states.

Suite: **51 → 75 tests**, **7 → 11 suites**, all green.

## Test plan
- [x] \`npm test\` clean
- [x] \`npx tsc --noEmit\` clean

## Followups
NInput, NIconButton, NTabBar, NScreenHeader, NModal not yet covered — NModal pulls in expo-blur which needs a separate transform ignore. Easy follow-up on top of this scaffold.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)