### PR TITLE
test(snapshots): regenerate after #325 theme change (fixes red main)

### DIFF
--- a/__tests__/neumorphic/__snapshots__/NButton.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/NButton.test.tsx.snap
@@ -53,11 +53,11 @@ exports[`NButton snapshots primary in light + dark: primary-dark 1`] = `
       style={
         [
           {
-            "backgroundColor": "#2A2D3A",
+            "backgroundColor": "#000000",
             "borderRadius": 18,
           },
           {
-            "shadowColor": "#1F2129",
+            "shadowColor": "#000000",
             "shadowOffset": {
               "height": 4,
               "width": 4,
@@ -93,7 +93,7 @@ exports[`NButton snapshots primary in light + dark: primary-dark 1`] = `
               "borderRadius": 18,
             },
             {
-              "shadowColor": "#353945",
+              "shadowColor": "#1F1F1F",
               "shadowOffset": {
                 "height": -4,
                 "width": -4,
@@ -118,7 +118,7 @@ exports[`NButton snapshots primary in light + dark: primary-dark 1`] = `
           style={
             [
               {
-                "color": "#8B9BE8",
+                "color": "#F2F2F7",
                 "fontSize": 16,
                 "fontWeight": "600",
               },
@@ -187,11 +187,11 @@ exports[`NButton snapshots primary in light + dark: primary-light 1`] = `
       style={
         [
           {
-            "backgroundColor": "#E0E5EC",
+            "backgroundColor": "#FFFFFF",
             "borderRadius": 18,
           },
           {
-            "shadowColor": "#A3B1C6",
+            "shadowColor": "#BFBFBF",
             "shadowOffset": {
               "height": 4,
               "width": 4,
@@ -252,7 +252,7 @@ exports[`NButton snapshots primary in light + dark: primary-light 1`] = `
           style={
             [
               {
-                "color": "#7B8CDE",
+                "color": "#1C1C1E",
                 "fontSize": 16,
                 "fontWeight": "600",
               },

--- a/__tests__/neumorphic/__snapshots__/NCard.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/NCard.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`NCard snapshots non-interactive light 1`] = `
   style={
     [
       {
-        "backgroundColor": "#E0E5EC",
+        "backgroundColor": "#FFFFFF",
         "borderRadius": 24,
       },
       {
-        "shadowColor": "#A3B1C6",
+        "shadowColor": "#BFBFBF",
         "shadowOffset": {
           "height": 4,
           "width": 4,

--- a/__tests__/neumorphic/__snapshots__/NChip.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/NChip.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`NChip snapshots inactive + active: chip-active 1`] = `
   style={
     [
       {
-        "backgroundColor": "#E0E5EC",
+        "backgroundColor": "#FFFFFF",
         "borderRadius": 999,
       },
       {
@@ -45,7 +45,7 @@ exports[`NChip snapshots inactive + active: chip-active 1`] = `
           "borderRadius": 999,
         },
         {
-          "shadowColor": "#A3B1C6",
+          "shadowColor": "#BFBFBF",
           "shadowOffset": {
             "height": -2,
             "width": -2,
@@ -59,7 +59,7 @@ exports[`NChip snapshots inactive + active: chip-active 1`] = `
   <Text
     style={
       {
-        "color": "#7B8CDE",
+        "color": "#1C1C1E",
         "fontSize": 14,
         "fontWeight": "600",
       }
@@ -75,11 +75,11 @@ exports[`NChip snapshots inactive + active: chip-inactive 1`] = `
   style={
     [
       {
-        "backgroundColor": "#E0E5EC",
+        "backgroundColor": "#FFFFFF",
         "borderRadius": 999,
       },
       {
-        "shadowColor": "#A3B1C6",
+        "shadowColor": "#BFBFBF",
         "shadowOffset": {
           "height": 2,
           "width": 2,
@@ -129,7 +129,7 @@ exports[`NChip snapshots inactive + active: chip-inactive 1`] = `
   <Text
     style={
       {
-        "color": "#2D3142",
+        "color": "#1C1C1E",
         "fontSize": 14,
         "fontWeight": "500",
       }

--- a/__tests__/neumorphic/__snapshots__/NGroup.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/NGroup.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`NGroup snapshots a 2-row group 1`] = `
   <Text
     style={
       {
-        "color": "#6B7280",
+        "color": "#6E6E73",
         "fontSize": 14,
         "fontWeight": "600",
         "letterSpacing": 0.6,
@@ -29,11 +29,11 @@ exports[`NGroup snapshots a 2-row group 1`] = `
     style={
       [
         {
-          "backgroundColor": "#E0E5EC",
+          "backgroundColor": "#FFFFFF",
           "borderRadius": 24,
         },
         {
-          "shadowColor": "#A3B1C6",
+          "shadowColor": "#BFBFBF",
           "shadowOffset": {
             "height": 4,
             "width": 4,
@@ -104,7 +104,7 @@ exports[`NGroup snapshots a 2-row group 1`] = `
     <View
       style={
         {
-          "backgroundColor": "#A3B1C6",
+          "backgroundColor": "#BFBFBF",
           "height": 1,
           "marginLeft": 16,
           "opacity": 0.18,

--- a/__tests__/neumorphic/__snapshots__/NToggle.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/NToggle.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`NToggle snapshots both states: toggle-off 1`] = `
     style={
       [
         {
-          "backgroundColor": "#E0E5EC",
+          "backgroundColor": "#FFFFFF",
           "borderRadius": 999,
         },
         {
@@ -78,7 +78,7 @@ exports[`NToggle snapshots both states: toggle-off 1`] = `
             "borderRadius": 999,
           },
           {
-            "shadowColor": "#A3B1C6",
+            "shadowColor": "#BFBFBF",
             "shadowOffset": {
               "height": -2,
               "width": -2,
@@ -122,11 +122,11 @@ exports[`NToggle snapshots both states: toggle-off 1`] = `
       <View
         style={
           {
-            "backgroundColor": "#E0E5EC",
+            "backgroundColor": "#FFFFFF",
             "borderRadius": 11,
             "elevation": 2,
             "height": 22,
-            "shadowColor": "#A3B1C6",
+            "shadowColor": "#BFBFBF",
             "shadowOffset": {
               "height": 1,
               "width": 1,
@@ -184,7 +184,7 @@ exports[`NToggle snapshots both states: toggle-on 1`] = `
     style={
       [
         {
-          "backgroundColor": "#E0E5EC",
+          "backgroundColor": "#FFFFFF",
           "borderRadius": 999,
         },
         {
@@ -220,7 +220,7 @@ exports[`NToggle snapshots both states: toggle-on 1`] = `
             "borderRadius": 999,
           },
           {
-            "shadowColor": "#A3B1C6",
+            "shadowColor": "#BFBFBF",
             "shadowOffset": {
               "height": -2,
               "width": -2,
@@ -264,11 +264,11 @@ exports[`NToggle snapshots both states: toggle-on 1`] = `
       <View
         style={
           {
-            "backgroundColor": "#E0E5EC",
+            "backgroundColor": "#FFFFFF",
             "borderRadius": 11,
             "elevation": 2,
             "height": 22,
-            "shadowColor": "#A3B1C6",
+            "shadowColor": "#BFBFBF",
             "shadowOffset": {
               "height": 1,
               "width": 1,

--- a/__tests__/neumorphic/__snapshots__/Surface.test.tsx.snap
+++ b/__tests__/neumorphic/__snapshots__/Surface.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`Surface snapshots a raised neumorphic Surface with a Text child 1`] = `
   style={
     [
       {
-        "backgroundColor": "#E0E5EC",
+        "backgroundColor": "#FFFFFF",
         "borderRadius": 18,
       },
       {
-        "shadowColor": "#A3B1C6",
+        "shadowColor": "#BFBFBF",
         "shadowOffset": {
           "height": 4,
           "width": 4,


### PR DESCRIPTION
## Why
Main CI is red after the merge cascade. Diagnosis: not a regression — pure snapshot rot.

PR #325 (theme neutralization) changed token hex values from \`#E0E5EC\`/\`#A3B1C6\`/\`#6B7280\` → \`#FFFFFF\`/\`#BFBFBF\`/\`#6E6E73\`. A parallel PR added \`@testing-library/react-native\` snapshot tests for the neumorphic primitives, captured against the old palette. The two landed in the same window without coordination.

## What
\`npx jest -u\` regenerated 9 snapshots across 6 test suites. All 117 tests pass.

## Verification
- \`npm run ts:check\` clean.
- \`npx jest --ci\` → 14 suites, 117 tests, 9 snapshots, all green.

## Test plan
- [ ] CI green on this PR
- [ ] Merge unblocks the rest of the queue (8 PRs still in conflict; will rebase after this lands)