### PR TITLE
Wave 1: Fix critical crash and data-loss bugs (#421, #425, #426, #423 B1)

### DIFF
--- a/__tests__/canvas-multi-embed.test.tsx
+++ b/__tests__/canvas-multi-embed.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
+
+jest.mock('expo-image', () => ({
+  Image: () => null,
+}));
+
+jest.mock('react-native-marked', () => {
+  class Renderer {
+    private key = 0;
+
+    getKey() {
+      this.key += 1;
+      return `renderer-key-${this.key}`;
+    }
+  }
+
+  return { Renderer };
+});
+
+const createRenderer = (CanvasPreview: React.ComponentType<{ canvasId: string }>) => new NotePreviewRenderer({
+  colors: {
+    primary: '#2563eb',
+    text: '#111827',
+    surfaceSecondary: '#e5e7eb',
+  },
+  CanvasPreview,
+});
+
+describe('canvas multi-embed regression', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders two canvas embeds without crashing', () => {
+    const renderer = createRenderer(({ canvasId }) => <Text testID={`canvas-${canvasId}`}>{canvasId}</Text>);
+
+    const screen = render(
+      <View>
+        {renderer.link([], 'canvas:canvas-1')}
+        {renderer.link([], 'canvas:canvas-2')}
+      </View>,
+    );
+
+    expect(screen.getByTestId('canvas-canvas-1')).toBeTruthy();
+    expect(screen.getByTestId('canvas-canvas-2')).toBeTruthy();
+  });
+
+  it('assigns stable unique keys to each canvas preview', () => {
+    const renderer = createRenderer(({ canvasId }) => <Text>{canvasId}</Text>);
+
+    const firstNode = renderer.link([], 'canvas:canvas-1') as React.ReactElement<{ children: React.ReactNode }>;
+    const secondNode = renderer.link([], 'canvas:canvas-2') as React.ReactElement<{ children: React.ReactNode }>;
+    const firstPreview = React.Children.only(firstNode.props.children) as React.ReactElement;
+    const secondPreview = React.Children.only(secondNode.props.children) as React.ReactElement;
+
+    expect(firstNode.key).toBe('canvas-boundary-canvas-1');
+    expect(secondNode.key).toBe('canvas-boundary-canvas-2');
+    expect(firstPreview.key).toBe('canvas-1');
+    expect(secondPreview.key).toBe('canvas-2');
+  });
+
+  it('shows a placeholder when canvas preview rendering throws', () => {
+    const renderer = createRenderer(({ canvasId }) => {
+      if (canvasId === 'canvas-2') {
+        throw new Error('Skia init failed');
+      }
+
+      return <Text testID={`canvas-${canvasId}`}>{canvasId}</Text>;
+    });
+
+    const screen = render(
+      <View>
+        {renderer.link([], 'canvas:canvas-1')}
+        {renderer.link([], 'canvas:canvas-2')}
+      </View>,
+    );
+
+    expect(screen.getByTestId('canvas-canvas-1')).toBeTruthy();
+    expect(screen.getByText('Canvas preview unavailable')).toBeTruthy();
+  });
+});

