### PR TITLE
fix: use theme tokens for dark mode modal backgrounds

### DIFF
--- a/src/components/GitHubPicker.tsx
+++ b/src/components/GitHubPicker.tsx
@@ -34,8 +34,7 @@ interface BottomSheetProps {
 }
 
 function BottomSheet({ visible, title, onClose, children }: BottomSheetProps) {
-  const { colors, isDark } = useTheme();
-  const sheetBg = isDark ? '#1C1C1E' : colors.surface;
+  const { colors } = useTheme();
   return (
     <Modal
       visible={visible}
@@ -49,7 +48,7 @@ function BottomSheet({ visible, title, onClose, children }: BottomSheetProps) {
       >
         <SafeAreaView
           edges={['top', 'bottom']}
-          style={[styles.sheet, { backgroundColor: sheetBg }]}
+          style={[styles.sheet, { backgroundColor: colors.elevated }]}
         >
           <View style={[styles.sheetHeader, { borderBottomColor: colors.border }]}>
             <Text style={[styles.sheetTitle, { color: colors.text }]}>{title}</Text>
@@ -246,7 +245,7 @@ export default function GitHubPicker({ value, onChange }: GitHubPickerProps) {
       </TouchableOpacity>
 
       {isExpanded && (
-        <View style={[styles.content, { backgroundColor: isDark ? colors.background : '#fafafa' }]}>
+        <View style={[styles.content, { backgroundColor: isDark ? colors.background : colors.surfaceSecondary }]}>
           {/* Repository */}
           <View style={styles.selectorRow}>
             <Text style={[styles.selectorLabel, { color: colors.textSecondary }]}>Repository</Text>

--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -86,15 +86,15 @@ export default function TemplateSelector({ visible, onClose, onSelect }: Templat
       fullWidth
       contentStyle={styles.modalContent}
     >
-      <View style={[styles.container, { backgroundColor: colors.background }]}>
-        <View style={[styles.header, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
+      <View style={[styles.container, { backgroundColor: colors.elevated }]}>
+        <View style={[styles.header, { backgroundColor: colors.elevated, borderBottomColor: colors.border }]}>
           <Text style={[styles.headerTitle, { color: colors.text }]}>Choose a Template</Text>
           <TouchableOpacity onPress={onClose}>
             <Ionicons name="close" size={24} color={colors.textSecondary} />
           </TouchableOpacity>
         </View>
 
-        <View style={[styles.searchContainer, { backgroundColor: colors.surface }]}>
+        <View style={[styles.searchContainer, { backgroundColor: colors.elevated }]}>
           <View style={[styles.searchInputContainer, { backgroundColor: colors.surfaceSecondary }]}>
             <Ionicons name="search" size={20} color={colors.textSecondary} />
             <TextInput
@@ -134,13 +134,9 @@ const styles = StyleSheet.create({
     padding: 0,
     width: '100%',
     height: '85%',
-    borderRadius: 24,
-    overflow: 'hidden',
   },
   container: {
     flex: 1,
-    borderRadius: 24,
-    overflow: 'hidden',
   },
   header: {
     flexDirection: 'row',

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Modal as RNModal, Pressable, StyleSheet, useWindowDimensions, ViewStyle, StyleProp } from 'react-native';
+import { Modal as RNModal, Pressable, StyleSheet, View, useWindowDimensions, ViewStyle, StyleProp } from 'react-native';
 import { BlurView } from 'expo-blur';
 import { Surface } from './Surface';
 import { useTheme, useTokens } from '../../contexts/ThemeContext';
@@ -16,11 +16,10 @@ export interface ModalProps {
 export function Modal(props: ModalProps) {
   const { visible, onRequestClose, dismissOnBackdrop = true, contentStyle, children, fullWidth = false } = props;
   const { isDark } = useTheme();
-  const { spacing } = useTokens();
+  const { spacing, colors } = useTokens();
   const { height: viewportHeight, width: viewportWidth } = useWindowDimensions();
 
   const pad = spacing[5];
-  // Definite pixel sizes so percentage heights on Surface (via contentStyle) resolve.
   const slotHeight = Math.max(0, viewportHeight - pad * 2);
   const slotWidth = Math.max(0, viewportWidth - pad * 2);
 
@@ -57,9 +56,9 @@ export function Modal(props: ModalProps) {
           <Surface
             elevation="floating"
             radius="lg"
-            style={[{ padding: pad, maxHeight: slotHeight }, contentStyle]}
+            style={[{ padding: pad, maxHeight: slotHeight, backgroundColor: colors.elevated }, contentStyle]}
           >
-            {children}
+            <View>{children}</View>
           </Surface>
         </Pressable>
       </Pressable>

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -15,6 +15,7 @@ export interface Palette {
   primary: string;
   border: string;
   card: string;
+  elevated: string;
 }
 
 // Neumorphic palette uses a near-pure white (light) / black (dark) surface
@@ -35,6 +36,7 @@ export const NEUMORPHIC_LIGHT: Palette = {
   primary: '#7B8CDE',
   border: '#D8D8D8',
   card: '#FFFFFF',
+  elevated: '#FFFFFF',
 };
 
 export const NEUMORPHIC_DARK: Palette = {
@@ -52,6 +54,7 @@ export const NEUMORPHIC_DARK: Palette = {
   primary: '#8B9BE8',
   border: '#262626',
   card: '#0A0A0A',
+  elevated: '#1C1C1E',
 };
 
 export const FLAT_LIGHT: Palette = {
@@ -69,6 +72,7 @@ export const FLAT_LIGHT: Palette = {
   primary: '#007AFF',
   border: '#c6c6c8',
   card: '#ffffff',
+  elevated: '#ffffff',
 };
 
 export const FLAT_DARK: Palette = {
@@ -86,6 +90,7 @@ export const FLAT_DARK: Palette = {
   primary: '#0a84ff',
   border: '#38383a',
   card: '#2c2c2e',
+  elevated: '#2c2c2e',
 };
 
 export const RADII = { sm: 12, md: 18, lg: 24, pill: 999 } as const;


### PR DESCRIPTION
## Summary
- Add `elevated` token to Palette — a dedicated color for modal/floating surfaces with proper contrast in dark mode
- Use `colors.elevated` in Modal.tsx Surface background instead of `colors.surface` (pure black in neumorphic dark)
- Replace hardcoded `'#1C1C1E'` in GitHubPicker BottomSheet with `colors.elevated`
- Replace hardcoded `'#fafafa'` in GitHubPicker content area with `colors.surfaceSecondary`
- Use `colors.elevated` in TemplateSelector container/header/search sections
- No hardcoded hex colors — all driven by theme tokens

### Token values
| Palette | elevated |
|---|---|
| NEUMORPHIC_LIGHT | #FFFFFF |
| NEUMORPHIC_DARK | #1C1C1E |
| FLAT_LIGHT | #ffffff |
| FLAT_DARK | #2c2c2e |

Closes #399, #400

### Supersedes
- PR #403 (GitHubPicker fix — used hardcoded `'#1C1C1E'`)
- PR #406 (TemplateSelector fix — used hardcoded `'#1C1C1E'` and `'#252528'`)