### PR TITLE
perf(NoteCard): wrap with React.memo (#270)

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -48,7 +48,7 @@ interface NoteCardProps {
   highlighted?: boolean;
 }
 
-export default function NoteCard({ note, onPress, onLongPress, compact = false, highlighted = false }: NoteCardProps) {
+function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted = false }: NoteCardProps) {
   const { colors, isDark } = useTheme();
   const { isTablet } = useResponsive();
   
@@ -149,6 +149,9 @@ export default function NoteCard({ note, onPress, onLongPress, compact = false, 
     </TouchableOpacity>
   );
 }
+
+const NoteCard = React.memo(NoteCardImpl);
+export default NoteCard;
 
 const styles = StyleSheet.create({
   card: {


### PR DESCRIPTION
## Summary
Wrap `NoteCard` with `React.memo`. `NotesListScreen` already passes stable `useCallback` handlers (`handleNotePress`, `handleNoteLongPress`), so memo skips re-renders when sibling notes change but a given card's props haven't.

The other findings in #270:
- AuthContext memoization → already fixed in #336 / PR #358
- HomeScreen `openItem` curried per item — separate follow-up if needed; impact is small (Home only renders \`recentLimit\` items max).

## Test plan
- [ ] Notes list scrolls without dropping cards
- [ ] Pin / unpin updates only the affected card
- [ ] Tag highlight on search still works

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)