### PR TITLE
fix: add ghost variant to IconButton, use for tree chevrons

### DIFF
--- a/src/components/RepoFileTree.tsx
+++ b/src/components/RepoFileTree.tsx
@@ -458,7 +458,7 @@ function TreeItem({ node, owner, repo, branch, level, onFilePress, onRefresh }: 
               loading ? (
                 <ActivityIndicator size="small" color={colors.textSecondary} style={treeStyles.loader} />
               ) : (
-                <IconButton size="sm" onPress={handleToggle} accessibilityLabel={expanded ? 'Collapse' : 'Expand'}>
+                <IconButton size="sm" variant="ghost" onPress={handleToggle} accessibilityLabel={expanded ? 'Collapse' : 'Expand'}>
                   <Ionicons
                     name={expanded ? 'chevron-down' : 'chevron-forward'}
                     size={14}

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -15,7 +15,7 @@ export interface IconButtonProps {
   size?: IconButtonSize;
   disabled?: boolean;
   active?: boolean;
-  variant?: 'default' | 'primary';
+  variant?: 'default' | 'primary' | 'ghost';
   style?: StyleProp<ViewStyle>;
   testID?: string;
   accessibilityLabel?: string;
@@ -43,8 +43,10 @@ export function IconButton(props: IconButtonProps) {
   const handlePressIn = useCallback(() => {
     scale.value = withSpring(0.94, { mass: 0.4, damping: 14, stiffness: 240 });
     setIsPressed(true);
-    Haptics.selectionAsync().catch(() => undefined);
-  }, [scale]);
+    if (variant !== 'ghost') {
+      Haptics.selectionAsync().catch(() => undefined);
+    }
+  }, [scale, variant]);
 
   const handlePressOut = useCallback(() => {
     scale.value = withSpring(1, { mass: 0.4, damping: 14, stiffness: 240 });
@@ -52,6 +54,36 @@ export function IconButton(props: IconButtonProps) {
   }, [scale]);
 
   const animatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
+
+  if (variant === 'ghost') {
+    return (
+      <Animated.View style={[{ opacity: disabled ? 0.5 : 1 }, animatedStyle]}>
+        <Pressable
+          testID={testID}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityRole="button"
+          onPress={disabled ? undefined : onPress}
+          onLongPress={disabled ? undefined : onLongPress}
+          onPressIn={disabled ? undefined : handlePressIn}
+          onPressOut={disabled ? undefined : handlePressOut}
+          disabled={disabled}
+          hitSlop={4}
+          style={[
+            {
+              width: dim,
+              height: dim,
+              alignItems: 'center',
+              justifyContent: 'center',
+            },
+            style,
+          ]}
+        >
+          {children}
+        </Pressable>
+      </Animated.View>
+    );
+  }
+
   const inset = isPressed || active;
   const elevation = variant === 'primary' ? 'raised' : 'raised';
 


### PR DESCRIPTION
## Summary
- Add `variant="ghost"` to IconButton that renders a borderless Pressable (no Surface, no shadow, no pill shape)
- Ghost variant skips haptic feedback (parent components handle their own)
- Use `variant="ghost"` on RepoFileTree collapse chevron to remove unwanted white pill background
- Maintains 36×36 hit target for accessibility

Closes #398