### PR TITLE
chore: remove legacy-peer-deps=true from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -5119,7 +5119,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -6608,7 +6608,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -15050,7 +15050,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
## Summary
Fixes #343

`legacy-peer-deps=true` suppressed peer dependency resolution errors during `npm install`. Verified that `npm install` completes without the flag — all peer dependencies resolve correctly.

The workaround was likely needed during an earlier React Native upgrade but is no longer required. Removing it restores strict peer dependency checking to catch real conflicts early.

### Verification
```
$ rm .npmrc && npm install
added 1136 packages, audited 1137 packages — no peer dependency errors
```

## Test plan
- [x] `npm install` succeeds without `legacy-peer-deps=true`
- [x] No peer dependency conflicts reported
- [x] Same 13 moderate CVEs as before (tracked in #222, all transitive build-time only)