### PR TITLE
fix(ai): correct Choose Chat Storage bottom sheet layout

### DIFF
--- a/src/components/ai/ChatRepoPickerModal.tsx
+++ b/src/components/ai/ChatRepoPickerModal.tsx
@@ -5,8 +5,8 @@ import {
   TouchableOpacity,
   StyleSheet,
   ScrollView,
-  Platform,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useTokens } from '../../contexts/ThemeContext';
 import { useRepoStore } from '../../stores/repoStore';
@@ -77,177 +77,221 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
   };
 
   return (
-    <Modal visible={visible} onRequestClose={onClose} bottomSheet fullWidth>
-      <View style={styles.modalHeader}>
-        <Text style={[styles.modalTitle, { color: colors.text }]}>Choose Chat Storage</Text>
-        <TouchableOpacity onPress={onClose} disabled={isInitializing}>
-          <Ionicons name="close" size={24} color={colors.textSecondary} />
-        </TouchableOpacity>
-      </View>
+    <Modal
+      visible={visible}
+      onRequestClose={onClose}
+      bottomSheet
+      contentStyle={{ height: '85%' }}
+    >
+      <SafeAreaView edges={['bottom']} style={styles.sheet}>
+        <View style={[styles.header, { borderBottomColor: colors.border }]}>
+          <View style={styles.headerSide} />
+          <Text style={[styles.title, { color: colors.text }]} numberOfLines={1}>
+            Choose Chat Storage
+          </Text>
+          <TouchableOpacity
+            onPress={onClose}
+            disabled={isInitializing}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            style={styles.headerSide}
+          >
+            <Ionicons name="close" size={24} color={colors.textSecondary} />
+          </TouchableOpacity>
+        </View>
 
-      <View style={styles.content}>
-        <Text style={[styles.description, { color: colors.textSecondary }]}>
-          Select a GitHub repository to store your AI chat conversations.
-        </Text>
+        <View style={styles.body}>
+          <Text style={[styles.description, { color: colors.textSecondary }]}>
+            Select a GitHub repository to store your AI chat conversations.
+          </Text>
 
-        {repositories.length === 0 ? (
-          <View style={styles.emptyState}>
-            <Ionicons name="folder-open-outline" size={48} color={colors.textSecondary} style={{ marginBottom: spacing[4] }} />
-            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              No repositories found. Add a repository in Settings first.
-            </Text>
-            {onGoToSettings && (
-              <Button
-                variant="primary"
-                onPress={onGoToSettings}
-              >
-                Go to Settings
-              </Button>
-            )}
-          </View>
-        ) : (
-          <>
-            <View style={styles.searchContainer}>
-              <SearchBar
-                value={searchQuery}
-                onChangeText={setSearchQuery}
-                placeholder="Search repositories..."
+          {repositories.length === 0 ? (
+            <View style={styles.emptyState}>
+              <Ionicons
+                name="folder-open-outline"
+                size={48}
+                color={colors.textSecondary}
+                style={{ marginBottom: spacing[4] }}
               />
-            </View>
-
-            <ScrollView style={styles.repoList} keyboardShouldPersistTaps="handled">
-              {filteredRepos.map((repo) => {
-                const isSelected = repo.path === selectedRepoPath;
-                return (
-                  <TouchableOpacity
-                    key={repo.path}
-                    onPress={() => handleSelectRepo(repo.path)}
-                    style={{ marginBottom: spacing[2] }}
-                  >
-                    <Surface
-                      elevation="flat"
-                      inset={isSelected}
-                      radius="md"
-                      style={[
-                        styles.repoItem,
-                        isSelected && { borderColor: colors.primary, borderWidth: 1 },
-                        !isSelected && { borderWidth: 1, borderColor: 'transparent' }
-                      ]}
-                    >
-                      <View style={styles.repoInfo}>
-                        <Text style={[styles.repoName, { color: colors.text }]}>
-                          {repo.path.includes('/') ? repo.path : repo.name}
-                        </Text>
-                      </View>
-                      {isSelected && (
-                        <Ionicons name="checkmark-circle" size={24} color={colors.primary} />
-                      )}
-                    </Surface>
-                  </TouchableOpacity>
-                );
-              })}
-              {filteredRepos.length === 0 && (
-                <Text style={[styles.noResults, { color: colors.textSecondary }]}>
-                  No matching repositories
-                </Text>
+              <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+                No repositories found. Add a repository in Settings first.
+              </Text>
+              {onGoToSettings && (
+                <Button variant="primary" onPress={onGoToSettings}>
+                  Go to Settings
+                </Button>
               )}
-            </ScrollView>
-
-            {selectedRepoPath && (
-              <View style={styles.branchConfig}>
-                <Text style={[styles.branchLabel, { color: colors.text }]}>Branch:</Text>
-                <View style={{ flex: 1 }}>
-                  <Input
-                    value={branch}
-                    onChangeText={setBranch}
-                    placeholder="main"
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                  />
-                </View>
+            </View>
+          ) : (
+            <>
+              <View style={styles.searchContainer}>
+                <SearchBar
+                  value={searchQuery}
+                  onChangeText={setSearchQuery}
+                  placeholder="Search repositories..."
+                />
               </View>
-            )}
-          </>
-        )}
-      </View>
 
-      <View style={styles.footer}>
-        <Button
-          variant="primary"
-          onPress={handleConfirm}
-          disabled={!selectedRepoPath || isInitializing}
-        >
-          {isInitializing ? 'Initializing...' : 'Confirm Selection'}
-        </Button>
-      </View>
+              <ScrollView
+                style={styles.repoList}
+                contentContainerStyle={styles.repoListContent}
+                keyboardShouldPersistTaps="handled"
+              >
+                {filteredRepos.map((repo) => {
+                  const isSelected = repo.path === selectedRepoPath;
+                  return (
+                    <TouchableOpacity
+                      key={repo.path}
+                      onPress={() => handleSelectRepo(repo.path)}
+                      style={{ marginBottom: spacing[2] }}
+                    >
+                      <Surface
+                        elevation="flat"
+                        inset={isSelected}
+                        radius="md"
+                        style={[
+                          styles.repoItem,
+                          isSelected && { borderColor: colors.primary, borderWidth: 1 },
+                          !isSelected && { borderWidth: 1, borderColor: 'transparent' },
+                        ]}
+                      >
+                        <View style={styles.repoInfo}>
+                          <Text
+                            style={[styles.repoName, { color: colors.text }]}
+                            numberOfLines={1}
+                          >
+                            {repo.path.includes('/') ? repo.path : repo.name}
+                          </Text>
+                        </View>
+                        {isSelected && (
+                          <Ionicons name="checkmark-circle" size={24} color={colors.primary} />
+                        )}
+                      </Surface>
+                    </TouchableOpacity>
+                  );
+                })}
+                {filteredRepos.length === 0 && (
+                  <Text style={[styles.noResults, { color: colors.textSecondary }]}>
+                    No matching repositories
+                  </Text>
+                )}
+              </ScrollView>
+
+              {selectedRepoPath && (
+                <View style={styles.branchConfig}>
+                  <Text style={[styles.branchLabel, { color: colors.text }]}>Branch:</Text>
+                  <View style={{ flex: 1 }}>
+                    <Input
+                      value={branch}
+                      onChangeText={setBranch}
+                      placeholder="main"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                    />
+                  </View>
+                </View>
+              )}
+            </>
+          )}
+        </View>
+
+        <View style={[styles.footer, { borderTopColor: colors.border }]}>
+          <Button
+            variant="primary"
+            onPress={handleConfirm}
+            disabled={!selectedRepoPath || isInitializing}
+          >
+            {isInitializing ? 'Initializing...' : 'Confirm Selection'}
+          </Button>
+        </View>
+      </SafeAreaView>
     </Modal>
   );
 };
 
 const styles = StyleSheet.create({
-  modalHeader: {
+  sheet: {
+    flex: 1,
+  },
+  header: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: 16,
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  modalTitle: {
-    fontSize: 20,
+  headerSide: {
+    width: 32,
+    alignItems: 'flex-end',
+  },
+  title: {
+    flex: 1,
+    fontSize: 17,
     fontWeight: '600',
+    textAlign: 'center',
   },
-  content: {
-    maxHeight: 500,
+  body: {
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingTop: 16,
   },
   description: {
-    fontSize: 15,
-    marginBottom: 20,
-    lineHeight: 22,
+    fontSize: 14,
+    marginBottom: 16,
+    lineHeight: 20,
   },
   searchContainer: {
-    marginBottom: 16,
+    marginBottom: 12,
   },
   repoList: {
-    maxHeight: 300,
+    flex: 1,
+  },
+  repoListContent: {
+    paddingBottom: 8,
   },
   repoItem: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    padding: 16,
+    padding: 14,
   },
   repoInfo: {
     flex: 1,
+    marginRight: 8,
   },
   repoName: {
-    fontSize: 16,
+    fontSize: 15,
     fontWeight: '500',
   },
   branchConfig: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginTop: 20,
-    marginBottom: 10,
+    marginTop: 12,
+    marginBottom: 4,
   },
   branchLabel: {
-    fontSize: 16,
+    fontSize: 15,
     marginRight: 10,
     fontWeight: '500',
   },
   footer: {
-    marginTop: 20,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 4,
+    borderTopWidth: StyleSheet.hairlineWidth,
   },
   emptyState: {
     alignItems: 'center',
     paddingVertical: 40,
   },
   emptyText: {
-    fontSize: 16,
+    fontSize: 15,
     textAlign: 'center',
     marginBottom: 24,
   },
   noResults: {
     textAlign: 'center',
     paddingVertical: 20,
-    fontSize: 15,
+    fontSize: 14,
   },
 });

--- a/src/components/ai/ChatRepoPickerModal.tsx
+++ b/src/components/ai/ChatRepoPickerModal.tsx
@@ -6,7 +6,7 @@ import {
   StyleSheet,
   ScrollView,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useTokens } from '../../contexts/ThemeContext';
 import { useRepoStore } from '../../stores/repoStore';
@@ -30,6 +30,7 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
   onGoToSettings,
 }) => {
   const { colors, spacing } = useTokens();
+  const insets = useSafeAreaInsets();
   const repositories = useRepoStore((state) => state.repositories);
   const setChatRepo = useAIStore((state) => state.setChatRepo);
 
@@ -83,7 +84,7 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
       bottomSheet
       contentStyle={{ height: '85%' }}
     >
-      <SafeAreaView edges={['bottom']} style={styles.sheet}>
+      <View style={styles.sheet}>
         <View style={[styles.header, { borderBottomColor: colors.border }]}>
           <View style={styles.headerSide} />
           <Text style={[styles.title, { color: colors.text }]} numberOfLines={1}>
@@ -194,7 +195,15 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
           )}
         </View>
 
