### PR TITLE
refactor: dedupe parseRepoPath into utils/gitPathParser (#341)

### DIFF
--- a/src/components/MoveNoteDialog.tsx
+++ b/src/components/MoveNoteDialog.tsx
@@ -21,7 +21,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { GitHubService, GitHubContent } from '../services/GitHubService';
 import { HapticService } from '../utils/haptics';
 import { Note, deriveFolderPath } from '../models/Note';
-import { parseRepoPath } from './RepoFileBrowser';
+import { parseRepoPath } from '../utils/gitPathParser';
 
 interface MoveNoteDialogProps {
   visible: boolean;

--- a/src/components/RepoFileBrowser.tsx
+++ b/src/components/RepoFileBrowser.tsx
@@ -30,18 +30,7 @@ interface RepoFileBrowserProps {
   onCreateNoteInFolder: (folderPath: string) => void;
 }
 
-function parseRepoPath(repoPath: string): { owner: string; repo: string } | null {
-  const cleaned = repoPath
-    .replace(/^https?:\/\/github\.com\//, '')
-    .replace(/^github\.com\//, '')
-    .replace(/\.git$/, '')
-    .trim();
-  const parts = cleaned.split('/');
-  if (parts.length >= 2) {
-    return { owner: parts[0], repo: parts[1] };
-  }
-  return null;
-}
+import { parseRepoPath } from '../utils/gitPathParser';
 
 async function deleteFolderRecursive(
   owner: string,
@@ -727,4 +716,3 @@ const fileStyles = StyleSheet.create({
   moveDestText: { fontSize: 14, fontWeight: '500' },
 });
 
-export { parseRepoPath };

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -18,7 +18,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useRepos } from '../contexts/RepoContext';
 import { GitRepository } from '../services/GitService';
 import { HapticService } from '../utils/haptics';
-import { parseRepoPath } from '../components/RepoFileBrowser';
+import { parseRepoPath } from '../utils/gitPathParser';
 import RepoFileTree, { TreeNode } from '../components/RepoFileTree';
 import { RootStackParamList } from '../navigation/types';
 import { NScreenHeader } from '../components/neumorphic';

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -10,7 +10,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useNotes } from '../contexts/NoteContext';
 import { useCanvases } from '../contexts/CanvasContext';
 import { Note, NoteFormat } from '../models/Note';
-import { parseRepoPath } from '../components/RepoFileBrowser';
+import { parseRepoPath } from '../utils/gitPathParser';
 import { HapticService } from '../utils/haptics';
 import TemplateSelector from '../components/TemplateSelector';
 import { NoteTemplate } from '../services/TemplateService';

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -38,7 +38,8 @@ import ContextMenu from "../components/ContextMenu";
 import NoteCard from "../components/NoteCard";
 import SearchBar from "../components/SearchBar";
 import { NScreenHeader } from "../components/neumorphic";
-import RepoFileBrowser, { parseRepoPath } from "../components/RepoFileBrowser";
+import RepoFileBrowser from "../components/RepoFileBrowser";
+import { parseRepoPath } from "../utils/gitPathParser";
 import { HapticService } from "../utils/haptics";
 import {
   ViewMode,

--- a/src/services/CanvasGitHubSyncService.ts
+++ b/src/services/CanvasGitHubSyncService.ts
@@ -1,23 +1,11 @@
 import { GitHubService } from './GitHubService';
 import { CanvasScene, slugifyCanvasTitle } from '../models/Canvas';
+import { parseRepoPath } from '../utils/gitPathParser';
 
 export interface CanvasGitHubSyncResult {
   success: boolean;
   filePath?: string;
   error?: string;
-}
-
-function parseRepoPath(repoPath: string): { owner: string; repo: string } | null {
-  const cleaned = repoPath
-    .replace(/^https?:\/\/github\.com\//, '')
-    .replace(/^github\.com\//, '')
-    .replace(/\.git$/, '')
-    .trim();
-  const parts = cleaned.split('/');
-  if (parts.length >= 2) {
-    return { owner: parts[0], repo: parts[1] };
-  }
-  return null;
 }
 
 export async function syncCanvasToGitHub(params: {

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StorageService } from './StorageService';
 import { GitHubService } from './GitHubService';
+import { parseRepoPath } from '../utils/gitPathParser';
 
 export interface GitRepository {
   id: string;
@@ -146,20 +147,6 @@ export class GitService {
     }
   }
 
-  private static parseRepoPath(repoPath: string): { owner: string; repo: string } | null {
-    // Handle formats: facebook/react, github.com/facebook/react, https://github.com/facebook/react
-    let cleaned = repoPath
-      .replace(/^https?:\/\/github\.com\//, '')
-      .replace(/^github\.com\//, '')
-      .trim();
-    
-    const parts = cleaned.split('/');
-    if (parts.length >= 2) {
-      return { owner: parts[0], repo: parts[1].replace(/\.git$/, '') };
-    }
-    return null;
-  }
-
   private static async fetchFromGitHub<T>(url: string): Promise<T | null> {
     try {
       const response = await fetch(url, {
@@ -189,7 +176,7 @@ export class GitService {
     const cached = await this.getCachedData<GitBranch[]>(cacheKey);
     if (cached) return cached;
 
-    const repoInfo = this.parseRepoPath(repoPath);
+    const repoInfo = parseRepoPath(repoPath);
     
     if (repoInfo) {
       // Try GitHub API
@@ -222,7 +209,7 @@ export class GitService {
     const cached = await this.getCachedData<GitCommit[]>(cacheKey);
     if (cached) return cached;
 
-    const repoInfo = this.parseRepoPath(repoPath);
+    const repoInfo = parseRepoPath(repoPath);
     
     if (repoInfo) {
       // Try GitHub API
@@ -264,7 +251,7 @@ export class GitService {
     const cached = await this.getCachedData<GitRepositoryFolder[]>(cacheKey);
     if (cached && cached.length > 0) return cached;
 
-    const repoInfo = this.parseRepoPath(repoPath);
+    const repoInfo = parseRepoPath(repoPath);
     if (!repoInfo) {
       return [];
     }

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -1,24 +1,12 @@
 import { GitHubService } from './GitHubService';
 import { NoteFormat } from '../models/Note';
 import * as FileSystem from 'expo-file-system/legacy';
+import { parseRepoPath } from '../utils/gitPathParser';
 
 export interface NoteGitHubSyncResult {
   success: boolean;
   filePath?: string;
   error?: string;
-}
-
-function parseRepoPath(repoPath: string): { owner: string; repo: string } | null {
-  const cleaned = repoPath
-    .replace(/^https?:\/\/github\.com\//, '')
-    .replace(/^github\.com\//, '')
-    .replace(/\.git$/, '')
-    .trim();
-  const parts = cleaned.split('/');
-  if (parts.length >= 2) {
-    return { owner: parts[0], repo: parts[1] };
-  }
-  return null;
 }
 
 function getExtension(format?: NoteFormat): string {

--- a/src/services/RepoFileSyncService.ts
+++ b/src/services/RepoFileSyncService.ts
@@ -1,6 +1,7 @@
 import { GitHubService } from './GitHubService';
 import { StorageService } from './StorageService';
 import { NoteFormat } from '../models/Note';
+import { parseRepoPath } from '../utils/gitPathParser';
 
 export interface SyncResult {
   total: number;
@@ -38,19 +39,6 @@ function buildGitHubContentsApiUrl(owner: string, repo: string, path: string, br
   const encodedPath = encodeGitHubPath(path);
   const refQuery = branch ? `?ref=${encodeURIComponent(branch)}` : '';
   return `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}${refQuery}`;
-}
-
-function parseRepoPath(repoPath: string): { owner: string; repo: string } | null {
-  const cleaned = repoPath
-    .replace(/^https?:\/\/github\.com\//, '')
-    .replace(/^github\.com\//, '')
-    .replace(/\.git$/, '')
-    .trim();
-  const parts = cleaned.split('/');
-  if (parts.length >= 2) {
-    return { owner: parts[0], repo: parts[1] };
-  }
-  return null;
 }
 
 class RepoFileSyncServiceClass {

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -3,19 +3,7 @@ import { StorageService } from './StorageService';
 import { createNote } from '../models/Note';
 import { createCanvas, updateCanvas, CanvasScene } from '../models/Canvas';
 import { createTodoItem, applyTodoUpdate } from '../models/Todo';
-
-function parseRepoPath(repoPath: string): { owner: string; repo: string } | null {
-  const cleaned = repoPath
-    .replace(/^https?:\/\/github\.com\//, '')
-    .replace(/^github\.com\//, '')
-    .replace(/\.git$/, '')
-    .trim();
-  const parts = cleaned.split('/');
-  if (parts.length >= 2) {
-    return { owner: parts[0], repo: parts[1] };
-  }
-  return null;
-}
+import { parseRepoPath } from '../utils/gitPathParser';
 
 async function fetchDirectoryFiles(
   owner: string,

--- a/src/services/TodoGitHubSyncService.ts
+++ b/src/services/TodoGitHubSyncService.ts
@@ -1,23 +1,11 @@
 import { GitHubService } from './GitHubService';
 import { Todo } from '../models/Todo';
+import { parseRepoPath } from '../utils/gitPathParser';
 
 export interface TodoGitHubSyncResult {
   success: boolean;
   filePath?: string;
   error?: string;
-}
-
-function parseRepoPath(repoPath: string): { owner: string; repo: string } | null {
-  const cleaned = repoPath
-    .replace(/^https?:\/\/github\.com\//, '')
-    .replace(/^github\.com\//, '')
-    .replace(/\.git$/, '')
-    .trim();
-  const parts = cleaned.split('/');
-  if (parts.length >= 2) {
-    return { owner: parts[0], repo: parts[1] };
-  }
-  return null;
 }
 
 function serializeTodo(todo: Partial<Todo>): string {

--- a/src/utils/gitPathParser.ts
+++ b/src/utils/gitPathParser.ts
@@ -1,0 +1,17 @@
+// Canonical owner/repo parser. Accepts:
+//   facebook/react
+//   github.com/facebook/react
+//   https://github.com/facebook/react
+//   facebook/react.git
+export function parseRepoPath(repoPath: string): { owner: string; repo: string } | null {
+  const cleaned = repoPath
+    .replace(/^https?:\/\/github\.com\//, '')
+    .replace(/^github\.com\//, '')
+    .replace(/\.git$/, '')
+    .trim();
+  const parts = cleaned.split('/');
+  if (parts.length >= 2) {
+    return { owner: parts[0], repo: parts[1] };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
Extract the duplicated owner/repo parser into `src/utils/gitPathParser.ts` and replace all 7 inline copies (GitService, RepoFileSyncService, RepoPullService, NoteGitHubSync, CanvasGitHubSync, TodoGitHubSync, plus the re-export from RepoFileBrowser).

Consumers (NotesList, Explore, Home, MoveNoteDialog) now import from the canonical path. RepoFileBrowser no longer re-exports it.

## Test plan
- [ ] Repo browser still resolves owner/repo
- [ ] Sync flows still authenticate against the right repo
- [ ] Search across notes/canvases/todos still derives owner from repo path

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)