### PR TITLE
fix(editor): bottom toolbar to NIconButton (#217 partial)

### DIFF
--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -1058,30 +1058,18 @@ export default function NoteEditorScreen() {
       </View>
 
       <View style={[styles.toolbar, { borderBottomColor: colors.border, backgroundColor: colors.surface }]}>
-        <TouchableOpacity
-          onPress={() => setShowVoiceModal(true)}
-          style={styles.toolbarButton}
-        >
-          <Ionicons name="mic-outline" size={22} color={colors.primary} />
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={() => setShowCanvasModal(true)}
-          style={styles.toolbarButton}
-        >
-          <Ionicons name="brush-outline" size={22} color={colors.primary} />
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={handlePickImage}
-          style={styles.toolbarButton}
-        >
-          <Ionicons name="image-outline" size={22} color={colors.primary} />
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={() => setShowCanvasPicker(true)}
-          style={styles.toolbarButton}
-        >
-          <Ionicons name="easel-outline" size={22} color={colors.primary} />
-        </TouchableOpacity>
+        <NIconButton size="sm" onPress={() => setShowVoiceModal(true)} accessibilityLabel="Voice input">
+          <Ionicons name="mic-outline" size={20} color={colors.primary} />
+        </NIconButton>
+        <NIconButton size="sm" onPress={() => setShowCanvasModal(true)} accessibilityLabel="Insert canvas">
+          <Ionicons name="brush-outline" size={20} color={colors.primary} />
+        </NIconButton>
+        <NIconButton size="sm" onPress={handlePickImage} accessibilityLabel="Insert image">
+          <Ionicons name="image-outline" size={20} color={colors.primary} />
+        </NIconButton>
+        <NIconButton size="sm" onPress={() => setShowCanvasPicker(true)} accessibilityLabel="Link existing canvas">
+          <Ionicons name="easel-outline" size={20} color={colors.primary} />
+        </NIconButton>
       </View>
 
       {sideBySide ? (


### PR DESCRIPTION
## Summary
Convert the edit-mode bottom action bar (voice / canvas / image / link-canvas) to `NIconButton`, matching the preview-mode header. Remaining items on #217 (tag pills → NChip, backlinks panel → NGroup) tracked separately.

## Test plan
- [ ] Bottom toolbar buttons still trigger their actions
- [ ] Visual parity with preview header

Refs #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)