### PR TITLE
feat(rendering): customize render styles per format, persisted to user repo

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,7 @@ import { NotificationService } from './src/services/NotificationService';
 import { StartupSyncGate } from './src/components/StartupSyncGate';
 import { GitHubActivityIndicator } from './src/components/GitHubActivityIndicator';
 import { bootstrapStorage } from './src/services/StorageBootstrap';
+import { useRenderStyleStore } from './src/stores/renderStyleStore';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const queryClient = new QueryClient({
@@ -42,6 +43,7 @@ export default function App() {
 
   const checkOnboarding = useCallback(async () => {
     await bootstrapStorage();
+    void useRenderStyleStore.getState().hydrate();
     const completed = await OnboardingService.isOnboardingCompleted();
     setShowOnboarding(!completed);
     await NotificationService.requestPermissions();

--- a/__tests__/services/RenderStyle.test.ts
+++ b/__tests__/services/RenderStyle.test.ts
@@ -1,0 +1,105 @@
+import {
+  EMPTY_RENDER_STYLE_SETTINGS,
+  RENDER_FORMATS,
+  RENDER_STYLE_PATH,
+  emptyFormatStyle,
+  mergeFormatStyle,
+} from '../../src/types/RenderStyle';
+
+jest.mock('../../src/services/GitHubService', () => ({
+  __esModule: true,
+  GitHubService: {
+    getFileContent: jest.fn(),
+    updateFile: jest.fn(),
+    getFileSha: jest.fn(),
+    getRepositories: jest.fn(),
+  },
+}));
+
+import { RenderStyleService } from '../../src/services/RenderStyleService';
+import { GitHubService } from '../../src/services/GitHubService';
+
+const mockGet = GitHubService.getFileContent as jest.Mock;
+const mockPut = GitHubService.updateFile as jest.Mock;
+const mockSha = GitHubService.getFileSha as jest.Mock;
+const mockRepos = GitHubService.getRepositories as jest.Mock;
+
+describe('RenderStyle types', () => {
+  it('declares all three formats', () => {
+    expect(RENDER_FORMATS).toEqual(['markdown', 'org', 'neorg']);
+  });
+
+  it('mergeFormatStyle deep-merges per-token', () => {
+    const base = emptyFormatStyle();
+    const merged = mergeFormatStyle(base, {
+      h1: { color: '#ff0000' },
+      codeBlock: { background: '#222' },
+    });
+    expect(merged.h1?.color).toBe('#ff0000');
+    expect(merged.codeBlock?.background).toBe('#222');
+  });
+
+  it('EMPTY_RENDER_STYLE_SETTINGS has version 1 and empty formats', () => {
+    expect(EMPTY_RENDER_STYLE_SETTINGS.version).toBe(1);
+    expect(EMPTY_RENDER_STYLE_SETTINGS.formats).toEqual({});
+  });
+});
+
+describe('RenderStyleService.load', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPut.mockReset();
+  });
+
+  it('returns empty settings when file is missing', async () => {
+    mockGet.mockResolvedValueOnce(null);
+    const out = await RenderStyleService.load({ owner: 'me', name: 'repo', branch: 'main' });
+    expect(out.formats).toEqual({});
+    expect(mockGet).toHaveBeenCalledWith('me', 'repo', RENDER_STYLE_PATH, 'main');
+  });
+
+  it('returns empty settings when JSON is malformed', async () => {
+    mockGet.mockResolvedValueOnce('{ not json');
+    const out = await RenderStyleService.load({ owner: 'me', name: 'repo', branch: 'main' });
+    expect(out.formats).toEqual({});
+  });
+
+  it('parses well-formed settings', async () => {
+    mockGet.mockResolvedValueOnce(
+      JSON.stringify({ version: 1, formats: { markdown: { h1: { color: '#abcdef' } } } }),
+    );
+    const out = await RenderStyleService.load({ owner: 'me', name: 'repo', branch: 'main' });
+    expect(out.formats.markdown?.h1?.color).toBe('#abcdef');
+  });
+
+  it('save calls updateFile with serialized JSON', async () => {
+    mockPut.mockResolvedValueOnce({ commit: { sha: 'abc' }, content: { sha: 'def' } });
+    const ok = await RenderStyleService.save(
+      { owner: 'me', name: 'repo', branch: 'main' },
+      { version: 1, formats: { neorg: { h2: { color: '#222222' } } } },
+    );
+    expect(ok).toBe(true);
+    const args = mockPut.mock.calls[0];
+    expect(args[0]).toBe('me');
+    expect(args[1]).toBe('repo');
+    expect(args[2]).toBe(RENDER_STYLE_PATH);
+    const body = JSON.parse(args[3]);
+    expect(body.formats.neorg.h2.color).toBe('#222222');
+    expect(body.version).toBe(1);
+  });
+
+  it('discoverExisting only includes repos that have settings/render.json', async () => {
+    mockRepos.mockResolvedValueOnce([
+      { id: 1, name: 'a', owner: { login: 'me' }, full_name: 'me/a' },
+      { id: 2, name: 'b', owner: { login: 'me' }, full_name: 'me/b' },
+    ]);
+    mockSha.mockImplementation(async (_owner: string, name: string) => {
+      if (name === 'a') return 'sha-a';
+      return null;
+    });
+    const found = await RenderStyleService.discoverExisting();
+    expect(found).toHaveLength(1);
+    expect(found[0].name).toBe('a');
+    expect(found[0].label).toBe('me/a');
+  });
+});

--- a/src/components/NeorgRenderer.tsx
+++ b/src/components/NeorgRenderer.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { NeorgContentBlock, NeorgHeading, NeorgListItem, NeorgChecklistItem, NeorgDefinitionItem } from '../models/NeorgContent';
 import { useTheme } from '../contexts/ThemeContext';
+import { useRenderStyle } from '../stores/renderStyleStore';
+import type { RenderFormat } from '../types/RenderStyle';
 
 interface NeorgRendererProps {
   blocks: NeorgContentBlock[];
+  /** Which format's render-style overrides to apply. Defaults to 'neorg'. */
+  format?: RenderFormat;
 }
 
 type InlineSegment =
@@ -19,8 +23,31 @@ type InlineSegment =
   | { type: 'link'; label: string; target: string }
   | { type: 'tag'; name: string };
 
-export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
+export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendererProps) {
   const { colors } = useTheme();
+  const overrides = useRenderStyle(format);
+
+  const headingColorFor = (level: number): string => {
+    if (level === 1) return overrides.h1?.color ?? colors.text;
+    if (level === 2) return overrides.h2?.color ?? colors.text;
+    if (level === 3) return overrides.h3?.color ?? colors.text;
+    return colors.text;
+  };
+  const headingWeightFor = (level: number): '400' | '500' | '600' | '700' | 'bold' | 'normal' | undefined => {
+    if (level === 1) return overrides.h1?.fontWeight;
+    if (level === 2) return overrides.h2?.fontWeight;
+    if (level === 3) return overrides.h3?.fontWeight;
+    return undefined;
+  };
+  const bodyColor = overrides.body?.color ?? colors.text;
+  const codeBg = overrides.codeBlock?.background ?? colors.surfaceSecondary;
+  const codeText = overrides.codeBlock?.text ?? colors.text;
+  const inlineBg = overrides.inlineCode?.background;
+  const inlineText = overrides.inlineCode?.text;
+  const linkColor = overrides.link?.color ?? colors.primary;
+  const quoteBar = overrides.blockquote?.bar ?? colors.primary;
+  const quoteText = overrides.blockquote?.text ?? colors.text;
+  const dividerColor = overrides.divider?.color ?? colors.border;
 
   const parseInline = (text: string): InlineSegment[] => {
     const segments: InlineSegment[] = [];
@@ -132,7 +159,14 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
               return <Text key={k} style={styles.strikethrough}>{seg.content}</Text>;
             case 'code':
               return (
-                <Text key={k} style={[styles.inlineCode, { backgroundColor: colors.surfaceSecondary }]}>
+                <Text
+                  key={k}
+                  style={[
+                    styles.inlineCode,
+                    { backgroundColor: inlineBg ?? colors.surfaceSecondary },
+                    inlineText ? { color: inlineText } : null,
+                  ]}
+                >
                   {seg.content}
                 </Text>
               );
@@ -142,7 +176,7 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
               return <Text key={k} style={styles.subscript}>{seg.content}</Text>;
             case 'link':
               return (
-                <Text key={k} style={[styles.link, { color: colors.primary }]}>
+                <Text key={k} style={[styles.link, { color: linkColor }]}>
                   {seg.label}
                 </Text>
               );
@@ -176,12 +210,18 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
 
   const renderHeading = (heading: NeorgHeading, blockIndex: number) => {
     const fontSize = 32 - (heading.level - 1) * 4;
+    const weight = headingWeightFor(heading.level);
     return (
       <Text
         key={`heading-${blockIndex}`}
         style={[
           styles.heading,
-          { fontSize, color: colors.text, marginTop: heading.level === 1 ? 16 : 12 },
+          {
+            fontSize,
+            color: headingColorFor(heading.level),
+            marginTop: heading.level === 1 ? 16 : 12,
+            ...(weight ? { fontWeight: weight } : {}),
+          },
         ]}
       >
         {renderInline(heading.text)}
@@ -234,17 +274,17 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
   };
 
   const renderParagraph = (text: string, blockIndex: number) => (
-    <Text key={`para-${blockIndex}`} style={[styles.paragraph, { color: colors.text }]}>
+    <Text key={`para-${blockIndex}`} style={[styles.paragraph, { color: bodyColor }]}>
       {renderInline(text)}
     </Text>
   );
 
   const renderCodeBlock = (code: { language?: string; content: string }, blockIndex: number) => (
-    <View key={`code-${blockIndex}`} style={[styles.codeBlock, { backgroundColor: colors.surfaceSecondary }]}>
+    <View key={`code-${blockIndex}`} style={[styles.codeBlock, { backgroundColor: codeBg }]}>
       {code.language && (
         <Text style={[styles.codeLanguage, { color: colors.textSecondary }]}>{code.language}</Text>
       )}
-      <Text style={[styles.codeContent, { color: colors.text }]}>{code.content}</Text>
+      <Text style={[styles.codeContent, { color: codeText }]}>{code.content}</Text>
     </View>
   );
 
@@ -285,14 +325,14 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
   const renderQuote = (text: string, blockIndex: number) => (
     <View
       key={`quote-${blockIndex}`}
-      style={[styles.quoteBlock, { backgroundColor: colors.primary + '15', borderLeftColor: colors.primary }]}
+      style={[styles.quoteBlock, { backgroundColor: quoteBar + '15', borderLeftColor: quoteBar }]}
     >
-      <Text style={[styles.quoteText, { color: colors.text }]}>{renderInline(text)}</Text>
+      <Text style={[styles.quoteText, { color: quoteText }]}>{renderInline(text)}</Text>
     </View>
   );
 
   const renderDivider = (blockIndex: number) => (
-    <View key={`hr-${blockIndex}`} style={[styles.divider, { backgroundColor: colors.border }]} />
+    <View key={`hr-${blockIndex}`} style={[styles.divider, { backgroundColor: dividerColor }]} />
   );
 
   const renderBlock = (block: NeorgContentBlock, index: number) => {

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -16,6 +16,8 @@ import PdfViewerScreen from '../screens/PdfViewerScreen';
 import FileViewerScreen from '../screens/FileViewerScreen';
 import ImageViewerScreen from '../screens/ImageViewerScreen';
 import VideoViewerScreen from '../screens/VideoViewerScreen';
+import RenderStyleSettingsScreen from '../screens/RenderStyleSettingsScreen';
+import RenderStyleEditorScreen from '../screens/RenderStyleEditorScreen';
 import NeumorphicGallery from '../screens/__dev__/NeumorphicGallery';
 import { FloatingAIButton } from '../components/ai/FloatingAIButton';
 import { ChatRepoPickerModal } from '../components/ai/ChatRepoPickerModal';
@@ -151,6 +153,16 @@ export default function AppNavigator() {
             <Stack.Screen
               name="ChatScreen"
               component={ChatScreen}
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="RenderStyleSettings"
+              component={RenderStyleSettingsScreen}
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="RenderStyleEditor"
+              component={RenderStyleEditorScreen}
               options={{ headerShown: false }}
             />
             {__DEV__ && (

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -10,6 +10,8 @@ type ProductionStackParamList = {
   CanvasList: undefined;
   ChatThreadList: undefined;
   ChatScreen: { threadId: string };
+  RenderStyleSettings: undefined;
+  RenderStyleEditor: { format: 'markdown' | 'org' | 'neorg' };
 };
 
 type DevOnlyStackParamList = {

--- a/src/screens/FileViewerScreen.tsx
+++ b/src/screens/FileViewerScreen.tsx
@@ -19,6 +19,7 @@ import { NeorgContentParser } from '../services/NeorgContentParser';
 import NeorgRenderer from '../components/NeorgRenderer';
 import { HapticService } from '../utils/haptics';
 import { getMarkdownStyles, stripTopMetadata } from '../utils/preview';
+import { useRenderStyle } from '../stores/renderStyleStore';
 
 type Mode = 'markdown' | 'neorg' | 'org' | 'code' | 'plain';
 
@@ -107,7 +108,11 @@ export default function FileViewerScreen() {
     return parsed.success && parsed.blocks ? parsed.blocks : null;
   }, [renderContent, mode]);
 
-  const markdownStyles = useMemo(() => getMarkdownStyles(colors, isDark), [colors, isDark]);
+  const markdownOverrides = useRenderStyle('markdown');
+  const markdownStyles = useMemo(
+    () => getMarkdownStyles(colors, isDark, markdownOverrides),
+    [colors, isDark, markdownOverrides],
+  );
 
   return (
     <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: colors.background }]}>
@@ -147,7 +152,7 @@ export default function FileViewerScreen() {
           {mode === 'markdown' ? (
             <MarkdownBody value={renderContent} styles={markdownStyles} />
           ) : (mode === 'neorg' || mode === 'org') && parsedNeorg ? (
-            <NeorgRenderer blocks={parsedNeorg} />
+            <NeorgRenderer blocks={parsedNeorg} format={mode === 'org' ? 'org' : 'neorg'} />
           ) : (
             <Text
               style={[

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -54,6 +54,7 @@ import { syncNoteToGitHub } from '../services/NoteGitHubSyncService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
 import { PositionMemoryService } from '../services/PositionMemoryService';
 import { getMarkdownStyles } from '../utils/preview';
+import { useRenderStyle } from '../stores/renderStyleStore';
 import { Button, IconButton, Modal } from '../components/ui';
 import { NotePreviewRenderer } from '../utils/markdownRenderer';
 
@@ -554,7 +555,11 @@ export default function NoteEditorScreen() {
     }
   }, [content, setContent]);
 
-  const markdownStyles = useMemo(() => getMarkdownStyles(colors, isDark), [colors, isDark]);
+  const markdownOverrides = useRenderStyle('markdown');
+  const markdownStyles = useMemo(
+    () => getMarkdownStyles(colors, isDark, markdownOverrides),
+    [colors, isDark, markdownOverrides],
+  );
 
 
   const previewContent = useMemo(() => {
@@ -821,7 +826,7 @@ export default function NoteEditorScreen() {
               noteFormat === 'markdown' ? (
                 <MarkdownBody value={previewContent} styles={markdownStyles} renderer={notePreviewRenderer} />
               ) : parsedStructuredContent ? (
-                <NeorgRenderer blocks={parsedStructuredContent} />
+                <NeorgRenderer blocks={parsedStructuredContent} format={noteFormat === 'org' ? 'org' : 'neorg'} />
               ) : (
                 <Text style={[styles.structuredFallback, { color: colors.text }]}>{previewContent}</Text>
               )
@@ -989,7 +994,7 @@ export default function NoteEditorScreen() {
         noteFormat === 'markdown' ? (
           <MarkdownBody value={previewContent} styles={markdownStyles} renderer={notePreviewRenderer} />
         ) : parsedStructuredContent ? (
-          <NeorgRenderer blocks={parsedStructuredContent} />
+          <NeorgRenderer blocks={parsedStructuredContent} format={noteFormat === 'org' ? 'org' : 'neorg'} />
         ) : (
           <Text style={[styles.structuredFallback, { color: colors.text }]}>{previewContent}</Text>
         )

--- a/src/screens/RenderStyleEditorScreen.tsx
+++ b/src/screens/RenderStyleEditorScreen.tsx
@@ -1,0 +1,294 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RouteProp } from '@react-navigation/native';
+
+import { useTheme } from '../contexts/ThemeContext';
+import { useRenderStyleStore } from '../stores/renderStyleStore';
+import NeorgRenderer from '../components/NeorgRenderer';
+import { NeorgContentParser } from '../services/NeorgContentParser';
+import { getMarkdownStyles } from '../utils/preview';
+import type { FormatRenderStyle, RenderFormat } from '../types/RenderStyle';
+import { formatLabel } from '../types/RenderStyle';
+import { useMarkdown } from 'react-native-marked';
+import type { RootStackParamList } from '../navigation/types';
+
+type Nav = NativeStackNavigationProp<RootStackParamList, 'RenderStyleEditor'>;
+type RouteParams = RouteProp<RootStackParamList, 'RenderStyleEditor'>;
+
+const SAMPLE_MARKDOWN = `# Heading 1\n## Heading 2\n### Heading 3\n\nBody text with a [link](https://example.com) and \`inline code\`.\n\n> Blockquote line.\n\n\`\`\`\nfenced code block\nlet x = 42;\n\`\`\`\n\n---\n`;
+const SAMPLE_NEORG = `* Heading 1\n** Heading 2\n*** Heading 3\n\nBody text with a {https://example.com}[link] and \`inline code\`.\n\n> Blockquote line.\n\n@code\nfenced code block\nlet x = 42;\n@end\n\n___\n`;
+const SAMPLE_ORG = `* Heading 1\n** Heading 2\n*** Heading 3\n\nBody text with a [[https://example.com][link]] and =inline code=.\n\n#+BEGIN_QUOTE\nBlockquote line.\n#+END_QUOTE\n\n#+BEGIN_SRC\nfenced code block\nlet x = 42;\n#+END_SRC\n\n-----\n`;
+
+function sampleFor(format: RenderFormat): string {
+  if (format === 'markdown') return SAMPLE_MARKDOWN;
+  if (format === 'org') return SAMPLE_ORG;
+  return SAMPLE_NEORG;
+}
+
+interface ColorFieldProps {
+  label: string;
+  value?: string;
+  onChange: (next?: string) => void;
+}
+
+function ColorField({ label, value, onChange }: ColorFieldProps) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.fieldRow}>
+      <Text style={[styles.fieldLabel, { color: colors.text }]}>{label}</Text>
+      <View style={styles.fieldRight}>
+        {value ? <View style={[styles.swatch, { backgroundColor: value, borderColor: colors.border }]} /> : null}
+        <TextInput
+          style={[styles.fieldInput, { color: colors.text, borderColor: colors.border, backgroundColor: colors.background }]}
+          placeholder="#rrggbb"
+          placeholderTextColor={colors.textSecondary}
+          autoCapitalize="none"
+          autoCorrect={false}
+          value={value ?? ''}
+          onChangeText={(t) => onChange(t.trim() ? t.trim() : undefined)}
+        />
+      </View>
+    </View>
+  );
+}
+
+function MarkdownPreview({ value, format, overrides }: { value: string; format: RenderFormat; overrides: FormatRenderStyle }) {
+  const { colors, isDark } = useTheme();
+  const styles2 = useMemo(() => getMarkdownStyles(colors, isDark, overrides), [colors, isDark, overrides]);
+  if (format === 'markdown') {
+    return <MarkdownNodes value={value} styles2={styles2} />;
+  }
+  const parsed = NeorgContentParser.parseContent(value);
+  if (!parsed.success || !parsed.blocks) {
+    return <Text style={{ color: colors.textSecondary }}>(preview unavailable)</Text>;
+  }
+  return <NeorgRenderer blocks={parsed.blocks} format={format} />;
+}
+
+function MarkdownNodes({ value, styles2 }: { value: string; styles2: ReturnType<typeof getMarkdownStyles> }) {
+  const nodes = useMarkdown(value, { styles: styles2 });
+  return <>{React.Children.toArray(nodes)}</>;
+}
+
+export default function RenderStyleEditorScreen() {
+  const navigation = useNavigation<Nav>();
+  const route = useRoute<RouteParams>();
+  const { format } = route.params;
+  const { colors } = useTheme();
+  const settings = useRenderStyleStore((s) => s.settings);
+  const updateFormat = useRenderStyleStore((s) => s.updateFormat);
+  const resetFormat = useRenderStyleStore((s) => s.resetFormat);
+  const save = useRenderStyleStore((s) => s.save);
+  const isSaving = useRenderStyleStore((s) => s.isSaving);
+  const binding = useRenderStyleStore((s) => s.binding);
+  const error = useRenderStyleStore((s) => s.error);
+
+  const overrides: FormatRenderStyle = settings.formats[format] ?? {};
+  const [localOverrides, setLocalOverrides] = useState<FormatRenderStyle>(overrides);
+  const [dirty, setDirty] = useState(false);
+
+  const setToken = useCallback(<K extends keyof FormatRenderStyle>(key: K, value: FormatRenderStyle[K]) => {
+    setLocalOverrides((prev) => {
+      const next = { ...prev, [key]: value };
+      // Strip empty token objects so reset is meaningful
+      if (value && typeof value === 'object' && Object.values(value).every((v) => v === undefined || v === '')) {
+        delete next[key];
+      }
+      updateFormat(format, next);
+      return next;
+    });
+    setDirty(true);
+  }, [format, updateFormat]);
+
+  const handleSave = useCallback(async () => {
+    if (!binding) {
+      Alert.alert('Pick a repo first', 'Render styles need a repo to save to. Go back and pick one in Note rendering settings.');
+      return;
+    }
+    const ok = await save();
+    if (ok) {
+      setDirty(false);
+      Alert.alert('Saved', `Render styles pushed to ${binding.owner}/${binding.name}/settings/render.json`);
+    }
+  }, [binding, save]);
+
+  const handleReset = useCallback(() => {
+    Alert.alert(
+      'Reset overrides?',
+      `Clear custom render styles for ${formatLabel(format)} and fall back to theme defaults.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Reset',
+          style: 'destructive',
+          onPress: () => {
+            resetFormat(format);
+            setLocalOverrides({});
+            setDirty(true);
+          },
+        },
+      ],
+    );
+  }, [format, resetFormat]);
+
+  const sample = useMemo(() => sampleFor(format), [format]);
+
+  return (
+    <SafeAreaView edges={['top', 'bottom']} style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <TouchableOpacity onPress={() => navigation.goBack()} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <Ionicons name="chevron-back" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>{formatLabel(format)}</Text>
+        <TouchableOpacity onPress={handleSave} disabled={isSaving || !dirty}>
+          {isSaving ? (
+            <ActivityIndicator color={colors.primary} />
+          ) : (
+            <Text style={[styles.headerAction, { color: dirty ? colors.primary : colors.textSecondary }]}>Save</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Live preview</Text>
+        <View style={[styles.preview, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+          <MarkdownPreview value={sample} format={format} overrides={localOverrides} />
+        </View>
+
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Headings</Text>
+        <View style={[styles.section, { backgroundColor: colors.surface }]}>
+          <ColorField
+            label="H1 color"
+            value={localOverrides.h1?.color}
+            onChange={(c) => setToken('h1', { ...localOverrides.h1, color: c })}
+          />
+          <ColorField
+            label="H2 color"
+            value={localOverrides.h2?.color}
+            onChange={(c) => setToken('h2', { ...localOverrides.h2, color: c })}
+          />
+          <ColorField
+            label="H3 color"
+            value={localOverrides.h3?.color}
+            onChange={(c) => setToken('h3', { ...localOverrides.h3, color: c })}
+          />
+        </View>
+
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Body</Text>
+        <View style={[styles.section, { backgroundColor: colors.surface }]}>
+          <ColorField
+            label="Body text color"
+            value={localOverrides.body?.color}
+            onChange={(c) => setToken('body', { color: c })}
+          />
+          <ColorField
+            label="Link color"
+            value={localOverrides.link?.color}
+            onChange={(c) => setToken('link', { color: c })}
+          />
+        </View>
+
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Code</Text>
+        <View style={[styles.section, { backgroundColor: colors.surface }]}>
+          <ColorField
+            label="Code block bg"
+            value={localOverrides.codeBlock?.background}
+            onChange={(c) => setToken('codeBlock', { ...localOverrides.codeBlock, background: c })}
+          />
+          <ColorField
+            label="Code block text (Neorg only)"
+            value={localOverrides.codeBlock?.text}
+            onChange={(c) => setToken('codeBlock', { ...localOverrides.codeBlock, text: c })}
+          />
+          <ColorField
+            label="Inline code bg"
+            value={localOverrides.inlineCode?.background}
+            onChange={(c) => setToken('inlineCode', { ...localOverrides.inlineCode, background: c })}
+          />
+          <ColorField
+            label="Inline code text"
+            value={localOverrides.inlineCode?.text}
+            onChange={(c) => setToken('inlineCode', { ...localOverrides.inlineCode, text: c })}
+          />
+        </View>
+
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Blockquote / divider</Text>
+        <View style={[styles.section, { backgroundColor: colors.surface }]}>
+          <ColorField
+            label="Blockquote bar color"
+            value={localOverrides.blockquote?.bar}
+            onChange={(c) => setToken('blockquote', { ...localOverrides.blockquote, bar: c })}
+          />
+          <ColorField
+            label="Blockquote text color"
+            value={localOverrides.blockquote?.text}
+            onChange={(c) => setToken('blockquote', { ...localOverrides.blockquote, text: c })}
+          />
+          <ColorField
+            label="Divider color"
+            value={localOverrides.divider?.color}
+            onChange={(c) => setToken('divider', { color: c })}
+          />
+        </View>
+
+        <TouchableOpacity style={[styles.resetButton, { borderColor: colors.border }]} onPress={handleReset}>
+          <Ionicons name="refresh-outline" size={16} color={colors.error} />
+          <Text style={[styles.resetButtonText, { color: colors.error }]}>Reset {formatLabel(format)} to defaults</Text>
+        </TouchableOpacity>
+
+        {error ? <Text style={[styles.error, { color: colors.error }]}>{error}</Text> : null}
+        <Text style={[styles.helperText, { color: colors.textSecondary }]}>
+          Save pushes settings/render.json to {binding ? `${binding.owner}/${binding.name}` : 'the bound repo'}. Other devices pick it up on next launch.
+        </Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  headerTitle: { fontSize: 17, fontWeight: '600' },
+  headerAction: { fontSize: 15, fontWeight: '600' },
+  scrollContent: { paddingBottom: 32 },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    paddingHorizontal: 16,
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  section: { borderRadius: 12, marginHorizontal: 12, paddingVertical: 4 },
+  preview: { borderRadius: 12, marginHorizontal: 12, padding: 16, borderWidth: 1 },
+  fieldRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 10, gap: 12 },
+  fieldLabel: { fontSize: 14, flex: 1 },
+  fieldRight: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  swatch: { width: 22, height: 22, borderRadius: 6, borderWidth: 1 },
+  fieldInput: { width: 110, fontSize: 13, borderWidth: 1, borderRadius: 8, paddingHorizontal: 10, paddingVertical: 6 },
+  resetButton: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, marginHorizontal: 12, marginTop: 16, paddingVertical: 12, borderRadius: 12, borderWidth: 1 },
+  resetButtonText: { fontSize: 14, fontWeight: '600' },
+  helperText: { fontSize: 12, lineHeight: 18, paddingHorizontal: 16, paddingTop: 12 },
+  error: { fontSize: 12, paddingHorizontal: 16, paddingTop: 8 },
+});

--- a/src/screens/RenderStyleSettingsScreen.tsx
+++ b/src/screens/RenderStyleSettingsScreen.tsx
@@ -1,0 +1,269 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import { useTheme } from '../contexts/ThemeContext';
+import { useRepos } from '../contexts/RepoContext';
+import { useRenderStyleStore } from '../stores/renderStyleStore';
+import { RenderStyleService, DiscoveredBinding } from '../services/RenderStyleService';
+import { RENDER_FORMATS, formatLabel } from '../types/RenderStyle';
+import { GitHubService } from '../services/GitHubService';
+import type { RootStackParamList } from '../navigation/types';
+
+type Nav = NativeStackNavigationProp<RootStackParamList, 'RenderStyleSettings'>;
+
+export default function RenderStyleSettingsScreen() {
+  const navigation = useNavigation<Nav>();
+  const { colors } = useTheme();
+  const { repositories } = useRepos();
+  const binding = useRenderStyleStore((s) => s.binding);
+  const settings = useRenderStyleStore((s) => s.settings);
+  const isLoading = useRenderStyleStore((s) => s.isLoading);
+  const setBinding = useRenderStyleStore((s) => s.setBinding);
+  const error = useRenderStyleStore((s) => s.error);
+
+  const [showRepoPicker, setShowRepoPicker] = useState(false);
+  const [discovering, setDiscovering] = useState(false);
+  const [discovered, setDiscovered] = useState<DiscoveredBinding[]>([]);
+
+  useEffect(() => {
+    if (!showRepoPicker || !GitHubService.isAuthenticated()) return;
+    setDiscovering(true);
+    void RenderStyleService.discoverExisting()
+      .then(setDiscovered)
+      .finally(() => setDiscovering(false));
+  }, [showRepoPicker]);
+
+  const handlePickRepo = useCallback(
+    async (owner: string, name: string, branch: string) => {
+      await setBinding({ owner, name, branch });
+      setShowRepoPicker(false);
+    },
+    [setBinding],
+  );
+
+  const handleClearBinding = useCallback(() => {
+    Alert.alert(
+      'Disconnect render styles repo?',
+      'Render styles will reset to theme defaults until you re-bind a repo. The settings/render.json file in the repo is left untouched.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Disconnect', style: 'destructive', onPress: () => void setBinding(null) },
+      ],
+    );
+  }, [setBinding]);
+
+  const overrideCount = useMemo(
+    () => Object.values(settings.formats).filter(Boolean).length,
+    [settings],
+  );
+
+  return (
+    <SafeAreaView edges={['top', 'bottom']} style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <TouchableOpacity onPress={() => navigation.goBack()} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <Ionicons name="chevron-back" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Note rendering</Text>
+        <View style={{ width: 24 }} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Storage</Text>
+        <View style={[styles.section, { backgroundColor: colors.surface }]}>
+          {binding ? (
+            <>
+              <View style={styles.row}>
+                <Ionicons name="cloud-outline" size={18} color={colors.textSecondary} />
+                <View style={{ flex: 1 }}>
+                  <Text style={[styles.rowLabel, { color: colors.text }]}>{binding.owner}/{binding.name}</Text>
+                  <Text style={[styles.rowSubLabel, { color: colors.textSecondary }]}>
+                    settings/render.json on {binding.branch}
+                  </Text>
+                </View>
+                {isLoading ? <ActivityIndicator color={colors.primary} /> : null}
+              </View>
+              <TouchableOpacity style={styles.row} onPress={() => setShowRepoPicker(true)}>
+                <Ionicons name="repeat" size={18} color={colors.primary} />
+                <Text style={[styles.rowLabel, { color: colors.primary }]}>Change repo</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.row} onPress={handleClearBinding}>
+                <Ionicons name="close-circle-outline" size={18} color={colors.error} />
+                <Text style={[styles.rowLabel, { color: colors.error }]}>Disconnect</Text>
+              </TouchableOpacity>
+            </>
+          ) : (
+            <TouchableOpacity style={styles.row} onPress={() => setShowRepoPicker(true)}>
+              <Ionicons name="add-circle-outline" size={18} color={colors.primary} />
+              <Text style={[styles.rowLabel, { color: colors.primary }]}>Pick a repo for render styles</Text>
+            </TouchableOpacity>
+          )}
+          {error ? <Text style={[styles.error, { color: colors.error }]}>{error}</Text> : null}
+          <Text style={[styles.helperText, { color: colors.textSecondary }]}>
+            Styles persist to {binding ? `${binding.owner}/${binding.name}/settings/render.json` : 'a repo of your choice'} so they sync across devices. Active overrides: {overrideCount}.
+          </Text>
+        </View>
+
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Formats</Text>
+        <View style={[styles.section, { backgroundColor: colors.surface }]}>
+          {RENDER_FORMATS.map((fmt) => {
+            const hasOverrides = !!settings.formats[fmt] && Object.keys(settings.formats[fmt] ?? {}).length > 0;
+            return (
+              <TouchableOpacity
+                key={fmt}
+                style={[styles.formatRow, { borderBottomColor: colors.border }]}
+                onPress={() => navigation.navigate('RenderStyleEditor', { format: fmt })}
+              >
+                <View style={{ flex: 1 }}>
+                  <Text style={[styles.rowLabel, { color: colors.text }]}>{formatLabel(fmt)}</Text>
+                  <Text style={[styles.rowSubLabel, { color: colors.textSecondary }]}>
+                    {hasOverrides ? 'Custom overrides applied' : 'Theme defaults'}
+                  </Text>
+                </View>
+                <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        <Text style={[styles.helperText, { color: colors.textSecondary, paddingHorizontal: 16 }]}>
+          Tip: pick the same repo where you store notes so render styles travel with the content.
+        </Text>
+      </ScrollView>
+
+      {showRepoPicker ? (
+        <RepoPickerSheet
+          repositories={repositories.map((r) => ({ owner: r.path.split('/')[0] ?? '', name: r.path.split('/')[1] ?? r.name, label: r.path }))}
+          discovered={discovered}
+          discovering={discovering}
+          onClose={() => setShowRepoPicker(false)}
+          onSelect={(owner, name, branch) => handlePickRepo(owner, name, branch)}
+        />
+      ) : null}
+    </SafeAreaView>
+  );
+}
+
+interface RepoChoice {
+  owner: string;
+  name: string;
+  label: string;
+}
+
+interface RepoPickerProps {
+  repositories: RepoChoice[];
+  discovered: DiscoveredBinding[];
+  discovering: boolean;
+  onClose: () => void;
+  onSelect: (owner: string, name: string, branch: string) => void;
+}
+
+function RepoPickerSheet(props: RepoPickerProps) {
+  const { repositories, discovered, discovering, onClose, onSelect } = props;
+  const { colors } = useTheme();
+
+  return (
+    <View style={[styles.sheetOverlay, { backgroundColor: colors.background + 'cc' }]}>
+      <View style={[styles.sheet, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+        <View style={[styles.sheetHeader, { borderBottomColor: colors.border }]}>
+          <Text style={[styles.sheetTitle, { color: colors.text }]}>Pick a repo</Text>
+          <TouchableOpacity onPress={onClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+            <Ionicons name="close" size={22} color={colors.textSecondary} />
+          </TouchableOpacity>
+        </View>
+        <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
+          {discovering ? (
+            <View style={styles.discoveringRow}>
+              <ActivityIndicator color={colors.primary} />
+              <Text style={[styles.rowSubLabel, { color: colors.textSecondary }]}>Scanning for existing settings/render.json…</Text>
+            </View>
+          ) : null}
+
+          {discovered.length > 0 ? (
+            <>
+              <Text style={[styles.sectionTitle, { color: colors.textSecondary, marginTop: 12 }]}>
+                {discovered.length === 1 ? 'Existing render styles repo found' : `${discovered.length} repos already host render styles`}
+              </Text>
+              {discovered.map((d) => (
+                <TouchableOpacity
+                  key={`${d.owner}/${d.name}`}
+                  style={[styles.formatRow, { borderBottomColor: colors.border }]}
+                  onPress={() => onSelect(d.owner, d.name, d.branch)}
+                >
+                  <Ionicons name="cloud-done-outline" size={18} color={colors.primary} />
+                  <Text style={[styles.rowLabel, { color: colors.text, flex: 1, marginLeft: 8 }]}>{d.label}</Text>
+                  <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
+                </TouchableOpacity>
+              ))}
+            </>
+          ) : null}
+
+          <Text style={[styles.sectionTitle, { color: colors.textSecondary, marginTop: 16 }]}>Your repos</Text>
+          {repositories.length === 0 ? (
+            <Text style={[styles.helperText, { color: colors.textSecondary }]}>
+              Add a repo from Settings → Repositories first.
+            </Text>
+          ) : (
+            repositories.map((r) => (
+              <TouchableOpacity
+                key={`${r.owner}/${r.name}`}
+                style={[styles.formatRow, { borderBottomColor: colors.border }]}
+                onPress={() => onSelect(r.owner, r.name, 'main')}
+              >
+                <Ionicons name="git-branch-outline" size={18} color={colors.text} />
+                <Text style={[styles.rowLabel, { color: colors.text, flex: 1, marginLeft: 8 }]}>{r.label}</Text>
+                <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
+              </TouchableOpacity>
+            ))
+          )}
+        </ScrollView>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  headerTitle: { fontSize: 17, fontWeight: '600' },
+  scrollContent: { paddingBottom: 32 },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    paddingHorizontal: 16,
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  section: { borderRadius: 12, marginHorizontal: 12, paddingVertical: 4 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 12, paddingHorizontal: 16, paddingVertical: 12 },
+  formatRow: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 14, borderBottomWidth: 1 },
+  rowLabel: { fontSize: 15, fontWeight: '500' },
+  rowSubLabel: { fontSize: 12, marginTop: 2 },
+  helperText: { fontSize: 12, lineHeight: 18, paddingHorizontal: 16, paddingTop: 8, paddingBottom: 12 },
+  error: { fontSize: 12, paddingHorizontal: 16, paddingTop: 4 },
+  sheetOverlay: { ...StyleSheet.absoluteFillObject, justifyContent: 'flex-end' },
+  sheet: { borderTopLeftRadius: 16, borderTopRightRadius: 16, borderWidth: 1, maxHeight: '80%' },
+  sheetHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 14, borderBottomWidth: 1 },
+  sheetTitle: { fontSize: 16, fontWeight: '600' },
+  discoveringRow: { flexDirection: 'row', alignItems: 'center', gap: 12, paddingHorizontal: 16, paddingVertical: 12 },
+});

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -33,6 +33,9 @@ import { HapticService } from '../utils/haptics';
 import SearchBar from '../components/SearchBar';
 import { useResponsive } from '../hooks/useResponsive';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../navigation/types';
 import { ModelSelector } from '../components/ai/ModelSelector';
 import { ProviderConfigModal } from '../components/ai/ProviderConfigModal';
 import { ChatRepoPickerModal } from '../components/ai/ChatRepoPickerModal';
@@ -42,6 +45,7 @@ import type { AIProviderConfig } from '../models/AIProvider';
 
 export default function SettingsScreen() {
   const { theme, colors, setTheme, style: uiStyle, setStyle } = useTheme();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { isTablet, maxContentWidth } = useResponsive();
   const { clearAllNotes, refreshNotes } = useNotes();
   const { refreshCanvases } = useCanvases();
@@ -423,6 +427,21 @@ export default function SettingsScreen() {
           >
             <Ionicons name="add" size={20} color={colors.primary} />
             <Text style={[styles.addRepoButtonText, { color: colors.primary }]}>Add Repository</Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* ── Note rendering ── */}
+        <View style={[styles.section, { backgroundColor: colors.surface }]}>
+          <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Note rendering</Text>
+          <TouchableOpacity
+            style={[styles.settingItem, { borderBottomColor: colors.border }]}
+            onPress={() => navigation.navigate('RenderStyleSettings')}
+          >
+            <View style={styles.settingLeft}>
+              <Ionicons name="color-palette-outline" size={20} color={colors.text} />
+              <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12 }]}>Customize render styles</Text>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
           </TouchableOpacity>
         </View>
 

--- a/src/services/RenderStyleService.ts
+++ b/src/services/RenderStyleService.ts
@@ -1,0 +1,100 @@
+import { GitHubService } from './GitHubService';
+import {
+  EMPTY_RENDER_STYLE_SETTINGS,
+  RENDER_STYLE_PATH,
+  RenderStyleSettings,
+} from '../types/RenderStyle';
+
+export interface RenderStyleRepoBinding {
+  owner: string;
+  name: string;
+  branch: string;
+}
+
+export interface DiscoveredBinding extends RenderStyleRepoBinding {
+  /** Human-friendly label "owner/name". */
+  label: string;
+}
+
+function safeParse(jsonText: string): RenderStyleSettings {
+  try {
+    const parsed = JSON.parse(jsonText) as Partial<RenderStyleSettings>;
+    if (parsed && typeof parsed === 'object' && parsed.formats && typeof parsed.formats === 'object') {
+      return { version: 1, formats: parsed.formats };
+    }
+  } catch {
+    // fall through to empty
+  }
+  return { ...EMPTY_RENDER_STYLE_SETTINGS };
+}
+
+export class RenderStyleService {
+  /**
+   * Pull `settings/render.json` from the bound repo. Returns empty
+   * settings if the file does not exist (404) or is unparseable.
+   */
+  static async load(binding: RenderStyleRepoBinding): Promise<RenderStyleSettings> {
+    const content = await GitHubService.getFileContent(
+      binding.owner,
+      binding.name,
+      RENDER_STYLE_PATH,
+      binding.branch,
+    );
+    if (!content) return { ...EMPTY_RENDER_STYLE_SETTINGS };
+    return safeParse(content);
+  }
+
+  /**
+   * Persist settings to `settings/render.json`. Creates the file if
+   * missing.
+   */
+  static async save(
+    binding: RenderStyleRepoBinding,
+    settings: RenderStyleSettings,
+  ): Promise<boolean> {
+    const json = JSON.stringify(settings, null, 2);
+    const result = await GitHubService.updateFile(
+      binding.owner,
+      binding.name,
+      RENDER_STYLE_PATH,
+      json,
+      'Update render style settings',
+      binding.branch,
+    );
+    return !!result;
+  }
+
+  /**
+   * Scan all repos accessible to the active GitHub token for an existing
+   * `settings/render.json`. The returned list lets the UI implement the
+   * 0/1/2+ selection rule from #434.
+   */
+  static async discoverExisting(): Promise<DiscoveredBinding[]> {
+    const repos = await GitHubService.getRepositories();
+    const found: DiscoveredBinding[] = [];
+    await Promise.all(
+      repos.map(async (repo) => {
+        try {
+          const sha = await GitHubService.getFileSha(
+            repo.owner.login,
+            repo.name,
+            RENDER_STYLE_PATH,
+          );
+          if (sha) {
+            found.push({
+              owner: repo.owner.login,
+              name: repo.name,
+              branch: 'main',
+              label: `${repo.owner.login}/${repo.name}`,
+            });
+          }
+        } catch {
+          // ignore — repo may not be readable or branch may differ
+        }
+      }),
+    );
+    return found.sort((a, b) => a.label.localeCompare(b.label));
+  }
+}
+
+export default RenderStyleService;

--- a/src/stores/renderStyleStore.ts
+++ b/src/stores/renderStyleStore.ts
@@ -1,0 +1,158 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+
+import {
+  EMPTY_RENDER_STYLE_SETTINGS,
+  FormatRenderStyle,
+  RenderFormat,
+  RenderStyleSettings,
+} from '../types/RenderStyle';
+import { RenderStyleService, RenderStyleRepoBinding } from '../services/RenderStyleService';
+
+const BINDING_KEY = '@gitnotes:render_style_binding';
+const CACHE_KEY = '@gitnotes:render_style_cache';
+
+interface RenderStyleState {
+  binding: RenderStyleRepoBinding | null;
+  settings: RenderStyleSettings;
+  isLoading: boolean;
+  isSaving: boolean;
+  error: string | null;
+  hasHydrated: boolean;
+}
+
+interface RenderStyleActions {
+  hydrate: () => Promise<void>;
+  setBinding: (binding: RenderStyleRepoBinding | null) => Promise<void>;
+  refreshFromRepo: () => Promise<void>;
+  /**
+   * Update a single format's overrides in memory. Use this for live
+   * preview while the user is editing. Call save() to push to GitHub.
+   */
+  updateFormat: (format: RenderFormat, overrides: FormatRenderStyle) => void;
+  /** Wipe a format back to theme defaults (no overrides). */
+  resetFormat: (format: RenderFormat) => void;
+  save: () => Promise<boolean>;
+}
+
+async function readBinding(): Promise<RenderStyleRepoBinding | null> {
+  const raw = await AsyncStorage.getItem(BINDING_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as RenderStyleRepoBinding;
+    if (parsed?.owner && parsed?.name) {
+      return { branch: parsed.branch || 'main', owner: parsed.owner, name: parsed.name };
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+async function readCache(): Promise<RenderStyleSettings> {
+  const raw = await AsyncStorage.getItem(CACHE_KEY);
+  if (!raw) return { ...EMPTY_RENDER_STYLE_SETTINGS };
+  try {
+    const parsed = JSON.parse(raw) as Partial<RenderStyleSettings>;
+    if (parsed && typeof parsed === 'object' && parsed.formats) {
+      return { version: 1, formats: parsed.formats };
+    }
+  } catch {
+    // fall through
+  }
+  return { ...EMPTY_RENDER_STYLE_SETTINGS };
+}
+
+async function writeCache(settings: RenderStyleSettings): Promise<void> {
+  await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(settings));
+}
+
+export const useRenderStyleStore = create<RenderStyleState & RenderStyleActions>()((set, get) => ({
+  binding: null,
+  settings: { ...EMPTY_RENDER_STYLE_SETTINGS },
+  isLoading: false,
+  isSaving: false,
+  error: null,
+  hasHydrated: false,
+
+  hydrate: async () => {
+    if (get().hasHydrated) return;
+    set({ isLoading: true, error: null });
+    const [binding, cached] = await Promise.all([readBinding(), readCache()]);
+    set({ binding, settings: cached, hasHydrated: true, isLoading: false });
+    if (binding) {
+      void get().refreshFromRepo();
+    }
+  },
+
+  setBinding: async (binding) => {
+    if (binding === null) {
+      await AsyncStorage.removeItem(BINDING_KEY);
+      set({ binding: null, settings: { ...EMPTY_RENDER_STYLE_SETTINGS }, error: null });
+      await writeCache({ ...EMPTY_RENDER_STYLE_SETTINGS });
+      return;
+    }
+    await AsyncStorage.setItem(BINDING_KEY, JSON.stringify(binding));
+    set({ binding, error: null });
+    await get().refreshFromRepo();
+  },
+
+  refreshFromRepo: async () => {
+    const { binding } = get();
+    if (!binding) return;
+    set({ isLoading: true, error: null });
+    try {
+      const remote = await RenderStyleService.load(binding);
+      set({ settings: remote, isLoading: false });
+      await writeCache(remote);
+    } catch (err) {
+      set({ isLoading: false, error: err instanceof Error ? err.message : 'Failed to load styles' });
+    }
+  },
+
+  updateFormat: (format, overrides) => {
+    set((state) => ({
+      settings: {
+        version: 1,
+        formats: { ...state.settings.formats, [format]: overrides },
+      },
+    }));
+  },
+
+  resetFormat: (format) => {
+    set((state) => {
+      const { [format]: _removed, ...rest } = state.settings.formats;
+      return { settings: { version: 1, formats: rest } };
+    });
+  },
+
+  save: async () => {
+    const { binding, settings } = get();
+    if (!binding) {
+      set({ error: 'No render style repo bound. Pick a repo first.' });
+      return false;
+    }
+    set({ isSaving: true, error: null });
+    try {
+      const ok = await RenderStyleService.save(binding, settings);
+      if (ok) await writeCache(settings);
+      set({ isSaving: false, error: ok ? null : 'Failed to save to GitHub' });
+      return ok;
+    } catch (err) {
+      set({
+        isSaving: false,
+        error: err instanceof Error ? err.message : 'Failed to save styles',
+      });
+      return false;
+    }
+  },
+}));
+
+/**
+ * React-friendly selector that returns the currently-active overrides
+ * for a given format. Returns an empty object when no overrides exist
+ * (renderers fall back to theme defaults).
+ */
+export function useRenderStyle(format: RenderFormat): FormatRenderStyle {
+  return useRenderStyleStore((state) => state.settings.formats[format] ?? {});
+}

--- a/src/types/RenderStyle.ts
+++ b/src/types/RenderStyle.ts
@@ -1,0 +1,70 @@
+/**
+ * User-customizable render style tokens per note format. All fields are
+ * optional — anything missing falls back to the active theme defaults.
+ *
+ * The shape persists to GitHub under `settings/render.json` in the repo
+ * the user picks for render-style storage. See RenderStyleService.
+ */
+
+export type RenderFormat = 'markdown' | 'org' | 'neorg';
+
+export interface HeadingTokens {
+  color?: string;
+  fontWeight?: '400' | '500' | '600' | '700' | 'bold' | 'normal';
+}
+
+export interface FormatRenderStyle {
+  h1?: HeadingTokens;
+  h2?: HeadingTokens;
+  h3?: HeadingTokens;
+  body?: { color?: string };
+  codeBlock?: { background?: string; text?: string };
+  inlineCode?: { background?: string; text?: string };
+  link?: { color?: string };
+  blockquote?: { bar?: string; text?: string };
+  divider?: { color?: string };
+}
+
+export interface RenderStyleSettings {
+  version: 1;
+  formats: Partial<Record<RenderFormat, FormatRenderStyle>>;
+}
+
+export const EMPTY_RENDER_STYLE_SETTINGS: RenderStyleSettings = {
+  version: 1,
+  formats: {},
+};
+
+export const RENDER_STYLE_PATH = 'settings/render.json';
+
+export const RENDER_FORMATS: RenderFormat[] = ['markdown', 'org', 'neorg'];
+
+export function formatLabel(format: RenderFormat): string {
+  switch (format) {
+    case 'markdown': return 'Markdown (.md)';
+    case 'org': return 'Org (.org)';
+    case 'neorg': return 'Neorg (.norg)';
+  }
+}
+
+export function emptyFormatStyle(): FormatRenderStyle {
+  return {};
+}
+
+export function mergeFormatStyle(
+  base: FormatRenderStyle,
+  override?: FormatRenderStyle,
+): FormatRenderStyle {
+  if (!override) return base;
+  return {
+    h1: { ...base.h1, ...override.h1 },
+    h2: { ...base.h2, ...override.h2 },
+    h3: { ...base.h3, ...override.h3 },
+    body: { ...base.body, ...override.body },
+    codeBlock: { ...base.codeBlock, ...override.codeBlock },
+    inlineCode: { ...base.inlineCode, ...override.inlineCode },
+    link: { ...base.link, ...override.link },
+    blockquote: { ...base.blockquote, ...override.blockquote },
+    divider: { ...base.divider, ...override.divider },
+  };
+}

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -1,5 +1,6 @@
 import { NoteFormat } from '../models/Note';
 import type { MarkedStyles } from 'react-native-marked';
+import type { FormatRenderStyle } from '../types/RenderStyle';
 
 interface ColorPalette {
   text: string;
@@ -42,40 +43,63 @@ export function stripTopMetadata(raw: string, format: NoteFormat): string {
   return raw;
 }
 
-export function getMarkdownStyles(colors: ColorPalette, isDark: boolean): MarkedStyles {
+export function getMarkdownStyles(
+  colors: ColorPalette,
+  isDark: boolean,
+  overrides?: FormatRenderStyle,
+): MarkedStyles {
+  const bodyColor = overrides?.body?.color ?? colors.text;
+  const h1Color = overrides?.h1?.color ?? colors.text;
+  const h2Color = overrides?.h2?.color ?? colors.text;
+  const h3Color = overrides?.h3?.color ?? colors.text;
+  const h1Weight = (overrides?.h1?.fontWeight ?? 'bold') as 'bold';
+  const h2Weight = (overrides?.h2?.fontWeight ?? 'bold') as 'bold';
+  const h3Weight = (overrides?.h3?.fontWeight ?? '600') as '600';
+  const codeBg = overrides?.codeBlock?.background ?? (isDark ? '#2c2c2e' : '#f5f5f5');
+  // Note: react-native-marked's `code` style is ViewStyle-only, so the
+  // codeBlock.text override does not apply to markdown fenced blocks.
+  // It still applies in NeorgRenderer where we render the text node
+  // directly. Markdown code text inherits the body color.
+  const inlineBg = overrides?.inlineCode?.background ?? (isDark ? '#2c2c2e' : '#f0f0f0');
+  const inlineText = overrides?.inlineCode?.text ?? colors.text;
+  const linkColor = overrides?.link?.color ?? colors.primary;
+  const quoteBar = overrides?.blockquote?.bar ?? colors.primary;
+  const quoteText = overrides?.blockquote?.text ?? colors.text;
+  const dividerColor = overrides?.divider?.color ?? colors.border;
+
   return {
-    text: { fontSize: 16, lineHeight: 26, color: colors.text },
-    h1: { fontSize: 28, lineHeight: 38, fontWeight: 'bold', marginBottom: 12, marginTop: 8, color: colors.text },
-    h2: { fontSize: 22, lineHeight: 32, fontWeight: 'bold', marginBottom: 10, marginTop: 8, color: colors.text },
-    h3: { fontSize: 18, lineHeight: 26, fontWeight: '600', marginBottom: 8, marginTop: 6, color: colors.text },
+    text: { fontSize: 16, lineHeight: 26, color: bodyColor },
+    h1: { fontSize: 28, lineHeight: 38, fontWeight: h1Weight, marginBottom: 12, marginTop: 8, color: h1Color },
+    h2: { fontSize: 22, lineHeight: 32, fontWeight: h2Weight, marginBottom: 10, marginTop: 8, color: h2Color },
+    h3: { fontSize: 18, lineHeight: 26, fontWeight: h3Weight, marginBottom: 8, marginTop: 6, color: h3Color },
     paragraph: { marginTop: 0, marginBottom: 12 },
     codespan: {
-      backgroundColor: isDark ? '#2c2c2e' : '#f0f0f0',
+      backgroundColor: inlineBg,
       paddingHorizontal: 4,
       borderRadius: 4,
       fontFamily: 'monospace',
       fontSize: 14,
-      color: colors.text,
+      color: inlineText,
     },
     code: {
-      backgroundColor: isDark ? '#2c2c2e' : '#f5f5f5',
+      backgroundColor: codeBg,
       padding: 12,
       borderRadius: 8,
       marginVertical: 8,
     },
     blockquote: {
-      backgroundColor: colors.primary + '15',
+      backgroundColor: quoteBar + '15',
       borderLeftWidth: 4,
-      borderLeftColor: colors.primary,
+      borderLeftColor: quoteBar,
       paddingLeft: 12,
       paddingVertical: 8,
       marginVertical: 8,
     },
-    link: { color: colors.primary },
-    li: { marginBottom: 4, color: colors.text },
+    link: { color: linkColor },
+    li: { marginBottom: 4, color: bodyColor },
     list: { marginBottom: 12 },
-    hr: { backgroundColor: colors.border, height: 1, marginVertical: 16 },
-    strong: { color: colors.text },
-    em: { color: colors.text },
+    hr: { backgroundColor: dividerColor, height: 1, marginVertical: 16 },
+    strong: { color: bodyColor },
+    em: { color: quoteText },
   };
 }


### PR DESCRIPTION
Closes #434.

End-to-end render-style customization for \`.md\` / \`.org\` / \`.norg\` notes. Settings persist to a user-chosen GitHub repo at \`settings/render.json\`, so styles travel between devices.

## What's in

### Types (\`src/types/RenderStyle.ts\`)
\`FormatRenderStyle\` covers heading colors + weights, body, code block, inline code, link, blockquote, divider. \`RenderStyleSettings\` is \`{ version: 1, formats: { markdown?, org?, neorg? } }\`. Path constant \`RENDER_STYLE_PATH = 'settings/render.json'\`.

### Service (\`RenderStyleService\`)
- \`load(binding)\` GETs the JSON via \`GitHubService.getFileContent\`, returns empty settings on 404 or parse error.
- \`save(binding, settings)\` PUTs through \`GitHubService.updateFile\`.
- \`discoverExisting()\` scans repos accessible to the active token for an existing \`settings/render.json\`. Implements the 0/1/2+ rule from #434:
  - **0** matches → user picks any of their added repos.
  - **1** match → surfaced at the top of the picker for one-tap reuse.
  - **2+** matches → all listed for the user to choose.

### Store (\`renderStyleStore\`)
Zustand store with binding + settings + isLoading/isSaving/error/hasHydrated state and \`hydrate / setBinding / refreshFromRepo / updateFormat / resetFormat / save\`. Local cache (\`@gitnotes:render_style_cache\`) kept so styles apply offline.

\`useRenderStyle(format)\` returns the current overrides for a given format — empty object means defaults.

### Renderers
- \`preview.ts getMarkdownStyles\` accepts an optional \`FormatRenderStyle\`. Heading color/weight, body color, inline code bg/text, link color, blockquote bar/text, divider color, code block bg all routed through the override → theme fallback chain.
- \`NeorgRenderer\` accepts a \`format\` prop ('neorg' default, 'org' when rendering org files). Same token plumbing as markdown plus inline code text color and quote text color.
- \`FileViewerScreen\` and \`NoteEditorScreen\` consume the markdown overrides via \`useRenderStyle('markdown')\` and pass \`format\` to \`NeorgRenderer\` based on note format.

### Screens + nav
- \`RenderStyleSettingsScreen\`: storage section (current binding / change repo / disconnect), formats section listing markdown / org / neorg, helper text. Repo picker sheet shows discovered render-styles repos at top, then your added repos.
- \`RenderStyleEditorScreen\`: live preview at top (markdown via \`react-native-marked\`, org/neorg via \`NeorgRenderer\`); hex inputs for every token grouped by Headings / Body / Code / Blockquote-divider. Save pushes JSON; Reset clears the format.
- \`AppNavigator\` + \`RootStackParamList\` register both screens.
- \`SettingsScreen\`: new "Note rendering" section navigates to \`RenderStyleSettings\`.
- \`App.tsx\`: hydrates the store on launch alongside other bootstrap.

## Caveats

- Markdown code-block text color is **not** customizable (react-native-marked's \`code\` style is ViewStyle-only). Neorg respects \`codeBlock.text\` because we render the text node directly. Editor labels the field as "Neorg only" to set expectations.
- Color picker is a hex \`TextInput\` with a swatch preview. Native color wheel is a follow-up — same store API.
- No org-specific block style yet beyond what NeorgRenderer covers; \`org\` overrides currently apply via the shared NeorgRenderer pipeline (FileViewer + Editor pass \`format='org'\`).

## Test plan

- [x] \`yarn ts:check\` clean
- [x] \`yarn test\` — 219 passed, 24 suites, 9 snapshots (8 new RenderStyle tests)
- [ ] Manual: open Settings → Note rendering → pick a repo (verify 0/1/2+ behavior in the picker)
- [ ] Manual: open Markdown editor → live preview matches list view; change H1 color → preview + saved Note view both update
- [ ] Manual: switch device / re-launch → styles re-load from repo + cache fallback works offline
- [ ] Manual: Reset clears overrides, theme defaults restored
- [ ] Manual: Org / Neorg preview reflects overrides

## Pairs with #430

When multi-account (PR #438) lands, the binding can be made per-account by routing reads/writes through \`AuthService.getTokenById\` from the chosen account. Out of scope for this PR — render-style storage uses the active account's token today, which matches how every other GitHub call worked before #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)