### PR TITLE
fix(nav): split dev-only routes + add token help docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ This project addresses the following security vulnerabilities:
    eas submit --platform android --profile production
    ```
 
+   This requires a `google-service-account.json` at the repo root (path
+   referenced from `eas.json`). The file is gitignored. See
+   [EAS docs](https://docs.expo.dev/submit/android/#creating-a-service-account)
+   for how to create one.
+
 ### EAS Configuration
 
 The project includes an `eas.json` configuration file with three build profiles:

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,4 +1,4 @@
-export type RootStackParamList = {
+type ProductionStackParamList = {
   MainTabs: undefined;
   NoteEditor: { noteId?: string; format?: 'markdown' | 'neorg' | 'org'; initialTitle?: string; initialContent?: string; repo?: string; branch?: string; folderPath?: string };
   NoteViewer: { noteId: string };
@@ -8,8 +8,13 @@ export type RootStackParamList = {
   VideoViewer: { owner: string; repo: string; branch?: string; path: string; title?: string; size?: number };
   CanvasEditor: { canvasId?: string; canvasWidth?: number; canvasHeight?: number; canvasTitle?: string };
   CanvasList: undefined;
+};
+
+type DevOnlyStackParamList = {
   NeumorphicGallery: undefined;
 };
+
+export type RootStackParamList = ProductionStackParamList & DevOnlyStackParamList;
 
 export type BottomTabParamList = {
   HomeTab: undefined;

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -111,11 +111,19 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
 
             <NButton
               variant="ghost"
-              onPress={() => Linking.openURL('https://github.com/settings/tokens/new?scopes=repo,read:user&description=GitNotes')}
-              leadingIcon={<Ionicons name="open-outline" size={14} color={colors.accent} />}
-              label="Generate token on GitHub"
+              onPress={() => Linking.openURL('https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens')}
+              leadingIcon={<Ionicons name="help-circle-outline" size={14} color={colors.accent} />}
+              label="How to create a token"
               // colors.text not colors.accent for AA contrast on light bg;
               // link affordance carried by the leading icon. (See #221.)
+              textStyle={{ color: colors.text, fontSize: 14, fontWeight: '500' }}
+              style={{ marginBottom: 8 }}
+            />
+            <NButton
+              variant="ghost"
+              onPress={() => Linking.openURL('https://github.com/settings/tokens/new?scopes=repo,read:user&description=GitNotes')}
+              leadingIcon={<Ionicons name="open-outline" size={14} color={colors.accent} />}
+              label="Open GitHub token settings"
               textStyle={{ color: colors.text, fontSize: 14, fontWeight: '500' }}
               style={{ marginBottom: 16 }}
             />

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -565,10 +565,17 @@ export default function SettingsScreen() {
               </Text>
               <TouchableOpacity
                 style={styles.generateLink}
+                onPress={() => Linking.openURL('https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens')}
+              >
+                <Ionicons name="help-circle-outline" size={14} color={colors.primary} />
+                <Text style={[styles.generateLinkText, { color: colors.primary }]}>How to create a token (GitHub docs)</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.generateLink}
                 onPress={() => Linking.openURL('https://github.com/settings/tokens/new?scopes=repo,read:user&description=GitNotes')}
               >
                 <Ionicons name="open-outline" size={14} color={colors.primary} />
-                <Text style={[styles.generateLinkText, { color: colors.primary }]}>Generate token on GitHub</Text>
+                <Text style={[styles.generateLinkText, { color: colors.primary }]}>Open GitHub token settings</Text>
               </TouchableOpacity>
               <View style={[styles.tokenInputRow, { borderColor: tokenError ? '#FF3B30' : colors.border, backgroundColor: colors.background }]}>
                 <TextInput


### PR DESCRIPTION
## Summary
Addresses #354

- Split `RootStackParamList` into `ProductionStackParamList` + `DevOnlyStackParamList` so dev-only screens (e.g. `NeumorphicGallery`) are type-isolated
- Add "How to create a token" docs link (GitHub PAT docs) in OnboardingScreen and SettingsScreen
- Add EAS service account documentation note in README
- Rename "Generate token on GitHub" → "Open GitHub token settings" for clarity

## Test plan
- [x] `npm run ts:check` passes
- [ ] Verify OnboardingScreen shows both help link and token settings link
- [ ] Verify SettingsScreen shows help link
- [ ] Verify NeumorphicGallery still accessible in dev