### PR TITLE
fix(nav): respect system dark mode in nav theme (#337)

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -45,9 +45,9 @@ const linking: LinkingOptions<RootStackParamList> = {
 };
 
 export default function AppNavigator() {
-  const { theme } = useTheme();
-  
-  const navigationTheme = theme === 'dark' ? DarkTheme : DefaultTheme;
+  const { isDark } = useTheme();
+
+  const navigationTheme = isDark ? DarkTheme : DefaultTheme;
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>


### PR DESCRIPTION
## Summary
Switch `AppNavigator` to use `isDark` from `useTheme()` so the navigation chrome (status bar, header tint) follows the system theme when the user picked `theme === 'system'`.

Before: `theme === 'dark' ? DarkTheme : DefaultTheme` — \`'system'\` always fell through to light.

## Test plan
- [ ] Set theme to System, OS in dark mode → nav chrome is dark
- [ ] Set theme to System, OS in light mode → nav chrome is light
- [ ] Explicit Dark / Light still work

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)