### PR TITLE
feat: add TanStack Query for GitHub API calls

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,16 @@ import { OnboardingService } from './src/services/OnboardingService';
 import { NotificationService } from './src/services/NotificationService';
 import { StartupSyncGate } from './src/components/StartupSyncGate';
 import { bootstrapStorage } from './src/services/StorageBootstrap';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 2,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 export default function App() {
   const [showOnboarding, setShowOnboarding] = useState<boolean | null>(null);
@@ -72,6 +82,7 @@ export default function App() {
   }
 
   return (
+    <QueryClientProvider client={queryClient}>
     <SafeAreaProvider>
       <ThemeProvider>
         <AuthProvider>
@@ -94,6 +105,7 @@ export default function App() {
         </AuthProvider>
       </ThemeProvider>
     </SafeAreaProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@react-navigation/native-stack": "^7.14.10",
     "@shopify/flash-list": "2.0.2",
     "@shopify/react-native-skia": "2.4.18",
+    "@tanstack/react-query": "^5.100.7",
     "axios": "^1.15.2",
     "date-fns": "^4.1.0",
     "expo": "^55.0.19",

--- a/src/hooks/useGitHubQueries.ts
+++ b/src/hooks/useGitHubQueries.ts
@@ -1,0 +1,151 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { GitHubService, GitHubRepository, GitHubContent, GitHubIssue, GitHubPullRequest, GitHubMilestone } from '../services/GitHubService';
+
+const STALE_TIMES = {
+  repos: 5 * 60 * 1000,
+  contents: 2 * 60 * 1000,
+  file: 5 * 60 * 1000,
+  tree: 5 * 60 * 1000,
+  issues: 60 * 1000,
+  prs: 60 * 1000,
+  milestones: 60 * 1000,
+  user: 10 * 60 * 1000,
+} as const;
+
+export function useGitHubRepos() {
+  return useQuery({
+    queryKey: ['github', 'repos'],
+    queryFn: () => GitHubService.getRepositories(),
+    staleTime: STALE_TIMES.repos,
+  });
+}
+
+export function useGitHubRepoContents(owner: string, repo: string, path: string = '', branch?: string) {
+  return useQuery({
+    queryKey: ['github', 'contents', owner, repo, path, branch],
+    queryFn: () => GitHubService.getRepoContents(owner, repo, path, branch),
+    staleTime: STALE_TIMES.contents,
+  });
+}
+
+export function useGitHubFileContent(owner: string, repo: string, path: string, branch?: string) {
+  return useQuery({
+    queryKey: ['github', 'file', owner, repo, path, branch],
+    queryFn: () => GitHubService.getFileContent(owner, repo, path, branch),
+    staleTime: STALE_TIMES.file,
+  });
+}
+
+export function useGitHubTree(owner: string, repo: string, branch?: string) {
+  return useQuery({
+    queryKey: ['github', 'tree', owner, repo, branch],
+    queryFn: () => GitHubService.getTreeRecursive(owner, repo, branch || 'main'),
+    staleTime: STALE_TIMES.tree,
+  });
+}
+
+export function useGitHubIssues(owner: string, repo: string) {
+  return useQuery({
+    queryKey: ['github', 'issues', owner, repo],
+    queryFn: () => GitHubService.getIssues(owner, repo),
+    staleTime: STALE_TIMES.issues,
+  });
+}
+
+export function useGitHubPullRequests(owner: string, repo: string) {
+  return useQuery({
+    queryKey: ['github', 'prs', owner, repo],
+    queryFn: () => GitHubService.getPullRequests(owner, repo),
+    staleTime: STALE_TIMES.prs,
+  });
+}
+
+export function useGitHubMilestones(owner: string, repo: string) {
+  return useQuery({
+    queryKey: ['github', 'milestones', owner, repo],
+    queryFn: () => GitHubService.getMilestones(owner, repo),
+    staleTime: STALE_TIMES.milestones,
+  });
+}
+
+export function useGitHubUser() {
+  return useQuery({
+    queryKey: ['github', 'user'],
+    queryFn: () => GitHubService.getUser(),
+    staleTime: STALE_TIMES.user,
+  });
+}
+
+export function useGitHubFileSha(owner: string, repo: string, path: string, branch?: string) {
+  return useQuery({
+    queryKey: ['github', 'sha', owner, repo, path, branch],
+    queryFn: () => GitHubService.getFileSha(owner, repo, path, branch),
+    staleTime: Infinity,
+  });
+}
+
+export function useCreateFile() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { owner: string; repo: string; path: string; content: string; message: string; branch: string }) =>
+      GitHubService.createFile(params.owner, params.repo, params.path, params.content, params.message, params.branch),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ['github', 'contents', variables.owner, variables.repo] });
+      qc.invalidateQueries({ queryKey: ['github', 'tree', variables.owner, variables.repo] });
+    },
+  });
+}
+
+export function useUpdateFile() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { owner: string; repo: string; path: string; content: string; message: string; branch: string }) =>
+      GitHubService.updateFile(params.owner, params.repo, params.path, params.content, params.message, params.branch),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ['github', 'contents', variables.owner, variables.repo] });
+      qc.invalidateQueries({ queryKey: ['github', 'file', variables.owner, variables.repo, variables.path] });
+      qc.invalidateQueries({ queryKey: ['github', 'tree', variables.owner, variables.repo] });
+    },
+  });
+}
+
+export function useDeleteFile() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { owner: string; repo: string; path: string; message: string; sha: string; branch: string }) =>
+      GitHubService.deleteFile(params.owner, params.repo, params.path, params.message, params.sha, params.branch),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ['github', 'contents', variables.owner, variables.repo] });
+      qc.invalidateQueries({ queryKey: ['github', 'tree', variables.owner, variables.repo] });
+    },
+  });
+}
+
+export function useMoveFile() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { owner: string; repo: string; oldPath: string; newPath: string; content: string; message: string; sha: string; branch: string }) =>
+      GitHubService.moveFile(params.owner, params.repo, params.oldPath, params.newPath, params.content, params.message, params.sha, params.branch),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ['github', 'contents', variables.owner, variables.repo] });
+      qc.invalidateQueries({ queryKey: ['github', 'tree', variables.owner, variables.repo] });
+    },
+  });
+}
+
+export function useCreateFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { owner: string; repo: string; path: string; branch: string }) =>
+      GitHubService.createFolder(params.owner, params.repo, params.path, params.branch),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ['github', 'contents', variables.owner, variables.repo] });
+      qc.invalidateQueries({ queryKey: ['github', 'tree', variables.owner, variables.repo] });
+    },
+  });
+}
+
+export function useInvalidateGitHubQueries() {
+  const qc = useQueryClient();
+  return () => qc.invalidateQueries({ queryKey: ['github'] });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,6 +2045,18 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@tanstack/query-core@5.100.7":
+  version "5.100.7"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.100.7.tgz#dbdc082b803824edac7caf5a787dc3ba01c35459"
+  integrity sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ==
+
+"@tanstack/react-query@^5.100.7":
+  version "5.100.7"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.100.7.tgz#268d3a087deea723d826b645d1fdbe9ae0d4b8c9"
+  integrity sha512-LoISYWz8dOOuQbeIctF8K6yi42TWtR1WPGpwGuRUpF3u79JVVIg/PVR0MQdIA0VSHqD/ydf/b7PhKTkg3I4fLQ==
+  dependencies:
+    "@tanstack/query-core" "5.100.7"
+
 "@testing-library/react-native@^13.3.3":
   version "13.3.3"
   resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-13.3.3.tgz#4bf02911c4e18075df40b5de0e029c209fb45bda"


### PR DESCRIPTION
## Summary
Fixes #328

Adds TanStack Query (`@tanstack/react-query`) for all GitHub API calls, providing caching, deduplication, retries, and stale-while-revalidate out of the box.

### Changes
- **`@tanstack/react-query@5.100.7`** added as dependency
- **`QueryClientProvider`** wraps the app in `App.tsx`
- **New hooks** in `src/hooks/useGitHubQueries.ts`:
  - **Query hooks**: `useGitHubRepos`, `useGitHubRepoContents`, `useGitHubFileContent`, `useGitHubTree`, `useGitHubIssues`, `useGitHubPullRequests`, `useGitHubMilestones`, `useGitHubUser`, `useGitHubFileSha`
  - **Mutation hooks**: `useCreateFile`, `useUpdateFile`, `useDeleteFile`, `useMoveFile`, `useCreateFolder`
  - **Utility**: `useInvalidateGitHubQueries` (for pull-to-refresh)

### Stale times per resource
| Resource | staleTime |
|----------|-----------|
| Repos | 5 min |
| Contents | 2 min |
| File content | 5 min |
| Tree | 5 min |
| Issues/PRs/Milestones | 1 min |
| User | 10 min |
| Blob SHA | Infinity |

### Mutation auto-invalidation
All mutations (`createFile`, `updateFile`, `deleteFile`, `moveFile`, `createFolder`) auto-invalidate dependent queries on success, so the UI updates automatically.

### Pairs with
- #330 (axios migration) — this branch is based on top of it
- Future: replace `StartupSyncGate` imperative re-fetches with `queryClient.refetchQueries`

## Test plan
- [x] `yarn ts:check` passes (0 errors)
- [x] All 14 test suites pass (117 tests)
- [ ] CI pipeline passes
- [ ] Manual: navigate to repo list — verify cached response
- [ ] Manual: pull-to-refresh — verify `invalidateQueries` refreshes data