### PR TITLE
feat(auth): multi-account / multi-token GitHub support

### DIFF
--- a/__tests__/services/AccountStorage.test.ts
+++ b/__tests__/services/AccountStorage.test.ts
@@ -1,0 +1,103 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+
+jest.mock('expo-secure-store', () => {
+  const mem: Record<string, string> = {};
+  return {
+    __esModule: true,
+    getItemAsync: jest.fn(async (k: string) => (k in mem ? mem[k] : null)),
+    setItemAsync: jest.fn(async (k: string, v: string) => {
+      mem[k] = v;
+    }),
+    deleteItemAsync: jest.fn(async (k: string) => {
+      delete mem[k];
+    }),
+  };
+});
+
+import { AccountStorage } from '../../src/services/AccountStorage';
+
+const profile = {
+  login: 'octocat',
+  name: 'Octo Cat',
+  email: 'octo@example.com',
+  avatarUrl: 'https://example.com/octo.png',
+};
+
+const profile2 = {
+  login: 'monalisa',
+  name: 'Mona Lisa',
+  email: 'mona@example.com',
+  avatarUrl: 'https://example.com/mona.png',
+};
+
+beforeEach(async () => {
+  await AsyncStorage.clear?.();
+  // SecureStore mem is module-scoped; reset by deleting known keys is impractical.
+  // Tests use distinct ids so collisions are unlikely.
+});
+
+describe('AccountStorage', () => {
+  it('starts empty', async () => {
+    const accounts = await AccountStorage.listAccounts();
+    expect(accounts).toEqual([]);
+    expect(await AccountStorage.getActiveAccountId()).toBeNull();
+    expect(await AccountStorage.getActiveToken()).toBeNull();
+  });
+
+  it('addAccount persists, sets active when none, returns the account', async () => {
+    const acc = await AccountStorage.addAccount('tok-1', profile);
+    expect(acc.login).toBe('octocat');
+    expect(acc.id).toMatch(/^acc-/);
+    expect(await AccountStorage.getActiveAccountId()).toBe(acc.id);
+    expect(await AccountStorage.getActiveToken()).toBe('tok-1');
+    expect(await AccountStorage.getTokenById(acc.id)).toBe('tok-1');
+    const list = await AccountStorage.listAccounts();
+    expect(list).toHaveLength(1);
+  });
+
+  it('adding a second account does not steal active', async () => {
+    const a = await AccountStorage.addAccount('tok-a', profile);
+    const b = await AccountStorage.addAccount('tok-b', profile2);
+    expect(b.id).not.toBe(a.id);
+    expect(await AccountStorage.getActiveAccountId()).toBe(a.id);
+    expect(await AccountStorage.getActiveToken()).toBe('tok-a');
+    expect(await AccountStorage.getTokenById(b.id)).toBe('tok-b');
+    const list = await AccountStorage.listAccounts();
+    expect(list).toHaveLength(2);
+  });
+
+  it('addAccount with same login replaces token + profile, no duplicate', async () => {
+    const first = await AccountStorage.addAccount('tok-1', profile);
+    const updated = await AccountStorage.addAccount('tok-2', { ...profile, name: 'Renamed' });
+    expect(updated.id).toBe(first.id);
+    expect(updated.name).toBe('Renamed');
+    expect(await AccountStorage.getTokenById(first.id)).toBe('tok-2');
+    const list = await AccountStorage.listAccounts();
+    expect(list).toHaveLength(1);
+  });
+
+  it('switching active and removing accounts works end-to-end', async () => {
+    const a = await AccountStorage.addAccount('tok-a', profile);
+    const b = await AccountStorage.addAccount('tok-b', profile2);
+    await AccountStorage.setActiveAccountId(b.id);
+    expect(await AccountStorage.getActiveToken()).toBe('tok-b');
+
+    await AccountStorage.removeAccount(b.id);
+    // active falls back to a remaining account
+    expect(await AccountStorage.getActiveAccountId()).toBe(a.id);
+    expect(await AccountStorage.getActiveToken()).toBe('tok-a');
+    expect(await AccountStorage.getTokenById(b.id)).toBeNull();
+
+    await AccountStorage.removeAccount(a.id);
+    expect(await AccountStorage.getActiveAccountId()).toBeNull();
+    expect(await AccountStorage.getActiveToken()).toBeNull();
+  });
+
+  it('falls back to legacy token when no accounts list exists', async () => {
+    // Simulate legacy install: SecureStore single-key from previous AuthService
+    await (SecureStore.setItemAsync as jest.Mock)('gitnotes_github_token', 'legacy-tok');
+    expect(await AccountStorage.listAccounts()).toEqual([]);
+    expect(await AccountStorage.getActiveToken()).toBe('legacy-tok');
+  });
+});

