### PR TITLE
security: strip console output in release builds

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,20 @@
-module.exports = function(api) {
+module.exports = function (api) {
   api.cache(true);
+
+  const isProduction =
+    process.env.BABEL_ENV === 'production' ||
+    process.env.NODE_ENV === 'production';
+
+  const plugins = [];
+  if (isProduction) {
+    plugins.push(['transform-remove-console', { exclude: ['error', 'warn'] }]);
+  }
+  // react-native-worklets/plugin must be the LAST plugin per the
+  // react-native-worklets / Reanimated 4 docs.
+  plugins.push('react-native-worklets/plugin');
+
   return {
     presets: ['babel-preset-expo'],
-    // react-native-worklets/plugin must be the LAST plugin per the
-    // react-native-worklets / Reanimated 4 docs.
-    plugins: ['react-native-worklets/plugin'],
+    plugins,
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@types/jest": "^30.0.0",
         "@types/react": "~19.1.10",
         "babel-jest": "^30.3.0",
+        "babel-plugin-transform-remove-console": "^6.9.4",
         "jest": "^30.3.0",
         "react-test-renderer": "^19.1.0",
         "typescript": "^5.6.3"
@@ -5810,6 +5811,13 @@
       "dependencies": {
         "@babel/plugin-syntax-flow": "^7.12.1"
       }
+    },
+    "node_modules/babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha512-88blrUrMX3SPiGkT1GnvVY8E/7A+k6oj3MNvUtTIxJflFzXTw1bHkuJ/y039ouhFMp2prRn5cQGzokViYi1dsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/jest": "^30.0.0",
     "@types/react": "~19.1.10",
     "babel-jest": "^30.3.0",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "jest": "^30.3.0",
     "react-test-renderer": "^19.1.0",
     "typescript": "^5.6.3"


### PR DESCRIPTION
## Summary
Fixes #268

Adds `babel-plugin-transform-remove-console` to strip `console.log/info/debug` in production builds, while preserving `console.error` and `console.warn` for crash reporting.

This is a defense-in-depth measure to prevent potential token/credential leakage through debug console output in release builds.

### Changes
- Add `babel-plugin-transform-remove-console` as devDependency
- Configure babel to strip console in production (keeps error/warn)
- Ensure `react-native-worklets/plugin` stays as last plugin

## Test plan
- [x] `npm install` succeeds
- [ ] Build Android release and verify no console.log output in logcat
- [ ] Build debug and verify console.log still works