### PR TITLE
refactor(context-menu): migrate to NModal

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Modal, View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
+import { NModal } from './neumorphic';
 
 export interface ContextMenuItem {
   icon: keyof typeof Ionicons.glyphMap;
@@ -38,90 +39,75 @@ export default function ContextMenu({
   const groups: ContextMenuSection[] = sections ?? (items ? [{ items }] : []);
 
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <TouchableOpacity style={styles.overlay} activeOpacity={1} onPress={onClose}>
-        <TouchableOpacity activeOpacity={1} onPress={() => undefined}>
-          <View style={[styles.menu, { backgroundColor: colors.surface }]}>
-            {(title || subtitle) ? (
-              <View style={[styles.header, { borderBottomColor: colors.border }]}>
-                {headerIcon ? (
-                  <Ionicons name={headerIcon} size={16} color={colors.textSecondary} />
-                ) : null}
-                <View style={styles.headerTextContainer}>
-                  {title ? (
-                    <Text style={[styles.headerTitle, { color: colors.text }]} numberOfLines={1}>
-                      {title}
-                    </Text>
-                  ) : null}
-                  {subtitle ? (
-                    <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]} numberOfLines={1}>
-                      {subtitle}
-                    </Text>
-                  ) : null}
-                </View>
-              </View>
+    <NModal
+      visible={visible}
+      onRequestClose={onClose}
+      contentStyle={{ padding: 0, overflow: 'hidden', minWidth: 280 }}
+    >
+      {(title || subtitle) ? (
+        <View style={[styles.header, { borderBottomColor: colors.border }]}>
+          {headerIcon ? (
+            <Ionicons name={headerIcon} size={16} color={colors.textSecondary} />
+          ) : null}
+          <View style={styles.headerTextContainer}>
+            {title ? (
+              <Text style={[styles.headerTitle, { color: colors.text }]} numberOfLines={1}>
+                {title}
+              </Text>
             ) : null}
-            {groups.map((group, gi) => (
-              <View key={gi}>
-                {gi > 0 ? <View style={[styles.divider, { backgroundColor: colors.border }]} /> : null}
-                {group.items.map((item, i) => (
-                  <TouchableOpacity
-                    key={i}
-                    style={styles.item}
-                    onPress={() => {
-                      onClose();
-                      item.onPress();
-                    }}
-                    activeOpacity={0.7}
-                  >
-                    <Ionicons
-                      name={item.icon}
-                      size={20}
-                      color={item.destructive ? colors.error : colors.primary}
-                    />
-                    <View style={styles.itemTextContainer}>
-                      <Text
-                        style={[
-                          styles.itemText,
-                          { color: item.destructive ? colors.error : colors.text },
-                        ]}
-                      >
-                        {item.label}
-                      </Text>
-                      {item.subtitle ? (
-                        <Text
-                          style={[styles.itemSubtitle, { color: colors.textSecondary }]}
-                          numberOfLines={1}
-                        >
-                          {item.subtitle}
-                        </Text>
-                      ) : null}
-                    </View>
-                  </TouchableOpacity>
-                ))}
-              </View>
-            ))}
+            {subtitle ? (
+              <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]} numberOfLines={1}>
+                {subtitle}
+              </Text>
+            ) : null}
           </View>
-        </TouchableOpacity>
-      </TouchableOpacity>
-    </Modal>
+        </View>
+      ) : null}
+      {groups.map((group, gi) => (
+        <View key={gi}>
+          {gi > 0 ? <View style={[styles.divider, { backgroundColor: colors.border }]} /> : null}
+          {group.items.map((item, i) => (
+            <TouchableOpacity
+              key={i}
+              style={styles.item}
+              onPress={() => {
+                onClose();
+                item.onPress();
+              }}
+              activeOpacity={0.7}
+            >
+              <Ionicons
+                name={item.icon}
+                size={20}
+                color={item.destructive ? colors.error : colors.primary}
+              />
+              <View style={styles.itemTextContainer}>
+                <Text
+                  style={[
+                    styles.itemText,
+                    { color: item.destructive ? colors.error : colors.text },
+                  ]}
+                >
+                  {item.label}
+                </Text>
+                {item.subtitle ? (
+                  <Text
+                    style={[styles.itemSubtitle, { color: colors.textSecondary }]}
+                    numberOfLines={1}
+                  >
+                    {item.subtitle}
+                  </Text>
+                ) : null}
+              </View>
+            </TouchableOpacity>
+          ))}
+        </View>
+      ))}
+    </NModal>
   );
 }
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
-  },
-  menu: {
-    width: 320,
-    maxWidth: '100%',
-    borderRadius: 14,
-    overflow: 'hidden',
-  },
   header: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
## Summary
\`ContextMenu\` was the cleanest candidate from #216 — already a centered popup with no fullscreen / bottom-sheet semantics. Swap the hand-rolled \`Modal\` + dim overlay + Surface-shaped \`View\` for \`<NModal>\`, which already provides:

- expo-blur scrim
- neumorphic floating Surface
- backdrop-tap dismiss
- consistent radius / padding tokens

Internal layout (header row, sections, item rows, divider) stays unchanged.

## Why not the other six?
\`FolderSelectionDialog\`, \`MoveNoteDialog\`, \`GitContextPicker\` (BottomSheet), \`GitHubPicker\`, \`VoiceInputModal\`, \`TemplateSelector\` all use **slide-up sheet or fullscreen pageSheet** presentation. \`NModal\` today is centered-floating only; migrating those would either compress a fullscreen list into a small popup or visually regress the bottom-sheet UX.

The follow-up they want is either an \`NSheet\` sibling primitive or an \`NModal\` \`presentation: 'floating' | 'sheet'\` prop. Filed as the natural next step on this branch's PR but not in scope here so the migration stays clean.

## Test plan
- [ ] Long-press a note in NotesList → ContextMenu opens with blur scrim
- [ ] Tap an item → action fires, menu dismisses
- [ ] Tap backdrop → menu dismisses
- [ ] Light + dark mode pass
- [ ] \`npx tsc --noEmit\` clean

Refs #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)