--- a/src/components/ActiveFilterStrip.tsx
+++ b/src/components/ActiveFilterStrip.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-nati
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import { FilterableItem, UseEntityFilterReturn } from '../hooks/useEntityFilter';
+import { useAuth } from '../contexts/AuthContext';
 
 interface Props<T extends FilterableItem> {
   filter: UseEntityFilterReturn<T>;
@@ -10,16 +11,19 @@ interface Props<T extends FilterableItem> {
 
 export function ActiveFilterStrip<T extends FilterableItem>({ filter }: Props<T>) {
   const { colors } = useTheme();
+  const { accounts } = useAuth();
   const {
     state,
     setSelectedRepo,
     setSelectedBranch,
     setSelectedFolder,
+    setSelectedAccountId,
     toggleTag,
     clearAll,
     activeCount,
   } = filter;
-  const { selectedRepo, selectedBranch, selectedFolder, selectedTags } = state;
+  const { selectedRepo, selectedBranch, selectedFolder, selectedTags, selectedAccountId } = state;
+  const selectedAccount = selectedAccountId ? accounts.find((a) => a.id === selectedAccountId) : null;
 
   if (activeCount === 0) return null;
 
@@ -48,6 +52,8 @@ export function ActiveFilterStrip<T extends FilterableItem>({ filter }: Props<T>
   return (
     <View style={styles.wrap}>
       <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.row}>
+        {selectedAccount &&
+          chip('account', 'person-outline', `@${selectedAccount.login}`, () => setSelectedAccountId(null))}
         {selectedRepo &&
           chip('repo', 'logo-github', selectedRepo.name, () => setSelectedRepo(null))}
         {selectedBranch &&

--- a/src/components/EntityFilterModal.tsx
+++ b/src/components/EntityFilterModal.tsx
@@ -14,6 +14,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { HapticService } from '../utils/haptics';
 import { GitRepository } from '../services/GitService';
 import { FilterableItem, UseEntityFilterReturn } from '../hooks/useEntityFilter';
+import { useAuth } from '../contexts/AuthContext';
 
 interface Props<T extends FilterableItem> {
   visible: boolean;
@@ -25,11 +26,14 @@ interface Props<T extends FilterableItem> {
 export function EntityFilterModal<T extends FilterableItem>(props: Props<T>) {
   const { visible, onClose, filter, repositories } = props;
   const { colors } = useTheme();
+  const { accounts } = useAuth();
+  const showAccountFilter = accounts.length >= 2;
   const {
     state,
     setSelectedRepo,
     setSelectedBranch,
     setSelectedFolder,
+    setSelectedAccountId,
     toggleTag,
     clearAll,
     allBranches,
@@ -37,7 +41,7 @@ export function EntityFilterModal<T extends FilterableItem>(props: Props<T>) {
     allTags,
     activeCount,
   } = filter;
-  const { selectedRepo, selectedBranch, selectedFolder, selectedTags } = state;
+  const { selectedRepo, selectedBranch, selectedFolder, selectedTags, selectedAccountId } = state;
 
   const renderChipRow = (
     items: string[],
@@ -111,6 +115,74 @@ export function EntityFilterModal<T extends FilterableItem>(props: Props<T>) {
         </View>
 
         <ScrollView contentContainerStyle={styles.content}>
+          {showAccountFilter && (
+            <>
+              <Text style={[styles.label, { color: colors.textSecondary }]}>Account</Text>
+              <FlatList
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                style={styles.chipRow}
+                data={accounts}
+                keyExtractor={(acc) => acc.id}
+                ListHeaderComponent={
+                  <TouchableOpacity
+                    style={[
+                      styles.chip,
+                      { borderColor: colors.border },
+                      !selectedAccountId && {
+                        borderColor: colors.primary,
+                        backgroundColor: colors.primary + '15',
+                      },
+                    ]}
+                    onPress={() => setSelectedAccountId(null)}
+                  >
+                    <Text
+                      style={[
+                        styles.chipText,
+                        { color: !selectedAccountId ? colors.primary : colors.text },
+                      ]}
+                    >
+                      All
+                    </Text>
+                  </TouchableOpacity>
+                }
+                renderItem={({ item: acc }) => {
+                  const isSelected = selectedAccountId === acc.id;
+                  return (
+                    <TouchableOpacity
+                      style={[
+                        styles.chip,
+                        { borderColor: colors.border },
+                        isSelected && {
+                          borderColor: colors.primary,
+                          backgroundColor: colors.primary + '15',
+                        },
+                      ]}
+                      onPress={() => {
+                        HapticService.selection();
+                        setSelectedAccountId(isSelected ? null : acc.id);
+                      }}
+                    >
+                      <Ionicons
+                        name="person-outline"
+                        size={13}
+                        color={isSelected ? colors.primary : colors.textSecondary}
+                      />
+                      <Text
+                        style={[
+                          styles.chipText,
+                          { color: isSelected ? colors.primary : colors.text },
+                        ]}
+                        numberOfLines={1}
+                      >
+                        @{acc.login}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                }}
+              />
+            </>
+          )}
           <Text style={[styles.label, { color: colors.textSecondary }]}>Repository</Text>
           <FlatList
             horizontal

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,13 +1,19 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react';
 import { AuthService, AuthState } from '../services/AuthService';
 import { GitHubService } from '../services/GitHubService';
+import type { StoredAccount } from '../services/AccountStorage';
 
 interface AuthContextType {
   authState: AuthState;
+  accounts: StoredAccount[];
+  activeAccountId: string | null;
   isLoading: boolean;
   refreshAuth: () => Promise<void>;
   setToken: (token: string) => Promise<boolean>;
   clearToken: () => Promise<void>;
+  addAccount: (token: string) => Promise<StoredAccount | null>;
+  removeAccount: (id: string) => Promise<void>;
+  switchAccount: (id: string) => Promise<boolean>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -16,48 +22,111 @@ interface AuthProviderProps {
   children: ReactNode;
 }
 
+const EMPTY_AUTH: AuthState = { isAuthenticated: false, user: null, token: null };
+
+type GhSetTokenUser = Parameters<typeof GitHubService.setToken>[1];
+
 export function AuthProvider({ children }: AuthProviderProps) {
-  const [authState, setAuthState] = useState<AuthState>({
-    isAuthenticated: false,
-    user: null,
-    token: null,
-  });
+  const [authState, setAuthState] = useState<AuthState>(EMPTY_AUTH);
+  const [accounts, setAccounts] = useState<StoredAccount[]>([]);
+  const [activeAccountId, setActiveAccountIdState] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  const refreshAccounts = useCallback(async () => {
+    const list = await AuthService.listAccounts();
+    const activeId = await AuthService.getActiveAccountId();
+    setAccounts(list);
+    setActiveAccountIdState(activeId);
+  }, []);
 
   const refreshAuth = useCallback(async () => {
     const state = await AuthService.checkAuthState();
     setAuthState(state);
-  }, []);
+    await refreshAccounts();
+  }, [refreshAccounts]);
 
   const setToken = useCallback(async (token: string): Promise<boolean> => {
     setIsLoading(true);
     const state = await AuthService.setToken(token);
     if (!state.isAuthenticated) {
-      // Validation failed — keep prior auth state untouched so a typo
-      // doesn't log the user out.
       setIsLoading(false);
       return false;
     }
-    // Pass the user we just validated so GitHubService doesn't re-hit /user.
-    // If the GitHubService write fails, roll AuthService back so the two
-    // services don't disagree about who's logged in.
-    const ghUser = await GitHubService.setToken(token, (state.user as unknown) as Parameters<typeof GitHubService.setToken>[1]);
+    const ghUser = await GitHubService.setToken(token, state.user as unknown as GhSetTokenUser);
     if (!ghUser) {
       await AuthService.clearToken();
-      setAuthState({ isAuthenticated: false, user: null, token: null });
+      setAuthState(EMPTY_AUTH);
+      await refreshAccounts();
       setIsLoading(false);
       return false;
     }
     setAuthState(state);
+    await refreshAccounts();
     setIsLoading(false);
     return true;
-  }, []);
+  }, [refreshAccounts]);
 
   const clearToken = useCallback(async () => {
     await AuthService.clearToken();
     await GitHubService.clearToken();
-    setAuthState({ isAuthenticated: false, user: null, token: null });
-  }, []);
+    setAuthState(EMPTY_AUTH);
+    await refreshAccounts();
+    const remaining = await AuthService.listAccounts();
+    if (remaining.length > 0) {
+      const promoted = remaining[0];
+      const next = await AuthService.setActiveAccount(promoted.id);
+      if (next.isAuthenticated && next.token) {
+        await GitHubService.setToken(next.token, next.user as unknown as GhSetTokenUser);
+        setAuthState(next);
+      }
+      await refreshAccounts();
+    }
+  }, [refreshAccounts]);
+
+  const addAccount = useCallback(async (token: string): Promise<StoredAccount | null> => {
+    const account = await AuthService.addAccount(token);
+    if (account) await refreshAccounts();
+    return account;
+  }, [refreshAccounts]);
+
+  const removeAccount = useCallback(async (id: string) => {
+    const wasActive = (await AuthService.getActiveAccountId()) === id;
+    await AuthService.removeAccount(id);
+    await refreshAccounts();
+
+    if (wasActive) {
+      const remaining = await AuthService.listAccounts();
+      if (remaining.length > 0) {
+        const next = await AuthService.setActiveAccount(remaining[0].id);
+        if (next.isAuthenticated && next.token) {
+          await GitHubService.setToken(next.token, next.user as unknown as GhSetTokenUser);
+          setAuthState(next);
+        }
+      } else {
+        await GitHubService.clearToken();
+        setAuthState(EMPTY_AUTH);
+      }
+      await refreshAccounts();
+    }
+  }, [refreshAccounts]);
+
+  const switchAccount = useCallback(async (id: string): Promise<boolean> => {
+    setIsLoading(true);
+    const next = await AuthService.setActiveAccount(id);
+    if (!next.isAuthenticated || !next.token) {
+      setIsLoading(false);
+      return false;
+    }
+    const ghUser = await GitHubService.setToken(next.token, next.user as unknown as GhSetTokenUser);
+    if (!ghUser) {
+      setIsLoading(false);
+      return false;
+    }
+    setAuthState(next);
+    await refreshAccounts();
+    setIsLoading(false);
+    return true;
+  }, [refreshAccounts]);
 
   useEffect(() => {
     refreshAuth()
@@ -69,8 +138,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   const value = useMemo(
-    () => ({ authState, isLoading, refreshAuth, setToken, clearToken }),
-    [authState, isLoading, refreshAuth, setToken, clearToken],
+    () => ({
+      authState,
+      accounts,
+      activeAccountId,
+      isLoading,
+      refreshAuth,
+      setToken,
+      clearToken,
+      addAccount,
+      removeAccount,
+      switchAccount,
+    }),
+    [authState, accounts, activeAccountId, isLoading, refreshAuth, setToken, clearToken, addAccount, removeAccount, switchAccount],
   );
 
   return (
@@ -86,6 +166,15 @@ export function useAuth() {
     throw new Error('useAuth must be used within an AuthProvider');
   }
   return context;
+}
+
+/**
+ * True when account-aware UI (picker, badges, filters) should render.
+ * Hidden in the single-account default.
+ */
+export function useShouldShowAccountUI(): boolean {
+  const { accounts } = useAuth();
+  return accounts.length >= 2;
 }
 
 export default AuthContext;

--- a/src/hooks/useEntityFilter.ts
+++ b/src/hooks/useEntityFilter.ts
@@ -7,6 +7,7 @@ export interface FilterableItem {
   filePath?: string;
   folderPath?: string;
   tags?: string[];
+  accountId?: string;
 }
 
 export interface EntityFilterState {
@@ -14,6 +15,7 @@ export interface EntityFilterState {
   selectedBranch: string | null;
   selectedFolder: string | null;
   selectedTags: string[];
+  selectedAccountId: string | null;
 }
 
 export interface UseEntityFilterReturn<T extends FilterableItem> {
@@ -21,6 +23,7 @@ export interface UseEntityFilterReturn<T extends FilterableItem> {
   setSelectedRepo: (repo: GitRepository | null) => void;
   setSelectedBranch: (branch: string | null) => void;
   setSelectedFolder: (folder: string | null) => void;
+  setSelectedAccountId: (accountId: string | null) => void;
   toggleTag: (tag: string) => void;
   clearAll: () => void;
   applyFilters: (input: T[]) => T[];
@@ -45,6 +48,7 @@ export function useEntityFilter<T extends FilterableItem>(items: T[]): UseEntity
   const [selectedBranch, setSelectedBranchState] = useState<string | null>(null);
   const [selectedFolder, setSelectedFolderState] = useState<string | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [selectedAccountId, setSelectedAccountIdState] = useState<string | null>(null);
 
   const setSelectedRepo = useCallback((repo: GitRepository | null) => {
     setSelectedRepoState(repo);
@@ -60,6 +64,10 @@ export function useEntityFilter<T extends FilterableItem>(items: T[]): UseEntity
     setSelectedFolderState(folder);
   }, []);
 
+  const setSelectedAccountId = useCallback((accountId: string | null) => {
+    setSelectedAccountIdState(accountId);
+  }, []);
+
   const toggleTag = useCallback((tag: string) => {
     setSelectedTags((prev) => (prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]));
   }, []);
@@ -69,6 +77,7 @@ export function useEntityFilter<T extends FilterableItem>(items: T[]): UseEntity
     setSelectedBranchState(null);
     setSelectedFolderState(null);
     setSelectedTags([]);
+    setSelectedAccountIdState(null);
   }, []);
 
   const allBranches = useMemo(() => {
@@ -111,6 +120,7 @@ export function useEntityFilter<T extends FilterableItem>(items: T[]): UseEntity
       return input.filter((item) => {
         if (selectedRepo && item.repo !== selectedRepo.path) return false;
         if (selectedBranch && item.branch !== selectedBranch) return false;
+        if (selectedAccountId && item.accountId !== selectedAccountId) return false;
         if (selectedFolder) {
           const cands = folderCandidates(item);
           const matches = cands.some(
@@ -125,20 +135,22 @@ export function useEntityFilter<T extends FilterableItem>(items: T[]): UseEntity
         return true;
       });
     },
-    [selectedRepo, selectedBranch, selectedFolder, selectedTags],
+    [selectedRepo, selectedBranch, selectedFolder, selectedTags, selectedAccountId],
   );
 
   const activeCount =
     (selectedRepo ? 1 : 0) +
     (selectedBranch ? 1 : 0) +
     (selectedFolder ? 1 : 0) +
-    (selectedTags.length > 0 ? 1 : 0);
+    (selectedTags.length > 0 ? 1 : 0) +
+    (selectedAccountId ? 1 : 0);
 
   return {
-    state: { selectedRepo, selectedBranch, selectedFolder, selectedTags },
+    state: { selectedRepo, selectedBranch, selectedFolder, selectedTags, selectedAccountId },
     setSelectedRepo,
     setSelectedBranch,
     setSelectedFolder,
+    setSelectedAccountId,
     toggleTag,
     clearAll,
     applyFilters,

--- a/src/models/AIProvider.ts
+++ b/src/models/AIProvider.ts
@@ -30,6 +30,7 @@ export interface AISettings {
   chatRepoOwner: string | null;
   chatRepoName: string | null;
   chatRepoBranch: string;
+  chatRepoAccountId: string | null;
   providers: AIProviderConfig[];
 }
 

--- a/src/models/Canvas.ts
+++ b/src/models/Canvas.ts
@@ -64,6 +64,7 @@ export interface Canvas {
   tags: string[];
   createdAt: number;
   updatedAt: number;
+  accountId?: string;
 }
 
 export interface CanvasCreateInput {
@@ -74,6 +75,7 @@ export interface CanvasCreateInput {
   branch?: string;
   filePath?: string;
   tags?: string[];
+  accountId?: string;
 }
 
 export interface CanvasUpdateInput {
@@ -85,6 +87,7 @@ export interface CanvasUpdateInput {
   branch?: string;
   filePath?: string;
   tags?: string[];
+  accountId?: string;
 }
 
 function generateId(): string {
@@ -116,6 +119,7 @@ export function createCanvas(input: CanvasCreateInput): Canvas {
     tags: input.tags ?? [],
     createdAt: now,
     updatedAt: now,
+    accountId: input.accountId,
   };
 }
 
@@ -129,6 +133,7 @@ export function updateCanvas(existing: Canvas, input: Partial<CanvasCreateInput>
     branch: input.branch ?? existing.branch,
     filePath: input.filePath ?? existing.filePath,
     tags: input.tags ?? existing.tags,
+    accountId: input.accountId ?? existing.accountId,
     updatedAt: Date.now(),
   };
 }

--- a/src/models/Note.ts
+++ b/src/models/Note.ts
@@ -28,6 +28,7 @@ export interface Note {
   format?: NoteFormat;
   github?: NoteGitHubLink;
   attachments?: Attachment[];
+  accountId?: string;
 }
 
 export interface NoteCreateInput {
@@ -42,6 +43,7 @@ export interface NoteCreateInput {
   isPinned?: boolean;
   format?: NoteFormat;
   attachments?: Attachment[];
+  accountId?: string;
 }
 
 export interface NoteUpdateInput {
@@ -57,6 +59,7 @@ export interface NoteUpdateInput {
   isPinned?: boolean;
   format?: NoteFormat;
   attachments?: Attachment[];
+  accountId?: string;
 }
 
 export function createNote(input: NoteCreateInput): Note {
@@ -76,6 +79,7 @@ export function createNote(input: NoteCreateInput): Note {
     isPinned: input.isPinned || false,
     format: input.format || 'markdown',
     attachments: input.attachments || [],
+    accountId: input.accountId,
   };
 }
 
@@ -93,6 +97,7 @@ export function updateNote(existing: Note, input: Partial<NoteCreateInput>): Not
     isPinned: input.isPinned ?? existing.isPinned,
     format: input.format ?? existing.format,
     attachments: input.attachments ?? existing.attachments,
+    accountId: input.accountId ?? existing.accountId,
     updatedAt: Date.now(),
   };
 }

--- a/src/models/Todo.ts
+++ b/src/models/Todo.ts
@@ -27,6 +27,7 @@ export interface Todo {
   repo?: string;
   branch?: string;
   filePath?: string;
+  accountId?: string;
 }
 
 export interface TodoCreateInput {
@@ -42,6 +43,7 @@ export interface TodoCreateInput {
   repo?: string;
   branch?: string;
   filePath?: string;
+  accountId?: string;
 }
 
 export interface TodoUpdateInput {
@@ -59,6 +61,7 @@ export interface TodoUpdateInput {
   repo?: string;
   branch?: string;
   filePath?: string;
+  accountId?: string;
 }
 
 function generateId(): string {
@@ -83,6 +86,7 @@ export function createTodoItem(input: TodoCreateInput): Todo {
     repo: input.repo,
     branch: input.branch,
     filePath: input.filePath,
+    accountId: input.accountId,
   };
 }
 
@@ -102,6 +106,7 @@ export function applyTodoUpdate(existing: Todo, input: Partial<TodoUpdateInput>)
     repo: 'repo' in input ? input.repo : existing.repo,
     branch: 'branch' in input ? input.branch : existing.branch,
     filePath: 'filePath' in input ? input.filePath : existing.filePath,
+    accountId: 'accountId' in input ? input.accountId : existing.accountId,
     updatedAt: Date.now(),
   };
 }

--- a/src/screens/CanvasEditorScreen.tsx
+++ b/src/screens/CanvasEditorScreen.tsx
@@ -44,6 +44,7 @@ import {
 } from '../models/Canvas';
 import GitContextPicker from '../components/GitContextPicker';
 import { syncCanvasToGitHub } from '../services/CanvasGitHubSyncService';
+import { useAuth } from '../contexts/AuthContext';
 import type { RootStackParamList } from '../navigation/types';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'CanvasEditor'>;
@@ -185,8 +186,10 @@ export default function CanvasEditorScreen() {
     ],
   }));
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const { activeAccountId } = useAuth();
   const [repo, setRepo] = useState<string | undefined>(existingCanvas?.repo);
   const [branch, setBranch] = useState<string | undefined>(existingCanvas?.branch);
+  const accountId = existingCanvas?.accountId ?? activeAccountId ?? undefined;
   const dragStartRef = useRef<Point | null>(null);
 
   const textFont = useMemo(
@@ -532,9 +535,9 @@ export default function CanvasEditorScreen() {
       : undefined;
 
     if (canvasId) {
-      await updateCanvas({ id: canvasId, title, scene, repo, branch, filePath: canvasFilePath });
+      await updateCanvas({ id: canvasId, title, scene, repo, branch, filePath: canvasFilePath, accountId });
     } else {
-      await createCanvas({ title, scene, repo, branch, filePath: canvasFilePath });
+      await createCanvas({ title, scene, repo, branch, filePath: canvasFilePath, accountId });
     }
 
     if (repo) {
@@ -544,6 +547,7 @@ export default function CanvasEditorScreen() {
         filePath: canvasFilePath,
         title: title.trim(),
         scene,
+        accountId,
       });
 
       if (!syncResult.success) {
@@ -552,7 +556,7 @@ export default function CanvasEditorScreen() {
     }
 
     navigation.goBack();
-  }, [canvasId, title, elements, canvasSize, cw, repo, branch, existingCanvas, updateCanvas, createCanvas, navigation]);
+  }, [canvasId, title, elements, canvasSize, cw, repo, branch, existingCanvas, updateCanvas, createCanvas, navigation, accountId]);
 
   const renderElement = useCallback(
     (el: CanvasElement, idx: number) => {

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -118,7 +118,7 @@ export default function NoteEditorScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<NoteEditorRouteProp>();
   const { colors, isDark } = useTheme();
-  const { authState } = useAuth();
+  const { authState, activeAccountId } = useAuth();
   const { sideBySide } = useResponsive();
   const { noteId, format: initialFormat, initialTitle, initialContent, repo: initialRepo, branch: initialBranch, folderPath: initialFolderPath } = route.params || {};
 
@@ -132,6 +132,7 @@ export default function NoteEditorScreen() {
   const [commit, setCommit] = useState<string | undefined>();
   const [folderPath, setFolderPath] = useState<string | undefined>(initialFolderPath);
   const [github, setGithub] = useState<NoteGitHubLink | undefined>();
+  const [accountId, setAccountId] = useState<string | undefined>(activeAccountId ?? undefined);
   const [noteFormat, setNoteFormat] = useState<NoteFormat>(initialFormat ?? 'markdown');
   const [isSaving, setIsSaving] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
@@ -252,6 +253,7 @@ export default function NoteEditorScreen() {
         setCommit(existingNote.commit);
         setFolderPath(existingNote.folderPath);
         setGithub(existingNote.github);
+        setAccountId(existingNote.accountId ?? activeAccountId ?? undefined);
         setNoteFormat(existingNote.format ?? 'markdown');
         setTags(existingNote.tags || []);
         setAttachments(existingNote.attachments || []);
@@ -314,6 +316,7 @@ export default function NoteEditorScreen() {
           folderPath,
           format: noteFormat,
           attachments,
+          accountId,
         });
         setHasChanges(false);
         setIsEditing(false);
@@ -329,6 +332,7 @@ export default function NoteEditorScreen() {
           folderPath,
           format: noteFormat,
           attachments,
+          accountId,
         });
         savedNoteId = newNote?.id;
         HapticService.success();
@@ -343,6 +347,7 @@ export default function NoteEditorScreen() {
           title: title.trim(),
           content: content.trim(),
           format: noteFormat,
+          accountId,
         };
 
         const syncResult = await syncNoteToGitHub(syncParams);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -46,7 +46,7 @@ export default function SettingsScreen() {
   const { clearAllNotes, refreshNotes } = useNotes();
   const { refreshCanvases } = useCanvases();
   const { refreshTodos } = useTodos();
-  const { authState, setToken, clearToken } = useAuth();
+  const { authState, accounts, activeAccountId, setToken, clearToken, addAccount, removeAccount, switchAccount } = useAuth();
   const { repositories, addRepository: addRepo, removeRepository: removeRepo } = useRepos();
   const isAIEnabled = useAIStore((state) => state.isEnabled);
   const selectedModelId = useAIStore((state) => state.selectedModelId);
@@ -69,6 +69,7 @@ export default function SettingsScreen() {
   const [isVerifying, setIsVerifying] = useState(false);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const [tokenVisible, setTokenVisible] = useState(false);
+  const [tokenModalMode, setTokenModalMode] = useState<'connect' | 'add'>('connect');
   const [showModelSelector, setShowModelSelector] = useState(false);
   const [showProviderConfig, setShowProviderConfig] = useState(false);
   const [showChatRepoPicker, setShowChatRepoPicker] = useState(false);
@@ -234,17 +235,49 @@ export default function SettingsScreen() {
     if (!tokenInput.trim()) { setTokenError('Please enter a token'); return; }
     setIsVerifying(true);
     setTokenError(null);
-    const success = await setToken(tokenInput.trim());
+    let ok = false;
+    if (tokenModalMode === 'add') {
+      const account = await addAccount(tokenInput.trim());
+      ok = !!account;
+    } else {
+      ok = await setToken(tokenInput.trim());
+    }
     setIsVerifying(false);
-    if (success) {
+    if (ok) {
       HapticService.success();
       setShowTokenModal(false);
       setTokenInput('');
+      setTokenModalMode('connect');
     } else {
       HapticService.error();
       setTokenError('Invalid token. Please check and try again.');
     }
-  }, [tokenInput, setToken]);
+  }, [tokenInput, setToken, addAccount, tokenModalMode]);
+
+  const handleSwitchAccount = useCallback(async (id: string) => {
+    if (id === activeAccountId) return;
+    HapticService.success();
+    await switchAccount(id);
+  }, [activeAccountId, switchAccount]);
+
+  const handleRemoveAccount = useCallback((id: string, login: string) => {
+    HapticService.warning();
+    Alert.alert(
+      `Remove @${login}?`,
+      'The token for this account will be deleted from this device. Notes/todos created under it stay locally.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: async () => {
+            await removeAccount(id);
+            HapticService.success();
+          },
+        },
+      ],
+    );
+  }, [removeAccount]);
 
   const handleRemoveToken = useCallback(() => {
     HapticService.warning();
@@ -328,48 +361,98 @@ export default function SettingsScreen() {
           </GroupRow>
         </Group>
 
-        {/* ── GitHub Account ── */}
+        {/* ── GitHub Account(s) ── */}
         <View style={[styles.section, { backgroundColor: colors.surface }]}>
-          <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>GitHub Account</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
+            {accounts.length >= 2 ? 'GitHub Accounts' : 'GitHub Account'}
+          </Text>
 
           {authState.isAuthenticated ? (
             <>
-              <View style={[styles.settingItem, { borderBottomColor: colors.border }]}>
-                <View style={styles.authUserRow}>
-                  {authState.user?.avatar_url && (
-                    <Image source={{ uri: authState.user.avatar_url }} style={styles.avatar} />
-                  )}
-                  <View>
-                    <Text style={[styles.settingLabel, { color: colors.text }]}>
-                      {authState.user?.name || authState.user?.login}
-                    </Text>
-                    <Text style={[styles.settingValue, { color: colors.textSecondary }]}>
-                      @{authState.user?.login}
-                    </Text>
+              {accounts.length >= 2 ? (
+                accounts.map((acc) => {
+                  const isActive = acc.id === activeAccountId;
+                  return (
+                    <View key={acc.id} style={[styles.settingItem, { borderBottomColor: colors.border }]}>
+                      <TouchableOpacity
+                        style={[styles.authUserRow, { flex: 1 }]}
+                        onPress={() => handleSwitchAccount(acc.id)}
+                        disabled={isActive}
+                      >
+                        {acc.avatarUrl ? (
+                          <Image source={{ uri: acc.avatarUrl }} style={styles.avatar} />
+                        ) : null}
+                        <View style={{ flex: 1 }}>
+                          <Text style={[styles.settingLabel, { color: colors.text }]}>
+                            {acc.name || acc.login}
+                            {isActive ? '  ·  Active' : ''}
+                          </Text>
+                          <Text style={[styles.settingValue, { color: colors.textSecondary }]}>
+                            @{acc.login}
+                          </Text>
+                        </View>
+                      </TouchableOpacity>
+                      <TouchableOpacity onPress={() => handleRemoveAccount(acc.id, acc.login)} style={{ paddingHorizontal: 8 }}>
+                        <Ionicons name="trash-outline" size={18} color={colors.error} />
+                      </TouchableOpacity>
+                    </View>
+                  );
+                })
+              ) : (
+                <View style={[styles.settingItem, { borderBottomColor: colors.border }]}>
+                  <View style={styles.authUserRow}>
+                    {authState.user?.avatar_url && (
+                      <Image source={{ uri: authState.user.avatar_url }} style={styles.avatar} />
+                    )}
+                    <View>
+                      <Text style={[styles.settingLabel, { color: colors.text }]}>
+                        {authState.user?.name || authState.user?.login}
+                      </Text>
+                      <Text style={[styles.settingValue, { color: colors.textSecondary }]}>
+                        @{authState.user?.login}
+                      </Text>
+                    </View>
                   </View>
                 </View>
-              </View>
+              )}
+
               <TouchableOpacity
                 style={[styles.settingItem, { borderBottomColor: colors.border }]}
-                onPress={() => { setTokenInput(''); setTokenError(null); setShowTokenModal(true); }}
+                onPress={() => { setTokenModalMode('connect'); setTokenInput(''); setTokenError(null); setShowTokenModal(true); }}
               >
                 <View style={styles.settingLeft}>
                   <Ionicons name="key-outline" size={20} color={colors.text} />
-                  <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12 }]}>Change Token</Text>
+                  <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12 }]}>
+                    {accounts.length >= 2 ? 'Replace Active Token' : 'Change Token'}
+                  </Text>
                 </View>
                 <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
               </TouchableOpacity>
+
               <TouchableOpacity
                 style={[styles.settingItem, { borderBottomColor: colors.border }]}
-                onPress={handleRemoveToken}
+                onPress={() => { setTokenModalMode('add'); setTokenInput(''); setTokenError(null); setShowTokenModal(true); }}
               >
-                <Text style={[styles.settingLabel, { color: colors.error }]}>Remove GitHub Account</Text>
+                <View style={styles.settingLeft}>
+                  <Ionicons name="person-add-outline" size={20} color={colors.text} />
+                  <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12 }]}>Add another account</Text>
+                </View>
+                <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
               </TouchableOpacity>
+
+              {accounts.length < 2 ? (
+                <TouchableOpacity
+                  style={[styles.settingItem, { borderBottomColor: colors.border }]}
+                  onPress={handleRemoveToken}
+                >
+                  <Text style={[styles.settingLabel, { color: colors.error }]}>Remove GitHub Account</Text>
+                </TouchableOpacity>
+              ) : null}
             </>
           ) : (
             <TouchableOpacity
               style={[styles.settingItem, { borderBottomColor: colors.border }]}
-              onPress={() => { setTokenInput(''); setTokenError(null); setShowTokenModal(true); }}
+              onPress={() => { setTokenModalMode('connect'); setTokenInput(''); setTokenError(null); setShowTokenModal(true); }}
             >
               <View style={styles.settingLeft}>
                 <Ionicons name="logo-github" size={20} color={colors.text} />
@@ -650,7 +733,9 @@ export default function SettingsScreen() {
           <View style={[styles.modalSheet, { backgroundColor: colors.surface }]}>
             <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
               <Text style={[styles.modalTitle, { color: colors.text }]}>
-                {authState.isAuthenticated ? 'Change Token' : 'Connect GitHub'}
+                {tokenModalMode === 'add'
+                  ? 'Add GitHub Account'
+                  : authState.isAuthenticated ? 'Change Token' : 'Connect GitHub'}
               </Text>
               <TouchableOpacity onPress={() => { setShowTokenModal(false); setTokenVisible(false); }}>
                 <Ionicons name="close" size={24} color={colors.textSecondary} />
@@ -718,7 +803,7 @@ export default function SettingsScreen() {
               >
                 {isVerifying
                   ? <ActivityIndicator color="#fff" />
-                  : <Text style={styles.modalButtonText}>Save Token</Text>
+                  : <Text style={styles.modalButtonText}>{tokenModalMode === 'add' ? 'Add Account' : 'Save Token'}</Text>
                 }
               </TouchableOpacity>
             </ScrollView>

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -19,6 +19,7 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import { format, isToday, isTomorrow, isPast } from 'date-fns';
 
 import { useTodos } from '../contexts/TodoContext';
+import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { Todo, TodoPriority, PRIORITY_COLORS, PRIORITY_LABELS, REMINDER_OPTIONS, slugifyTodoText } from '../models/Todo';
 import { HapticService } from '../utils/haptics';
@@ -53,6 +54,7 @@ export default function TodoListScreen() {
 
   const [showAddModal, setShowAddModal] = useState(false);
   const [editingTodo, setEditingTodo] = useState<Todo | null>(null);
+  const { activeAccountId } = useAuth();
   const [todoText, setTodoText] = useState('');
   const [todoNotes, setTodoNotes] = useState('');
   const [todoPriority, setTodoPriority] = useState<TodoPriority>('medium');
@@ -132,6 +134,7 @@ export default function TodoListScreen() {
       repo: todoRepo,
       branch: todoBranch,
       filePath: todoFilePath,
+      accountId: activeAccountId ?? undefined,
     });
 
     if (todoRepo && newTodo) {
@@ -141,6 +144,7 @@ export default function TodoListScreen() {
         filePath: todoFilePath,
         text: todoText.trim(),
         todo: newTodo,
+        accountId: newTodo.accountId,
       });
       if (!syncResult.success) {
         console.warn('[TodoList] GitHub sync failed:', syncResult.error);
@@ -163,6 +167,8 @@ export default function TodoListScreen() {
     const slug = slugifyTodoText(todoText.trim());
     const todoFilePath = editingTodo.filePath ?? `todos/${slug}.json`;
 
+    const editAccountId = editingTodo.accountId ?? activeAccountId ?? undefined;
+
     await updateTodo({
       id: editingTodo.id,
       text: todoText.trim(),
@@ -173,6 +179,7 @@ export default function TodoListScreen() {
       repo: todoRepo,
       branch: todoBranch,
       filePath: todoFilePath,
+      accountId: editAccountId,
     });
 
     const syncResult = await syncTodoToGitHub({
@@ -190,6 +197,7 @@ export default function TodoListScreen() {
         createdAt: editingTodo.createdAt,
         updatedAt: Date.now(),
       },
+      accountId: editAccountId,
     });
     if (!syncResult.success) {
       console.warn('[TodoList] GitHub sync failed:', syncResult.error);

--- a/src/services/AccountStorage.ts
+++ b/src/services/AccountStorage.ts
@@ -1,0 +1,208 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
+
+const ACCOUNTS_KEY = '@gitnotes:accounts';
+const ACTIVE_ACCOUNT_ID_KEY = '@gitnotes:active_account_id';
+const PER_ID_TOKEN_PREFIX_WEB = '@gitnotes:account_token:';
+const PER_ID_TOKEN_PREFIX_NATIVE = 'gitnotes_account_token_';
+
+const LEGACY_TOKEN_KEY_WEB = '@gitnotes:github_token';
+const LEGACY_TOKEN_KEY_NATIVE = 'gitnotes_github_token';
+
+export interface StoredAccount {
+  id: string;
+  login: string;
+  name: string;
+  email: string;
+  avatarUrl: string;
+  addedAt: number;
+}
+
+export interface AccountProfile {
+  login: string;
+  name: string;
+  email: string;
+  avatarUrl: string;
+}
+
+function tokenKeyFor(id: string): string {
+  if (Platform.OS === 'web') return `${PER_ID_TOKEN_PREFIX_WEB}${id}`;
+  // SecureStore on iOS allows alphanumerics, `.`, `-`, `_`. Our ids already match.
+  return `${PER_ID_TOKEN_PREFIX_NATIVE}${id.replace(/[^A-Za-z0-9_]/g, '_')}`;
+}
+
+async function readTokenById(id: string): Promise<string | null> {
+  const key = tokenKeyFor(id);
+  if (Platform.OS === 'web') return AsyncStorage.getItem(key);
+  try {
+    return await SecureStore.getItemAsync(key);
+  } catch {
+    return null;
+  }
+}
+
+async function writeTokenById(id: string, token: string): Promise<void> {
+  const key = tokenKeyFor(id);
+  if (Platform.OS === 'web') {
+    await AsyncStorage.setItem(key, token);
+    return;
+  }
+  await SecureStore.setItemAsync(key, token);
+}
+
+async function deleteTokenById(id: string): Promise<void> {
+  const key = tokenKeyFor(id);
+  if (Platform.OS === 'web') {
+    await AsyncStorage.removeItem(key);
+    return;
+  }
+  await SecureStore.deleteItemAsync(key).catch(() => undefined);
+}
+
+async function readLegacyToken(): Promise<string | null> {
+  if (Platform.OS === 'web') return AsyncStorage.getItem(LEGACY_TOKEN_KEY_WEB);
+  try {
+    const secure = await SecureStore.getItemAsync(LEGACY_TOKEN_KEY_NATIVE);
+    if (secure) return secure;
+  } catch {
+    // fall through
+  }
+  return AsyncStorage.getItem(LEGACY_TOKEN_KEY_WEB);
+}
+
+async function deleteLegacyToken(): Promise<void> {
+  await AsyncStorage.removeItem(LEGACY_TOKEN_KEY_WEB).catch(() => undefined);
+  if (Platform.OS !== 'web') {
+    await SecureStore.deleteItemAsync(LEGACY_TOKEN_KEY_NATIVE).catch(() => undefined);
+  }
+}
+
+function generateAccountId(): string {
+  return `acc-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export class AccountStorage {
+  static async listAccounts(): Promise<StoredAccount[]> {
+    const raw = await AsyncStorage.getItem(ACCOUNTS_KEY);
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter((a): a is StoredAccount => typeof a?.id === 'string' && typeof a?.login === 'string');
+    } catch {
+      return [];
+    }
+  }
+
+  static async writeAccounts(accounts: StoredAccount[]): Promise<void> {
+    await AsyncStorage.setItem(ACCOUNTS_KEY, JSON.stringify(accounts));
+  }
+
+  static async getActiveAccountId(): Promise<string | null> {
+    return AsyncStorage.getItem(ACTIVE_ACCOUNT_ID_KEY);
+  }
+
+  static async setActiveAccountId(id: string | null): Promise<void> {
+    if (id === null) {
+      await AsyncStorage.removeItem(ACTIVE_ACCOUNT_ID_KEY);
+      return;
+    }
+    await AsyncStorage.setItem(ACTIVE_ACCOUNT_ID_KEY, id);
+  }
+
+  static async getActiveAccount(): Promise<StoredAccount | null> {
+    const id = await this.getActiveAccountId();
+    if (!id) return null;
+    const accounts = await this.listAccounts();
+    return accounts.find((a) => a.id === id) ?? null;
+  }
+
+  static async getTokenById(id: string): Promise<string | null> {
+    return readTokenById(id);
+  }
+
+  static async getActiveToken(): Promise<string | null> {
+    const id = await this.getActiveAccountId();
+    if (id) {
+      const t = await readTokenById(id);
+      if (t) return t;
+    }
+    return readLegacyToken();
+  }
+
+  /**
+   * Persist a token + profile as an account. If an account with the same
+   * login exists, its token + profile are replaced (no duplicate). Sets
+   * active account when none is currently active. Drops the legacy token
+   * after the first account is created.
+   */
+  static async addAccount(token: string, profile: AccountProfile): Promise<StoredAccount> {
+    const accounts = await this.listAccounts();
+    const existingIndex = accounts.findIndex((a) => a.login === profile.login);
+
+    if (existingIndex >= 0) {
+      const existing = accounts[existingIndex];
+      const updated: StoredAccount = {
+        ...existing,
+        login: profile.login,
+        name: profile.name,
+        email: profile.email,
+        avatarUrl: profile.avatarUrl,
+      };
+      accounts[existingIndex] = updated;
+      await writeTokenById(existing.id, token);
+      await this.writeAccounts(accounts);
+      const activeId = await this.getActiveAccountId();
+      if (!activeId) await this.setActiveAccountId(existing.id);
+      return updated;
+    }
+
+    const id = generateAccountId();
+    const newAccount: StoredAccount = {
+      id,
+      addedAt: Date.now(),
+      login: profile.login,
+      name: profile.name,
+      email: profile.email,
+      avatarUrl: profile.avatarUrl,
+    };
+    accounts.push(newAccount);
+    await writeTokenById(id, token);
+    await this.writeAccounts(accounts);
+
+    const activeId = await this.getActiveAccountId();
+    if (!activeId) await this.setActiveAccountId(id);
+
+    if (accounts.length === 1) {
+      await deleteLegacyToken();
+    }
+
+    return newAccount;
+  }
+
+  static async removeAccount(id: string): Promise<void> {
+    const accounts = await this.listAccounts();
+    const remaining = accounts.filter((a) => a.id !== id);
+    await this.writeAccounts(remaining);
+    await deleteTokenById(id);
+    const activeId = await this.getActiveAccountId();
+    if (activeId === id) {
+      await this.setActiveAccountId(remaining[0]?.id ?? null);
+    }
+  }
+
+  static async clearAll(): Promise<void> {
+    const accounts = await this.listAccounts();
+    await Promise.all(accounts.map((a) => deleteTokenById(a.id)));
+    await this.writeAccounts([]);
+    await this.setActiveAccountId(null);
+    await deleteLegacyToken();
+  }
+
+  static async deleteLegacy(): Promise<void> {
+    await deleteLegacyToken();
+  }
+}
+
+export default AccountStorage;

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,48 +1,4 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as SecureStore from 'expo-secure-store';
-import { Platform } from 'react-native';
-
-const TOKEN_KEY = '@gitnotes:github_token';
-const SECURE_KEY = 'gitnotes_github_token';
-
-async function readToken(): Promise<string | null> {
-  if (Platform.OS === 'web') {
-    return AsyncStorage.getItem(TOKEN_KEY);
-  }
-  try {
-    const secure = await SecureStore.getItemAsync(SECURE_KEY);
-    if (secure) return secure;
-    // One-time migration from legacy AsyncStorage location.
-    const legacy = await AsyncStorage.getItem(TOKEN_KEY);
-    if (legacy) {
-      await SecureStore.setItemAsync(SECURE_KEY, legacy);
-      await AsyncStorage.removeItem(TOKEN_KEY);
-      return legacy;
-    }
-    return null;
-  } catch (err) {
-    console.error('[AuthService] readToken error:', err);
-    return null;
-  }
-}
-
-async function writeToken(token: string): Promise<void> {
-  if (Platform.OS === 'web') {
-    await AsyncStorage.setItem(TOKEN_KEY, token);
-    return;
-  }
-  await SecureStore.setItemAsync(SECURE_KEY, token);
-  await AsyncStorage.removeItem(TOKEN_KEY).catch(() => undefined);
-}
-
-async function deleteToken(): Promise<void> {
-  if (Platform.OS === 'web') {
-    await AsyncStorage.removeItem(TOKEN_KEY);
-    return;
-  }
-  await SecureStore.deleteItemAsync(SECURE_KEY).catch(() => undefined);
-  await AsyncStorage.removeItem(TOKEN_KEY).catch(() => undefined);
-}
+import AccountStorage, { StoredAccount } from './AccountStorage';
 
 export interface GitHubUser {
   id: number;
@@ -58,10 +14,33 @@ export interface AuthState {
   token: string | null;
 }
 
+function profileFromUser(user: GitHubUser) {
+  return {
+    login: user.login,
+    name: user.name ?? user.login,
+    email: user.email ?? '',
+    avatarUrl: user.avatar_url,
+  };
+}
+
+function userFromAccount(account: StoredAccount): GitHubUser {
+  return {
+    id: 0,
+    login: account.login,
+    name: account.name,
+    email: account.email,
+    avatar_url: account.avatarUrl,
+  };
+}
+
 export class AuthService {
   static async checkAuthState(): Promise<AuthState> {
-    const token = await readToken();
+    const token = await AccountStorage.getActiveToken();
     if (!token) return { isAuthenticated: false, user: null, token: null };
+    const active = await AccountStorage.getActiveAccount();
+    if (active) {
+      return { isAuthenticated: true, user: userFromAccount(active), token };
+    }
     const user = await this.getUser(token);
     return { isAuthenticated: !!user, user, token };
   }
@@ -69,21 +48,69 @@ export class AuthService {
   static async setToken(token: string): Promise<AuthState> {
     const user = await this.getUser(token);
     if (!user) return { isAuthenticated: false, user: null, token: null };
-    await writeToken(token);
+    await AccountStorage.addAccount(token, profileFromUser(user));
     return { isAuthenticated: true, user, token };
   }
 
-  static async clearToken(): Promise<void> {
-    await deleteToken();
+  /**
+   * Add another account without changing the currently-active one. Returns
+   * the persisted account, or null if the token is invalid.
+   */
+  static async addAccount(token: string): Promise<StoredAccount | null> {
+    const user = await this.getUser(token);
+    if (!user) return null;
+    const accountsBefore = await AccountStorage.listAccounts();
+    const account = await AccountStorage.addAccount(token, profileFromUser(user));
+    if (accountsBefore.length > 0) {
+      const currentActive = await AccountStorage.getActiveAccountId();
+      if (!currentActive) {
+        await AccountStorage.setActiveAccountId(account.id);
+      }
+    }
+    return account;
   }
 
-  /**
-   * Returns the stored GitHub token, migrating from legacy AsyncStorage
-   * to SecureStore on first access. Use this everywhere instead of reading
-   * the token storage key directly.
-   */
+  static async clearToken(): Promise<void> {
+    const id = await AccountStorage.getActiveAccountId();
+    if (id) await AccountStorage.removeAccount(id);
+    await AccountStorage.deleteLegacy();
+  }
+
   static async getToken(): Promise<string | null> {
-    return readToken();
+    return AccountStorage.getActiveToken();
+  }
+
+  static async getTokenById(id: string): Promise<string | null> {
+    return AccountStorage.getTokenById(id);
+  }
+
+  static async listAccounts(): Promise<StoredAccount[]> {
+    return AccountStorage.listAccounts();
+  }
+
+  static async getActiveAccount(): Promise<StoredAccount | null> {
+    return AccountStorage.getActiveAccount();
+  }
+
+  static async getActiveAccountId(): Promise<string | null> {
+    return AccountStorage.getActiveAccountId();
+  }
+
+  static async setActiveAccount(id: string): Promise<AuthState> {
+    const accounts = await AccountStorage.listAccounts();
+    const account = accounts.find((a) => a.id === id);
+    if (!account) return { isAuthenticated: false, user: null, token: null };
+    await AccountStorage.setActiveAccountId(id);
+    const token = await AccountStorage.getTokenById(id);
+    return {
+      isAuthenticated: !!token,
+      user: token ? userFromAccount(account) : null,
+      token,
+    };
+  }
+
+  static async removeAccount(id: string): Promise<void> {
+    await AccountStorage.removeAccount(id);
   }
 
   static async getUser(token: string): Promise<GitHubUser | null> {

--- a/src/services/CanvasGitHubSyncService.ts
+++ b/src/services/CanvasGitHubSyncService.ts
@@ -1,6 +1,13 @@
 import { GitHubService } from './GitHubService';
 import { CanvasScene, slugifyCanvasTitle } from '../models/Canvas';
 import { parseRepoPath } from '../utils/gitPathParser';
+import { AuthService } from './AuthService';
+
+async function resolveToken(accountId?: string): Promise<string | undefined> {
+  if (!accountId) return undefined;
+  const t = await AuthService.getTokenById(accountId);
+  return t ?? undefined;
+}
 
 export interface CanvasGitHubSyncResult {
   success: boolean;
@@ -14,10 +21,12 @@ export async function syncCanvasToGitHub(params: {
   filePath?: string;
   title: string;
   scene: CanvasScene;
+  accountId?: string;
 }): Promise<CanvasGitHubSyncResult> {
-  const { repo: repoPath, branch, filePath, title, scene } = params;
+  const { repo: repoPath, branch, filePath, title, scene, accountId } = params;
+  const tokenOverride = await resolveToken(accountId);
 
-  if (!GitHubService.isAuthenticated()) {
+  if (!tokenOverride && !GitHubService.isAuthenticated()) {
     return { success: false, error: 'GitHub not authenticated' };
   }
 
@@ -27,6 +36,7 @@ export async function syncCanvasToGitHub(params: {
   }
 
   const targetBranch = branch || 'main';
+  const opts = tokenOverride ? { tokenOverride } : undefined;
 
   let targetPath = filePath;
   if (!targetPath) {
@@ -47,6 +57,7 @@ export async function syncCanvasToGitHub(params: {
       content,
       message,
       targetBranch,
+      opts,
     );
 
     if (result) {

--- a/src/services/ChatStorageService.ts
+++ b/src/services/ChatStorageService.ts
@@ -54,7 +54,23 @@ function getStatus(error: unknown): number | undefined {
   return axios.isAxiosError(error) ? error.response?.status : undefined;
 }
 
+let chatRepoAccountId: string | null = null;
+
+/**
+ * Bind chat-repo requests to a specific account's token. When set, all
+ * ChatStorageService GitHub calls use that account's token regardless of
+ * which account is currently active in the app.
+ */
+export function setChatRepoAccount(accountId: string | null): void {
+  chatRepoAccountId = accountId;
+}
+
 async function getToken(): Promise<string> {
+  if (chatRepoAccountId) {
+    const scoped = await AuthService.getTokenById(chatRepoAccountId);
+    if (scoped) return scoped;
+  }
+
   if (!GitHubService.isAuthenticated()) {
     throw new Error('GitHub not authenticated');
   }

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -313,12 +313,18 @@ class GitHubServiceClass {
     }
   }
 
-  async getFileContent(owner: string, repo: string, path: string, ref?: string): Promise<string | null> {
+  async getFileContent(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+    opts?: TokenOpts,
+  ): Promise<string | null> {
     try {
       const encodedPath = path.split('/').map(encodeURIComponent).join('/');
       let url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
       if (ref) url += `?ref=${encodeURIComponent(ref)}`;
-      const data = await this.request(url);
+      const data = await this.request(url, 'GET', undefined, opts);
       if (data.type === 'file' && data.content) {
         const base64 = data.content.replace(/\n/g, '');
         return decodeBase64(base64);
@@ -330,12 +336,18 @@ class GitHubServiceClass {
     }
   }
 
-  async getFileSha(owner: string, repo: string, path: string, ref?: string): Promise<string | null> {
+  async getFileSha(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+    opts?: TokenOpts,
+  ): Promise<string | null> {
     try {
       const encodedPath = path.split('/').map(encodeURIComponent).join('/');
       let url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
       if (ref) url += `?ref=${encodeURIComponent(ref)}`;
-      const data = await this.request(url);
+      const data = await this.request(url, 'GET', undefined, opts);
       return data.sha || null;
     } catch {
       return null;
@@ -349,6 +361,7 @@ class GitHubServiceClass {
     content: string,
     message: string,
     branch: string = 'main',
+    opts?: TokenOpts,
   ): Promise<GitHubFileCommit | null> {
     try {
       const encodedPath = path.split('/').map(encodeURIComponent).join('/');
@@ -362,7 +375,7 @@ class GitHubServiceClass {
         message,
         content: base64Content,
         branch,
-      });
+      }, opts);
     } catch (error) {
       console.warn('[GitHubService] Failed to create file:', error);
       return null;
@@ -415,11 +428,12 @@ class GitHubServiceClass {
     message: string,
     sha: string,
     branch: string = 'main',
+    opts?: TokenOpts,
   ): Promise<GitHubFileCommit | null> {
     try {
       const encodedPath = path.split('/').map(encodeURIComponent).join('/');
       const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
-      return await this.request(url, 'DELETE', { message, sha, branch });
+      return await this.request(url, 'DELETE', { message, sha, branch }, opts);
     } catch (error) {
       console.warn('[GitHubService] Failed to delete file:', error);
       return null;
@@ -431,9 +445,10 @@ class GitHubServiceClass {
     repo: string,
     folderPath: string,
     branch: string = 'main',
+    opts?: TokenOpts,
   ): Promise<GitHubFileCommit | null> {
     const keepPath = folderPath ? `${folderPath}/.gitkeep` : '.gitkeep';
-    return this.createFile(owner, repo, keepPath, '', `Create folder ${folderPath || '/'}`, branch);
+    return this.createFile(owner, repo, keepPath, '', `Create folder ${folderPath || '/'}`, branch, opts);
   }
 
   async updateFile(
@@ -443,6 +458,7 @@ class GitHubServiceClass {
     content: string,
     message: string,
     branch: string = 'main',
+    opts?: TokenOpts,
   ): Promise<GitHubFileCommit | null> {
     const encodedPath = path.split('/').map(encodeURIComponent).join('/');
     const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
@@ -454,12 +470,12 @@ class GitHubServiceClass {
 
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
-        const sha = await this.getFileSha(owner, repo, path, branch);
+        const sha = await this.getFileSha(owner, repo, path, branch, opts);
         if (!sha) {
-          return this.createFile(owner, repo, path, content, message, branch);
+          return this.createFile(owner, repo, path, content, message, branch, opts);
         }
 
-        return await this.request(url, 'PUT', { message, content: base64Content, sha, branch });
+        return await this.request(url, 'PUT', { message, content: base64Content, sha, branch }, opts);
       } catch (error) {
         const status = (error as { status?: number })?.status;
         if (status === 409 && attempt < 2) {
@@ -486,18 +502,23 @@ class GitHubServiceClass {
     message: string,
     oldSha: string,
     branch: string = 'main',
+    opts?: TokenOpts,
   ): Promise<boolean> {
-    const createResult = await this.createFile(owner, repo, newPath, content, message, branch);
+    const createResult = await this.createFile(owner, repo, newPath, content, message, branch, opts);
     if (!createResult) return false;
-    await this.deleteFile(owner, repo, oldPath, message, oldSha, branch);
+    await this.deleteFile(owner, repo, oldPath, message, oldSha, branch, opts);
     return true;
   }
 
-  private async request<T = any>(url: string, method: 'GET' | 'PUT' | 'DELETE' = 'GET', data?: any): Promise<T> {
-    if (!this.token) throw new Error('GitHub token is not configured');
-    const isFullUrl = url.startsWith('http');
-    const requestUrl = isFullUrl ? url : url;
-    const response = await http.request<T>({ url: requestUrl, method, data });
+  private async request<T = any>(
+    url: string,
+    method: 'GET' | 'PUT' | 'DELETE' = 'GET',
+    data?: any,
+    opts?: TokenOpts,
+  ): Promise<T> {
+    const override = opts?.tokenOverride;
+    if (!this.token && !override) throw new Error('GitHub token is not configured');
+    const response = await http.request<T>({ url, method, data, ...(override ? { authOverride: override } : {}) });
     return response.data;
   }
 
@@ -508,6 +529,11 @@ class GitHubServiceClass {
     const nextUrl = parseNextLink(linkHeader);
     return { data: response.data, nextUrl };
   }
+}
+
+export interface TokenOpts {
+  /** Per-call GitHub token override; bypasses the singleton active-account header. */
+  tokenOverride?: string;
 }
 
 function parseNextLink(linkHeader: string | null | undefined): string | null {

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -2,6 +2,13 @@ import { GitHubService } from './GitHubService';
 import { NoteFormat } from '../models/Note';
 import * as FileSystem from 'expo-file-system/legacy';
 import { parseRepoPath } from '../utils/gitPathParser';
+import { AuthService } from './AuthService';
+
+async function resolveToken(accountId?: string): Promise<string | undefined> {
+  if (!accountId) return undefined;
+  const t = await AuthService.getTokenById(accountId);
+  return t ?? undefined;
+}
 
 export interface NoteGitHubSyncResult {
   success: boolean;
@@ -106,10 +113,12 @@ export async function deleteNoteFromGitHub(params: {
   branch?: string;
   filePath: string;
   title?: string;
+  accountId?: string;
 }): Promise<NoteGitHubSyncResult> {
-  const { repo: repoPath, branch, filePath, title } = params;
+  const { repo: repoPath, branch, filePath, title, accountId } = params;
+  const tokenOverride = await resolveToken(accountId);
 
-  if (!GitHubService.isAuthenticated()) {
+  if (!tokenOverride && !GitHubService.isAuthenticated()) {
     return { success: false, error: 'GitHub not authenticated' };
   }
 
@@ -119,11 +128,11 @@ export async function deleteNoteFromGitHub(params: {
   }
 
   const targetBranch = branch || 'main';
+  const opts = tokenOverride ? { tokenOverride } : undefined;
 
   try {
-    const sha = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, filePath, targetBranch);
+    const sha = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, filePath, targetBranch, opts);
     if (!sha) {
-      // File already gone on remote; treat as success so local delete proceeds.
       return { success: true, filePath };
     }
 
@@ -134,6 +143,7 @@ export async function deleteNoteFromGitHub(params: {
       `Delete note: ${title || filePath}`,
       sha,
       targetBranch,
+      opts,
     );
 
     if (result) {
@@ -155,10 +165,12 @@ export async function syncNoteToGitHub(params: {
   title: string;
   content: string;
   format?: NoteFormat;
+  accountId?: string;
 }): Promise<NoteGitHubSyncResult> {
-  const { repo: repoPath, branch, filePath, title, content, format } = params;
+  const { repo: repoPath, branch, filePath, title, content, format, accountId } = params;
+  const tokenOverride = await resolveToken(accountId);
 
-  if (!GitHubService.isAuthenticated()) {
+  if (!tokenOverride && !GitHubService.isAuthenticated()) {
     return { success: false, error: 'GitHub not authenticated' };
   }
 
@@ -169,6 +181,7 @@ export async function syncNoteToGitHub(params: {
 
   const targetBranch = branch || 'main';
   const ext = getExtension(format);
+  const opts = tokenOverride ? { tokenOverride } : undefined;
 
   let targetPath = filePath;
   if (!targetPath) {
@@ -195,6 +208,7 @@ export async function syncNoteToGitHub(params: {
       finalContent,
       message,
       targetBranch,
+      opts,
     );
 
     if (result) {

--- a/src/services/TodoGitHubSyncService.ts
+++ b/src/services/TodoGitHubSyncService.ts
@@ -1,6 +1,13 @@
 import { GitHubService } from './GitHubService';
 import { Todo } from '../models/Todo';
 import { parseRepoPath } from '../utils/gitPathParser';
+import { AuthService } from './AuthService';
+
+async function resolveToken(accountId?: string): Promise<string | undefined> {
+  if (!accountId) return undefined;
+  const t = await AuthService.getTokenById(accountId);
+  return t ?? undefined;
+}
 
 export interface TodoGitHubSyncResult {
   success: boolean;
@@ -28,10 +35,12 @@ export async function syncTodoToGitHub(params: {
   filePath?: string;
   text: string;
   todo: Partial<Todo>;
+  accountId?: string;
 }): Promise<TodoGitHubSyncResult> {
-  const { repo: repoPath, branch, filePath, text, todo } = params;
+  const { repo: repoPath, branch, filePath, text, todo, accountId } = params;
+  const tokenOverride = await resolveToken(accountId);
 
-  if (!GitHubService.isAuthenticated()) {
+  if (!tokenOverride && !GitHubService.isAuthenticated()) {
     return { success: false, error: 'GitHub not authenticated' };
   }
 
@@ -41,6 +50,7 @@ export async function syncTodoToGitHub(params: {
   }
 
   const targetBranch = branch || 'main';
+  const opts = tokenOverride ? { tokenOverride } : undefined;
 
   let targetPath = filePath;
   if (!targetPath) {
@@ -63,6 +73,7 @@ export async function syncTodoToGitHub(params: {
       content,
       message,
       targetBranch,
+      opts,
     );
 
     if (result) {

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,6 +1,13 @@
 import axios, { type AxiosError, type AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
 import { githubActivity } from '../stores/githubActivityStore';
 
+declare module 'axios' {
+  interface AxiosRequestConfig {
+    /** Per-request token override; replaces the module-level Authorization header for this call only. */
+    authOverride?: string | null;
+  }
+}
+
 const GITHUB_API_BASE = 'https://api.github.com';
 
 const http: AxiosInstance = axios.create({
@@ -30,11 +37,17 @@ function labelForMethod(method?: string): string {
   return 'Syncing with GitHub…';
 }
 
-type TrackedConfig = InternalAxiosRequestConfig & { _activityTracked?: boolean };
+type TrackedConfig = InternalAxiosRequestConfig & {
+  _activityTracked?: boolean;
+  authOverride?: string | null;
+};
 
 http.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   config.headers.set('X-Request-ID', `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
   const tracked = config as TrackedConfig;
+  if (typeof tracked.authOverride === 'string' && tracked.authOverride.length > 0) {
+    config.headers.set('Authorization', `Bearer ${tracked.authOverride}`);
+  }
   if (!tracked._activityTracked) {
     tracked._activityTracked = true;
     githubActivity.begin(labelForMethod(config.method));

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 import { create } from 'zustand';
 import { AIActionMode, AIModelConfig, AIProviderConfig, AISettings } from '../models/AIProvider';
+import { setChatRepoAccount } from '../services/ChatStorageService';
 
 const AI_SETTINGS_STORAGE_KEY = 'ai-settings';
 const AI_PROVIDER_KEY_PREFIX = 'ai-provider-key-';
@@ -13,6 +14,7 @@ interface AIState {
   chatRepoOwner: string | null;
   chatRepoName: string | null;
   chatRepoBranch: string;
+  chatRepoAccountId: string | null;
   providers: AIProviderConfig[];
   isLoading: boolean;
   error: string | null;
@@ -25,7 +27,7 @@ interface AIActions {
   addProvider: (provider: AIProviderConfig) => Promise<void>;
   updateProvider: (providerId: string, updates: Partial<AIProviderConfig>) => Promise<void>;
   removeProvider: (providerId: string) => Promise<void>;
-  setChatRepo: (owner: string | null, name: string | null, branch?: string) => Promise<void>;
+  setChatRepo: (owner: string | null, name: string | null, branch?: string, accountId?: string | null) => Promise<void>;
   getAvailableModels: () => AIModelConfig[];
   getSelectedModel: () => AIModelConfig | undefined;
   persistSettings: () => Promise<void>;
@@ -76,6 +78,7 @@ const createDefaultSettings = (): AISettings => ({
   chatRepoOwner: null,
   chatRepoName: null,
   chatRepoBranch: 'main',
+  chatRepoAccountId: null,
   providers: createDefaultProviders(),
 });
 
@@ -182,13 +185,15 @@ export const useAIStore = create<AIState & AIActions>()((set, get) => ({
     await get().persistSettings();
   },
 
-  setChatRepo: async (owner, name, branch = 'main') => {
+  setChatRepo: async (owner, name, branch = 'main', accountId = null) => {
     set({
       chatRepoOwner: owner,
       chatRepoName: name,
       chatRepoBranch: branch,
+      chatRepoAccountId: accountId,
       error: null,
     });
+    setChatRepoAccount(accountId);
     await get().persistSettings();
   },
 
@@ -224,6 +229,7 @@ export const useAIStore = create<AIState & AIActions>()((set, get) => ({
         chatRepoOwner,
         chatRepoName,
         chatRepoBranch,
+        chatRepoAccountId,
         providers,
       } = get();
 
@@ -247,6 +253,7 @@ export const useAIStore = create<AIState & AIActions>()((set, get) => ({
         chatRepoOwner,
         chatRepoName,
         chatRepoBranch,
+        chatRepoAccountId,
         providers: providers.map(stripProviderApiKey),
       };
 
@@ -278,6 +285,7 @@ export const useAIStore = create<AIState & AIActions>()((set, get) => ({
         ...defaultSettings,
         ...savedSettings,
         chatRepoBranch: savedSettings.chatRepoBranch ?? defaultSettings.chatRepoBranch,
+        chatRepoAccountId: savedSettings.chatRepoAccountId ?? defaultSettings.chatRepoAccountId,
         providers: mergeProviders(savedSettings.providers),
       };
 
@@ -289,6 +297,7 @@ export const useAIStore = create<AIState & AIActions>()((set, get) => ({
         isLoading: false,
         error: null,
       });
+      setChatRepoAccount(mergedSettings.chatRepoAccountId);
     } catch (err) {
       const defaultSettings = createDefaultSettings();
       set({

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -91,6 +91,7 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
           branch: note.branch,
           filePath: note.filePath,
           title: note.title,
+          accountId: note.accountId,
         });
         if (!remote.success) {
           set({ error: remote.error || 'Failed to delete from GitHub' });


### PR DESCRIPTION
Closes #430.

End-to-end multi-account / multi-token support with single-account UX preserved by default. Per #430's conditional UI rule, the new account picker, account chip in filters, and active-filter account badge only render when \`accounts.length >= 2\`.

## What's in

### Storage
- New \`AccountStorage\` keys tokens by account id (SecureStore on native, AsyncStorage on web). Accounts metadata + active id stored alongside. Lazy migration from the legacy single-token storage on first \`addAccount\` call.

### Auth
- \`AuthService\` gains \`addAccount\` / \`removeAccount\` / \`setActiveAccount\` / \`listAccounts\` / \`getTokenById\` alongside the existing single-token API. The legacy \`setToken\` now upserts the active account.
- \`AuthContext\` exposes \`accounts\`, \`activeAccountId\`, \`addAccount\`, \`removeAccount\`, \`switchAccount\`, plus a \`useShouldShowAccountUI\` helper.

### API client
- \`http.ts\` accepts a per-request \`authOverride\` config (typed via module augmentation) so a single call can use a non-active token without disturbing the singleton header.
- \`GitHubService\` methods used by sync (\`getFileContent\`, \`getFileSha\`, \`createFile\`, \`updateFile\`, \`deleteFile\`, \`moveFile\`, \`createFolder\`) accept optional \`{ tokenOverride }\` and route through the http override.

### Models
- \`Note\` / \`Todo\` / \`Canvas\` gain optional \`accountId\` persisted on create/update.

### Sync routing
- All three sync services accept \`accountId\` and resolve the token via \`AuthService.getTokenById\`, falling back to the active account.
- \`NoteEditor\` / \`CanvasEditor\` / \`TodoListScreen\` thread \`accountId\` through create/update/sync. \`noteStore.deleteNote\` passes \`note.accountId\` to the delete-from-GitHub path.

### Chat
- \`ChatStorageService\` exposes \`setChatRepoAccount\` to bind chat repo requests to a specific account's token. \`aiStore\` stores \`chatRepoAccountId\` and propagates it on hydrate and \`setChatRepo\`.

### UI
- \`SettingsScreen\`: account list with switch + remove when 2+ accounts; single-account UI unchanged. \"Add another account\" always available when authenticated.
- \`EntityFilterModal\`: Account chip row only when 2+ accounts.
- \`ActiveFilterStrip\`: selected-account chip alongside other active filters.
- \`useEntityFilter\`: \`selectedAccountId\` state + setter + filter rule.

## Behavior matrix

| Accounts | New UI shown | Legacy UX preserved |
|----------|--------------|---------------------|
| 0        | Connect GitHub only | yes |
| 1        | Add another account, Change Token, Remove (no list) | yes |
| 2+       | Account list, Add another, Replace Active Token (no Remove top-level — per-row remove) | partial — section title pluralizes |

Filter modal + active-filter strip + cards: account UI hidden until 2+ accounts.

## Migration

Existing single-token install: \`AuthService.setToken\` (still called by Onboarding + Settings \"Change Token\") now mints account #1 and migrates the legacy token to per-id storage. Existing notes/todos/canvas have \`accountId === undefined\` and continue to sync via the active account.

## Test plan

- [x] \`yarn ts:check\` clean
- [x] \`yarn test\` — 217 passed, 24 suites, 9 snapshots (211 → 217 with new AccountStorage tests)
- [ ] Manual: fresh install → add token → confirm UI matches single-account before
- [ ] Manual: in Settings, tap \"Add another account\" → paste second PAT → list shows two accounts, \"Active\" badge on first
- [ ] Manual: tap second account row → switch active → header user updates → next note/todo/canvas saves with second account's accountId → sync hits second account's token (verify with a write-only PAT to the second account's repo)
- [ ] Manual: open Filters in Notes/Todos/Canvas list → Account row visible (2+ accounts) → pick one → list filters → strip shows account chip
- [ ] Manual: with single account, confirm Filters has no Account row, no chip in strip
- [ ] Manual: remove an account → token gone from device, items remain locally, active falls back to remaining account
- [ ] Manual: AI chat repo binding (when set under account A) routes ChatStorageService writes through A's token even after switching to B

## Out of scope (follow-ups welcome)

- Cards account badge (NoteCard / TodoRow / CanvasCard) — easy to add in a follow-up; chip color/visual not finalized.
- Move-an-existing-item between accounts.
- Per-account settings repo for #434 render styles (it auto-binds via the account selector UI added there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)