-        <View style={[styles.footer, { borderTopColor: colors.border }]}>
+        <View
+          style={[
+            styles.footer,
+            {
+              borderTopColor: colors.border,
+              paddingBottom: Math.max(insets.bottom, 16),
+            },
+          ]}
+        >
           <Button
             variant="primary"
             onPress={handleConfirm}
@@ -203,7 +212,7 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
             {isInitializing ? 'Initializing...' : 'Confirm Selection'}
           </Button>
         </View>
-      </SafeAreaView>
+      </View>
     </Modal>
   );
 };


### PR DESCRIPTION
## Summary
- Drop ineffective `fullWidth` prop on `bottomSheet` Modal — bottomSheet variant ignores it and strips Surface padding, leaving content flush against sheet edges.
- Pin sheet height with `contentStyle={{ height: '85%' }}` so the picker has consistent dimensions across devices instead of relying on the arbitrary `maxHeight: 500` cap.
- Wrap content in `SafeAreaView edges={['bottom']}` so the Confirm button is no longer obscured by the iOS home indicator.
- Restructure into header / scrollable body / pinned footer; reuse the existing `EntityFilterModal` / `GitContextPicker` sheet style (centered title, top divider, hairline borders) for visual consistency.

## Why
`Choose Chat Storage` was visibly broken — text touched the screen edge, the repo list was vertically clipped by a hard 500px cap, and the action button sat under the home indicator. The fix aligns the modal with the rest of the app's bottom-sheet pickers without changing behavior.

## Test plan
- [ ] Open Settings → Chat Storage → modal renders with rounded top corners, padded content, and action button above the home indicator.
- [ ] Long repo list scrolls inside the sheet; sheet itself stays at 85% of viewport.
- [ ] Empty state (no repositories) renders without overflow; "Go to Settings" reachable.
- [ ] Tap a repo → branch input appears under the list, Confirm becomes enabled.
- [ ] Backdrop tap dismisses; close (X) still works while initializing is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)