### PR TITLE
fix(nav): respect system dark mode in navigation theme

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -45,9 +45,9 @@ const linking: LinkingOptions<RootStackParamList> = {
 };
 
 export default function AppNavigator() {
-  const { theme } = useTheme();
-  
-  const navigationTheme = theme === 'dark' ? DarkTheme : DefaultTheme;
+  const { isDark } = useTheme();
+
+  const navigationTheme = isDark ? DarkTheme : DefaultTheme;
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>


### PR DESCRIPTION
## Summary
Relates to #337

`AppNavigator` used `theme === 'dark'` to pick navigation theme, which ignored the `'system'` option. When device is in dark mode but app theme is `'system'`, navigation chrome (status bar, back button) stayed light.

### Fix
Use `isDark` from `useTheme()` instead of comparing `theme === 'dark'`.

## Test plan
- [ ] Set theme to "system", device to dark mode → navigation chrome should be dark
- [ ] Set theme to "system", device to light mode → navigation chrome should be light
- [ ] Set theme to "dark" → always dark nav chrome
- [ ] Set theme to "light" → always light nav chrome