### PR TITLE
fix: point token links to fine-grained PATs instead of classic tokens

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -106,12 +106,12 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
 
             <Text style={[styles.title, { color: colors.text }]}>Connect GitHub</Text>
             <Text style={[styles.description, { color: colors.textSecondary }]}>
-              Enter a Personal Access Token to link your notes to GitHub issues and milestones. You can skip this and add it later in Settings.
+              Enter a Fine-grained Personal Access Token to link your notes to GitHub repositories. Create one with read/write access to your chosen repositories. You can skip this and add it later in Settings.
             </Text>
 
             <Button
               variant="ghost"
-              onPress={() => Linking.openURL('https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens')}
+              onPress={() => Linking.openURL('https://docs.github.com/en/authentication/managing-fine-grained-personal-access-tokens')}
               leadingIcon={<Ionicons name="help-circle-outline" size={14} color={colors.accent} />}
               label="How to create a token"
               // colors.text not colors.accent for AA contrast on light bg;
@@ -121,7 +121,7 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
             />
             <Button
               variant="ghost"
-              onPress={() => Linking.openURL('https://github.com/settings/tokens/new?scopes=repo,read:user&description=GitNotes')}
+              onPress={() => Linking.openURL('https://github.com/settings/personal-access-tokens/new?description=GitNotes')}
               leadingIcon={<Ionicons name="open-outline" size={14} color={colors.accent} />}
               label="Open GitHub token settings"
               textStyle={{ color: colors.text, fontSize: 14, fontWeight: '500' }}
@@ -129,7 +129,7 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
             />
 
             <Input
-              placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+              placeholder="github_pat_xxxxxxxxxxxxxxxxxxxx"
               value={token}
               onChangeText={(t) => { setToken(t); setTokenError(null); }}
               secureTextEntry

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -560,19 +560,18 @@ export default function SettingsScreen() {
               contentContainerStyle={{ paddingBottom: 16 }}
             >
               <Text style={[styles.modalDesc, { color: colors.textSecondary }]}>
-                Personal Access Token with <Text style={{ fontWeight: '600' }}>repo</Text> and{' '}
-                <Text style={{ fontWeight: '600' }}>read:user</Text> scopes.
+                Fine-grained Personal Access Token with read/write access to your repositories.
               </Text>
               <TouchableOpacity
                 style={styles.generateLink}
-                onPress={() => Linking.openURL('https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens')}
+                onPress={() => Linking.openURL('https://docs.github.com/en/authentication/managing-fine-grained-personal-access-tokens')}
               >
                 <Ionicons name="help-circle-outline" size={14} color={colors.primary} />
                 <Text style={[styles.generateLinkText, { color: colors.primary }]}>How to create a token (GitHub docs)</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 style={styles.generateLink}
-                onPress={() => Linking.openURL('https://github.com/settings/tokens/new?scopes=repo,read:user&description=GitNotes')}
+                onPress={() => Linking.openURL('https://github.com/settings/personal-access-tokens/new?description=GitNotes')}
               >
                 <Ionicons name="open-outline" size={14} color={colors.primary} />
                 <Text style={[styles.generateLinkText, { color: colors.primary }]}>Open GitHub token settings</Text>
@@ -580,7 +579,7 @@ export default function SettingsScreen() {
               <View style={[styles.tokenInputRow, { borderColor: tokenError ? '#FF3B30' : colors.border, backgroundColor: colors.background }]}>
                 <TextInput
                   style={[styles.tokenInputInner, { color: colors.text }]}
-                  placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+                  placeholder="github_pat_xxxxxxxxxxxxxxxxxxxx"
                   placeholderTextColor={colors.textSecondary}
                   value={tokenInput}
                   onChangeText={(t) => { setTokenInput(t); setTokenError(null); }}


### PR DESCRIPTION
## Summary
Fixes #377

Updates token creation links in both Onboarding and Settings screens to point to **fine-grained Personal Access Tokens** instead of classic tokens.

### Changes

| Screen | Change |
|--------|--------|
| Onboarding | Docs URL → fine-grained PAT management docs |
| Onboarding | Token creation URL → fine-grained PAT creation page |
| Onboarding | Description → references fine-grained PATs with repo read/write |
| Onboarding | Placeholder → `github_pat_` prefix |
| Settings | Docs URL → fine-grained PAT management docs |
| Settings | Token creation URL → fine-grained PAT creation page |
| Settings | Scope text → fine-grained PAT with read/write access |
| Settings | Placeholder → `github_pat_` prefix |

### Backward Compatibility
Classic tokens (`ghp_`) continue to work. This only changes what we point *new* users toward.

## Test plan
- [ ] Open onboarding screen, verify "How to create a token" links to fine-grained docs
- [ ] Verify "Open GitHub token settings" opens fine-grained token creation page
- [ ] Open settings token modal, verify same links updated
- [ ] Verify placeholder shows `github_pat_` prefix