### PR TITLE
refactor: replace react-native-drax with gesture-handler/reanimated DnD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
-        "react-native-drax": "^1.1.0",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-markdown-display": "^7.0.2",
         "react-native-reanimated": "~4.1.1",
@@ -13360,22 +13359,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-native-drax": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-drax/-/react-native-drax-1.1.0.tgz",
-      "integrity": "sha512-MBAmlMZe/sSCwq2EXdxH8Dc2Gy9y+tvRJn/EWPtAsEoRkIVWeCFg8+7q7ABkmIDLwHGobuIRVC5M6OL6+2ldgQ==",
-      "license": "MIT",
-      "workspaces": [
-        "example",
-        "docs-site"
-      ],
-      "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-native": ">=0.68.0",
-        "react-native-gesture-handler": ">=2.0.0",
-        "react-native-reanimated": "^4.0.0"
       }
     },
     "node_modules/react-native-fit-image": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
-    "react-native-drax": "^1.1.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-markdown-display": "^7.0.2",
     "react-native-reanimated": "~4.1.1",

--- a/src/components/FolderTreeView.tsx
+++ b/src/components/FolderTreeView.tsx
@@ -9,9 +9,9 @@ import {
   UIManager,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { DraxView } from 'react-native-drax';
 import { Folder } from '../models/Folder';
 import { useTheme } from '../contexts/ThemeContext';
+import { DragDropBoundary, useDropTarget } from './dragdrop/DragDropContext';
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
@@ -39,6 +39,28 @@ interface FolderItemProps {
   onDrop?: (noteId: string, folder: Folder) => void;
   isDragActive?: boolean;
   colors: any;
+}
+
+interface FolderDropZoneProps {
+  enabled: boolean;
+  onDrop: (noteId: string) => void;
+  highlightColor: string;
+  children: React.ReactNode;
+}
+
+function FolderDropZone({ enabled, onDrop, highlightColor, children }: FolderDropZoneProps) {
+  const { ref, onLayout, isActive } = useDropTarget({ enabled, onDrop });
+
+  return (
+    <View
+      ref={ref}
+      onLayout={onLayout}
+      collapsable={false}
+      style={[styles.dropZone, isActive && { backgroundColor: highlightColor, borderRadius: 10 }]}
+    >
+      {children}
+    </View>
+  );
 }
 
 const FolderItem = ({
@@ -125,17 +147,13 @@ const FolderItem = ({
   return (
     <View>
       {onDrop ? (
-        <DraxView
-          style={styles.dropZone}
-          receptive
-          onReceiveDragDrop={({ dragged }) => {
-            if (dragged.payload && typeof dragged.payload === 'string') {
-              handleDrop(dragged.payload as string);
-            }
-          }}
+        <FolderDropZone
+          enabled={Boolean(isDragActive ?? true)}
+          onDrop={handleDrop}
+          highlightColor={colors.primary + '12'}
         >
           {folderRow}
-        </DraxView>
+        </FolderDropZone>
       ) : (
         folderRow
       )}
@@ -164,7 +182,7 @@ const FolderItem = ({
   );
 };
 
-export default function FolderTreeView({
+function FolderTreeViewContent({
   folders,
   selectedFolderId,
   onSelectFolder,
@@ -247,17 +265,13 @@ export default function FolderTreeView({
     <View style={styles.container}>
       {showRoot && (
         onDropToFolder ? (
-          <DraxView
-            style={styles.dropZone}
-            receptive
-            onReceiveDragDrop={({ dragged }) => {
-              if (dragged.payload && typeof dragged.payload === 'string') {
-                handleDropToRoot(dragged.payload as string);
-              }
-            }}
+          <FolderDropZone
+            enabled={Boolean(isDragActive ?? true)}
+            onDrop={handleDropToRoot}
+            highlightColor={colors.primary + '12'}
           >
             {rootFolderRow}
-          </DraxView>
+          </FolderDropZone>
         ) : (
           rootFolderRow
         )
@@ -291,6 +305,14 @@ export default function FolderTreeView({
         </View>
       )}
     </View>
+  );
+}
+
+export default function FolderTreeView(props: FolderTreeViewProps) {
+  return (
+    <DragDropBoundary>
+      <FolderTreeViewContent {...props} />
+    </DragDropBoundary>
   );
 }
 

--- a/src/components/MoveNoteDialog.tsx
+++ b/src/components/MoveNoteDialog.tsx
@@ -14,14 +14,16 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 
 type IoniconName = keyof typeof Ionicons.glyphMap;
-import { DraxView, DraxProvider } from 'react-native-drax';
 import { useTheme } from '../contexts/ThemeContext';
 import { GitHubService, GitHubContent } from '../services/GitHubService';
 import { HapticService } from '../utils/haptics';
 import { Note, deriveFolderPath } from '../models/Note';
 import { parseRepoPath } from '../utils/gitPathParser';
+import { DragDropBoundary, useDragDrop, useDropTarget } from './dragdrop/DragDropContext';
 
 interface MoveNoteDialogProps {
   visible: boolean;
@@ -35,6 +37,160 @@ interface ContentItem {
   path: string;
   type: 'file' | 'dir';
   sha?: string;
+}
+
+interface DraggableFileRowProps {
+  itemPath: string;
+  children: React.ReactNode;
+}
+
+function DraggableFileRow({ itemPath, children }: DraggableFileRowProps) {
+  const { startDrag, updateDrag, endDrag, cancelDrag } = useDragDrop();
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const scale = useSharedValue(1);
+  const dragActiveRef = useRef(false);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const resetPosition = useCallback(() => {
+    translateX.value = withSpring(0, { damping: 18, stiffness: 220 });
+    translateY.value = withSpring(0, { damping: 18, stiffness: 220 });
+    scale.value = withSpring(1, { damping: 18, stiffness: 220 });
+  }, [scale, translateX, translateY]);
+
+  const handleDragStart = useCallback((absoluteX: number, absoluteY: number) => {
+    dragActiveRef.current = true;
+    setIsDragging(true);
+    scale.value = withSpring(1.02, { damping: 18, stiffness: 220 });
+    HapticService.light();
+    startDrag(itemPath, { x: absoluteX, y: absoluteY });
+  }, [itemPath, scale, startDrag]);
+
+  const handleDragUpdate = useCallback((absoluteX: number, absoluteY: number) => {
+    if (!dragActiveRef.current) {
+      return;
+    }
+
+    updateDrag({ x: absoluteX, y: absoluteY });
+  }, [updateDrag]);
+
+  const finishDrag = useCallback((shouldDrop: boolean) => {
+    if (!dragActiveRef.current) {
+      return;
+    }
+
+    dragActiveRef.current = false;
+    setIsDragging(false);
+    if (shouldDrop) {
+      endDrag();
+    } else {
+      cancelDrag();
+    }
+  }, [cancelDrag, endDrag]);
+
+  const gesture = useMemo(() => Gesture.Pan()
+    .activateAfterLongPress(500)
+    .onStart((event) => {
+      runOnJS(handleDragStart)(event.absoluteX, event.absoluteY);
+    })
+    .onUpdate((event) => {
+      translateX.value = event.translationX;
+      translateY.value = event.translationY;
+      runOnJS(handleDragUpdate)(event.absoluteX, event.absoluteY);
+    })
+    .onEnd(() => {
+      runOnJS(finishDrag)(true);
+      translateX.value = withSpring(0, { damping: 18, stiffness: 220 });
+      translateY.value = withSpring(0, { damping: 18, stiffness: 220 });
+      scale.value = withSpring(1, { damping: 18, stiffness: 220 });
+    })
+    .onFinalize(() => {
+      runOnJS(finishDrag)(false);
+      translateX.value = withSpring(0, { damping: 18, stiffness: 220 });
+      translateY.value = withSpring(0, { damping: 18, stiffness: 220 });
+      scale.value = withSpring(1, { damping: 18, stiffness: 220 });
+    }), [finishDrag, handleDragStart, handleDragUpdate, scale, translateX, translateY]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.value },
+      { translateY: translateY.value },
+      { scale: scale.value },
+    ],
+    opacity: isDragging ? 0.92 : 1,
+    zIndex: isDragging ? 100 : 0,
+    elevation: isDragging ? 10 : 0,
+    shadowColor: '#000',
+    shadowOpacity: isDragging ? 0.18 : 0,
+    shadowRadius: isDragging ? 10 : 0,
+    shadowOffset: { width: 0, height: 6 },
+  }), [isDragging]);
+
+  useEffect(() => () => {
+    resetPosition();
+  }, [resetPosition]);
+
+  return (
+    <GestureDetector gesture={gesture}>
+      <Animated.View style={animatedStyle}>
+        {children}
+      </Animated.View>
+    </GestureDetector>
+  );
+}
+
+interface DirectoryDropRowProps {
+  itemPath: string;
+  onDrop: (dragPath: string, targetPath: string) => void;
+  highlightColor: string;
+  children: React.ReactNode;
+}
+
+function DirectoryDropRow({ itemPath, onDrop, highlightColor, children }: DirectoryDropRowProps) {
+  const { ref, onLayout, isActive } = useDropTarget({
+    onDrop: (dragPath) => {
+      if (dragPath !== itemPath) {
+        onDrop(dragPath, itemPath);
+      }
+    },
+  });
+
+  return (
+    <View
+      ref={ref}
+      onLayout={onLayout}
+      collapsable={false}
+      style={[exploreStyles.dropZone, isActive && { backgroundColor: highlightColor, borderRadius: 10 }]}
+    >
+      {children}
+    </View>
+  );
+}
+
+interface ListDropContainerProps {
+  targetPath: string;
+  onDrop: (dragPath: string, targetPath: string) => void;
+  highlightColor: string;
+  children: React.ReactNode;
+}
+
+function ListDropContainer({ targetPath, onDrop, highlightColor, children }: ListDropContainerProps) {
+  const { ref, onLayout, isActive } = useDropTarget({
+    onDrop: (dragPath) => {
+      onDrop(dragPath, targetPath);
+    },
+  });
+
+  return (
+    <View
+      ref={ref}
+      onLayout={onLayout}
+      collapsable={false}
+      style={[exploreStyles.listDropContainer, isActive && { backgroundColor: highlightColor }]}
+    >
+      {children}
+    </View>
+  );
 }
 
 export default function MoveNoteDialog({ visible, note, onClose, onMoved }: MoveNoteDialogProps) {
@@ -276,16 +432,10 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
 
     if (isDir) {
       return (
-        <DraxView
-          style={exploreStyles.dropZone}
-          receptive
-          longPressDelay={500}
-          onReceiveDragDrop={({ dragged }) => {
-            const dragPath = dragged.payload as string | undefined;
-            if (dragPath && dragPath !== item.path) {
-              handleMoveItemToFolder(dragPath, item.path);
-            }
-          }}
+        <DirectoryDropRow
+          itemPath={item.path}
+          onDrop={handleMoveItemToFolder}
+          highlightColor={colors.primary + '12'}
         >
           <TouchableOpacity
             onPress={() => navigateToFolder(item.path)}
@@ -293,19 +443,14 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
           >
             {itemContent}
           </TouchableOpacity>
-        </DraxView>
+        </DirectoryDropRow>
       );
     }
 
     return (
-      <DraxView
-        dragPayload={item.path}
-        longPressDelay={500}
-        draggingStyle={{ opacity: 0.6 }}
-        dragReleasedStyle={{ opacity: 0.6 }}
-      >
+      <DraggableFileRow itemPath={item.path}>
         {itemContent}
-      </DraxView>
+      </DraggableFileRow>
     );
   }, [colors, navigateToFolder, handleMoveItemToFolder, getFileIcon]);
 
@@ -313,7 +458,7 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
 
   return (
     <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
-      <DraxProvider>
+      <DragDropBoundary>
         <SafeAreaView style={[exploreStyles.container, { backgroundColor: colors.background }]} edges={['top', 'bottom']}>
           <View style={[exploreStyles.header, { borderBottomColor: colors.border }]}>
             <TouchableOpacity onPress={onClose} style={exploreStyles.headerBtn}>
@@ -403,16 +548,10 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
               <ActivityIndicator size="large" color={colors.primary} />
             </View>
           ) : (
-            <DraxView
-              receptive
-              style={{ flex: 1 }}
-              onReceiveDragDrop={({ dragged }) => {
-                const dragPath = dragged.payload as string | undefined;
-                if (dragPath) {
-                  const parentPath = currentPath.split('/').slice(0, -1).join('/');
-                  handleMoveItemToFolder(dragPath, parentPath);
-                }
-              }}
+            <ListDropContainer
+              targetPath={currentPath.split('/').slice(0, -1).join('/')}
+              onDrop={handleMoveItemToFolder}
+              highlightColor={colors.primary + '0D'}
             >
               <FlatList
                 data={contents}
@@ -428,10 +567,10 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
                   </View>
                 }
               />
-            </DraxView>
+            </ListDropContainer>
           )}
         </SafeAreaView>
-      </DraxProvider>
+      </DragDropBoundary>
     </Modal>
   );
 }
@@ -523,6 +662,7 @@ const exploreStyles = StyleSheet.create({
   itemName: { fontSize: 15, flex: 1, fontWeight: '400' },
   itemMeta: { fontSize: 12, fontWeight: '500', textTransform: 'uppercase' },
   dropZone: { minHeight: 44 },
+  listDropContainer: { flex: 1 },
   loading: { flex: 1, justifyContent: 'center', alignItems: 'center', paddingVertical: 40 },
   emptyList: { flexGrow: 1 },
   emptyContainer: { alignItems: 'center', justifyContent: 'center', paddingTop: 40 },

--- a/src/components/dragdrop/DragDropContext.tsx
+++ b/src/components/dragdrop/DragDropContext.tsx
@@ -1,0 +1,224 @@
+import React, {
+  createContext,
+  ReactNode,
+  RefObject,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { LayoutChangeEvent, View } from 'react-native';
+
+interface DragPoint {
+  x: number;
+  y: number;
+}
+
+interface DragTargetRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface RegisteredDropTarget {
+  enabled: boolean;
+  onDrop: (payload: string) => void;
+  measure: () => void;
+}
+
+interface DragDropContextValue {
+  isDragging: boolean;
+  activeTargetId: string | null;
+  startDrag: (payload: string, point: DragPoint) => void;
+  updateDrag: (point: DragPoint) => void;
+  endDrag: () => void;
+  cancelDrag: () => void;
+  registerDropTarget: (id: string, target: RegisteredDropTarget) => () => void;
+  updateTargetRect: (id: string, rect: DragTargetRect | null) => void;
+}
+
+const DragDropContext = createContext<DragDropContextValue | null>(null);
+
+export function DragDropBoundary({ children }: { children: ReactNode }) {
+  const parentContext = useContext(DragDropContext);
+  if (parentContext) {
+    return <>{children}</>;
+  }
+
+  return <DragDropProvider>{children}</DragDropProvider>;
+}
+
+export function DragDropProvider({ children }: { children: ReactNode }) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [activeTargetId, setActiveTargetId] = useState<string | null>(null);
+  const dragPayloadRef = useRef<string | null>(null);
+  const targetsRef = useRef(new Map<string, RegisteredDropTarget>());
+  const targetRectsRef = useRef(new Map<string, DragTargetRect>());
+  const activeTargetIdRef = useRef<string | null>(null);
+
+  const updateActiveTarget = useCallback((nextTargetId: string | null) => {
+    activeTargetIdRef.current = nextTargetId;
+    setActiveTargetId((currentTargetId) => (currentTargetId === nextTargetId ? currentTargetId : nextTargetId));
+  }, []);
+
+  const resolveTargetId = useCallback((point: DragPoint) => {
+    for (const [id, target] of Array.from(targetsRef.current.entries())) {
+      if (!target.enabled) {
+        continue;
+      }
+
+      const rect = targetRectsRef.current.get(id);
+      if (!rect) {
+        continue;
+      }
+
+      const isInside = point.x >= rect.x
+        && point.x <= rect.x + rect.width
+        && point.y >= rect.y
+        && point.y <= rect.y + rect.height;
+
+      if (isInside) {
+        return id;
+      }
+    }
+
+    return null;
+  }, []);
+
+  const refreshTargetMeasurements = useCallback(() => {
+    for (const target of Array.from(targetsRef.current.values())) {
+      target.measure();
+    }
+  }, []);
+
+  const startDrag = useCallback((payload: string, point: DragPoint) => {
+    dragPayloadRef.current = payload;
+    setIsDragging(true);
+    refreshTargetMeasurements();
+    requestAnimationFrame(() => {
+      updateActiveTarget(resolveTargetId(point));
+    });
+  }, [refreshTargetMeasurements, resolveTargetId, updateActiveTarget]);
+
+  const updateDrag = useCallback((point: DragPoint) => {
+    if (!dragPayloadRef.current) {
+      return;
+    }
+
+    updateActiveTarget(resolveTargetId(point));
+  }, [resolveTargetId, updateActiveTarget]);
+
+  const finishDrag = useCallback((shouldDrop: boolean) => {
+    const payload = dragPayloadRef.current;
+    const targetId = activeTargetIdRef.current;
+
+    dragPayloadRef.current = null;
+    updateActiveTarget(null);
+    setIsDragging(false);
+
+    if (!shouldDrop || !payload || !targetId) {
+      return;
+    }
+
+    const target = targetsRef.current.get(targetId);
+    target?.onDrop(payload);
+  }, [updateActiveTarget]);
+
+  const endDrag = useCallback(() => {
+    finishDrag(true);
+  }, [finishDrag]);
+
+  const cancelDrag = useCallback(() => {
+    finishDrag(false);
+  }, [finishDrag]);
+
+  const registerDropTarget = useCallback((id: string, target: RegisteredDropTarget) => {
+    targetsRef.current.set(id, target);
+
+    return () => {
+      targetsRef.current.delete(id);
+      targetRectsRef.current.delete(id);
+      if (activeTargetIdRef.current === id) {
+        updateActiveTarget(null);
+      }
+    };
+  }, [updateActiveTarget]);
+
+  const updateTargetRect = useCallback((id: string, rect: DragTargetRect | null) => {
+    if (!rect) {
+      targetRectsRef.current.delete(id);
+      return;
+    }
+
+    targetRectsRef.current.set(id, rect);
+  }, []);
+
+  const value = useMemo<DragDropContextValue>(() => ({
+    isDragging,
+    activeTargetId,
+    startDrag,
+    updateDrag,
+    endDrag,
+    cancelDrag,
+    registerDropTarget,
+    updateTargetRect,
+  }), [activeTargetId, cancelDrag, endDrag, isDragging, registerDropTarget, startDrag, updateDrag, updateTargetRect]);
+
+  return (
+    <DragDropContext.Provider value={value}>
+      {children}
+    </DragDropContext.Provider>
+  );
+}
+
+function useDragDropContext() {
+  const context = useContext(DragDropContext);
+  if (!context) {
+    throw new Error('DragDropProvider is required for drag and drop interactions.');
+  }
+
+  return context;
+}
+
+let targetIdCounter = 0;
+
+interface UseDropTargetOptions {
+  enabled?: boolean;
+  onDrop: (payload: string) => void;
+}
+
+export function useDropTarget({ enabled = true, onDrop }: UseDropTargetOptions) {
+  const { activeTargetId, isDragging, registerDropTarget, updateTargetRect } = useDragDropContext();
+  const targetIdRef = useRef(`drop-target-${targetIdCounter += 1}`);
+  const viewRef = useRef<View>(null);
+
+  const measure = useCallback(() => {
+    viewRef.current?.measureInWindow((x, y, width, height) => {
+      if (width <= 0 || height <= 0) {
+        updateTargetRect(targetIdRef.current, null);
+        return;
+      }
+
+      updateTargetRect(targetIdRef.current, { x, y, width, height });
+    });
+  }, [updateTargetRect]);
+
+  useEffect(() => registerDropTarget(targetIdRef.current, { enabled, onDrop, measure }), [enabled, measure, onDrop, registerDropTarget]);
+
+  const onLayout = useCallback((_event: LayoutChangeEvent) => {
+    requestAnimationFrame(measure);
+  }, [measure]);
+
+  return {
+    ref: viewRef as RefObject<View>,
+    onLayout,
+    isActive: isDragging && activeTargetId === targetIdRef.current,
+  };
+}
+
+export function useDragDrop() {
+  return useDragDropContext();
+}


### PR DESCRIPTION
## Summary
Fixes #256

Replaces the unmaintained \`react-native-drax\` (last published 2022) with a custom drag-and-drop implementation using \`react-native-gesture-handler\` + \`react-native-reanimated\` (both already installed).

### Changes
- New: \`src/components/dragdrop/DragDropContext.tsx\` — shared DnD provider with pan gesture, drop target registration, and drag session state
- Updated \`MoveNoteDialog.tsx\` — replaced DraxView/DraxList with gesture-handler Pan + DragDropContext
- Updated \`FolderTreeView.tsx\` — replaced DraxView drop targets with DragDropContext drop targets
- Removed \`react-native-drax\` from dependencies

### Verification
- \`npm run ts:check\` passes ✅

## Test plan
- [ ] Open MoveNoteDialog, drag a note to a different position (reorder)
- [ ] Drag a note to a folder (move between folders)
- [ ] Open FolderTreeView, verify folder expand/collapse works
- [ ] Verify drop target highlighting works during drag