### PR TITLE
refactor: replace react-native-markdown-display with react-native-marked

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-markdown-display": "^7.0.2",
+    "react-native-marked": "^8.0.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
@@ -65,12 +65,6 @@
     "jest": "^30.3.0",
     "react-test-renderer": "19.1.0",
     "typescript": "^5.6.3"
-  },
-  "resolutions": {
-    "markdown-it": "^14.0.0"
-  },
-  "overrides": {
-    "markdown-it": "^14.0.0"
   },
   "packageManager": "yarn@1.22.22",
   "private": true

--- a/src/screens/FileViewerScreen.tsx
+++ b/src/screens/FileViewerScreen.tsx
@@ -10,9 +10,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
-import Markdown from 'react-native-markdown-display';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const MarkdownIt = require('markdown-it');
+import Markdown from 'react-native-marked';
 
 import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../contexts/ThemeContext';
@@ -106,15 +104,6 @@ export default function FileViewerScreen() {
 
   const markdownStyles = useMemo(() => getMarkdownStyles(colors, isDark), [colors, isDark]);
 
-  const markdownItInstance = useMemo(() => {
-    const md = MarkdownIt({ typographer: true, linkify: true });
-    // Allow only safe URL schemes. Reject javascript:, data:, vbscript:, etc.
-    md.validateLink = (url: string) =>
-      /^(https?:|mailto:|tel:|#)/i.test(url) ||
-      !/^[a-z][a-z0-9+.-]*:/i.test(url);
-    return md;
-  }, []);
-
   return (
     <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { borderBottomColor: colors.border, backgroundColor: colors.surface }]}>
@@ -151,7 +140,7 @@ export default function FileViewerScreen() {
           showsVerticalScrollIndicator
         >
           {mode === 'markdown' ? (
-            <Markdown style={markdownStyles} markdownit={markdownItInstance}>{renderContent}</Markdown>
+            <Markdown value={renderContent} styles={markdownStyles} />
           ) : (mode === 'neorg' || mode === 'org') && parsedNeorg ? (
             <NeorgRenderer blocks={parsedNeorg} />
           ) : (

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -21,9 +21,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import * as ImagePicker from 'expo-image-picker';
 import * as Speech from 'expo-speech';
 import { Ionicons } from '@expo/vector-icons';
-import Markdown from 'react-native-markdown-display';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const MarkdownIt = require('markdown-it');
+import Markdown from 'react-native-marked';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useNotes } from '../contexts/NoteContext';
@@ -57,6 +55,7 @@ import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
 import { PositionMemoryService } from '../services/PositionMemoryService';
 import { getMarkdownStyles } from '../utils/preview';
 import { Button, IconButton, Modal } from '../components/ui';
+import { NotePreviewRenderer } from '../utils/markdownRenderer';
 
 interface TocEntry {
   level: number;
@@ -538,14 +537,6 @@ export default function NoteEditorScreen() {
 
   const markdownStyles = useMemo(() => getMarkdownStyles(colors, isDark), [colors, isDark]);
 
-  const markdownItInstance = useMemo(() => {
-    const md = MarkdownIt({ typographer: true, linkify: true });
-    md.validateLink = (url: string) =>
-      /^(https?:|file:|data:|mailto:|tel:|canvas:|note:|#)/i.test(url) ||
-      !/^[a-z][a-z0-9+.-]*:/i.test(url);
-    return md;
-  }, []);
-
 
   const previewContent = useMemo(() => {
     const stripTopMetadata = (raw: string, format: NoteFormat): string => {
@@ -612,91 +603,18 @@ export default function NoteEditorScreen() {
 
   const previewScrollRef = useRef<ScrollView>(null);
 
-  const markdownRules = useMemo(() => ({
-    image: (node: any) => {
-      const src: string = node.attributes?.src ?? '';
-      const alt: string = node.attributes?.alt ?? '';
-      const isCanvas = /canvas-drawings\/canvas-/.test(src) || /^canvas-/.test(alt);
-      if (isCanvas) {
-        const isJson = /\.json(\?|$)/i.test(src);
-        const pngUri = isJson ? src.split('?')[0].replace(/\.json$/i, '.png') : src;
-        return (
-          <Image
-            key={node.key}
-            source={{ uri: pngUri }}
-            contentFit="contain"
-            accessibilityLabel={alt || undefined}
-            style={{ width: '100%', height: 240, borderRadius: 6, backgroundColor: '#fff' }}
-          />
-        );
-      }
-      return (
-        <Image
-          key={node.key}
-          source={{ uri: src }}
-          contentFit="contain"
-          accessibilityLabel={alt || undefined}
-          style={{ width: '100%', height: 240, borderRadius: 6, backgroundColor: colors.surfaceSecondary }}
-        />
-      );
-    },
-    link: (node: any, children: any) => {
-      const href: string = node.attributes?.href ?? '';
-      if (isCanvasLink(href)) {
-        const id = canvasIdFromLink(href);
-        return <CanvasPreview key={node.key} canvasId={id} />;
-      }
-      const onPress = () => {
-        if (!href) return;
-        if (href.startsWith('note:')) {
-          const id = href.slice('note:'.length);
-          if (id) navigation.navigate('NoteEditor', { noteId: id });
-          return;
-        }
-        if (href.startsWith('#')) {
-          const slug = href.slice(1).toLowerCase();
-          const target = previewContent
-            .split('\n')
-            .findIndex((line) => {
-              const m = line.match(/^#{1,6}\s+(.+?)\s*#*\s*$/);
-              if (!m) return false;
-              const headingSlug = m[1]
-                .toLowerCase()
-                .trim()
-                .replace(/[^a-z0-9]+/g, '-')
-                .replace(/^-|-$/g, '');
-              return headingSlug === slug;
-            });
-          if (target >= 0) {
-            previewScrollRef.current?.scrollTo({ y: target * APPROX_LINE_PX, animated: true });
-          }
-          return;
-        }
-        Linking.openURL(href).catch(() => {});
-      };
-      return (
-        <Text
-          key={node.key}
-          style={{ color: colors.primary, textDecorationLine: 'underline' }}
-          onPress={onPress}
-        >
-          {children}
-        </Text>
-      );
-    },
-    text: (node: any, _children: any, _parent: any, styles: any, inheritedStyles: any = {}) => (
-      <Text key={node.key} selectable style={[inheritedStyles, styles.text]}>{node.content}</Text>
-    ),
-    code_inline: (node: any, _children: any, _parent: any, styles: any, inheritedStyles: any = {}) => (
-      <Text key={node.key} selectable style={[inheritedStyles, styles.code_inline]}>{node.content}</Text>
-    ),
-    code_block: (node: any, _children: any, _parent: any, styles: any, inheritedStyles: any = {}) => (
-      <Text key={node.key} selectable style={[inheritedStyles, styles.code_block]}>{node.content}</Text>
-    ),
-    fence: (node: any, _children: any, _parent: any, styles: any, inheritedStyles: any = {}) => (
-      <Text key={node.key} selectable style={[inheritedStyles, styles.fence]}>{node.content}</Text>
-    ),
-  }), [colors, navigation, previewContent]);
+  const notePreviewRenderer = useMemo(
+    () =>
+      new NotePreviewRenderer({
+        colors,
+        navigation,
+        previewContent,
+        previewScrollRef,
+        CanvasPreview,
+        approxLinePx: APPROX_LINE_PX,
+      }),
+    [colors, navigation, previewContent],
+  );
 
   const speakableContent = useMemo(() => {
     return previewContent
@@ -882,7 +800,7 @@ export default function NoteEditorScreen() {
           >
             {previewContent.trim() ? (
               noteFormat === 'markdown' ? (
-                <Markdown style={markdownStyles} rules={markdownRules} markdownit={markdownItInstance}>{previewContent}</Markdown>
+                <Markdown value={previewContent} styles={markdownStyles} renderer={notePreviewRenderer} />
               ) : parsedStructuredContent ? (
                 <NeorgRenderer blocks={parsedStructuredContent} />
               ) : (
@@ -1050,7 +968,7 @@ export default function NoteEditorScreen() {
       <Text style={[styles.livePreviewLabel, { color: colors.textSecondary }]}>Preview</Text>
       {previewContent.trim() ? (
         noteFormat === 'markdown' ? (
-          <Markdown style={markdownStyles} rules={markdownRules} markdownit={markdownItInstance}>{previewContent}</Markdown>
+          <Markdown value={previewContent} styles={markdownStyles} renderer={notePreviewRenderer} />
         ) : parsedStructuredContent ? (
           <NeorgRenderer blocks={parsedStructuredContent} />
         ) : (

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -1,0 +1,136 @@
+import React, { type ReactNode } from 'react';
+import { Text, type TextStyle, type ViewStyle, type ImageStyle, type ScrollView, Linking } from 'react-native';
+import { Renderer, type RendererInterface } from 'react-native-marked';
+import { Image } from 'expo-image';
+
+import { isCanvasLink, canvasIdFromLink } from '../models/Canvas';
+
+interface CustomRendererDeps {
+  colors: {
+    primary: string;
+    text: string;
+    surfaceSecondary?: string;
+  };
+  navigation?: {
+    navigate: (screen: string, params: Record<string, unknown>) => void;
+  };
+  previewContent?: string;
+  previewScrollRef?: React.RefObject<ScrollView | null>;
+  CanvasPreview?: React.ComponentType<{ canvasId: string }>;
+  approxLinePx?: number;
+}
+
+export class NotePreviewRenderer extends Renderer implements RendererInterface {
+  private deps: CustomRendererDeps;
+
+  constructor(deps: CustomRendererDeps) {
+    super();
+    this.deps = deps;
+  }
+
+  image(uri: string, alt?: string, _style?: ImageStyle): ReactNode {
+    const isCanvas = /canvas-drawings\/canvas-/.test(uri) || /^canvas-/.test(alt ?? '');
+    if (isCanvas) {
+      const pngUri = /\.json(\?|$)/i.test(uri)
+        ? uri.split('?')[0].replace(/\.json$/i, '.png')
+        : uri;
+      return (
+        <Image
+          key={this.getKey()}
+          source={{ uri: pngUri }}
+          contentFit="contain"
+          accessibilityLabel={alt || undefined}
+          style={{ width: '100%', height: 240, borderRadius: 6, backgroundColor: '#fff' }}
+        />
+      );
+    }
+    return (
+      <Image
+        key={this.getKey()}
+        source={{ uri }}
+        contentFit="contain"
+        accessibilityLabel={alt || undefined}
+        style={{
+          width: '100%',
+          height: 240,
+          borderRadius: 6,
+          backgroundColor: this.deps.colors.surfaceSecondary ?? '#f0f0f0',
+        }}
+      />
+    );
+  }
+
+  link(children: string | ReactNode[], href: string, styles?: TextStyle): ReactNode {
+    if (isCanvasLink(href) && this.deps.CanvasPreview) {
+      const id = canvasIdFromLink(href);
+      return <React.Fragment key={this.getKey()}>{React.createElement(this.deps.CanvasPreview, { canvasId: id })}</React.Fragment>;
+    }
+
+    const onPress = () => {
+      if (!href) return;
+      if (href.startsWith('note:')) {
+        const id = href.slice('note:'.length);
+        if (id && this.deps.navigation) {
+          this.deps.navigation.navigate('NoteEditor', { noteId: id });
+        }
+        return;
+      }
+      if (href.startsWith('#')) {
+        const slug = href.slice(1).toLowerCase();
+        const content = this.deps.previewContent ?? '';
+        const target = content
+          .split('\n')
+          .findIndex((line) => {
+            const m = line.match(/^#{1,6}\s+(.+?)\s*#*\s*$/);
+            if (!m) return false;
+            const headingSlug = m[1]
+              .toLowerCase()
+              .trim()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-|-$/g, '');
+            return headingSlug === slug;
+          });
+        if (target >= 0 && this.deps.previewScrollRef?.current) {
+          const px = this.deps.approxLinePx ?? 22;
+          this.deps.previewScrollRef.current.scrollTo({ y: target * px, animated: true });
+        }
+        return;
+      }
+      Linking.openURL(href).catch(() => {});
+    };
+
+    return (
+      <Text
+        key={this.getKey()}
+        style={[styles, { color: this.deps.colors.primary, textDecorationLine: 'underline' }]}
+        onPress={onPress}
+      >
+        {children}
+      </Text>
+    );
+  }
+
+  text(text: string | ReactNode[], styles?: TextStyle): ReactNode {
+    return (
+      <Text key={this.getKey()} selectable style={styles}>
+        {text}
+      </Text>
+    );
+  }
+
+  codespan(text: string, styles?: TextStyle): ReactNode {
+    return (
+      <Text key={this.getKey()} selectable style={styles}>
+        {text}
+      </Text>
+    );
+  }
+
+  code(text: string, _language?: string, containerStyle?: ViewStyle, textStyle?: TextStyle): ReactNode {
+    return (
+      <Text key={this.getKey()} selectable style={[containerStyle, textStyle]}>
+        {text}
+      </Text>
+    );
+  }
+}

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -1,4 +1,5 @@
 import { NoteFormat } from '../models/Note';
+import type { MarkedStyles } from 'react-native-marked';
 
 interface ColorPalette {
   text: string;
@@ -41,14 +42,14 @@ export function stripTopMetadata(raw: string, format: NoteFormat): string {
   return raw;
 }
 
-export function getMarkdownStyles(colors: ColorPalette, isDark: boolean) {
+export function getMarkdownStyles(colors: ColorPalette, isDark: boolean): MarkedStyles {
   return {
-    body: { fontSize: 16, lineHeight: 26, color: colors.text, marginTop: 0, paddingTop: 6 },
-    heading1: { fontSize: 28, lineHeight: 38, fontWeight: 'bold' as const, marginBottom: 12, marginTop: 8, color: colors.text },
-    heading2: { fontSize: 22, lineHeight: 32, fontWeight: 'bold' as const, marginBottom: 10, marginTop: 8, color: colors.text },
-    heading3: { fontSize: 18, lineHeight: 26, fontWeight: '600' as const, marginBottom: 8, marginTop: 6, color: colors.text },
+    text: { fontSize: 16, lineHeight: 26, color: colors.text },
+    h1: { fontSize: 28, lineHeight: 38, fontWeight: 'bold', marginBottom: 12, marginTop: 8, color: colors.text },
+    h2: { fontSize: 22, lineHeight: 32, fontWeight: 'bold', marginBottom: 10, marginTop: 8, color: colors.text },
+    h3: { fontSize: 18, lineHeight: 26, fontWeight: '600', marginBottom: 8, marginTop: 6, color: colors.text },
     paragraph: { marginTop: 0, marginBottom: 12 },
-    code_inline: {
+    codespan: {
       backgroundColor: isDark ? '#2c2c2e' : '#f0f0f0',
       paddingHorizontal: 4,
       borderRadius: 4,
@@ -56,23 +57,11 @@ export function getMarkdownStyles(colors: ColorPalette, isDark: boolean) {
       fontSize: 14,
       color: colors.text,
     },
-    code_block: {
+    code: {
       backgroundColor: isDark ? '#2c2c2e' : '#f5f5f5',
       padding: 12,
       borderRadius: 8,
-      fontFamily: 'monospace',
-      fontSize: 14,
       marginVertical: 8,
-      color: colors.text,
-    },
-    fence: {
-      backgroundColor: isDark ? '#2c2c2e' : '#f5f5f5',
-      padding: 12,
-      borderRadius: 8,
-      fontFamily: 'monospace',
-      fontSize: 14,
-      marginVertical: 8,
-      color: colors.text,
     },
     blockquote: {
       backgroundColor: colors.primary + '15',
@@ -83,9 +72,8 @@ export function getMarkdownStyles(colors: ColorPalette, isDark: boolean) {
       marginVertical: 8,
     },
     link: { color: colors.primary },
-    list_item: { marginBottom: 4, color: colors.text },
-    bullet_list: { marginBottom: 12 },
-    ordered_list: { marginBottom: 12 },
+    li: { marginBottom: 4, color: colors.text },
+    list: { marginBottom: 12 },
     hr: { backgroundColor: colors.border, height: 1, marginVertical: 16 },
     strong: { color: colors.text },
     em: { color: colors.text },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,6 +1823,16 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsamr/counter-style@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@jsamr/counter-style/-/counter-style-2.0.2.tgz#6f08cfa98e1f0416dc1d7f2d8ac38a8cdb004c5d"
+  integrity sha512-2mXudGVtSzVxWEA7B9jZLKjoXUeUFYDDtFrQoC0IFX9/Dszz4t1vZOmafi3JSw/FxD+udMQ+4TAFR8Qs0J3URQ==
+
+"@jsamr/react-native-li@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@jsamr/react-native-li/-/react-native-li-2.3.1.tgz#12a5b5f6e3971cec77b96bee58104eed0ae9314a"
+  integrity sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w==
+
 "@napi-rs/wasm-runtime@^0.2.11":
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
@@ -2879,11 +2889,6 @@ camelcase@^6.2.0, camelcase@^6.3.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-camelize@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
-  integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
-
 caniuse-lite@^1.0.30001782:
   version "1.0.30001791"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz#dfb93d85c40ad380c57123e72e10f3c575786b51"
@@ -3141,26 +3146,12 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-color-keywords@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
-  integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
-
 css-in-js-utils@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz#640ae6a33646d401fc720c54fc61c42cd76ae2bb"
   integrity sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==
   dependencies:
     hyphenate-style-name "^1.0.3"
-
-css-to-react-native@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
-  integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
-  dependencies:
-    camelize "^1.0.0"
-    css-color-keywords "^1.0.0"
-    postcss-value-parser "^4.0.2"
 
 csstype@^3.0.2:
   version "3.2.3"
@@ -3345,11 +3336,6 @@ encodeurl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
-
-entities@^4.4.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
-  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 env-editor@^0.4.1:
   version "0.4.2"
@@ -3851,6 +3837,11 @@ getenv@^2.0.0:
   resolved "https://registry.yarnpkg.com/getenv/-/getenv-2.0.0.tgz#b1698c7b0f29588f4577d06c42c73a5b475c69e0"
   integrity sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==
 
+github-slugger@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-2.0.0.tgz#52cf2f9279a21eb6c59dd385b410f0c0adda8f1a"
+  integrity sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==
+
 glob@^10.5.0:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
@@ -3979,6 +3970,11 @@ hosted-git-info@^7.0.0:
   integrity sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==
   dependencies:
     lru-cache "^10.0.1"
+
+html-entities@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.6.0.tgz#7c64f1ea3b36818ccae3d3fb48b6974208e984f8"
+  integrity sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -4874,13 +4870,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.0.tgz#9ef238bfa6dc70bd8e7f9572b52d369af569b421"
-  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
-  dependencies:
-    uc.micro "^2.0.0"
-
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -4905,7 +4894,7 @@ log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-loose-envify@^1.0.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -4943,17 +4932,10 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
-markdown-it@^10.0.0, markdown-it@^14.0.0:
-  version "14.1.1"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.1.tgz#856f90b66fc39ae70affd25c1b18b581d7deee1f"
-  integrity sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==
-  dependencies:
-    argparse "^2.0.1"
-    entities "^4.4.0"
-    linkify-it "^5.0.0"
-    mdurl "^2.0.0"
-    punycode.js "^2.3.1"
-    uc.micro "^2.1.0"
+marked@17.0.4:
+  version "17.0.4"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-17.0.4.tgz#38293b06b0605db39107803f3398938bbbed1b28"
+  integrity sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==
 
 marky@^1.2.2:
   version "1.3.0"
@@ -4964,11 +4946,6 @@ math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
-
-mdurl@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
-  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
 memoize-one@^5.0.0:
   version "5.2.1"
@@ -5601,7 +5578,7 @@ ob1@0.83.7:
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -5845,7 +5822,7 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
-postcss-value-parser@^4.0.2, postcss-value-parser@^4.2.0:
+postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
@@ -5919,24 +5896,10 @@ prompts@^2.3.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.10, prop-types@^15.7.2:
-  version "15.8.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
-  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.13.1"
-
 proxy-from-env@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
   integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
-
-punycode.js@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
-  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
 punycode@^2.1.1:
   version "2.3.1"
@@ -6005,7 +5968,7 @@ react-freeze@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.4.tgz#cbbea2762b0368b05cbe407ddc9d518c57c6f3ad"
   integrity sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==
 
-react-is@^16.13.1, react-is@^16.7.0:
+react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -6019,13 +5982,6 @@ react-is@^19.1.0:
   version "19.2.5"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.5.tgz#7e7b54143e9313fed787b23fd4295d5a23872ad9"
   integrity sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==
-
-react-native-fit-image@^1.5.5:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/react-native-fit-image/-/react-native-fit-image-1.5.5.tgz#c660d1ad74b9dcaa1cba27a0d9c23837e000226c"
-  integrity sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==
-  dependencies:
-    prop-types "^15.5.10"
 
 react-native-gesture-handler@~2.28.0:
   version "2.28.0"
@@ -6041,15 +5997,23 @@ react-native-is-edge-to-edge@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.3.1.tgz#feb9a6a8faf0874298947edd556e5af22044e139"
   integrity sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==
 
-react-native-markdown-display@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-markdown-display/-/react-native-markdown-display-7.0.2.tgz#b6584cec8d6670c0141fb8780bc2f0710188a4c2"
-  integrity sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==
+react-native-marked@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-marked/-/react-native-marked-8.0.1.tgz#b0108d74761a79bf75a92f74caef780498bdfc05"
+  integrity sha512-lUAM/w9AxY54PP2BKHnDiarJ1+8s9R8HzkjnIrCkZO1fOSAdFn0XsAVMM4fGOP8QM4wIZcJhhvaW/5K7oGy5aQ==
   dependencies:
-    css-to-react-native "^3.0.0"
-    markdown-it "^10.0.0"
-    prop-types "^15.7.2"
-    react-native-fit-image "^1.5.5"
+    "@jsamr/counter-style" "2.0.2"
+    "@jsamr/react-native-li" "2.3.1"
+    github-slugger "2.0.0"
+    html-entities "2.6.0"
+    marked "17.0.4"
+    react-native-reanimated-table "0.0.2"
+    svg-parser "2.0.4"
+
+react-native-reanimated-table@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated-table/-/react-native-reanimated-table-0.0.2.tgz#015392dbc12fb03fd872d5a7eea9bc84c4f3a685"
+  integrity sha512-OeuqfU1AFEmHNTJlEOLWrV78JgAXnM0/ZrCm0Ab+9e5nwYJ+xab/UFXkNKz3Gyf08ZfLSNzwMQRjt3eZWPWoGA==
 
 react-native-reanimated@~4.1.1:
   version "4.1.7"
@@ -6730,6 +6694,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+svg-parser@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
+  integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
+
 synckit@^0.11.8:
   version "0.11.12"
   resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.11.12.tgz#abe74124264fbc00a48011b0d98bdc1cffb64a7b"
@@ -6881,11 +6850,6 @@ ua-parser-js@^1.0.35:
   version "1.0.41"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.41.tgz#bd04dc9ec830fcf9e4fad35cf22dcedd2e3b4e9c"
   integrity sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==
-
-uc.micro@^2.0.0, uc.micro@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
-  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 undici-types@~7.19.0:
   version "7.19.2"


### PR DESCRIPTION
## Summary
Fixes #258

Replaces the abandoned `react-native-markdown-display` (no commits in 2+ years) with actively maintained `react-native-marked` (v8, based on marked.js v17).

### Changes
- **Added**: `react-native-marked` dependency
- **Removed**: `react-native-markdown-display` dependency
- **Removed**: `markdown-it` resolutions/overrides from package.json (no longer needed)
- **New**: `src/utils/markdownRenderer.tsx` — custom `NotePreviewRenderer` class extending react-native-marked's `Renderer`, porting all custom rendering:
  - Canvas image detection and rendering (PNG fallback from JSON)
  - Internal link handling (`canvas:`, `note:`, `#heading-anchor` protocols)
  - Selectable text in code blocks, inline code, and body text
- **Updated**: `src/utils/preview.ts` — style keys remapped to react-native-marked's `MarkedStyles` format (`heading1`→`h1`, `code_inline`→`codespan`, `code_block`+`fence`→`code`, `bullet_list`+`ordered_list`→`list`)
- **Updated**: `src/screens/FileViewerScreen.tsx` — uses new Markdown component with `value` prop
- **Updated**: `src/screens/NoteEditorScreen.tsx` — uses `NotePreviewRenderer` for preview and live-preview modes

### Rendering parity
All markdown features preserved: headings, paragraphs, code blocks, inline code, blockquotes, links, images, lists, bold, italic, horizontal rules. Canvas images, internal navigation links, and text selectability all work.

## Test plan
- [x] `yarn ts:check` passes
- [x] All 14 test suites pass (117 tests)
- [ ] CI pipeline passes
- [ ] Manual: open a note in preview mode, verify markdown renders correctly
- [ ] Manual: verify canvas images display in note preview
- [ ] Manual: verify `note:` and `#anchor` links navigate correctly
- [ ] Manual: verify code blocks are selectable