### PR TITLE
refactor: adopt axios for GitHub HTTP layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@react-navigation/native-stack": "^7.14.10",
     "@shopify/flash-list": "^2.3.1",
     "@shopify/react-native-skia": "2.2.12",
+    "axios": "^1.15.2",
     "date-fns": "^4.1.0",
     "expo": "~54.0.34",
     "expo-blur": "~15.0.8",

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import http, { setAuthToken, clearAuthToken } from './http';
 
 const TOKEN_KEY = '@gitnotes:github_token';
 const USER_KEY = '@gitnotes:github_user';
@@ -159,6 +160,7 @@ class GitHubServiceClass {
     try {
       this.token = await AsyncStorage.getItem(TOKEN_KEY);
       if (!this.token) return;
+      setAuthToken(this.token);
       const userJson = await AsyncStorage.getItem(USER_KEY);
       if (userJson) {
         this.user = JSON.parse(userJson);
@@ -175,12 +177,11 @@ class GitHubServiceClass {
 
   async setToken(token: string, user?: GitHubUser | null): Promise<GitHubUser | null> {
     this.token = token;
-    // If the caller already validated the token + fetched the user
-    // (AuthContext does this via AuthService.setToken), trust it instead
-    // of round-tripping /user a second time.
+    setAuthToken(token);
     const resolvedUser = user === undefined ? await this.fetchUser() : user;
     if (!resolvedUser) {
       this.token = null;
+      clearAuthToken();
       return null;
     }
     this.user = resolvedUser;
@@ -192,6 +193,7 @@ class GitHubServiceClass {
   async clearToken(): Promise<void> {
     this.token = null;
     this.user = null;
+    clearAuthToken();
     await AsyncStorage.multiRemove([TOKEN_KEY, USER_KEY]);
   }
 
@@ -205,7 +207,7 @@ class GitHubServiceClass {
 
   private async fetchUser(): Promise<GitHubUser | null> {
     try {
-      return await this.fetchWithAuth('https://api.github.com/user');
+      return await this.request<GitHubUser>('https://api.github.com/user');
     } catch {
       return null;
     }
@@ -222,7 +224,7 @@ class GitHubServiceClass {
     let url: string | null = `https://api.github.com/user/repos?${params.toString()}`;
     try {
       while (url) {
-        const { data, nextUrl } = await this.fetchWithAuthPaginated(url);
+        const { data, nextUrl } = await this.requestPaginated(url);
         if (Array.isArray(data)) all.push(...data);
         url = nextUrl;
       }
@@ -235,7 +237,7 @@ class GitHubServiceClass {
 
   async getIssues(owner: string, repo: string): Promise<GitHubIssue[]> {
     try {
-      const data = await this.fetchWithAuth(
+      const data = await this.request(
         `https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=50`
       );
       return Array.isArray(data) ? data : [];
@@ -247,7 +249,7 @@ class GitHubServiceClass {
 
   async getPullRequests(owner: string, repo: string): Promise<GitHubPullRequest[]> {
     try {
-      const data = await this.fetchWithAuth(
+      const data = await this.request(
         `https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=50`
       );
       return Array.isArray(data) ? data : [];
@@ -259,7 +261,7 @@ class GitHubServiceClass {
 
   async getMilestones(owner: string, repo: string): Promise<GitHubMilestone[]> {
     try {
-      const data = await this.fetchWithAuth(
+      const data = await this.request(
         `https://api.github.com/repos/${owner}/${repo}/milestones?state=open&per_page=50`
       );
       return Array.isArray(data) ? data : [];
@@ -274,7 +276,7 @@ class GitHubServiceClass {
       const encodedPath = path.split('/').map(encodeURIComponent).join('/');
       let url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
       if (ref) url += `?ref=${encodeURIComponent(ref)}`;
-      const data = await this.fetchWithAuth(url);
+      const data = await this.request(url);
       if (Array.isArray(data)) {
         return data;
       }
@@ -294,7 +296,7 @@ class GitHubServiceClass {
   ): Promise<{ path: string; type: 'blob' | 'tree'; sha: string }[]> {
     try {
       const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
-      const data = await this.fetchWithAuth(url);
+      const data = await this.request(url);
       if (!Array.isArray(data?.tree)) return [];
       return data.tree.map((item: any) => ({
         path: item.path,
@@ -314,7 +316,7 @@ class GitHubServiceClass {
       const encodedPath = path.split('/').map(encodeURIComponent).join('/');
       let url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
       if (ref) url += `?ref=${encodeURIComponent(ref)}`;
-      const data = await this.fetchWithAuth(url);
+      const data = await this.request(url);
       if (data.type === 'file' && data.content) {
         const base64 = data.content.replace(/\n/g, '');
         return decodeBase64(base64);
@@ -331,7 +333,7 @@ class GitHubServiceClass {
       const encodedPath = path.split('/').map(encodeURIComponent).join('/');
       let url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
       if (ref) url += `?ref=${encodeURIComponent(ref)}`;
-      const data = await this.fetchWithAuth(url);
+      const data = await this.request(url);
       return data.sha || null;
     } catch {
       return null;
@@ -354,13 +356,10 @@ class GitHubServiceClass {
       let binary = '';
       bytes.forEach((b) => { binary += String.fromCharCode(b); });
       const base64Content = btoa(binary);
-      return await this.fetchWithAuth(url, {
-        method: 'PUT',
-        body: JSON.stringify({
-          message,
-          content: base64Content,
-          branch,
-        }),
+      return await this.request(url, 'PUT', {
+        message,
+        content: base64Content,
+        branch,
       });
     } catch (error) {
       console.warn('[GitHubService] Failed to create file:', error);
@@ -389,10 +388,7 @@ class GitHubServiceClass {
         };
         if (existingSha) body.sha = existingSha;
 
-        return await this.fetchWithAuth(url, {
-          method: 'PUT',
-          body: JSON.stringify(body),
-        });
+        return await this.request(url, 'PUT', body);
       } catch (error) {
         const status = (error as { status?: number })?.status;
         if (status === 409 && attempt < 2) {
@@ -421,10 +417,7 @@ class GitHubServiceClass {
     try {
       const encodedPath = path.split('/').map(encodeURIComponent).join('/');
       const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
-      return await this.fetchWithAuth(url, {
-        method: 'DELETE',
-        body: JSON.stringify({ message, sha, branch }),
-      });
+      return await this.request(url, 'DELETE', { message, sha, branch });
     } catch (error) {
       console.warn('[GitHubService] Failed to delete file:', error);
       return null;
@@ -464,10 +457,7 @@ class GitHubServiceClass {
           return this.createFile(owner, repo, path, content, message, branch);
         }
 
-        return await this.fetchWithAuth(url, {
-          method: 'PUT',
-          body: JSON.stringify({ message, content: base64Content, sha, branch }),
-        });
+        return await this.request(url, 'PUT', { message, content: base64Content, sha, branch });
       } catch (error) {
         const status = (error as { status?: number })?.status;
         if (status === 409 && attempt < 2) {
@@ -501,58 +491,24 @@ class GitHubServiceClass {
     return true;
   }
 
-  private async fetchWithAuth(url: string, options?: RequestInit): Promise<any> {
+  private async request<T = any>(url: string, method: 'GET' | 'PUT' | 'DELETE' = 'GET', data?: any): Promise<T> {
     if (!this.token) throw new Error('GitHub token is not configured');
-
-    const response = await fetch(url, {
-      ...options,
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-        ...options?.headers,
-      },
-    });
-
-    if (!response.ok) {
-      const err = new Error(`GitHub API error: ${response.status}`) as Error & { status?: number };
-      err.status = response.status;
-      throw err;
-    }
-
-    return response.json();
+    const isFullUrl = url.startsWith('http');
+    const requestUrl = isFullUrl ? url : url;
+    const response = await http.request<T>({ url: requestUrl, method, data });
+    return response.data;
   }
 
-  private async fetchWithAuthPaginated(
-    url: string,
-    options?: RequestInit,
-  ): Promise<{ data: any; nextUrl: string | null }> {
+  private async requestPaginated(url: string): Promise<{ data: any; nextUrl: string | null }> {
     if (!this.token) throw new Error('GitHub token is not configured');
-
-    const response = await fetch(url, {
-      ...options,
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-        ...options?.headers,
-      },
-    });
-
-    if (!response.ok) {
-      const err = new Error(`GitHub API error: ${response.status}`) as Error & { status?: number };
-      err.status = response.status;
-      throw err;
-    }
-
-    const data = await response.json();
-    const linkHeader = response.headers.get('Link');
+    const response = await http.get(url);
+    const linkHeader = response.headers['link'] as string | null;
     const nextUrl = parseNextLink(linkHeader);
-    return { data, nextUrl };
+    return { data: response.data, nextUrl };
   }
 }
 
-function parseNextLink(linkHeader: string | null): string | null {
+function parseNextLink(linkHeader: string | null | undefined): string | null {
   if (!linkHeader) return null;
   const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
   return match ? match[1] : null;

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,0 +1,49 @@
+import axios, { type AxiosError, type AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
+
+const GITHUB_API_BASE = 'https://api.github.com';
+
+const http: AxiosInstance = axios.create({
+  baseURL: GITHUB_API_BASE,
+  headers: {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  },
+});
+
+let authToken: string | null = null;
+
+export function setAuthToken(token: string | null): void {
+  authToken = token;
+  if (token) {
+    http.defaults.headers.common.Authorization = `Bearer ${token}`;
+  } else {
+    delete http.defaults.headers.common.Authorization;
+  }
+}
+
+export function clearAuthToken(): void {
+  authToken = null;
+  delete http.defaults.headers.common.Authorization;
+}
+
+http.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  config.headers.set('X-Request-ID', `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
+  return config;
+});
+
+http.interceptors.response.use(
+  (response) => response,
+  (error: AxiosError) => {
+    const status = error.response?.status;
+    // Prevent credential leaks in error messages
+    const safeMessage = status
+      ? `GitHub API error: ${status}`
+      : error.message?.replace(/Bearer\s+\S+/gi, 'Bearer ***') ?? 'Network error';
+
+    const normalized = new Error(safeMessage) as Error & { status?: number };
+    normalized.status = status;
+    throw normalized;
+  },
+);
+
+export default http;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,12 +2493,26 @@ async-lock@^1.4.1:
   resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.4.1.tgz#56b8718915a9b68b10fce2f2a9a3dddf765ef53f"
   integrity sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+axios@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.2.tgz#eb8fb6d30349abace6ade5b4cb4d9e8a0dc23e5b"
+  integrity sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==
+  dependencies:
+    follow-redirects "^1.15.11"
+    form-data "^4.0.5"
+    proxy-from-env "^2.1.0"
 
 babel-jest@30.3.0, babel-jest@^30.3.0:
   version "30.3.0"
@@ -3032,6 +3046,13 @@ color@^4.2.3:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^12.0.0:
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
@@ -3229,6 +3250,11 @@ define-properties@^1.1.3, define-properties@^1.2.1:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -3360,6 +3386,16 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
@@ -3700,6 +3736,11 @@ flow-enums-runtime@^0.0.6:
   resolved "https://registry.yarnpkg.com/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz#5bb0cd1b0a3e471330f4d109039b7eba5cb3e787"
   integrity sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==
 
+follow-redirects@^1.15.11:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
+
 fontfaceobserver@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz#5fb392116e75d5024b7ec8e4f2ce92106d1488c8"
@@ -3719,6 +3760,17 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
+
+form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
 
 freeport-async@^2.0.0:
   version "2.0.0"
@@ -3760,7 +3812,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.2.4, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.4, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -5343,7 +5395,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.1.27, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -5875,6 +5927,11 @@ prop-types@^15.5.10, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 punycode.js@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
## Summary
Fixes #330

Replaces raw `fetch()` calls in GitHubService with axios, providing interceptors, automatic JSON parsing, and cleaner error handling.

### Changes
- **New**: `src/services/http.ts` — configured axios instance with GitHub API defaults, auth token management, request correlation header, and error normalization (strips tokens from error messages)
- **Updated**: `src/services/GitHubService.ts` — replaced `fetchWithAuth`/`fetchWithAuthPaginated` with `request`/`requestPaginated` using axios
- Token management centralized via `setAuthToken`/`clearAuthToken` exports from http.ts
- All public method signatures unchanged — zero breaking changes for consumers

### Before
- 2 raw `fetch()` sites with manual header setting, `response.ok` checks, `.json()` parsing
- Token manually concatenated into Authorization header at every call site

### After
- Single configured axios instance with interceptors
- Token set once via `setAuthToken()`, applied automatically
- Errors auto-normalized with status codes, tokens redacted
- Request correlation via `X-Request-ID` header

## Test plan
- [x] `yarn ts:check` passes
- [x] All 14 test suites pass (117 tests)
- [ ] CI pipeline passes
- [ ] Manual: browse repos, view files, upload notes — verify GitHub API calls work