--- a/__tests__/canvas-race.test.ts
+++ b/__tests__/canvas-race.test.ts
@@ -1,0 +1,179 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  let store: Record<string, string> = {};
+  let blockNextCanvasWrite = false;
+  let blockedCanvasWrite: {
+    promise: Promise<void>;
+    release: () => void;
+    started: Promise<void>;
+    markStarted: () => void;
+  } | null = null;
+
+  const createBlockedWrite = () => {
+    let release = () => {};
+    let markStarted = () => {};
+    const promise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    return { promise, release, started, markStarted };
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (key: string) => (key in store ? store[key] : null)),
+      setItem: jest.fn(async (key: string, value: string) => {
+        if (key === '@gitnotes:canvases' && blockNextCanvasWrite) {
+          blockNextCanvasWrite = false;
+          blockedCanvasWrite = createBlockedWrite();
+          blockedCanvasWrite.markStarted();
+          await blockedCanvasWrite.promise;
+          blockedCanvasWrite = null;
+        }
+        store[key] = value;
+      }),
+      removeItem: jest.fn(async (key: string) => {
+        delete store[key];
+      }),
+      multiGet: jest.fn(async (keys: string[]) => keys.map((key) => [key, key in store ? store[key] : null])),
+      multiSet: jest.fn(async (pairs: [string, string][]) => {
+        for (const [key, value] of pairs) {
+          store[key] = value;
+        }
+      }),
+      multiRemove: jest.fn(async (keys: string[]) => {
+        for (const key of keys) {
+          delete store[key];
+        }
+      }),
+      clear: jest.fn(async () => {
+        store = {};
+      }),
+      __reset: () => {
+        blockedCanvasWrite?.release();
+        store = {};
+        blockNextCanvasWrite = false;
+        blockedCanvasWrite = null;
+      },
+      __blockNextCanvasWrite: () => {
+        blockNextCanvasWrite = true;
+      },
+      __waitForBlockedCanvasWrite: async () => {
+        for (let attempt = 0; attempt < 20 && !blockedCanvasWrite; attempt += 1) {
+          await Promise.resolve();
+        }
+        if (!blockedCanvasWrite) {
+          throw new Error('No blocked canvas write in progress');
+        }
+        await blockedCanvasWrite.started;
+      },
+      __releaseBlockedCanvasWrite: () => {
+        blockedCanvasWrite?.release();
+      },
+    },
+  };
+});
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getTreeRecursive: jest.fn(async () => []),
+    getRepoContents: jest.fn(async (_owner: string, _repo: string, dirPath: string) => {
+      if (dirPath !== 'canvases') return [];
+      return [{ type: 'file', path: 'canvases/remote-canvas.json', download_url: 'https://example.com/remote-canvas.json' }];
+    }),
+    getFileContent: jest.fn(async (_owner: string, _repo: string, path: string) => {
+      if (path !== 'canvases/remote-canvas.json') return null;
+      return JSON.stringify({
+        version: 1,
+        width: 640,
+        height: 480,
+        background: '#FFFFFF',
+        elements: [
+          {
+            type: 'text',
+            id: 'remote-text',
+            text: 'remote',
+            x: 16,
+            y: 24,
+            fontSize: 18,
+            color: '#000000',
+          },
+        ],
+      });
+    }),
+  },
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createCanvas } from '../src/models/Canvas';
+import { pullFromSingleRepo } from '../src/services/RepoPullService';
+import { StorageService } from '../src/services/StorageService';
+
+const CANVASES_STORAGE_KEY = '@gitnotes:canvases';
+const CANVASES_BACKUP_STORAGE_KEY = '@gitnotes:canvases.bak';
+
+type AsyncStorageMock = {
+  __reset: () => void;
+  __blockNextCanvasWrite: () => void;
+  __waitForBlockedCanvasWrite: () => Promise<void>;
+  __releaseBlockedCanvasWrite: () => void;
+};
+
+describe('canvas storage race handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage as unknown as AsyncStorageMock).__reset();
+  });
+
+  test('concurrent local save and repo pull preserve both changes', async () => {
+    const localCanvas = createCanvas({
+      title: 'Local canvas',
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'canvases/local-canvas.json',
+    });
+
+    await StorageService.saveAllCanvases([localCanvas]);
+    await StorageService.saveRepositories([{ id: 'repo-1', name: 'repo', path: 'owner/repo', branch: 'main' }]);
+
+    (AsyncStorage as unknown as AsyncStorageMock).__blockNextCanvasWrite();
+
+    const updatePromise = StorageService.updateCanvas({ id: localCanvas.id, title: 'Local canvas edited' });
+    await (AsyncStorage as unknown as AsyncStorageMock).__waitForBlockedCanvasWrite();
+
+    const pullPromise = pullFromSingleRepo('owner/repo');
+
+    (AsyncStorage as unknown as AsyncStorageMock).__releaseBlockedCanvasWrite();
+
+    const [updatedCanvas, pullResult] = await Promise.all([updatePromise, pullPromise]);
+    const canvases = await StorageService.getAllCanvases();
+
+    expect(updatedCanvas?.title).toBe('Local canvas edited');
+    expect(pullResult.canvases).toBe(1);
+    expect(canvases).toHaveLength(2);
+    expect(canvases.find((canvas) => canvas.id === localCanvas.id)?.title).toBe('Local canvas edited');
+    expect(canvases.find((canvas) => canvas.filePath === 'canvases/remote-canvas.json')?.scene.elements).toHaveLength(1);
+  });
+
+  test('malformed canvas JSON returns [] instead of throwing', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await AsyncStorage.setItem(CANVASES_STORAGE_KEY, '{not json');
+
+    await expect(StorageService.getAllCanvases()).resolves.toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error reading canvases from storage:', expect.any(Error));
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('canvas writes keep a backup of the previous blob', async () => {
+    await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify([{ id: 'old-canvas' }]));
+
+    await StorageService.saveAllCanvases([createCanvas({ title: 'New canvas' })]);
+
+    await expect(AsyncStorage.getItem(CANVASES_BACKUP_STORAGE_KEY)).resolves.toBe(JSON.stringify([{ id: 'old-canvas' }]));
+  });
+});

--- a/__tests__/neorg-null-guard.test.ts
+++ b/__tests__/neorg-null-guard.test.ts
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { NeorgContentParser } from '../src/services/NeorgContentParser';
+import { ErrorBoundary } from '../src/components/ui/ErrorBoundary';
+import { TestThemeProvider } from './ui/testThemeProvider';
+
+describe('Neorg null guard and ErrorBoundary', () => {
+  it('returns a structured error for null content', () => {
+    const result = NeorgContentParser.parseContent(null as unknown as string);
+
+    expect(result.success).toBe(false);
+    expect(result.blocks).toEqual([]);
+    expect(result.error).toBe('Invalid content: expected string');
+  });
+
+  it('returns a structured error for undefined content', () => {
+    const result = NeorgContentParser.parseContent(undefined as unknown as string);
+
+    expect(result.success).toBe(false);
+    expect(result.blocks).toEqual([]);
+    expect(result.error).toBe('Invalid content: expected string');
+  });
+
+  it('catches render errors and shows fallback UI', () => {
+    const Boom = () => {
+      throw new Error('boom');
+    };
+
+    const { getByText, queryByText } = render(
+      React.createElement(
+        TestThemeProvider,
+        null,
+        React.createElement(ErrorBoundary, { children: React.createElement(Boom) }),
+      ),
+    );
+
+    expect(getByText('Something went wrong')).toBeTruthy();
+    expect(getByText('Retry')).toBeTruthy();
+    expect(queryByText('boom')).toBeNull();
+  });
+
+  it('renders a custom fallback when provided', () => {
+    const Boom = () => {
+      throw new Error('boom');
+    };
+
+    const { getByText, queryByText } = render(
+      React.createElement(
+        TestThemeProvider,
+        null,
+        React.createElement(
+          ErrorBoundary,
+          {
+            fallback: React.createElement(Text, null, 'custom fallback'),
+            children: React.createElement(Boom),
+          },
+        ),
+      ),
+    );
+
+    expect(getByText('custom fallback')).toBeTruthy();
+    expect(queryByText('Something went wrong')).toBeNull();
+  });
+});

