### PR TITLE
refactor: migrate tree-view components to neumorphic UI primitives

### DIFF
--- a/src/components/FolderTreeView.tsx
+++ b/src/components/FolderTreeView.tsx
@@ -3,7 +3,6 @@ import {
   View,
   Text,
   StyleSheet,
-  TouchableOpacity,
   LayoutAnimation,
   Platform,
   UIManager,
@@ -12,6 +11,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Folder } from '../models/Folder';
 import { useTheme } from '../contexts/ThemeContext';
 import { DragDropBoundary, useDropTarget } from './dragdrop/DragDropContext';
+import { Group, GroupRow, IconButton } from './ui';
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
@@ -103,45 +103,44 @@ const FolderItem = ({
   }, [folder, onDrop]);
 
   const folderRow = (
-    <TouchableOpacity
-      style={[
-        styles.folderItem,
-        { backgroundColor: isSelected ? colors.primary + '20' : 'transparent' },
-        { paddingLeft: 16 + level * 20 },
-      ]}
+    <GroupRow
       onPress={handleSelect}
       onLongPress={onLongPress ? handleLongPress : undefined}
-      activeOpacity={0.7}
+      style={[
+        isSelected && { backgroundColor: colors.primary + '14' },
+        { paddingLeft: 16 + level * 20 },
+      ]}
+      leading={
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+          {hasChildren ? (
+            <IconButton size="sm" onPress={handleToggle} accessibilityLabel={isExpanded ? 'Collapse' : 'Expand'}>
+              <Ionicons
+                name={isExpanded ? 'chevron-down' : 'chevron-forward'}
+                size={14}
+                color={colors.textSecondary}
+              />
+            </IconButton>
+          ) : (
+            <View style={{ width: 36 }} />
+          )}
+          <Ionicons
+            name={isExpanded ? 'folder-open' : 'folder'}
+            size={20}
+            color={isSelected ? colors.primary : colors.textSecondary}
+          />
+        </View>
+      }
     >
-      <View style={styles.folderContent}>
-        {hasChildren ? (
-          <TouchableOpacity onPress={handleToggle} style={styles.chevronContainer}>
-            <Ionicons
-              name={isExpanded ? 'chevron-down' : 'chevron-forward'}
-              size={16}
-              color={colors.textSecondary}
-            />
-          </TouchableOpacity>
-        ) : (
-          <View style={styles.chevronContainer} />
-        )}
-        <Ionicons
-          name={isExpanded ? 'folder-open' : 'folder'}
-          size={20}
-          color={isSelected ? colors.primary : colors.textSecondary}
-          style={styles.folderIcon}
-        />
-        <Text
-          style={[
-            styles.folderName,
-            { color: isSelected ? colors.primary : colors.text },
-          ]}
-          numberOfLines={1}
-        >
-          {folder.name}
-        </Text>
-      </View>
-    </TouchableOpacity>
+      <Text
+        style={[
+          styles.folderName,
+          { color: isSelected ? colors.primary : colors.text },
+        ]}
+        numberOfLines={1}
+      >
+        {folder.name}
+      </Text>
+    </GroupRow>
   );
 
   return (
@@ -231,38 +230,37 @@ function FolderTreeViewContent({
   }, [onDropToFolder]);
 
   const rootFolderRow = (
-    <TouchableOpacity
+    <GroupRow
+      onPress={handleSelectRoot}
       style={[
-        styles.folderItem,
-        { backgroundColor: selectedFolderId === null ? colors.primary + '20' : 'transparent' },
+        selectedFolderId === null && { backgroundColor: colors.primary + '14' },
         { paddingLeft: 16 },
       ]}
-      onPress={handleSelectRoot}
-      activeOpacity={0.7}
+      leading={
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+          <View style={{ width: 36 }} />
+          <Ionicons
+            name="home"
+            size={20}
+            color={selectedFolderId === null ? colors.primary : colors.textSecondary}
+          />
+        </View>
+      }
     >
-      <View style={styles.folderContent}>
-        <View style={styles.chevronContainer} />
-        <Ionicons
-          name="home"
-          size={20}
-          color={selectedFolderId === null ? colors.primary : colors.textSecondary}
-          style={styles.folderIcon}
-        />
-        <Text
-          style={[
-            styles.folderName,
-            { color: selectedFolderId === null ? colors.primary : colors.text },
-          ]}
-          numberOfLines={1}
-        >
-          All Notes
-        </Text>
-      </View>
-    </TouchableOpacity>
+      <Text
+        style={[
+          styles.folderName,
+          { color: selectedFolderId === null ? colors.primary : colors.text },
+        ]}
+        numberOfLines={1}
+      >
+        All Notes
+      </Text>
+    </GroupRow>
   );
 
   return (
-    <View style={styles.container}>
+    <Group>
       {showRoot && (
         onDropToFolder ? (
           <FolderDropZone
@@ -304,7 +302,7 @@ function FolderTreeViewContent({
           </Text>
         </View>
       )}
-    </View>
+    </Group>
   );
 }
 
@@ -317,29 +315,8 @@ export default function FolderTreeView(props: FolderTreeViewProps) {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
   dropZone: {
     minHeight: 44,
-  },
-  folderItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 12,
-    paddingRight: 16,
-  },
-  folderContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
-  chevronContainer: {
-    width: 20,
-    alignItems: 'center',
-  },
-  folderIcon: {
-    marginHorizontal: 8,
   },
   folderName: {
     fontSize: 16,

--- a/src/components/RepoFileBrowser.tsx
+++ b/src/components/RepoFileBrowser.tsx
@@ -3,18 +3,16 @@ import {
   View,
   Text,
   StyleSheet,
-  TouchableOpacity,
   FlatList,
   ActivityIndicator,
   Alert,
-  TextInput,
-  Modal,
   ScrollView,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import { GitHubService, GitHubContent } from '../services/GitHubService';
 import { HapticService } from '../utils/haptics';
+import { Group, GroupRow, IconButton, Modal, Input, Button } from './ui';
 
 interface RepoFileItem {
   name: string;
@@ -310,8 +308,7 @@ export default function RepoFileBrowser({
   const renderItem = useCallback(({ item }: { item: RepoFileItem }) => {
     const isDir = item.type === 'dir';
     return (
-      <TouchableOpacity
-        style={[fileStyles.item, { borderBottomColor: colors.border }]}
+      <GroupRow
         onPress={() => {
           if (isDir) {
             navigateToFolder(item.path);
@@ -320,18 +317,18 @@ export default function RepoFileBrowser({
             onFilePress(item.path);
           }
         }}
-        onLongPress={() => {
-          if (isDir) handleFolderLongPress(item);
-        }}
-        activeOpacity={0.7}
+        onLongPress={isDir ? () => handleFolderLongPress(item) : undefined}
+        leading={
+          <Ionicons
+            name={isDir ? 'folder' : 'document-text'}
+            size={22}
+            color={isDir ? '#FF9500' : colors.primary}
+          />
+        }
+        trailing={isDir ? <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} /> : undefined}
+        style={fileStyles.itemRow}
       >
-        <Ionicons
-          name={isDir ? 'folder' : 'document-text'}
-          size={22}
-          color={isDir ? '#FF9500' : colors.primary}
-          style={fileStyles.itemIcon}
-        />
-        <View style={fileStyles.itemText}>
+        <View>
           <Text style={[fileStyles.itemName, { color: colors.text }]} numberOfLines={1}>
             {item.name}
           </Text>
@@ -339,10 +336,7 @@ export default function RepoFileBrowser({
             {item.path}
           </Text>
         </View>
-        {isDir && (
-          <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
-        )}
-      </TouchableOpacity>
+      </GroupRow>
     );
   }, [colors, navigateToFolder, onFilePress, handleFolderLongPress]);
 
@@ -356,19 +350,11 @@ export default function RepoFileBrowser({
     }
     return (
       <ScrollView horizontal showsHorizontalScrollIndicator={false} style={fileStyles.breadcrumb} contentContainerStyle={fileStyles.breadcrumbContent}>
-        <TouchableOpacity onPress={() => navigateToBreadcrumb(-1)}>
-          <Text style={[fileStyles.crumb, { color: !currentPath ? colors.primary : colors.textSecondary }]}>
-            {repo}
-          </Text>
-        </TouchableOpacity>
+        <Button variant="ghost" label={repo} onPress={() => navigateToBreadcrumb(-1)} textStyle={[fileStyles.crumb, { color: !currentPath ? colors.primary : colors.textSecondary }]} />
         {pathParts.map((part, i) => (
           <View key={`crumb-${part}`} style={{ flexDirection: 'row', alignItems: 'center' }}>
             <Text style={[fileStyles.crumbSep, { color: colors.textSecondary }]}> / </Text>
-            <TouchableOpacity onPress={() => navigateToBreadcrumb(i)}>
-              <Text style={[fileStyles.crumb, { color: i === pathParts.length - 1 ? colors.primary : colors.textSecondary }]}>
-                {part}
-              </Text>
-            </TouchableOpacity>
+            <Button variant="ghost" label={part} onPress={() => navigateToBreadcrumb(i)} textStyle={[fileStyles.crumb, { color: i === pathParts.length - 1 ? colors.primary : colors.textSecondary }]} />
           </View>
         ))}
       </ScrollView>
@@ -381,40 +367,42 @@ export default function RepoFileBrowser({
         {renderBreadcrumb()}
         <View style={fileStyles.headerActions}>
           {currentPath && browseMode === 'folder' ? (
-            <TouchableOpacity style={fileStyles.headerBtn} onPress={navigateUp}>
+            <IconButton size="sm" onPress={navigateUp} accessibilityLabel="Go back">
               <Ionicons name="arrow-back" size={20} color={colors.primary} />
-            </TouchableOpacity>
+            </IconButton>
           ) : null}
-          <TouchableOpacity
-            style={fileStyles.headerBtn}
+          <IconButton
+            size="sm"
             onPress={() => {
               HapticService.light();
               setBrowseMode((m) => (m === 'folder' ? 'all' : 'folder'));
               setCurrentPath('');
             }}
+            accessibilityLabel="Toggle browse mode"
           >
             <Ionicons
               name={browseMode === 'all' ? 'list' : 'folder'}
               size={20}
               color={browseMode === 'all' ? colors.primary : colors.textSecondary}
             />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={fileStyles.headerBtn}
+          </IconButton>
+          <IconButton
+            size="sm"
             onPress={() => { HapticService.light(); onCreateNoteInFolder(currentPath); }}
+            accessibilityLabel="Create note"
           >
             <Ionicons name="add" size={22} color={colors.primary} />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={fileStyles.headerBtn}
+          </IconButton>
+          <IconButton
+            size="sm"
             onPress={() => { HapticService.light(); setShowNewFolderModal(true); }}
+            accessibilityLabel="New folder"
           >
             <Ionicons name="folder-outline" size={20} color={colors.primary} />
-            <Ionicons name="add" size={12} color={colors.primary} style={fileStyles.badge} />
-          </TouchableOpacity>
-          <TouchableOpacity style={fileStyles.headerBtn} onPress={loadContents}>
+          </IconButton>
+          <IconButton size="sm" onPress={loadContents} accessibilityLabel="Refresh">
             <Ionicons name="refresh" size={20} color={colors.textSecondary} />
-          </TouchableOpacity>
+          </IconButton>
         </View>
       </View>
 
@@ -423,134 +411,93 @@ export default function RepoFileBrowser({
           <ActivityIndicator size="large" color={colors.primary} />
         </View>
       ) : (
-        <FlatList
-          data={items}
-          keyExtractor={(item) => item.path}
-          renderItem={renderItem}
-          contentContainerStyle={items.length === 0 ? fileStyles.emptyList : fileStyles.listContent}
-          ListEmptyComponent={
-            <View style={fileStyles.emptyContainer}>
-              <Ionicons name="folder-open-outline" size={48} color={colors.textSecondary} />
-              <Text style={[fileStyles.emptyTitle, { color: colors.text }]}>Empty Folder</Text>
-              <Text style={[fileStyles.emptySub, { color: colors.textSecondary }]}>
-                Create a note or folder to get started
-              </Text>
-            </View>
-          }
-        />
+        <Group style={{ flex: 1 }}>
+          <FlatList
+            data={items}
+            keyExtractor={(item) => item.path}
+            renderItem={renderItem}
+            contentContainerStyle={items.length === 0 ? fileStyles.emptyList : fileStyles.listContent}
+            ListEmptyComponent={
+              <View style={fileStyles.emptyContainer}>
+                <Ionicons name="folder-open-outline" size={48} color={colors.textSecondary} />
+                <Text style={[fileStyles.emptyTitle, { color: colors.text }]}>Empty Folder</Text>
+                <Text style={[fileStyles.emptySub, { color: colors.textSecondary }]}>
+                  Create a note or folder to get started
+                </Text>
+              </View>
+            }
+          />
+        </Group>
       )}
 
-      <Modal visible={showNewFolderModal} transparent animationType="fade">
-        <View style={fileStyles.modalOverlay}>
-          <View style={[fileStyles.modalSheet, { backgroundColor: colors.surface }]}>
-            <Text style={[fileStyles.modalTitle, { color: colors.text }]}>New Folder</Text>
-            <TextInput
-              style={[fileStyles.modalInput, { color: colors.text, borderColor: colors.border, backgroundColor: colors.background }]}
-              placeholder="Folder name"
-              placeholderTextColor={colors.textSecondary}
-              value={newFolderName}
-              onChangeText={setNewFolderName}
-              autoFocus
-              autoCapitalize="none"
-              autoCorrect={false}
-              returnKeyType="done"
-              onSubmitEditing={handleCreateFolder}
-            />
-            <View style={fileStyles.modalButtons}>
-              <TouchableOpacity
-                style={[fileStyles.modalBtn, { borderColor: colors.border }]}
-                onPress={() => { setShowNewFolderModal(false); setNewFolderName(''); }}
-              >
-                <Text style={[fileStyles.modalBtnText, { color: colors.textSecondary }]}>Cancel</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[fileStyles.modalBtn, { backgroundColor: colors.primary }]}
-                onPress={handleCreateFolder}
-                disabled={!newFolderName.trim() || isCreating}
-              >
-                {isCreating
-                  ? <ActivityIndicator size="small" color="#fff" />
-                  : <Text style={fileStyles.modalBtnPrimary}>Create</Text>
-                }
-              </TouchableOpacity>
-            </View>
-          </View>
+      <Modal visible={showNewFolderModal} onRequestClose={() => { setShowNewFolderModal(false); setNewFolderName(''); }}>
+        <Text style={[fileStyles.modalTitle, { color: colors.text }]}>New Folder</Text>
+        <Input
+          value={newFolderName}
+          onChangeText={setNewFolderName}
+          placeholder="Folder name"
+          autoFocus
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="done"
+          onSubmitEditing={handleCreateFolder}
+        />
+        <View style={fileStyles.modalButtons}>
+          <Button variant="secondary" label="Cancel" onPress={() => { setShowNewFolderModal(false); setNewFolderName(''); }} />
+          <Button variant="primary" label="Create" onPress={handleCreateFolder} disabled={!newFolderName.trim() || isCreating} />
         </View>
       </Modal>
 
-      <Modal visible={showMoveFolderDialog} animationType="slide" onRequestClose={() => setShowMoveFolderDialog(false)}>
-        <View style={[fileStyles.moveDialogContainer, { backgroundColor: colors.background }]}>
-          <View style={[fileStyles.moveDialogHeader, { borderBottomColor: colors.border }]}>
-            <TouchableOpacity onPress={() => { setShowMoveFolderDialog(false); setFolderToMove(null); }} style={fileStyles.headerBtn}>
-              <Text style={[fileStyles.headerBtnText, { color: colors.primary }]}>Cancel</Text>
-            </TouchableOpacity>
-            <Text style={[fileStyles.moveDialogTitle, { color: colors.text }]}>Move "{folderToMove?.name}"</Text>
-            <TouchableOpacity
-              onPress={handleMoveFolderConfirm}
-              disabled={isMovingFolder}
-              style={fileStyles.headerBtn}
-            >
-              {isMovingFolder
-                ? <ActivityIndicator size="small" color={colors.primary} />
-                : <Text style={[fileStyles.headerBtnText, { color: colors.primary, fontWeight: '600' }]}>Move</Text>
-              }
-            </TouchableOpacity>
-          </View>
-
-    <ScrollView horizontal showsHorizontalScrollIndicator={false} style={fileStyles.breadcrumb} contentContainerStyle={fileStyles.breadcrumbContent}>
-            <TouchableOpacity onPress={() => navigateMoveDialogBreadcrumb(-1)}>
-              <Text style={[fileStyles.crumb, { color: !moveDialogPath ? colors.primary : colors.textSecondary }]}>
-                {repo}
-              </Text>
-            </TouchableOpacity>
-            {moveDialogPathParts.map((part, i) => (
-              <View key={`mc-${part}`} style={{ flexDirection: 'row', alignItems: 'center' }}>
-                <Text style={[fileStyles.crumbSep, { color: colors.textSecondary }]}> / </Text>
-                <TouchableOpacity onPress={() => navigateMoveDialogBreadcrumb(i)}>
-                  <Text style={[fileStyles.crumb, { color: i === moveDialogPathParts.length - 1 ? colors.primary : colors.textSecondary }]}>
-                    {part}
-                  </Text>
-                </TouchableOpacity>
-              </View>
-            ))}
-          </ScrollView>
-
-          <View style={[fileStyles.moveDestination, { backgroundColor: colors.primary + '10', borderColor: colors.primary + '30' }]}>
-            <Ionicons name="folder-open-outline" size={18} color={colors.primary} />
-            <Text style={[fileStyles.moveDestText, { color: colors.primary }]}>
-              Move to: {moveDialogPath || '(root)'}
-            </Text>
-          </View>
-
-          {moveDialogLoading ? (
-            <View style={fileStyles.loading}>
-              <ActivityIndicator size="large" color={colors.primary} />
-            </View>
-          ) : (
-            <FlatList
-              data={moveDialogFolders}
-              keyExtractor={(item) => item.path}
-              renderItem={({ item }) => (
-                <TouchableOpacity
-                  style={[fileStyles.item, { borderBottomColor: colors.border }]}
-                  onPress={() => loadMoveDialogFolders(item.path)}
-                  activeOpacity={0.7}
-                >
-                  <Ionicons name="folder" size={22} color="#FF9500" style={fileStyles.itemIcon} />
-                  <Text style={[fileStyles.itemName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
-                  <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
-                </TouchableOpacity>
-              )}
-              contentContainerStyle={moveDialogFolders.length === 0 ? fileStyles.emptyList : undefined}
-              ListEmptyComponent={
-                <View style={fileStyles.emptyContainer}>
-                  <Ionicons name="folder-open-outline" size={40} color={colors.textSecondary} />
-                  <Text style={[fileStyles.emptySub, { color: colors.textSecondary }]}>No subfolders</Text>
-                </View>
-              }
-            />
-          )}
+      <Modal visible={showMoveFolderDialog} onRequestClose={() => setShowMoveFolderDialog(false)} fullWidth>
+        <View style={[fileStyles.moveDialogHeader, { borderBottomColor: colors.border }]}>
+          <Button variant="ghost" label="Cancel" onPress={() => { setShowMoveFolderDialog(false); setFolderToMove(null); }} />
+          <Text style={[fileStyles.moveDialogTitle, { color: colors.text }]}>Move "{folderToMove?.name}"</Text>
+          <Button variant="ghost" label="Move" onPress={handleMoveFolderConfirm} disabled={isMovingFolder} textStyle={{ fontWeight: '600' }} />
         </View>
+
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={fileStyles.breadcrumb} contentContainerStyle={fileStyles.breadcrumbContent}>
+          <Button variant="ghost" label={repo} onPress={() => navigateMoveDialogBreadcrumb(-1)} textStyle={[fileStyles.crumb, { color: !moveDialogPath ? colors.primary : colors.textSecondary }]} />
+          {moveDialogPathParts.map((part, i) => (
+            <View key={`mc-${part}`} style={{ flexDirection: 'row', alignItems: 'center' }}>
+              <Text style={[fileStyles.crumbSep, { color: colors.textSecondary }]}> / </Text>
+              <Button variant="ghost" label={part} onPress={() => navigateMoveDialogBreadcrumb(i)} textStyle={[fileStyles.crumb, { color: i === moveDialogPathParts.length - 1 ? colors.primary : colors.textSecondary }]} />
+            </View>
+          ))}
+        </ScrollView>
+
+        <View style={[fileStyles.moveDestination, { backgroundColor: colors.primary + '10', borderColor: colors.primary + '30' }]}>
+          <Ionicons name="folder-open-outline" size={18} color={colors.primary} />
+          <Text style={[fileStyles.moveDestText, { color: colors.primary }]}>
+            Move to: {moveDialogPath || '(root)'}
+          </Text>
+        </View>
+
+        {moveDialogLoading ? (
+          <View style={fileStyles.loading}>
+            <ActivityIndicator size="large" color={colors.primary} />
+          </View>
+        ) : (
+          <FlatList
+            data={moveDialogFolders}
+            keyExtractor={(item) => item.path}
+            renderItem={({ item }) => (
+              <GroupRow
+                onPress={() => loadMoveDialogFolders(item.path)}
+                leading={<Ionicons name="folder" size={22} color="#FF9500" />}
+                trailing={<Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />}
+              >
+                <Text style={[fileStyles.itemName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
+              </GroupRow>
+            )}
+            contentContainerStyle={moveDialogFolders.length === 0 ? fileStyles.emptyList : undefined}
+            ListEmptyComponent={
+              <View style={fileStyles.emptyContainer}>
+                <Ionicons name="folder-open-outline" size={40} color={colors.textSecondary} />
+                <Text style={[fileStyles.emptySub, { color: colors.textSecondary }]}>No subfolders</Text>
+              </View>
+            }
+          />
+        )}
       </Modal>
     </View>
   );
@@ -571,17 +518,6 @@ const fileStyles = StyleSheet.create({
     alignItems: 'center',
     gap: 4,
   },
-  headerBtn: {
-    padding: 8,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  headerBtnText: { fontSize: 16 },
-  badge: {
-    position: 'absolute',
-    top: 4,
-    right: 4,
-  },
   breadcrumb: {
     flex: 1,
   },
@@ -596,19 +532,7 @@ const fileStyles = StyleSheet.create({
   crumbSep: {
     fontSize: 14,
   },
-  item: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-  },
-  itemIcon: {
-    marginRight: 12,
-  },
-  itemText: {
-    flex: 1,
-  },
+  itemRow: {},
   itemName: {
     fontSize: 16,
     fontWeight: '500',
@@ -645,66 +569,29 @@ const fileStyles = StyleSheet.create({
     marginTop: 4,
     textAlign: 'center',
   },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
-  },
-  modalSheet: {
-    width: '100%',
-    borderRadius: 16,
-    padding: 20,
-  },
   modalTitle: {
     fontSize: 18,
     fontWeight: '600',
     marginBottom: 16,
   },
-  modalInput: {
-    borderWidth: 1,
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    fontSize: 15,
-    marginBottom: 16,
-  },
   modalButtons: {
     flexDirection: 'row',
     gap: 8,
+    marginTop: 16,
+    justifyContent: 'flex-end',
   },
-  modalBtn: {
-    flex: 1,
-    paddingVertical: 12,
-    borderRadius: 10,
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: 'transparent',
-  },
-  modalBtnText: {
-    fontSize: 15,
-    fontWeight: '600',
-  },
-  modalBtnPrimary: {
-    color: '#fff',
-    fontSize: 15,
-    fontWeight: '600',
-  },
-  moveDialogContainer: { flex: 1 },
   moveDialogHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
+    paddingBottom: 12,
     borderBottomWidth: 1,
+    marginBottom: 8,
   },
   moveDialogTitle: { fontSize: 17, fontWeight: '600', flex: 1, textAlign: 'center' },
   moveDestination: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginHorizontal: 16,
     marginTop: 12,
     marginBottom: 8,
     paddingHorizontal: 12,

--- a/src/components/RepoFileTree.tsx
+++ b/src/components/RepoFileTree.tsx
@@ -3,22 +3,19 @@ import {
   View,
   Text,
   StyleSheet,
-  TouchableOpacity,
   ActivityIndicator,
   LayoutAnimation,
   Platform,
   UIManager,
-  Modal,
-  TextInput,
   Alert,
   ScrollView,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import { GitHubService, GitHubContent } from '../services/GitHubService';
 import { HapticService } from '../utils/haptics';
 import ContextMenu from './ContextMenu';
+import { Group, GroupRow, IconButton, Modal, Input, Button } from './ui';
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
@@ -110,7 +107,7 @@ interface RenameDialogProps {
 function RenameDialog({ visible, node, onClose, onRename }: RenameDialogProps) {
   const { colors } = useTheme();
   const [name, setName] = useState('');
-  const inputRef = useRef<TextInput>(null);
+  const inputRef = useRef<any>(null);
 
   useEffect(() => {
     if (visible && node) {
@@ -140,37 +137,29 @@ function RenameDialog({ visible, node, onClose, onRename }: RenameDialogProps) {
   if (!node) return null;
 
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <View style={dialogStyles.overlay}>
-        <View style={[dialogStyles.card, { backgroundColor: colors.surface }]}>
-          <Text style={[dialogStyles.title, { color: colors.text }]}>Rename</Text>
-          <Text style={[dialogStyles.subtitle, { color: colors.textSecondary }]}>
-            {node.name}
-          </Text>
-          <TextInput
-            ref={inputRef}
-            style={[dialogStyles.input, { color: colors.text, borderColor: colors.border, backgroundColor: colors.background }]}
-            value={name}
-            onChangeText={setName}
-            autoCapitalize="none"
-            autoCorrect={false}
-            selectTextOnFocus
-            returnKeyType="done"
-            onSubmitEditing={handleRename}
-          />
-          <View style={dialogStyles.buttons}>
-            <TouchableOpacity onPress={onClose} style={dialogStyles.button}>
-              <Text style={[dialogStyles.buttonText, { color: colors.textSecondary }]}>Cancel</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={handleRename}
-              style={[dialogStyles.button, dialogStyles.primaryButton, { backgroundColor: colors.primary }]}
-              disabled={!name.trim() || name.trim() === (node.type === 'file' ? node.name.replace(/\.[^.]+$/, '') : node.name)}
-            >
-              <Text style={[dialogStyles.buttonText, { color: '#fff' }]}>Rename</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
+    <Modal visible={visible} onRequestClose={onClose}>
+      <Text style={[dialogStyles.title, { color: colors.text }]}>Rename</Text>
+      <Text style={[dialogStyles.subtitle, { color: colors.textSecondary }]}>
+        {node.name}
+      </Text>
+      <Input
+        ref={inputRef}
+        value={name}
+        onChangeText={setName}
+        autoCapitalize="none"
+        autoCorrect={false}
+        selectTextOnFocus
+        returnKeyType="done"
+        onSubmitEditing={handleRename}
+      />
+      <View style={dialogStyles.buttons}>
+        <Button variant="secondary" label="Cancel" onPress={onClose} />
+        <Button
+          variant="primary"
+          label="Rename"
+          onPress={handleRename}
+          disabled={!name.trim() || name.trim() === (node.type === 'file' ? node.name.replace(/\.[^.]+$/, '') : node.name)}
+        />
       </View>
     </Modal>
   );
@@ -192,7 +181,7 @@ function MoveDialog({ visible, node, owner, repo, branch, onClose, onMove }: Mov
   const [loading, setLoading] = useState(false);
   const [selectedPath, setSelectedPath] = useState('');
   const [customPath, setCustomPath] = useState('');
-  const inputRef = useRef<TextInput>(null);
+  const inputRef = useRef<any>(null);
 
   useEffect(() => {
     if (visible && node) {
@@ -221,78 +210,65 @@ function MoveDialog({ visible, node, owner, repo, branch, onClose, onMove }: Mov
   if (!node) return null;
 
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <View style={dialogStyles.overlay}>
-        <View style={[dialogStyles.card, { backgroundColor: colors.surface }, { maxHeight: '80%' }]}>
-          <Text style={[dialogStyles.title, { color: colors.text }]}>Move</Text>
-          <Text style={[dialogStyles.subtitle, { color: colors.textSecondary }]}>
-            {node.name}
-          </Text>
+    <Modal visible={visible} onRequestClose={onClose} contentStyle={{ maxHeight: '80%' }}>
+      <Text style={[dialogStyles.title, { color: colors.text }]}>Move</Text>
+      <Text style={[dialogStyles.subtitle, { color: colors.textSecondary }]}>
+        {node.name}
+      </Text>
 
-          <Text style={[dialogStyles.label, { color: colors.textSecondary }]}>Destination folder</Text>
+      <Text style={[dialogStyles.label, { color: colors.textSecondary }]}>Destination folder</Text>
 
-          {loading ? (
-            <ActivityIndicator size="small" color={colors.primary} style={{ marginVertical: 12 }} />
-          ) : (
-            <ScrollView style={dialogStyles.folderList} keyboardShouldPersistTaps="handled">
-              <TouchableOpacity
-                style={[
-                  dialogStyles.folderItem,
-                  { borderColor: colors.border },
-                  selectedPath === '' && { backgroundColor: colors.primary + '15', borderColor: colors.primary },
-                ]}
-                onPress={() => { setSelectedPath(''); setCustomPath(''); }}
-              >
-                <Ionicons name="home-outline" size={16} color={selectedPath === '' ? colors.primary : colors.textSecondary} />
-                <Text style={[dialogStyles.folderItemText, { color: selectedPath === '' ? colors.primary : colors.text }]}>
-                  / (root)
-                </Text>
-              </TouchableOpacity>
-              {folders.map(folder => (
-                <TouchableOpacity
-                  key={folder.path}
-                  style={[
-                    dialogStyles.folderItem,
-                    { borderColor: colors.border },
-                    selectedPath === folder.path && { backgroundColor: colors.primary + '15', borderColor: colors.primary },
-                  ]}
-                  onPress={() => { setSelectedPath(folder.path); setCustomPath(''); }}
-                >
-                  <Ionicons name="folder-outline" size={16} color={selectedPath === folder.path ? colors.primary : '#FF9500'} />
-                  <Text style={[dialogStyles.folderItemText, { color: selectedPath === folder.path ? colors.primary : colors.text }]}>
-                    {folder.path}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </ScrollView>
-          )}
-
-          <Text style={[dialogStyles.label, { color: colors.textSecondary, marginTop: 8 }]}>Or type a path</Text>
-          <TextInput
-            ref={inputRef}
-            style={[dialogStyles.input, { color: colors.text, borderColor: colors.border, backgroundColor: colors.background }]}
-            placeholder="e.g. notes/archive"
-            placeholderTextColor={colors.textSecondary}
-            value={customPath}
-            onChangeText={(text) => { setCustomPath(text); if (text) setSelectedPath(''); }}
-            autoCapitalize="none"
-            autoCorrect={false}
-            returnKeyType="done"
-          />
-
-          <View style={dialogStyles.buttons}>
-            <TouchableOpacity onPress={onClose} style={dialogStyles.button}>
-              <Text style={[dialogStyles.buttonText, { color: colors.textSecondary }]}>Cancel</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={handleMove}
-              style={[dialogStyles.button, dialogStyles.primaryButton, { backgroundColor: colors.primary }]}
-              disabled={!selectedPath && !customPath.trim()}
+      {loading ? (
+        <ActivityIndicator size="small" color={colors.primary} style={{ marginVertical: 12 }} />
+      ) : (
+        <ScrollView style={dialogStyles.folderList} keyboardShouldPersistTaps="handled">
+          <GroupRow
+            onPress={() => { setSelectedPath(''); setCustomPath(''); }}
+            style={[
+              selectedPath === '' && { backgroundColor: colors.primary + '15' },
+            ]}
+            leading={<Ionicons name="home-outline" size={16} color={selectedPath === '' ? colors.primary : colors.textSecondary} />}
+          >
+            <Text style={[dialogStyles.folderItemText, { color: selectedPath === '' ? colors.primary : colors.text }]}>
+              / (root)
+            </Text>
+          </GroupRow>
+          {folders.map(folder => (
+            <GroupRow
+              key={folder.path}
+              onPress={() => { setSelectedPath(folder.path); setCustomPath(''); }}
+              style={[
+                selectedPath === folder.path && { backgroundColor: colors.primary + '15' },
+              ]}
+              leading={<Ionicons name="folder-outline" size={16} color={selectedPath === folder.path ? colors.primary : '#FF9500'} />}
             >
-              <Text style={[dialogStyles.buttonText, { color: '#fff' }]}>Move</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
+              <Text style={[dialogStyles.folderItemText, { color: selectedPath === folder.path ? colors.primary : colors.text }]}>
+                {folder.path}
+              </Text>
+            </GroupRow>
+          ))}
+        </ScrollView>
+      )}
+
+      <Text style={[dialogStyles.label, { color: colors.textSecondary, marginTop: 8 }]}>Or type a path</Text>
+      <Input
+        ref={inputRef}
+        value={customPath}
+        onChangeText={(text) => { setCustomPath(text); if (text) setSelectedPath(''); }}
+        placeholder="e.g. notes/archive"
+        autoCapitalize="none"
+        autoCorrect={false}
+        returnKeyType="done"
+      />
+
+      <View style={dialogStyles.buttons}>
+        <Button variant="secondary" label="Cancel" onPress={onClose} />
+        <Button
+          variant="primary"
+          label="Move"
+          onPress={handleMove}
+          disabled={!selectedPath && !customPath.trim()}
+        />
       </View>
     </Modal>
   );
@@ -471,51 +447,55 @@ function TreeItem({ node, owner, repo, branch, level, onFilePress, onRefresh }: 
 
   return (
     <View>
-      <TouchableOpacity
-        style={[
-          treeStyles.row,
-          { paddingLeft: 16 + level * 20 },
-        ]}
+      <GroupRow
         onPress={isDir ? handleToggle : handleFilePress}
         onLongPress={handleLongPress}
-        activeOpacity={0.6}
         disabled={isOperating}
-      >
-        <View style={treeStyles.chevronSlot}>
-          {isDir ? (
-            loading ? (
-              <ActivityIndicator size="small" color={colors.textSecondary} style={treeStyles.loader} />
+        style={{ paddingLeft: 16 + level * 20 }}
+        leading={
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+            {isDir ? (
+              loading ? (
+                <ActivityIndicator size="small" color={colors.textSecondary} style={treeStyles.loader} />
+              ) : (
+                <IconButton size="sm" onPress={handleToggle} accessibilityLabel={expanded ? 'Collapse' : 'Expand'}>
+                  <Ionicons
+                    name={expanded ? 'chevron-down' : 'chevron-forward'}
+                    size={14}
+                    color={colors.textSecondary}
+                  />
+                </IconButton>
+              )
             ) : (
-              <Ionicons
-                name={expanded ? 'chevron-down' : 'chevron-forward'}
-                size={16}
-                color={colors.textSecondary}
-              />
-            )
-          ) : (
-            <View style={treeStyles.chevronPlaceholder} />
-          )}
-        </View>
-        <Ionicons name={iconName} size={20} color={iconColor} style={treeStyles.icon} />
+              <View style={{ width: 36 }} />
+            )}
+            <Ionicons name={iconName} size={20} color={iconColor} />
+          </View>
+        }
+        trailing={
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+            {isOperating && (
+              <ActivityIndicator size="small" color={colors.primary} />
+            )}
+            {!isDir && (
+              <View style={treeStyles.fileMetaRow}>
+                {node.size != null ? (
+                  <Text style={[treeStyles.size, { color: colors.textSecondary }]}>
+                    {formatBytes(node.size)}
+                  </Text>
+                ) : null}
+                <Text style={[treeStyles.ext, { color: colors.textSecondary }]}>
+                  {node.name.split('.').pop()}
+                </Text>
+              </View>
+            )}
+          </View>
+        }
+      >
         <Text style={[treeStyles.name, { color: colors.text }]} numberOfLines={1}>
           {node.name}
         </Text>
-        {isOperating && (
-          <ActivityIndicator size="small" color={colors.primary} style={treeStyles.opIndicator} />
-        )}
-        {!isDir && (
-          <View style={treeStyles.fileMetaRow}>
-            {node.size != null ? (
-              <Text style={[treeStyles.size, { color: colors.textSecondary }]}>
-                {formatBytes(node.size)}
-              </Text>
-            ) : null}
-            <Text style={[treeStyles.ext, { color: colors.textSecondary }]}>
-              {node.name.split('.').pop()}
-            </Text>
-          </View>
-        )}
-      </TouchableOpacity>
+      </GroupRow>
 
       {expanded && children.map((child) => (
         <TreeItem
@@ -713,9 +693,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
       <View style={treeStyles.center}>
         <Ionicons name="alert-circle-outline" size={40} color={colors.textSecondary} />
         <Text style={[treeStyles.emptyText, { color: colors.text }]}>Failed to load</Text>
-        <TouchableOpacity onPress={loadRoot} style={[treeStyles.retryBtn, { borderColor: colors.border }]}>
-          <Text style={[treeStyles.retryText, { color: colors.primary }]}>Retry</Text>
-        </TouchableOpacity>
+        <Button variant="secondary" label="Retry" onPress={loadRoot} style={{ marginTop: 8 }} />
       </View>
     );
   }
@@ -733,7 +711,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
   }
 
   return (
-    <View style={treeStyles.container}>
+    <Group style={{ flex: 1 }}>
       {rootItems.map((item) => (
         <TreeItem
           key={item.path}
@@ -746,33 +724,19 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
           onRefresh={loadRoot}
         />
       ))}
-    </View>
+    </Group>
   );
 }
 
 const treeStyles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingVertical: 11,
     paddingRight: 16,
   },
-  chevronSlot: {
-    width: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  chevronPlaceholder: {
-    width: 16,
-  },
   loader: {
     transform: [{ scale: 0.7 }],
-  },
-  icon: {
-    marginHorizontal: 8,
   },
   name: {
     fontSize: 15,
@@ -790,9 +754,6 @@ const treeStyles = StyleSheet.create({
   },
   size: {
     fontSize: 11,
-  },
-  opIndicator: {
-    marginHorizontal: 4,
   },
   center: {
     flex: 1,
@@ -813,41 +774,17 @@ const treeStyles = StyleSheet.create({
   emptySub: {
     fontSize: 13,
   },
-  retryBtn: {
-    marginTop: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 8,
-    borderWidth: 1,
-  },
-  retryText: {
-    fontSize: 14,
-    fontWeight: '600',
-  },
 });
 
 const dialogStyles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
-  },
-  card: {
-    width: '100%',
-    maxWidth: 400,
-    borderRadius: 16,
-    padding: 20,
-    gap: 8,
-  },
   title: {
     fontSize: 18,
     fontWeight: '700',
+    marginBottom: 4,
   },
   subtitle: {
     fontSize: 13,
-    marginBottom: 4,
+    marginBottom: 8,
   },
   label: {
     fontSize: 12,
@@ -855,92 +792,19 @@ const dialogStyles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 0.5,
     marginTop: 4,
-  },
-  input: {
-    height: 44,
-    borderWidth: 1,
-    borderRadius: 10,
-    paddingHorizontal: 12,
-    fontSize: 15,
+    marginBottom: 4,
   },
   buttons: {
     flexDirection: 'row',
     justifyContent: 'flex-end',
     gap: 8,
-    marginTop: 8,
-  },
-  button: {
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    borderRadius: 10,
-    minWidth: 70,
-    alignItems: 'center',
-  },
-  primaryButton: {
-  },
-  buttonText: {
-    fontSize: 15,
-    fontWeight: '600',
+    marginTop: 12,
   },
   folderList: {
     maxHeight: 200,
-    borderWidth: 1,
-    borderRadius: 10,
-    padding: 4,
-  },
-  folderItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderRadius: 8,
-    borderWidth: 1,
-    gap: 8,
-    marginVertical: 2,
   },
   folderItemText: {
     fontSize: 14,
   },
 });
 
-const contextStyles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
-  },
-  menu: {
-    width: '100%',
-    maxWidth: 300,
-    borderRadius: 14,
-    overflow: 'hidden',
-  },
-  menuHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    gap: 8,
-  },
-  menuHeaderTitle: {
-    fontSize: 14,
-    fontWeight: '500',
-    flex: 1,
-  },
-  menuItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    gap: 12,
-  },
-  menuItemText: {
-    fontSize: 16,
-  },
-  menuDivider: {
-    height: StyleSheet.hairlineWidth,
-  },
-});


### PR DESCRIPTION
## Summary
Fixes #219

Migrates three nested-tree components to use neumorphic UI primitives from `src/components/ui/`.

### Changes
- **FolderTreeView.tsx**: Folder rows → `GroupRow`, carets → `IconButton size="sm"`, entire tree wrapped in single `<Group>` (one shadow per viewport, never per-row Surfaces)
- **RepoFileBrowser.tsx**: Header action buttons → `IconButton`, file rows → `GroupRow`, modals → `Modal` + `Input` + `Button`, FlatList wrapped in `Group`, breadcrumb crumbs → `Button variant="ghost"`
- **RepoFileTree.tsx**: Tree rows → `GroupRow`, chevrons → `IconButton size="sm"`, rename/move dialogs → `Modal` + `Input` + `Button`, root tree wrapped in `Group`, retry button → `Button`

### Strategy (per issue)
- Single `<Group>` wrapper per tree — avoids per-row Surface perf hit on long trees
- `GroupRow` provides subtle press feedback (inset on press) via `Pressable`
- Indentation stays via `paddingLeft` on `GroupRow` style prop
- `IconButton size="sm"` for expand/collapse carets (36px hit area)
- `colors.shadow` at low alpha used by `Group`'s internal dividers

### Removed styles
- `folderItem`, `folderContent`, `chevronContainer`, `folderIcon` (FolderTreeView)
- `modalOverlay`, `modalSheet`, `modalInput`, `modalBtn`, `headerBtn`, `badge` (RepoFileBrowser)
- `overlay`, `card`, `input`, `button`, `primaryButton`, `buttonText`, `folderItem`, `retryBtn`, `contextStyles` (RepoFileTree)
- Net: **-272 lines**

## Test plan
- [x] `yarn ts:check` passes (0 errors)
- [x] All 14 test suites pass (117 tests)
- [ ] CI pipeline passes
- [ ] Manual: browse repo files, verify Group shadow renders once
- [ ] Manual: expand/collapse folders, verify IconButton carets work
- [ ] Manual: rename/move dialogs with Input + Button
- [ ] Manual: dark mode check