### PR TITLE
perf(contexts): memoize Auth/Canvas/Todo (#336, #340, #355)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react';
 import { AuthService, AuthState } from '../services/AuthService';
 import { GitHubService } from '../services/GitHubService';
 
@@ -24,12 +24,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
   });
   const [isLoading, setIsLoading] = useState(true);
 
-  const refreshAuth = async () => {
+  const refreshAuth = useCallback(async () => {
     const state = await AuthService.checkAuthState();
     setAuthState(state);
-  };
+  }, []);
 
-  const setToken = async (token: string): Promise<boolean> => {
+  const setToken = useCallback(async (token: string): Promise<boolean> => {
     setIsLoading(true);
     const state = await AuthService.setToken(token);
     if (!state.isAuthenticated) {
@@ -51,13 +51,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setAuthState(state);
     setIsLoading(false);
     return true;
-  };
+  }, []);
 
-  const clearToken = async () => {
+  const clearToken = useCallback(async () => {
     await AuthService.clearToken();
     await GitHubService.clearToken();
     setAuthState({ isAuthenticated: false, user: null, token: null });
-  };
+  }, []);
 
   useEffect(() => {
     refreshAuth()
@@ -68,8 +68,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
       .finally(() => setIsLoading(false));
   }, []);
 
+  const value = useMemo(
+    () => ({ authState, isLoading, refreshAuth, setToken, clearToken }),
+    [authState, isLoading, refreshAuth, setToken, clearToken],
+  );
+
   return (
-    <AuthContext.Provider value={{ authState, isLoading, refreshAuth, setToken, clearToken }}>
+    <AuthContext.Provider value={value}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/contexts/CanvasContext.tsx
+++ b/src/contexts/CanvasContext.tsx
@@ -107,7 +107,10 @@ export function CanvasProvider({ children }: CanvasProviderProps) {
     setError(null);
   }, []);
 
-  const filteredCanvases = searchQuery ? filterCanvasesBySearch(canvases, searchQuery) : canvases;
+  const filteredCanvases = useMemo(
+    () => (searchQuery ? filterCanvasesBySearch(canvases, searchQuery) : canvases),
+    [canvases, searchQuery],
+  );
 
   const value: CanvasContextType = useMemo(
     () => ({

--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Todo, TodoCreateInput, TodoUpdateInput } from '../models/Todo';
 import { StorageService } from '../services/StorageService';
 import { NotificationService } from '../services/NotificationService';
@@ -18,6 +18,13 @@ const TodoContext = createContext<TodoContextValue | undefined>(undefined);
 export function TodoProvider({ children }: { children: React.ReactNode }) {
   const [todos, setTodos] = useState<Todo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  // Stable ref so deleteTodo/toggleTodo callbacks don't churn on each todos
+  // mutation (which would cascade re-renders to every consumer).
+  const todosRef = useRef(todos);
+  useEffect(() => {
+    todosRef.current = todos;
+  }, [todos]);
 
   const loadTodos = useCallback(async () => {
     const loaded = await StorageService.getAllTodos();
@@ -60,7 +67,7 @@ export function TodoProvider({ children }: { children: React.ReactNode }) {
 
   const deleteTodo = useCallback(async (id: string): Promise<boolean> => {
     try {
-      const todo = todos.find((t) => t.id === id);
+      const todo = todosRef.current.find((t) => t.id === id);
       if (todo) await NotificationService.cancelAllForTodo(todo);
       const ok = await StorageService.deleteTodo(id);
       if (ok) setTodos((prev) => prev.filter((t) => t.id !== id));
@@ -68,10 +75,10 @@ export function TodoProvider({ children }: { children: React.ReactNode }) {
     } catch {
       return false;
     }
-  }, [todos]);
+  }, []);
 
   const toggleTodo = useCallback(async (id: string): Promise<boolean> => {
-    const todo = todos.find((t) => t.id === id);
+    const todo = todosRef.current.find((t) => t.id === id);
     if (!todo) return false;
     const updated = await StorageService.updateTodo({ id, completed: !todo.completed });
     if (!updated) return false;
@@ -87,14 +94,19 @@ export function TodoProvider({ children }: { children: React.ReactNode }) {
     }
     setTodos((prev) => prev.map((t) => (t.id === id ? updated : t)));
     return true;
-  }, [todos]);
+  }, []);
 
   const refreshTodos = useCallback(async () => {
     await loadTodos();
   }, [loadTodos]);
 
+  const value = useMemo(
+    () => ({ todos, isLoading, createTodo, updateTodo, deleteTodo, toggleTodo, refreshTodos }),
+    [todos, isLoading, createTodo, updateTodo, deleteTodo, toggleTodo, refreshTodos],
+  );
+
   return (
-    <TodoContext.Provider value={{ todos, isLoading, createTodo, updateTodo, deleteTodo, toggleTodo, refreshTodos }}>
+    <TodoContext.Provider value={value}>
       {children}
     </TodoContext.Provider>
   );


### PR DESCRIPTION
## Summary
- AuthContext: stable refreshAuth/setToken/clearToken via useCallback; provider value useMemo'd
- CanvasContext: filteredCanvases now memoized (was recomputing every render)
- TodoContext: deleteTodo/toggleTodo no longer churn on each todos mutation (todosRef pattern); provider value memoized

## Test plan
- [ ] Auth: sign in / sign out flows still work
- [ ] Canvas: search filtering still works
- [ ] Todo: delete and toggle behave correctly

Closes #336
Closes #340
Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)