--- a/__tests__/swipe-delete.test.tsx
+++ b/__tests__/swipe-delete.test.tsx
@@ -1,0 +1,300 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import NotesListScreen from '../src/screens/NotesListScreen';
+import { Note } from '../src/models/Note';
+
+let mockViewMode: 'list' | 'journal' = 'list';
+let mockNotesSeed: Note[] = [];
+let latestSetNotes: React.Dispatch<React.SetStateAction<Note[]>> | null = null;
+const mockSwipeableCloseFns: Record<string, jest.Mock> = {};
+
+const mockSetViewMode = jest.fn();
+const mockRefreshNotes = jest.fn(async () => undefined);
+const mockTogglePin = jest.fn(async () => true);
+const mockCreateNote = jest.fn(async () => null);
+const mockDeleteNote = jest.fn(async (id: string) => {
+  latestSetNotes?.((prev) => prev.filter((note) => note.id !== id));
+  return true;
+});
+const mockUseNoteStore: any = jest.fn();
+mockUseNoteStore.getState = () => ({ error: null });
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f4f4f4',
+      primary: '#2563eb',
+      text: '#111',
+      textSecondary: '#666',
+      border: '#ddd',
+      error: '#dc2626',
+    },
+  }),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null } }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({ repositories: [] }),
+}));
+
+jest.mock('../src/contexts/ViewModeContext', () => ({
+  useViewMode: () => ({ viewMode: mockViewMode, setViewMode: mockSetViewMode }),
+}));
+
+jest.mock('../src/contexts/NoteContext', () => {
+  const React = require('react');
+  return {
+    useNotes: () => {
+      const [notes, setNotes] = React.useState(mockNotesSeed);
+      latestSetNotes = setNotes;
+      return {
+        notes,
+        filteredNotes: notes,
+        isLoading: false,
+        searchQuery: '',
+        setSearchQuery: jest.fn(),
+        deleteNote: mockDeleteNote,
+        refreshNotes: mockRefreshNotes,
+        togglePin: mockTogglePin,
+        error: null,
+        createNote: mockCreateNote,
+      };
+    },
+  };
+});
+
+jest.mock('../src/stores/noteStore', () => {
+  return { useNoteStore: mockUseNoteStore };
+});
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: { setToken: jest.fn() },
+}));
+
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    pendingCount: jest.fn(async () => 0),
+    subscribe: jest.fn(() => jest.fn()),
+    drain: jest.fn(async () => ({ succeeded: 0 })),
+  },
+}));
+
+jest.mock('../src/services/RepoPullService', () => ({
+  pullAllFromRepos: jest.fn(async () => undefined),
+}));
+
+jest.mock('../src/services/ShareService', () => ({
+  ShareService: { shareText: jest.fn() },
+}));
+
+jest.mock('../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({ isTablet: false, maxContentWidth: 0 }),
+}));
+
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: {
+    light: jest.fn(),
+    medium: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    selection: jest.fn(),
+  },
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+
+jest.mock('../src/components/SearchBar', () => {
+  const { TextInput } = require('react-native');
+  return ({ value, onChangeText }: { value: string; onChangeText: (value: string) => void }) => (
+    <TextInput value={value} onChangeText={onChangeText} />
+  );
+});
+
+jest.mock('../src/components/ui', () => ({
+  ScreenHeader: ({ title }: { title: string }) => {
+    const { Text } = require('react-native');
+    return <Text>{title}</Text>;
+  },
+}));
+
+jest.mock('../src/components/NoteCard', () => ({
+  __esModule: true,
+  default: ({ note }: { note: Note }) => {
+    const { Text } = require('react-native');
+    return <Text>{note.title}</Text>;
+  },
+}));
+
+jest.mock('@shopify/flash-list', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    FlashList: React.forwardRef(({ data, renderItem, ListEmptyComponent }: any, _ref: any) => {
+      if (!data?.length) {
+        return <View>{ListEmptyComponent ?? null}</View>;
+      }
+      return <View>{data.map((item: Note, index: number) => renderItem({ item, index }))}</View>;
+    }),
+  };
+});
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { Pressable, View } = require('react-native');
+
+  return React.forwardRef(
+    ({ children, renderRightActions, onSwipeableWillOpen }: any, ref: any) => {
+      const [isOpen, setIsOpen] = React.useState(false);
+      const noteId = children?.props?.note?.id ?? 'unknown';
+      const closeRef = React.useRef();
+      const methodsRef = React.useRef();
+
+      if (!closeRef.current) {
+        closeRef.current = jest.fn(() => setIsOpen(false));
+      }
+
+      if (!methodsRef.current) {
+        methodsRef.current = {
+          close: closeRef.current,
+          openLeft: jest.fn(),
+          openRight: jest.fn(),
+          reset: jest.fn(),
+        };
+      }
+
+      const close = closeRef.current;
+      const methods = methodsRef.current;
+
+      mockSwipeableCloseFns[noteId] = close;
+
+      React.useEffect(() => {
+        if (typeof ref === 'function') {
+          ref(methods);
+          return () => ref(null);
+        }
+
+        if (ref) {
+          ref.current = methods;
+          return () => {
+            ref.current = null;
+          };
+        }
+
+        return undefined;
+      }, [ref, methods]);
+
+      return (
+        <View>
+          <Pressable
+            testID={`open-swipe-${noteId}`}
+            onPress={() => {
+              onSwipeableWillOpen?.();
+              setIsOpen(true);
+            }}
+          />
+          {children}
+          {isOpen ? (
+            <View testID={`swipe-actions-${noteId}`}>
+              {renderRightActions?.(undefined, undefined, methods)}
+            </View>
+          ) : null}
+        </View>
+      );
+    },
+  );
+});
+
+const createNote = (id: string, title: string): Note => ({
+  id,
+  title,
+  content: `${title} content`,
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  format: 'markdown',
+});
+
+const confirmLatestDeleteAlert = async () => {
+  const alertCalls = (Alert.alert as jest.Mock).mock.calls;
+  const lastCall = alertCalls[alertCalls.length - 1];
+  if (!lastCall) {
+    throw new Error('Expected delete alert to be shown');
+  }
+
+  const buttons = lastCall[2] as Array<{ text?: string; onPress?: () => void | Promise<void> }>;
+  const deleteButton = buttons.find((button) => button.text === 'Delete');
+  if (!deleteButton?.onPress) {
+    throw new Error('Expected delete confirmation button');
+  }
+
+  await act(async () => {
+    await deleteButton.onPress?.();
+  });
+};
+
+describe('NotesListScreen swipe delete regression', () => {
+  beforeEach(() => {
+    mockViewMode = 'list';
+    mockNotesSeed = [
+      createNote('note-1', 'First note'),
+      createNote('note-2', 'Second note'),
+      createNote('note-3', 'Third note'),
+    ];
+    latestSetNotes = null;
+    Object.keys(mockSwipeableCloseFns).forEach((key) => delete mockSwipeableCloseFns[key]);
+    mockDeleteNote.mockClear();
+    mockSetViewMode.mockClear();
+    mockRefreshNotes.mockClear();
+    mockTogglePin.mockClear();
+    mockCreateNote.mockClear();
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each(['list', 'journal'] as const)(
+    'closes swiped state before deleting in %s mode so recycled cards do not stay open',
+    async (viewMode) => {
+      mockViewMode = viewMode;
+      const screen = render(<NotesListScreen />);
+
+      fireEvent.press(screen.getByTestId('open-swipe-note-1'));
+      expect(screen.getByTestId('swipe-actions-note-1')).toBeTruthy();
+
+      fireEvent.press(screen.getByText('Delete'));
+      await confirmLatestDeleteAlert();
+
+      await waitFor(() => expect(screen.queryByText('First note')).toBeNull());
+      expect(screen.queryByTestId('swipe-actions-note-2')).toBeNull();
+      expect(screen.queryAllByText('Delete')).toHaveLength(0);
+    },
+  );
+
+  it('keeps only one swipeable card open at a time', async () => {
+    const screen = render(<NotesListScreen />);
+
+    fireEvent.press(screen.getByTestId('open-swipe-note-1'));
+    expect(screen.getByTestId('swipe-actions-note-1')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('open-swipe-note-2'));
+
+    await waitFor(() => expect(mockSwipeableCloseFns['note-1']).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('swipe-actions-note-2')).toBeTruthy();
+  });
+});

--- a/__tests__/useNetworkStatus.test.ts
+++ b/__tests__/useNetworkStatus.test.ts
@@ -1,0 +1,80 @@
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn();
+  const fetch = jest.fn();
+
+  return {
+    __esModule: true,
+    default: {
+      addEventListener,
+      fetch,
+    },
+  };
+});
+
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import NetInfo from '@react-native-community/netinfo';
+import { useNetworkStatus } from '../src/hooks/useNetworkStatus';
+
+const netInfo = NetInfo as jest.Mocked<typeof NetInfo>;
+
+describe('useNetworkStatus', () => {
+  let unsubscribe: jest.Mock;
+  let emitState: ((state: any) => void) | undefined;
+  let resolveFetch: ((state: any) => void) | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    unsubscribe = jest.fn();
+    emitState = undefined;
+    resolveFetch = undefined;
+
+    netInfo.addEventListener.mockImplementation(((listener: any) => {
+      emitState = listener;
+      return unsubscribe;
+    }) as any);
+    netInfo.fetch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve as any;
+        }) as any,
+    );
+  });
+
+  test('starts optimistic and unsubscribes on unmount', () => {
+    const { result, unmount } = renderHook(() => useNetworkStatus());
+
+    expect(result.current).toEqual({ isConnected: true, isInternetReachable: true });
+    expect(netInfo.addEventListener).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test('updates when netinfo emits online and offline states', () => {
+    const { result } = renderHook(() => useNetworkStatus());
+
+    act(() => {
+      emitState?.({ isConnected: false, isInternetReachable: false });
+    });
+    expect(result.current).toEqual({ isConnected: false, isInternetReachable: false });
+
+    act(() => {
+      emitState?.({ isConnected: true, isInternetReachable: true });
+    });
+    expect(result.current).toEqual({ isConnected: true, isInternetReachable: true });
+  });
+
+  test('uses the first fetched status once available', async () => {
+    const { result } = renderHook(() => useNetworkStatus());
+
+    expect(result.current).toEqual({ isConnected: true, isInternetReachable: true });
+
+    act(() => {
+      resolveFetch?.({ isConnected: false, isInternetReachable: false });
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ isConnected: false, isInternetReachable: false });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-native-ai/llama": "0.10.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.6.0",
+    "@react-native-community/netinfo": "^12.0.1",
     "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",

--- a/src/components/CanvasPreview.tsx
+++ b/src/components/CanvasPreview.tsx
@@ -19,7 +19,7 @@ import {
 import { useCanvases } from '../contexts/CanvasContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { RootStackParamList } from '../navigation/types';
-import { Canvas, CanvasElement } from '../models/Canvas';
+import { CanvasChart, CanvasShape, CanvasStroke, CanvasText } from '../models/Canvas';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -76,6 +76,71 @@ function buildLinePath(x1: number, y1: number, x2: number, y2: number) {
   return p;
 }
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isPoint(point: unknown): point is { x: number; y: number } {
+  return !!point
+    && typeof point === 'object'
+    && isFiniteNumber((point as { x?: unknown }).x)
+    && isFiniteNumber((point as { y?: unknown }).y);
+}
+
+function isStrokeElement(el: unknown): el is CanvasStroke {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'stroke'
+    && Array.isArray((el as { points?: unknown }).points)
+    && (el as { points: unknown[] }).points.every(isPoint)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isString((el as { tool?: unknown }).tool);
+}
+
+function isShapeElement(el: unknown): el is CanvasShape {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'shape'
+    && isString((el as { shape?: unknown }).shape)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isFiniteNumber((el as { x1?: unknown }).x1)
+    && isFiniteNumber((el as { y1?: unknown }).y1)
+    && isFiniteNumber((el as { x2?: unknown }).x2)
+    && isFiniteNumber((el as { y2?: unknown }).y2)
+    && ((el as { fillColor?: unknown }).fillColor === undefined || isString((el as { fillColor?: unknown }).fillColor));
+}
+
+function isTextElement(el: unknown): el is CanvasText {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'text'
+    && isString((el as { text?: unknown }).text)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { x?: unknown }).x)
+    && isFiniteNumber((el as { y?: unknown }).y);
+}
+
+function isChartElement(el: unknown): el is CanvasChart {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'chart'
+    && isString((el as { chartType?: unknown }).chartType)
+    && Array.isArray((el as { labels?: unknown }).labels)
+    && (el as { labels: unknown[] }).labels.every(isString)
+    && Array.isArray((el as { values?: unknown }).values)
+    && (el as { values: unknown[] }).values.every(isFiniteNumber)
+    && isFiniteNumber((el as { x?: unknown }).x)
+    && isFiniteNumber((el as { y?: unknown }).y)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isFiniteNumber((el as { height?: unknown }).height);
+}
+
 export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTheme();
@@ -111,17 +176,17 @@ export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
   }
 
   const scene = canvasData.scene;
-  const elements = scene?.elements ?? [];
-  const sceneWidth = scene?.width ?? 800;
-  const sceneHeight = scene?.height ?? 600;
+  const elements: unknown[] = Array.isArray(scene?.elements) ? scene.elements : [];
+  const sceneWidth = isFiniteNumber(scene?.width) && scene.width > 0 ? scene.width : 800;
+  const sceneHeight = isFiniteNumber(scene?.height) && scene.height > 0 ? scene.height : 600;
   const previewWidth = Dimensions.get('window').width - 32;
   const previewHeight = 140;
   const scaleX = previewWidth / sceneWidth;
   const scaleY = previewHeight / sceneHeight;
   const scale = Math.min(scaleX, scaleY);
 
-  const renderElement = (el: CanvasElement, idx: number) => {
-    if (el.type === 'stroke') {
+  const renderElement = (el: unknown, idx: number) => {
+    if (isStrokeElement(el)) {
       const path = buildStrokePath(el.points);
       if (!path) return null;
       const strokeColor = el.tool === 'highlighter' ? hexToRgba(el.color, 0.3) : el.color;
@@ -133,7 +198,7 @@ export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
       );
     }
 
-    if (el.type === 'shape') {
+    if (isShapeElement(el)) {
       const { x1, y1, x2, y2, shape, color: sColor, fillColor, width: sw } = el;
       const minX = Math.min(x1, x2);
       const minY = Math.min(y1, y2);
@@ -181,11 +246,11 @@ export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
       }
     }
 
-    if (el.type === 'text') {
+    if (isTextElement(el)) {
       return <SkiaText key={el.id ?? idx} x={el.x} y={el.y} text={el.text} font={font} color={el.color} />;
     }
 
-    if (el.type === 'chart') {
+    if (isChartElement(el)) {
       const chartColors = ['#007AFF', '#FF3B30', '#34C759', '#FF9500', '#AF52DE'];
       if (el.chartType === 'bar') {
         const maxVal = Math.max(...el.values, 1);

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,77 @@
+import React, { Component, ReactNode } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+
+interface ErrorBoundaryProps {
+  children?: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundaryBase extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return <DefaultFallback onRetry={this.handleRetry} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+function DefaultFallback({ onRetry }: { onRetry: () => void }) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.title, { color: colors.text }]}>Something went wrong</Text>
+      <Pressable onPress={onRetry} style={[styles.button, { backgroundColor: colors.primary }]}>
+        <Text style={[styles.buttonText, { color: '#fff' }]}>Retry</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export function ErrorBoundary(props: ErrorBoundaryProps) {
+  return <ErrorBoundaryBase {...props} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 12,
+    minHeight: 120,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  button: {
+    borderRadius: 999,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  buttonText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import NetInfo, { type NetInfoState } from '@react-native-community/netinfo';
+
+export interface NetworkStatus {
+  isConnected: boolean;
+  isInternetReachable: boolean;
+}
+
+function toNetworkStatus(state: NetInfoState): NetworkStatus {
+  const isConnected = state.isConnected ?? false;
+  return {
+    isConnected,
+    isInternetReachable: state.isInternetReachable ?? isConnected,
+  };
+}
+
+export function useNetworkStatus(): NetworkStatus {
+  const [status, setStatus] = useState<NetworkStatus>({
+    isConnected: true,
+    isInternetReachable: true,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      if (active) {
+        setStatus(toNetworkStatus(state));
+      }
+    });
+
+    NetInfo.fetch().then((state) => {
+      if (active) {
+        setStatus(toNetworkStatus(state));
+      }
+    });
+
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, []);
+
+  return status;
+}

--- a/src/screens/CanvasEditorScreen.tsx
+++ b/src/screens/CanvasEditorScreen.tsx
@@ -547,7 +547,7 @@ export default function CanvasEditorScreen() {
       });
 
       if (!syncResult.success) {
-        console.warn('[CanvasEditor] GitHub sync failed:', syncResult.error);
+        Alert.alert('Sync Failed', syncResult.error || 'Canvas changes were saved locally but could not sync to GitHub.');
       }
     }
 

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -21,7 +21,9 @@ import { FlashList, FlashListRef } from "@shopify/flash-list";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Ionicons } from "@expo/vector-icons";
-import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
+import ReanimatedSwipeable, {
+  type SwipeableMethods,
+} from "react-native-gesture-handler/ReanimatedSwipeable";
 
 import { useNotes } from "../contexts/NoteContext";
 import { useNoteStore } from "../stores/noteStore";
@@ -79,6 +81,10 @@ export default function NotesListScreen() {
   const { isTablet, maxContentWidth } = useResponsive();
   const { repositories } = useRepos();
   const listRef = useRef<FlashListRef<Note>>(null);
+  const swipeableRefs = useRef<
+    Record<string, React.RefObject<SwipeableMethods | null>>
+  >({});
+  const openSwipeableRef = useRef<SwipeableMethods | null>(null);
 
   useEffect(() => {
     if (authState.token) {
@@ -91,6 +97,38 @@ export default function NotesListScreen() {
   const [currentSearchMatchIndex, setCurrentSearchMatchIndex] = useState(0);
   const [pendingSync, setPendingSync] = useState(0);
   const [isManualSyncing, setIsManualSyncing] = useState(false);
+
+  const closeOpenSwipeable = useCallback(() => {
+    openSwipeableRef.current?.close();
+    openSwipeableRef.current = null;
+  }, []);
+
+  const getSwipeableRef = useCallback((noteId: string) => {
+    if (!swipeableRefs.current[noteId]) {
+      swipeableRefs.current[noteId] = React.createRef<SwipeableMethods>();
+    }
+
+    return swipeableRefs.current[noteId];
+  }, []);
+
+  const handleSwipeableWillOpen = useCallback((noteId: string) => {
+    const swipeable = swipeableRefs.current[noteId]?.current;
+
+    if (openSwipeableRef.current && openSwipeableRef.current !== swipeable) {
+      openSwipeableRef.current.close();
+    }
+
+    if (swipeable) {
+      openSwipeableRef.current = swipeable;
+    }
+  }, []);
+
+  const handleSwipeableWillClose = useCallback((noteId: string) => {
+    const swipeable = swipeableRefs.current[noteId]?.current;
+    if (openSwipeableRef.current === swipeable) {
+      openSwipeableRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -290,6 +328,7 @@ export default function NotesListScreen() {
 
   const handleDeleteFromSwipe = useCallback(
     (note: Note) => {
+      closeOpenSwipeable();
       Alert.alert("Delete Note", `Delete "${note.title || "Untitled"}"?`, [
         { text: "Cancel", style: "cancel" },
         {
@@ -305,7 +344,7 @@ export default function NotesListScreen() {
         },
       ]);
     },
-    [deleteNote],
+    [closeOpenSwipeable, deleteNote],
   );
 
   const scrollToSearchMatch = useCallback(
@@ -382,8 +421,12 @@ export default function NotesListScreen() {
   const renderSwipeableNote = useCallback(
     (note: Note, index: number) => (
       <ReanimatedSwipeable
+        key={note.id}
+        ref={getSwipeableRef(note.id)}
         overshootRight={false}
         rightThreshold={40}
+        onSwipeableWillOpen={() => handleSwipeableWillOpen(note.id)}
+        onSwipeableWillClose={() => handleSwipeableWillClose(note.id)}
         renderRightActions={() => renderSwipeActions(note)}
       >
         <NoteCard
@@ -396,6 +439,9 @@ export default function NotesListScreen() {
     ),
     [
       currentSearchMatchIndex,
+      getSwipeableRef,
+      handleSwipeableWillClose,
+      handleSwipeableWillOpen,
       handleNoteLongPress,
       handleNotePress,
       hasActiveSearch,
@@ -411,7 +457,7 @@ export default function NotesListScreen() {
 
   const renderJournalNote = useCallback(
     ({ item, index }: { item: Note; index: number }) => (
-      <View style={styles.journalItem}>
+      <View key={item.id} style={styles.journalItem}>
         <Text style={[styles.journalDate, { color: colors.textSecondary }]}>
           {item.updatedAt ? new Date(item.updatedAt).toLocaleDateString() : ""}
         </Text>

--- a/src/services/NeorgContentParser.ts
+++ b/src/services/NeorgContentParser.ts
@@ -2,6 +2,10 @@ import { NeorgHeading, NeorgListItem, NeorgContentBlock, NeorgChecklistItem, Neo
 
 export class NeorgContentParser {
   static parseContent(content: string): NeorgContentParseResult {
+    if (typeof content !== 'string') {
+      return { success: false, blocks: [], error: 'Invalid content: expected string' };
+    }
+
     try {
       const lines = content.split('\n');
       const blocks: NeorgContentBlock[] = [];

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -163,53 +163,43 @@ async function pullCanvasesFromRepo(
     const files = await fetchDirectoryFiles(owner, repo, 'canvases', branch);
     if (files.length === 0) return 0;
 
-    // Single read → mutate in memory → single write. Previous code re-read
-    // and re-wrote inside each iteration which lost interleaved edits when
-    // pulls ran in parallel (Promise.all in pullAllFromRepos).
-    const allCanvases = await StorageService.getAllCanvases();
-    let dirty = false;
+    await StorageService.mutateCanvases((allCanvases) => {
+      for (const file of files) {
+        if (!file.path.endsWith('.json')) continue;
 
-    for (const file of files) {
-      if (!file.path.endsWith('.json')) continue;
+        let scene: CanvasScene;
+        try {
+          scene = JSON.parse(file.content);
+        } catch {
+          continue;
+        }
 
-      let scene: CanvasScene;
-      try {
-        scene = JSON.parse(file.content);
-      } catch {
-        continue;
-      }
+        const titleFromPath = file.path
+          .replace(/^canvases\//, '')
+          .replace(/\.json$/, '')
+          .replace(/-/g, ' ');
 
-      const titleFromPath = file.path
-        .replace(/^canvases\//, '')
-        .replace(/\.json$/, '')
-        .replace(/-/g, ' ');
-
-      const idx = allCanvases.findIndex((c) => c.filePath === file.path);
-      if (idx !== -1) {
-        const existing = allCanvases[idx];
-        if (JSON.stringify(existing.scene) !== JSON.stringify(scene)) {
-          allCanvases[idx] = updateCanvas(existing, { scene });
-          dirty = true;
+        const idx = allCanvases.findIndex((c) => c.filePath === file.path);
+        if (idx !== -1) {
+          const existing = allCanvases[idx];
+          if (JSON.stringify(existing.scene) !== JSON.stringify(scene)) {
+            allCanvases[idx] = updateCanvas(existing, { scene });
+            pulled++;
+          }
+        } else {
+          allCanvases.push(
+            createCanvas({
+              title: titleFromPath,
+              scene,
+              repo: repoPath,
+              branch,
+              filePath: file.path,
+            }),
+          );
           pulled++;
         }
-      } else {
-        allCanvases.push(
-          createCanvas({
-            title: titleFromPath,
-            scene,
-            repo: repoPath,
-            branch,
-            filePath: file.path,
-          }),
-        );
-        dirty = true;
-        pulled++;
       }
-    }
-
-    if (dirty) {
-      await StorageService.saveAllCanvases(allCanvases);
-    }
+    });
   } catch {
     console.warn(`[RepoPullService] Failed to pull canvases from ${owner}/${repo}`);
   }

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -3,11 +3,12 @@ import { Note, NoteCreateInput, NoteUpdateInput, createNote, updateNote } from '
 import { Folder, FolderCreateInput, createFolder, updateFolder } from '../models/Folder';
 import { GitRepository } from './GitService';
 import { Todo, TodoCreateInput, TodoUpdateInput, createTodoItem, applyTodoUpdate } from '../models/Todo';
-import { Canvas, CanvasCreateInput, CanvasUpdateInput, createCanvas, updateCanvas, sortCanvasesByUpdated } from '../models/Canvas';
+import { Canvas, CanvasCreateInput, CanvasUpdateInput, createCanvas, updateCanvas } from '../models/Canvas';
 import { NOTE_INDEX_KEY, noteKey, getBootValue } from './StorageBootstrap';
 
 const TODOS_STORAGE_KEY = '@gitnotes:todos';
 const CANVASES_STORAGE_KEY = '@gitnotes:canvases';
+const CANVASES_BACKUP_STORAGE_KEY = '@gitnotes:canvases.bak';
 const LEGACY_NOTES_KEY = '@gitnotes:notes';
 const REPOS_STORAGE_KEY = '@gitnotes:repos';
 const FOLDERS_STORAGE_KEY = '@gitnotes:folders';
@@ -38,6 +39,47 @@ async function migrateFromBlob(): Promise<void> {
 }
 
 export class StorageService {
+  private static canvasWriteQueue: Promise<void> = Promise.resolve();
+
+  private static enqueueCanvasWrite<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.canvasWriteQueue.catch(() => undefined).then(operation);
+    this.canvasWriteQueue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  private static async readAllCanvasesRaw(): Promise<Canvas[]> {
+    try {
+      const boot = getBootValue('@gitnotes:canvases');
+      const json = boot ?? await AsyncStorage.getItem(CANVASES_STORAGE_KEY);
+      return json ? JSON.parse(json) : [];
+    } catch (error) {
+      console.error('Error reading canvases from storage:', error);
+      return [];
+    }
+  }
+
+  private static async backupCanvasBlob(): Promise<void> {
+    const current = await AsyncStorage.getItem(CANVASES_STORAGE_KEY);
+    if (current !== null) {
+      await AsyncStorage.setItem(CANVASES_BACKUP_STORAGE_KEY, current);
+    }
+  }
+
+  static async mutateCanvases<T>(mutator: (canvases: Canvas[]) => Promise<T> | T): Promise<T> {
+    return this.enqueueCanvasWrite(async () => {
+      const canvases = await this.readAllCanvasesRaw();
+      const result = await mutator(canvases);
+      try {
+        await this.backupCanvasBlob();
+        await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify(canvases));
+      } catch (error) {
+        console.error('Error saving canvases to storage:', error);
+        throw error;
+      }
+      return result;
+    });
+  }
+
   static async getAllNotes(): Promise<Note[]> {
     await migrateFromBlob();
     try {
@@ -323,22 +365,20 @@ export class StorageService {
   }
 
   static async getAllCanvases(): Promise<Canvas[]> {
-    try {
-      const boot = getBootValue('@gitnotes:canvases');
-      const json = boot ?? await AsyncStorage.getItem(CANVASES_STORAGE_KEY);
-      return json ? JSON.parse(json) : [];
-    } catch {
-      return [];
-    }
+    await this.canvasWriteQueue;
+    return this.readAllCanvasesRaw();
   }
 
   static async saveAllCanvases(canvases: Canvas[]): Promise<void> {
-    try {
-      await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify(canvases));
-    } catch (error) {
-      console.error('Error saving canvases to storage:', error);
-      throw error;
-    }
+    await this.enqueueCanvasWrite(async () => {
+      try {
+        await this.backupCanvasBlob();
+        await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify(canvases));
+      } catch (error) {
+        console.error('Error saving canvases to storage:', error);
+        throw error;
+      }
+    });
   }
 
   static async getCanvasById(id: string): Promise<Canvas | null> {
@@ -347,27 +387,28 @@ export class StorageService {
   }
 
   static async createCanvas(input: CanvasCreateInput): Promise<Canvas> {
-    const canvases = await this.getAllCanvases();
-    const newCanvas = createCanvas(input);
-    canvases.push(newCanvas);
-    await this.saveAllCanvases(canvases);
-    return newCanvas;
+    return this.mutateCanvases((canvases) => {
+      const newCanvas = createCanvas(input);
+      canvases.push(newCanvas);
+      return newCanvas;
+    });
   }
 
   static async updateCanvas(input: CanvasUpdateInput): Promise<Canvas | null> {
-    const canvases = await this.getAllCanvases();
-    const idx = canvases.findIndex((c) => c.id === input.id);
-    if (idx === -1) return null;
-    canvases[idx] = updateCanvas(canvases[idx], input);
-    await this.saveAllCanvases(canvases);
-    return canvases[idx];
+    return this.mutateCanvases((canvases) => {
+      const idx = canvases.findIndex((c) => c.id === input.id);
+      if (idx === -1) return null;
+      canvases[idx] = updateCanvas(canvases[idx], input);
+      return canvases[idx];
+    });
   }
 
   static async deleteCanvas(id: string): Promise<boolean> {
-    const canvases = await this.getAllCanvases();
-    const filtered = canvases.filter((c) => c.id !== id);
-    if (filtered.length === canvases.length) return false;
-    await this.saveAllCanvases(filtered);
-    return true;
+    return this.mutateCanvases((canvases) => {
+      const idx = canvases.findIndex((c) => c.id === id);
+      if (idx === -1) return false;
+      canvases.splice(idx, 1);
+      return true;
+    });
   }
 }

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -4,6 +4,7 @@ import { Renderer, type RendererInterface } from 'react-native-marked';
 import { Image } from 'expo-image';
 
 import { isCanvasLink, canvasIdFromLink } from '../models/Canvas';
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 
 interface CustomRendererDeps {
   colors: {
@@ -26,6 +27,24 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
   constructor(deps: CustomRendererDeps) {
     super();
     this.deps = deps;
+  }
+
+  private renderCanvasFallback(id: string): ReactNode {
+    return (
+      <Text
+        key={`canvas-fallback-${id}`}
+        style={{
+          color: this.deps.colors.text,
+          backgroundColor: this.deps.colors.surfaceSecondary ?? '#f0f0f0',
+          borderRadius: 8,
+          overflow: 'hidden',
+          paddingHorizontal: 12,
+          paddingVertical: 10,
+        }}
+      >
+        Canvas preview unavailable
+      </Text>
+    );
   }
 
   image(uri: string, alt?: string, _style?: ImageStyle): ReactNode {
@@ -63,7 +82,11 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
   link(children: string | ReactNode[], href: string, styles?: TextStyle): ReactNode {
     if (isCanvasLink(href) && this.deps.CanvasPreview) {
       const id = canvasIdFromLink(href);
-      return <React.Fragment key={this.getKey()}>{React.createElement(this.deps.CanvasPreview, { canvasId: id })}</React.Fragment>;
+      return React.createElement(
+        ErrorBoundary,
+        { key: `canvas-boundary-${id}`, fallback: this.renderCanvasFallback(id) },
+        React.createElement(this.deps.CanvasPreview, { key: id, canvasId: id }),
+      );
     }
 
     const onPress = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,6 +1854,11 @@
   dependencies:
     invariant "^2.2.4"
 
+"@react-native-community/netinfo@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-12.0.1.tgz#fec75f4093c27778479d8927b4f51f133b8a13a4"
+  integrity sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ==
+
 "@react-native/assets-registry@0.83.6":
   version "0.83.6"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.83.6.tgz#36c4d986aa2903ab05c29589749618cfd9d2a258"


### PR DESCRIPTION
## Summary

Fixes all critical crash and data-loss bugs plus foundation work for offline detection:

### Critical Fixes
- **#421** — Swipe-to-delete: adjacent card no longer opens after deletion. Tracks open swipeable ref, closes before delete alert, adds `key={note.id}` for FlashList recycling.
- **#425** — Canvas tap-to-open crash: serialized canvas storage writes via promise queue to prevent read-modify-write race between editor saves and GitHub pulls. Sync failures now surfaced as Alert.
- **#426** — Second canvas crash: added stable `key={id}` to CanvasPreview createElement, wrapped in ErrorBoundary, added element shape validation before Skia rendering.

### Foundation
- **#423 B1** — Neorg null crash: added null/undefined guard to `NeorgContentParser.parseContent()`. Created reusable `ErrorBoundary` component.
- Added `@react-native-community/netinfo` + `useNetworkStatus` hook (foundation for #413, #420).

### Test Results
- **227 tests passing** (16 new tests added, 0 regressions)
- 0 TypeScript errors

## Test plan
- [x] Swipe-delete: after deleting swiped card, no adjacent card shows open swipe state
- [x] Canvas: note with two `[canvas:...]` embeds renders without crash
- [x] Canvas: concurrent save + pull never lose data
- [x] Renderer: `parseContent(null)` returns structured error
- [x] NetInfo hook: returns correct online/offline state