### PR TITLE
Fix all 20 GitHub issues — Wave 1-5 complete (#410-#429)

### DIFF
--- a/.sisyphus/notepads/ai-chat/decisions.md
+++ b/.sisyphus/notepads/ai-chat/decisions.md
@@ -15,3 +15,7 @@
 - Confirm mode stays inline in the conversation via a pending confirmation card driven by `executeToolCall(..., 'confirm')`, while Apply re-runs the same tool in auto mode so the screen never mutates note/todo stores directly.
 - Keep AI chat entry out of tab navigation; register `ChatThreadList`/`ChatScreen` only in the root stack and mount `FloatingAIButton` plus `ChatRepoPickerModal` as navigator-level overlays.
 - Use the chat repo from `aiStore` as the source of truth for AI context browsing, with `GitHubService.getTreeRecursive()` providing the file/folder lists shown in the modal.
+
+## 2026-05-03
+- Added `classifyHref` as a pure utility so link routing rules are unit-testable outside the renderer.
+- Kept external `http(s)`, `mailto:`, and `tel:` links on the native platform via `Linking.openURL` instead of adding in-app web handling.

--- a/.sisyphus/notepads/ai-chat/decisions.md
+++ b/.sisyphus/notepads/ai-chat/decisions.md
@@ -20,3 +20,4 @@
 - Added `classifyHref` as a pure utility so link routing rules are unit-testable outside the renderer.
 - Kept external `http(s)`, `mailto:`, and `tel:` links on the native platform via `Linking.openURL` instead of adding in-app web handling.
 - Kept renderer bug coverage in a dedicated `__tests__/renderer-pipeline.test.ts` regression file so markdown and Neorg pipeline fixes for issue #423 stay exercised together.
+- Used a dedicated `templateStore` for custom template CRUD + pin state, while leaving built-in templates in `TemplateService` so the default catalog stays static.

--- a/.sisyphus/notepads/ai-chat/decisions.md
+++ b/.sisyphus/notepads/ai-chat/decisions.md
@@ -19,3 +19,4 @@
 ## 2026-05-03
 - Added `classifyHref` as a pure utility so link routing rules are unit-testable outside the renderer.
 - Kept external `http(s)`, `mailto:`, and `tel:` links on the native platform via `Linking.openURL` instead of adding in-app web handling.
+- Kept renderer bug coverage in a dedicated `__tests__/renderer-pipeline.test.ts` regression file so markdown and Neorg pipeline fixes for issue #423 stay exercised together.

--- a/.sisyphus/notepads/ai-chat/learnings.md
+++ b/.sisyphus/notepads/ai-chat/learnings.md
@@ -35,3 +35,5 @@
 - Markdown fenced code rendering can stay lightweight: a plain `<Text>` language label above the existing code body fixes dropped language metadata without adding syntax highlighting.
 - Neorg inline parsing is safer when URL-shaped substrings are reserved before italic matching and repeated parses are cached behind a memoized parser function.
 - Neorg list indentation needs adaptive parsing: the first indented space-based sibling should define the indent width, while tabs should count as one nesting level.
+- Custom template persistence can stay isolated from note storage by using dedicated AsyncStorage keys for template blobs and pin IDs, with a small Zustand store handling merge/sort behavior.
+- Settings rows can reuse the existing `settingItem` visual pattern for new affordances without introducing new navigation scaffolding in this branch.

--- a/.sisyphus/notepads/ai-chat/learnings.md
+++ b/.sisyphus/notepads/ai-chat/learnings.md
@@ -32,3 +32,6 @@
 ## 2026-05-03
 - Markdown preview links need target classification before routing; raw `Linking.openURL` breaks internal note navigation and fragment scrolling behavior.
 - Relative note links should resolve against the current note file path, while stored note lookups should normalize away leading slashes because folder selections use `/path` but synced note `filePath` values do not.
+- Markdown fenced code rendering can stay lightweight: a plain `<Text>` language label above the existing code body fixes dropped language metadata without adding syntax highlighting.
+- Neorg inline parsing is safer when URL-shaped substrings are reserved before italic matching and repeated parses are cached behind a memoized parser function.
+- Neorg list indentation needs adaptive parsing: the first indented space-based sibling should define the indent width, while tabs should count as one nesting level.

--- a/.sisyphus/notepads/ai-chat/learnings.md
+++ b/.sisyphus/notepads/ai-chat/learnings.md
@@ -28,3 +28,7 @@
 - Context pickers can reuse the authenticated GitHub tree API directly for file/folder selection instead of relying on placeholder copy or store-only repo metadata.
 
 - Plan-compliance review needs to verify behavior, not just file existence: route overlays rendered outside `NavigationContainer`, placeholder context tabs, and local-only rename flows can still pass typecheck/tests while missing the requested user flow.
+
+## 2026-05-03
+- Markdown preview links need target classification before routing; raw `Linking.openURL` breaks internal note navigation and fragment scrolling behavior.
+- Relative note links should resolve against the current note file path, while stored note lookups should normalize away leading slashes because folder selections use `/path` but synced note `filePath` values do not.

--- a/.sisyphus/notepads/ai-chat/problems.md
+++ b/.sisyphus/notepads/ai-chat/problems.md
@@ -1,2 +1,3 @@
 # AI Chat Feature - Problems
 
+- `SettingsScreen` now exposes a `Manage templates` row, but this task intentionally did not add the `TemplateManager` screen or register a new navigation route.

--- a/.sisyphus/notepads/fix-all-github-issues/decisions.md
+++ b/.sisyphus/notepads/fix-all-github-issues/decisions.md
@@ -1,0 +1,3 @@
+## Decisions
+- Shared todo ordering now lives in `src/models/Todo.ts` via `compareTodos`/`reorderTodos` so the screen, store refresh path, and repo pull path all use one stable ordering rule.
+- Todo completion now persists the reordered list after toggle and syncs repo-backed todos to GitHub before refreshes, which keeps pull-to-refresh from reintroducing stale completion state.

--- a/.sisyphus/notepads/fix-all-github-issues/learnings.md
+++ b/.sisyphus/notepads/fix-all-github-issues/learnings.md
@@ -1,0 +1,3 @@
+## Learnings
+- Offline banners can stay lightweight by reading `useNetworkStatus` directly and returning `null` when connected.
+- For UI tests, mocking theme/network hooks is enough; no provider setup is needed for a simple present/hidden assertion.

--- a/.sisyphus/notepads/fix-all-github-issues/learnings.md
+++ b/.sisyphus/notepads/fix-all-github-issues/learnings.md
@@ -1,3 +1,5 @@
 ## Learnings
 - Offline banners can stay lightweight by reading `useNetworkStatus` directly and returning `null` when connected.
 - For UI tests, mocking theme/network hooks is enough; no provider setup is needed for a simple present/hidden assertion.
+- Todo completion has to persist the same sorted order used by the list UI; otherwise refresh can reload a stale top-of-list ordering and cause visible reflow glitches.
+- Toggling a repo-backed todo must sync its updated `completed` state back to GitHub, or the next pull will overwrite the local completion state.

--- a/.sisyphus/notepads/wave3-ux/decisions.md
+++ b/.sisyphus/notepads/wave3-ux/decisions.md
@@ -1,2 +1,3 @@
 - Kept the canvas pan/fit logic inside `CanvasEditorScreen` as exported pure helpers so the screen and unit test stay in sync without changing the canvas data model.
 - Used the same fit-to-content translation for initial auto-fit and the reset button so both flows center existing content consistently.
+- Introduced `src/utils/noteTagSupport.ts` for tag-format capability checks so `NoteEditorScreen` and `RepoPullService` no longer depend on `NoteGitHubSyncService` for a pure predicate.

--- a/.sisyphus/notepads/wave3-ux/decisions.md
+++ b/.sisyphus/notepads/wave3-ux/decisions.md
@@ -1,0 +1,2 @@
+- Kept the canvas pan/fit logic inside `CanvasEditorScreen` as exported pure helpers so the screen and unit test stay in sync without changing the canvas data model.
+- Used the same fit-to-content translation for initial auto-fit and the reset button so both flows center existing content consistently.

--- a/.sisyphus/notepads/wave3-ux/issues.md
+++ b/.sisyphus/notepads/wave3-ux/issues.md
@@ -1,0 +1,1 @@
+- The canvas screen now has several gesture worklet closures that depend on viewport size and bounds; any future gesture refactor should keep those dependencies explicit so clamping stays correct after layout changes.

--- a/.sisyphus/notepads/wave3-ux/learnings.md
+++ b/.sisyphus/notepads/wave3-ux/learnings.md
@@ -1,3 +1,5 @@
 - Markdown preview text selection needs to cover link text too; links can stay pressable and selectable together.
 - For nested Neorg inline rendering, setting selectable on every Text node is the safest way to keep copy/paste working across headings, lists, tables, quotes, and inline styles.
 - RNTL `UNSAFE_getAllByType(Text)` is enough to verify selectable props on rendered preview text without adding UI-specific assertions.
+- Canvas viewport clamping is easiest when the content bbox and fit-to-center translation are pure helpers shared by the gesture worklets and reset/open flows.
+- The pan clamp needs to be scale-aware; clamping against screen-space bbox edges keeps at least the requested margin visible after pinch zoom.

--- a/.sisyphus/notepads/wave3-ux/learnings.md
+++ b/.sisyphus/notepads/wave3-ux/learnings.md
@@ -1,0 +1,3 @@
+- Markdown preview text selection needs to cover link text too; links can stay pressable and selectable together.
+- For nested Neorg inline rendering, setting selectable on every Text node is the safest way to keep copy/paste working across headings, lists, tables, quotes, and inline styles.
+- RNTL `UNSAFE_getAllByType(Text)` is enough to verify selectable props on rendered preview text without adding UI-specific assertions.

--- a/.sisyphus/notepads/wave3-ux/learnings.md
+++ b/.sisyphus/notepads/wave3-ux/learnings.md
@@ -3,3 +3,5 @@
 - RNTL `UNSAFE_getAllByType(Text)` is enough to verify selectable props on rendered preview text without adding UI-specific assertions.
 - Canvas viewport clamping is easiest when the content bbox and fit-to-center translation are pure helpers shared by the gesture worklets and reset/open flows.
 - The pan clamp needs to be scale-aware; clamping against screen-space bbox edges keeps at least the requested margin visible after pinch zoom.
+- Tags need a shared format-support helper; importing it from the sync service caused unrelated Jest mocks to break, so a tiny utility module kept the editor, pull flow, and tests aligned.
+- Markdown/org/neorg tag persistence works best when sync and pull use matching serializers/parsers; write the metadata once at save time and read it back during repo refresh.

--- a/__mocks__/expo-blur.ts
+++ b/__mocks__/expo-blur.ts
@@ -1,0 +1,7 @@
+const { View } = require('react-native');
+
+module.exports = {
+  __esModule: true,
+  BlurView: View,
+  default: View,
+};

--- a/__mocks__/expo-file-system-legacy.ts
+++ b/__mocks__/expo-file-system-legacy.ts
@@ -1,0 +1,6 @@
+module.exports = {
+  __esModule: true,
+  EncodingType: { Base64: 'base64' },
+  readAsStringAsync: jest.fn(),
+  default: {},
+};

--- a/__tests__/Note.test.ts
+++ b/__tests__/Note.test.ts
@@ -173,7 +173,7 @@ describe('format helpers', () => {
   });
 
   test('getSupportedFileExtensions / isSupportedFileExtension', () => {
-    expect(getSupportedFileExtensions()).toEqual(['.md', '.norg', '.org', '.pdf']);
+    expect(getSupportedFileExtensions()).toEqual(['.md', '.norg', '.org', '.pdf', '.json']);
     expect(isSupportedFileExtension('a.md')).toBe(true);
     expect(isSupportedFileExtension('A.PDF')).toBe(true);
     expect(isSupportedFileExtension('a.txt')).toBe(false);

--- a/__tests__/canvas-multi-embed.test.tsx
+++ b/__tests__/canvas-multi-embed.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
+
+jest.mock('expo-image', () => ({
+  Image: () => null,
+}));
+
+jest.mock('react-native-marked', () => {
+  class Renderer {
+    private key = 0;
+
+    getKey() {
+      this.key += 1;
+      return `renderer-key-${this.key}`;
+    }
+  }
+
+  return { Renderer };
+});
+
+const createRenderer = (CanvasPreview: React.ComponentType<{ canvasId: string }>) => new NotePreviewRenderer({
+  colors: {
+    primary: '#2563eb',
+    text: '#111827',
+    surfaceSecondary: '#e5e7eb',
+  },
+  CanvasPreview,
+});
+
+describe('canvas multi-embed regression', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders two canvas embeds without crashing', () => {
+    const renderer = createRenderer(({ canvasId }) => <Text testID={`canvas-${canvasId}`}>{canvasId}</Text>);
+
+    const screen = render(
+      <View>
+        {renderer.link([], 'canvas:canvas-1')}
+        {renderer.link([], 'canvas:canvas-2')}
+      </View>,
+    );
+
+    expect(screen.getByTestId('canvas-canvas-1')).toBeTruthy();
+    expect(screen.getByTestId('canvas-canvas-2')).toBeTruthy();
+  });
+
+  it('assigns stable unique keys to each canvas preview', () => {
+    const renderer = createRenderer(({ canvasId }) => <Text>{canvasId}</Text>);
+
+    const firstNode = renderer.link([], 'canvas:canvas-1') as React.ReactElement<{ children: React.ReactNode }>;
+    const secondNode = renderer.link([], 'canvas:canvas-2') as React.ReactElement<{ children: React.ReactNode }>;
+    const firstPreview = React.Children.only(firstNode.props.children) as React.ReactElement;
+    const secondPreview = React.Children.only(secondNode.props.children) as React.ReactElement;
+
+    expect(firstNode.key).toBe('canvas-boundary-canvas-1');
+    expect(secondNode.key).toBe('canvas-boundary-canvas-2');
+    expect(firstPreview.key).toBe('canvas-1');
+    expect(secondPreview.key).toBe('canvas-2');
+  });
+
+  it('shows a placeholder when canvas preview rendering throws', () => {
+    const renderer = createRenderer(({ canvasId }) => {
+      if (canvasId === 'canvas-2') {
+        throw new Error('Skia init failed');
+      }
+
+      return <Text testID={`canvas-${canvasId}`}>{canvasId}</Text>;
+    });
+
+    const screen = render(
+      <View>
+        {renderer.link([], 'canvas:canvas-1')}
+        {renderer.link([], 'canvas:canvas-2')}
+      </View>,
+    );
+
+    expect(screen.getByTestId('canvas-canvas-1')).toBeTruthy();
+    expect(screen.getByText('Canvas preview unavailable')).toBeTruthy();
+  });
+});

--- a/__tests__/canvas-pan-clamp.test.ts
+++ b/__tests__/canvas-pan-clamp.test.ts
@@ -1,0 +1,84 @@
+import React from 'react';
+import type { CanvasElement } from '../src/models/Canvas';
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@react-navigation/native', () => ({ useNavigation: () => ({}), useRoute: () => ({ params: {} }) }));
+jest.mock('@react-navigation/native-stack', () => ({}));
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: () => null,
+  Gesture: {
+    Pan: () => ({
+      maxPointers: () => ({
+        onStart: () => ({
+          onChange: () => ({
+            onEnd: () => ({}),
+          }),
+        }),
+      }),
+      minPointers: () => ({
+        averageTouches: () => ({
+          onStart: () => ({
+            onUpdate: () => ({}),
+          }),
+        }),
+      }),
+    }),
+    Pinch: () => ({
+      onStart: () => ({
+        onUpdate: () => ({}),
+      }),
+    }),
+    Simultaneous: () => ({}),
+  },
+  GestureHandlerRootView: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: {},
+  runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+  useAnimatedStyle: () => ({}),
+  useDerivedValue: (fn: () => unknown) => ({ value: fn() }),
+  useSharedValue: (value: unknown) => ({ value }),
+  withSpring: (value: unknown) => value,
+}));
+jest.mock('@shopify/react-native-skia', () => ({
+  Canvas: () => null,
+  Path: () => null,
+  Rect: () => null,
+  Oval: () => null,
+  RoundedRect: () => null,
+  Fill: () => null,
+  Group: () => null,
+  Skia: { Path: { Make: () => ({ moveTo: () => {}, lineTo: () => {}, close: () => {}, rewind: () => {}, setIsVolatile: () => ({}) }) } },
+  matchFont: () => ({}),
+  Text: () => null,
+}));
+jest.mock('../src/contexts/CanvasContext', () => ({ useCanvases: () => ({ getCanvasById: () => undefined, createCanvas: async () => undefined, updateCanvas: async () => undefined }) }));
+jest.mock('../src/contexts/ThemeContext', () => ({ useTheme: () => ({ colors: { background: '#fff', border: '#ddd', surface: '#fff', text: '#111', textSecondary: '#666', primary: '#2563eb' } }) }));
+jest.mock('../src/components/GitContextPicker', () => () => null);
+jest.mock('../src/services/CanvasGitHubSyncService', () => ({ syncCanvasToGitHub: async () => ({ success: true }) }));
+
+import { clampCanvasTranslation, getCanvasContentBounds, getCanvasFitTranslation } from '../src/screens/CanvasEditorScreen';
+
+describe('canvas pan clamp helpers', () => {
+  const elements: CanvasElement[] = [
+    { type: 'stroke', id: 'stroke-1', tool: 'pen', color: '#000', width: 8, points: [{ x: 20, y: 40 }, { x: 60, y: 10 }] },
+    { type: 'shape', id: 'shape-1', shape: 'rect', color: '#111', width: 4, x1: -30, y1: 80, x2: 0, y2: 100 },
+    { type: 'chart', id: 'chart-1', chartType: 'bar', title: 'Sales', labels: ['A'], values: [1], x: 200, y: 300, width: 50, height: 60 },
+  ];
+
+  it('computes a bounding box across mixed canvas elements', () => {
+    expect(getCanvasContentBounds(elements)).toEqual({ minX: -32, minY: 6, maxX: 250, maxY: 360 });
+  });
+
+  it('centers non-empty content in the viewport for auto-fit/reset', () => {
+    expect(getCanvasFitTranslation({ minX: -32, minY: 6, maxX: 250, maxY: 360 }, 400, 400, 1)).toEqual({ translateX: 91, translateY: 17 });
+  });
+
+  it('clamps pan translation so at least 80px stays visible', () => {
+    const bounds = { minX: -32, minY: 6, maxX: 250, maxY: 360 };
+
+    expect(clampCanvasTranslation(-500, -500, 1, bounds, 400, 400)).toEqual({ translateX: -170, translateY: -280 });
+    expect(clampCanvasTranslation(-500, -900, 2, bounds, 400, 400)).toEqual({ translateX: -420, translateY: -640 });
+  });
+});

--- a/__tests__/canvas-race.test.ts
+++ b/__tests__/canvas-race.test.ts
@@ -1,0 +1,179 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  let store: Record<string, string> = {};
+  let blockNextCanvasWrite = false;
+  let blockedCanvasWrite: {
+    promise: Promise<void>;
+    release: () => void;
+    started: Promise<void>;
+    markStarted: () => void;
+  } | null = null;
+
+  const createBlockedWrite = () => {
+    let release = () => {};
+    let markStarted = () => {};
+    const promise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    return { promise, release, started, markStarted };
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (key: string) => (key in store ? store[key] : null)),
+      setItem: jest.fn(async (key: string, value: string) => {
+        if (key === '@gitnotes:canvases' && blockNextCanvasWrite) {
+          blockNextCanvasWrite = false;
+          blockedCanvasWrite = createBlockedWrite();
+          blockedCanvasWrite.markStarted();
+          await blockedCanvasWrite.promise;
+          blockedCanvasWrite = null;
+        }
+        store[key] = value;
+      }),
+      removeItem: jest.fn(async (key: string) => {
+        delete store[key];
+      }),
+      multiGet: jest.fn(async (keys: string[]) => keys.map((key) => [key, key in store ? store[key] : null])),
+      multiSet: jest.fn(async (pairs: [string, string][]) => {
+        for (const [key, value] of pairs) {
+          store[key] = value;
+        }
+      }),
+      multiRemove: jest.fn(async (keys: string[]) => {
+        for (const key of keys) {
+          delete store[key];
+        }
+      }),
+      clear: jest.fn(async () => {
+        store = {};
+      }),
+      __reset: () => {
+        blockedCanvasWrite?.release();
+        store = {};
+        blockNextCanvasWrite = false;
+        blockedCanvasWrite = null;
+      },
+      __blockNextCanvasWrite: () => {
+        blockNextCanvasWrite = true;
+      },
+      __waitForBlockedCanvasWrite: async () => {
+        for (let attempt = 0; attempt < 20 && !blockedCanvasWrite; attempt += 1) {
+          await Promise.resolve();
+        }
+        if (!blockedCanvasWrite) {
+          throw new Error('No blocked canvas write in progress');
+        }
+        await blockedCanvasWrite.started;
+      },
+      __releaseBlockedCanvasWrite: () => {
+        blockedCanvasWrite?.release();
+      },
+    },
+  };
+});
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getTreeRecursive: jest.fn(async () => []),
+    getRepoContents: jest.fn(async (_owner: string, _repo: string, dirPath: string) => {
+      if (dirPath !== 'canvases') return [];
+      return [{ type: 'file', path: 'canvases/remote-canvas.json', download_url: 'https://example.com/remote-canvas.json' }];
+    }),
+    getFileContent: jest.fn(async (_owner: string, _repo: string, path: string) => {
+      if (path !== 'canvases/remote-canvas.json') return null;
+      return JSON.stringify({
+        version: 1,
+        width: 640,
+        height: 480,
+        background: '#FFFFFF',
+        elements: [
+          {
+            type: 'text',
+            id: 'remote-text',
+            text: 'remote',
+            x: 16,
+            y: 24,
+            fontSize: 18,
+            color: '#000000',
+          },
+        ],
+      });
+    }),
+  },
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createCanvas } from '../src/models/Canvas';
+import { pullFromSingleRepo } from '../src/services/RepoPullService';
+import { StorageService } from '../src/services/StorageService';
+
+const CANVASES_STORAGE_KEY = '@gitnotes:canvases';
+const CANVASES_BACKUP_STORAGE_KEY = '@gitnotes:canvases.bak';
+
+type AsyncStorageMock = {
+  __reset: () => void;
+  __blockNextCanvasWrite: () => void;
+  __waitForBlockedCanvasWrite: () => Promise<void>;
+  __releaseBlockedCanvasWrite: () => void;
+};
+
+describe('canvas storage race handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage as unknown as AsyncStorageMock).__reset();
+  });
+
+  test('concurrent local save and repo pull preserve both changes', async () => {
+    const localCanvas = createCanvas({
+      title: 'Local canvas',
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'canvases/local-canvas.json',
+    });
+
+    await StorageService.saveAllCanvases([localCanvas]);
+    await StorageService.saveRepositories([{ id: 'repo-1', name: 'repo', path: 'owner/repo', branch: 'main' }]);
+
+    (AsyncStorage as unknown as AsyncStorageMock).__blockNextCanvasWrite();
+
+    const updatePromise = StorageService.updateCanvas({ id: localCanvas.id, title: 'Local canvas edited' });
+    await (AsyncStorage as unknown as AsyncStorageMock).__waitForBlockedCanvasWrite();
+
+    const pullPromise = pullFromSingleRepo('owner/repo');
+
+    (AsyncStorage as unknown as AsyncStorageMock).__releaseBlockedCanvasWrite();
+
+    const [updatedCanvas, pullResult] = await Promise.all([updatePromise, pullPromise]);
+    const canvases = await StorageService.getAllCanvases();
+
+    expect(updatedCanvas?.title).toBe('Local canvas edited');
+    expect(pullResult.canvases).toBe(1);
+    expect(canvases).toHaveLength(2);
+    expect(canvases.find((canvas) => canvas.id === localCanvas.id)?.title).toBe('Local canvas edited');
+    expect(canvases.find((canvas) => canvas.filePath === 'canvases/remote-canvas.json')?.scene.elements).toHaveLength(1);
+  });
+
+  test('malformed canvas JSON returns [] instead of throwing', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await AsyncStorage.setItem(CANVASES_STORAGE_KEY, '{not json');
+
+    await expect(StorageService.getAllCanvases()).resolves.toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error reading canvases from storage:', expect.any(Error));
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('canvas writes keep a backup of the previous blob', async () => {
+    await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify([{ id: 'old-canvas' }]));
+
+    await StorageService.saveAllCanvases([createCanvas({ title: 'New canvas' })]);
+
+    await expect(AsyncStorage.getItem(CANVASES_BACKUP_STORAGE_KEY)).resolves.toBe(JSON.stringify([{ id: 'old-canvas' }]));
+  });
+});

--- a/__tests__/custom-templates.test.ts
+++ b/__tests__/custom-templates.test.ts
@@ -1,0 +1,82 @@
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: {
+    fetch: jest.fn(async () => ({ isConnected: true, isInternetReachable: true })),
+    addEventListener: jest.fn(() => jest.fn()),
+  },
+}));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    loadCustomTemplates: jest.fn(async () => []),
+    loadTemplatePins: jest.fn(async () => []),
+    saveCustomTemplates: jest.fn(async () => undefined),
+    saveTemplatePins: jest.fn(async () => undefined),
+  },
+}));
+
+import { NOTE_TEMPLATES } from '../src/services/TemplateService';
+import { StorageService } from '../src/services/StorageService';
+import { useTemplateStore } from '../src/stores/templateStore';
+
+describe('custom templates store', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useTemplateStore.setState({ customTemplates: [], pinnedIds: [], isLoading: false });
+  });
+
+  test('createTemplate adds to customTemplates', async () => {
+    const template = await useTemplateStore.getState().createTemplate({
+      name: 'Custom',
+      icon: 'document-outline',
+      description: 'desc',
+      content: 'body',
+      tags: ['x'],
+    });
+
+    expect(template.isCustom).toBe(true);
+    expect(useTemplateStore.getState().customTemplates).toHaveLength(1);
+    expect(StorageService.saveCustomTemplates).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ name: 'Custom' })]));
+  });
+
+  test('deleteTemplate removes custom templates but not built-ins', async () => {
+    const custom = await useTemplateStore.getState().createTemplate({
+      name: 'Custom',
+      icon: 'document-outline',
+      description: 'desc',
+      content: 'body',
+      tags: [],
+    });
+
+    await useTemplateStore.getState().deleteTemplate(custom.id);
+    await useTemplateStore.getState().deleteTemplate(NOTE_TEMPLATES[0].id);
+
+    expect(useTemplateStore.getState().customTemplates).toHaveLength(0);
+    expect(StorageService.saveCustomTemplates).toHaveBeenCalledTimes(2);
+  });
+
+  test('togglePin adds and removes ids', async () => {
+    await useTemplateStore.getState().togglePin('blank');
+    expect(useTemplateStore.getState().pinnedIds).toEqual(['blank']);
+
+    await useTemplateStore.getState().togglePin('blank');
+    expect(useTemplateStore.getState().pinnedIds).toEqual([]);
+    expect(StorageService.saveTemplatePins).toHaveBeenCalledTimes(2);
+  });
+
+  test('getAllTemplates merges built-ins and custom with pinned first', async () => {
+    await useTemplateStore.getState().createTemplate({
+      name: 'Custom',
+      icon: 'document-outline',
+      description: 'desc',
+      content: 'body',
+      tags: [],
+    });
+    await useTemplateStore.getState().togglePin('blank');
+
+    const all = useTemplateStore.getState().getAllTemplates();
+    expect(all[0].id).toBe('blank');
+    expect(all.some((t) => t.name === 'Custom')).toBe(true);
+    expect(all.some((t) => t.id === 'blank' && t.isPinned)).toBe(true);
+  });
+});

--- a/__tests__/file-tree-bg.test.tsx
+++ b/__tests__/file-tree-bg.test.tsx
@@ -1,0 +1,74 @@
+import { StyleSheet } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+
+import { Group } from '../src/components/ui';
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#111111',
+      surface: '#222222',
+      primary: '#2563eb',
+      text: '#f9fafb',
+      textSecondary: '#9ca3af',
+      border: '#374151',
+    },
+  }),
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    getRepoContents: jest.fn().mockResolvedValue([
+      { name: 'notes.md', path: 'notes.md', type: 'file', sha: 'abc', size: 12 },
+    ]),
+    getFileContent: jest.fn(),
+    getFileSha: jest.fn(),
+    moveFile: jest.fn(),
+    deleteFile: jest.fn(),
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+jest.mock('../src/components/ui', () => {
+  const ReactMock = require('react');
+  const { View: RNView, Text: RNText } = require('react-native');
+  const { forwardRef } = ReactMock;
+
+  const passthrough = (Component: any = RNView) =>
+    forwardRef(({ children, style, ...props }: any, ref: any) => (
+      <Component ref={ref} style={style} {...props}>
+        {children}
+      </Component>
+    ));
+
+  return {
+    Group: passthrough(RNView),
+    GroupRow: passthrough(RNView),
+    Modal: ({ children }: any) => <RNView>{children}</RNView>,
+    Input: forwardRef((props: any, ref: any) => <RNView ref={ref} {...props} />),
+    Button: ({ label }: any) => <RNText>{label}</RNText>,
+  };
+});
+
+import RepoFileTree from '../src/components/RepoFileTree';
+
+const isBlackBg = (value: unknown) =>
+  value === '#000' || value === '#000000' || value === 'black';
+
+describe('file tree backgrounds', () => {
+  it('uses theme colors instead of black backgrounds', async () => {
+    const screen = render(<RepoFileTree owner="acme" repo="notes" />);
+
+    await waitFor(() => expect(screen.queryAllByText('notes.md').length).toBeGreaterThan(0));
+
+    const group = screen.UNSAFE_getByType(Group);
+    const styles = StyleSheet.flatten(group.props.style);
+
+    expect(isBlackBg(styles?.backgroundColor)).toBe(false);
+    expect(styles?.backgroundColor).toBe('#222222');
+  });
+});

--- a/__tests__/filter-modal-overflow.test.tsx
+++ b/__tests__/filter-modal-overflow.test.tsx
@@ -1,6 +1,12 @@
 import { TouchableOpacity } from 'react-native';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
 import NotesListScreen from '../src/screens/NotesListScreen';
 import { Note } from '../src/models/Note';
 

--- a/__tests__/filter-modal-overflow.test.tsx
+++ b/__tests__/filter-modal-overflow.test.tsx
@@ -1,0 +1,196 @@
+import { TouchableOpacity } from 'react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import NotesListScreen from '../src/screens/NotesListScreen';
+import { Note } from '../src/models/Note';
+
+const mockNotes: Note[] = Array.from({ length: 20 }, (_, index) => ({
+  id: `note-${index + 1}`,
+  title: `Note ${index + 1}`,
+  content: `Content ${index + 1}`,
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [`tag-${index + 1}`],
+  repo: 'repo-one',
+  branch: `branch-${(index % 3) + 1}`,
+  folderPath: `folder-${index + 1}`,
+  format: 'markdown',
+}));
+
+const mockColorProxy = new Proxy(
+  {
+    background: '#fff',
+    surface: '#f4f4f4',
+    surfaceSecondary: '#e5e7eb',
+    surfaceTertiary: '#d1d5db',
+    primary: '#2563eb',
+    text: '#111827',
+    textSecondary: '#6b7280',
+    border: '#d1d5db',
+    error: '#dc2626',
+    success: '#16a34a',
+  },
+  {
+    get(target, key: string) {
+      return key in target ? (target as Record<string, string>)[key] : '#111827';
+    },
+  },
+);
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: mockColorProxy }),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null } }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({
+    repositories: [
+      { id: 'repo-one', name: 'Repo One', path: 'repo-one', branch: 'main' },
+    ],
+  }),
+}));
+
+jest.mock('../src/contexts/ViewModeContext', () => ({
+  useViewMode: () => ({ viewMode: 'list', setViewMode: jest.fn() }),
+}));
+
+jest.mock('../src/contexts/NoteContext', () => ({
+  useNotes: () => ({
+    notes: mockNotes,
+    filteredNotes: mockNotes,
+    isLoading: false,
+    searchQuery: '',
+    setSearchQuery: jest.fn(),
+    deleteNote: jest.fn(),
+    refreshNotes: jest.fn(async () => undefined),
+    togglePin: jest.fn(async () => true),
+    error: null,
+    createNote: jest.fn(async () => null),
+  }),
+}));
+
+jest.mock('../src/stores/noteStore', () => ({
+  useNoteStore: {
+    getState: () => ({ error: null }),
+  },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: { setToken: jest.fn() },
+}));
+
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    pendingCount: jest.fn(async () => 0),
+    subscribe: jest.fn(() => jest.fn()),
+    drain: jest.fn(async () => ({ succeeded: 0 })),
+  },
+}));
+
+jest.mock('../src/services/RepoPullService', () => ({
+  pullAllFromRepos: jest.fn(async () => undefined),
+}));
+
+jest.mock('../src/services/ShareService', () => ({
+  ShareService: { shareText: jest.fn() },
+}));
+
+jest.mock('../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({ isTablet: false, maxContentWidth: 0 }),
+}));
+
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: {
+    light: jest.fn(),
+    medium: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    selection: jest.fn(),
+  },
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+
+jest.mock('../src/components/SearchBar', () => {
+  const { TextInput } = require('react-native');
+  return ({ value, onChangeText }: { value: string; onChangeText: (value: string) => void }) => (
+    <TextInput value={value} onChangeText={onChangeText} />
+  );
+});
+
+jest.mock('../src/components/ui', () => ({
+  ScreenHeader: ({ title }: { title: string }) => {
+    const { Text } = require('react-native');
+    return <Text>{title}</Text>;
+  },
+}));
+
+jest.mock('../src/components/NoteCard', () => ({
+  __esModule: true,
+  default: ({ note }: { note: Note }) => {
+    const { Text } = require('react-native');
+    return <Text>{note.title}</Text>;
+  },
+}));
+
+jest.mock('@shopify/flash-list', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    FlashList: React.forwardRef(({ data, renderItem, ListEmptyComponent }: any, _ref: any) => {
+      if (!data?.length) {
+        return <View>{ListEmptyComponent ?? null}</View>;
+      }
+
+      return <View>{data.map((item: Note, index: number) => renderItem({ item, index }))}</View>;
+    }),
+  };
+});
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return React.forwardRef(({ children }: any, ref: any) => {
+    React.useEffect(() => {
+      if (ref) {
+        ref.current = { close: jest.fn(), openLeft: jest.fn(), openRight: jest.fn(), reset: jest.fn() };
+      }
+      return () => {
+        if (ref) ref.current = null;
+      };
+    }, [ref]);
+
+    return <View>{children}</View>;
+  });
+});
+
+const openFilterModal = (screen: ReturnType<typeof render>) => {
+  const buttons = (screen as any).UNSAFE_getAllByType(TouchableOpacity);
+  fireEvent.press(buttons[1]);
+};
+
+describe('filter modal chip overflow regression', () => {
+  it('renders all folder chips when the list wraps', async () => {
+    const screen = render(<NotesListScreen />);
+
+    openFilterModal(screen);
+
+    await waitFor(() => expect(screen.getByText('Filter Notes')).toBeTruthy());
+    fireEvent.press(screen.getAllByText('Repo One')[0]);
+
+    expect(screen.getAllByText(/^folder-/)).toHaveLength(20);
+    expect(screen.getAllByText(/^branch-/)).toHaveLength(3);
+    expect(screen.getAllByText(/^tag-/)).toHaveLength(20);
+  });
+});

--- a/__tests__/glossy-ui.test.tsx
+++ b/__tests__/glossy-ui.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { ThemeProvider, useTheme } from '../src/contexts/ThemeContext';
+import { Surface } from '../src/components/ui/Surface';
+import SettingsScreen from '../src/screens/SettingsScreen';
+import { NavigationContainer } from '@react-navigation/native';
+import { AuthProvider } from '../src/contexts/AuthContext';
+import { NoteProvider } from '../src/contexts/NoteContext';
+import { RepoProvider } from '../src/contexts/RepoContext';
+import { CanvasProvider } from '../src/contexts/CanvasContext';
+import { TodoProvider } from '../src/contexts/TodoContext';
+import { View, Text } from 'react-native';
+
+// Mock AsyncStorage
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+jest.mock('@react-native-community/netinfo', () => ({
+  useNetInfo: () => ({ isConnected: true, isInternetReachable: true }),
+  addEventListener: jest.fn(),
+  fetch: jest.fn(() => Promise.resolve({ isConnected: true })),
+}));
+
+// Mock expo-blur
+jest.mock('expo-blur', () => {
+  const { View } = require('react-native');
+  return {
+    BlurView: (props: any) => <View {...props} testID="blur-view" />
+  };
+});
+
+jest.mock('expo-image', () => ({
+  Image: () => null,
+}));
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+}));
+
+jest.mock('expo-constants', () => ({
+  expoConfig: { version: '1.0.0' },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('expo-file-system/legacy', () => ({
+  readAsStringAsync: jest.fn(),
+  writeAsStringAsync: jest.fn(),
+  deleteAsync: jest.fn(),
+  makeDirectoryAsync: jest.fn(),
+  getInfoAsync: jest.fn(),
+}));
+
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+}));
+
+// Mock hooks
+jest.mock('../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    isTablet: false,
+    maxContentWidth: 600,
+  }),
+}));
+
+const renderWithProviders = (component: React.ReactElement) => {
+  return render(
+    <ThemeProvider>
+      <AuthProvider>
+        <RepoProvider>
+          <NoteProvider>
+            <CanvasProvider>
+              <TodoProvider>
+                <NavigationContainer>
+                  {component}
+                </NavigationContainer>
+              </TodoProvider>
+            </CanvasProvider>
+          </NoteProvider>
+        </RepoProvider>
+      </AuthProvider>
+    </ThemeProvider>
+  );
+};
+
+const TestConsumer = () => {
+  const { glossy, setGlossy, style, setStyle } = useTheme();
+  return (
+    <View>
+      <Text testID="glossy-val">{String(glossy)}</Text>
+      <Text testID="style-val">{style}</Text>
+    </View>
+  );
+};
+
+describe('Glossy UI mode', () => {
+  it('is OFF by default and turning it ON disables Neumorphic', async () => {
+    const { getByTestId, getByText } = renderWithProviders(
+      <>
+        <TestConsumer />
+        <SettingsScreen />
+      </>
+    );
+
+    // Initial state: default is flat or neumorphic (neumorphic typically), glossy false
+    await waitFor(() => {
+      expect(getByTestId('glossy-val').props.children).toBe('false');
+    });
+
+    // Toggle Glossy ON
+    const glossyToggle = getByTestId('glossy-toggle');
+    fireEvent(glossyToggle, 'valueChange', true);
+
+    await waitFor(() => {
+      expect(getByTestId('glossy-val').props.children).toBe('true');
+      expect(getByTestId('style-val').props.children).toBe('flat'); // Neumorphic disabled
+    });
+    
+    // Toggle Neumorphic ON
+    const neuToggle = getByTestId('neu-toggle');
+    fireEvent(neuToggle, 'valueChange', true);
+    
+    await waitFor(() => {
+      expect(getByTestId('style-val').props.children).toBe('neumorphic');
+      expect(getByTestId('glossy-val').props.children).toBe('false'); // Glossy disabled
+    });
+  });
+
+  it('renders BlurView when glossy is ON', async () => {
+    const { getByTestId, queryByTestId, getAllByTestId } = render(
+      <ThemeProvider>
+        <TestSurface />
+      </ThemeProvider>
+    );
+
+    // Initial glossy false
+    expect(queryByTestId('blur-view')).toBeNull();
+    
+    // Check after toggling
+    fireEvent.press(getByTestId('toggle-btn'));
+    
+    await waitFor(() => {
+      expect(getAllByTestId('blur-view').length).toBeGreaterThan(0);
+    });
+  });
+});
+
+const TestSurface = () => {
+  const { setGlossy, glossy } = useTheme();
+  return (
+    <View>
+      <Surface testID="test-surface" />
+      {glossy && <Surface testID="test-surface-2" />}
+      <Text testID="toggle-btn" onPress={() => setGlossy(true)}>Toggle</Text>
+    </View>
+  );
+};

--- a/__tests__/ionicon-replacements.test.tsx
+++ b/__tests__/ionicon-replacements.test.tsx
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+
+const TARGET_FILES = [
+  '../src/screens/CanvasEditorScreen.tsx',
+  '../src/components/CanvasModal.tsx',
+  '../src/components/NoteCard.tsx',
+];
+
+const RAW_UI_EMOJIS = ['✏️', '🖊', '🧹', '🗑', '☝️', '📂', '📁', '🌿'];
+
+describe('ionicon replacements', () => {
+  it('removes raw UI emoji from the canvas and note chrome', () => {
+    for (const relPath of TARGET_FILES) {
+      const filePath = path.join(__dirname, relPath);
+      const content = fs.readFileSync(filePath, 'utf8');
+      for (const emoji of RAW_UI_EMOJIS) {
+        expect(content.includes(emoji)).toBe(false);
+      }
+    }
+  });
+});

--- a/__tests__/json-renderer.test.tsx
+++ b/__tests__/json-renderer.test.tsx
@@ -1,0 +1,45 @@
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import { JsonRenderer } from '../src/components/JsonRenderer';
+import { NEUMORPHIC_DARK, NEUMORPHIC_LIGHT } from '../src/theme/tokens';
+import { TestThemeProvider } from './ui/testThemeProvider';
+
+describe('JsonRenderer', () => {
+  it('renders formatted JSON with themed syntax colors', () => {
+    const { getByText, toJSON } = render(
+      <TestThemeProvider mode="light">
+        <JsonRenderer content='{"name":"GitNotes","count":2,"enabled":true,"nested":{"slug":"wave"}}' />
+      </TestThemeProvider>,
+    );
+    const tree = toJSON();
+
+    const key = getByText('"name"');
+    const value = getByText('"GitNotes"');
+    const number = getByText('2');
+
+    expect(StyleSheet.flatten(key.props.style).color).toBe(NEUMORPHIC_LIGHT.textSecondary);
+    expect(StyleSheet.flatten(value.props.style).color).toBe(NEUMORPHIC_LIGHT.text);
+    expect(StyleSheet.flatten(number.props.style).color).toBe(NEUMORPHIC_LIGHT.primary);
+    expect((tree as { children?: Array<{ children?: unknown[] }> } | null)?.children?.[1]?.children?.[0]).toBe('  ');
+  });
+
+  it('uses dark theme colors and falls back to raw text for malformed JSON', () => {
+    const raw = '{"oops": }';
+    const { getByText } = render(
+      <TestThemeProvider mode="dark">
+        <JsonRenderer content={raw} />
+      </TestThemeProvider>,
+    );
+
+    expect(getByText(raw)).toBeTruthy();
+    expect(StyleSheet.flatten(getByText(raw).props.style).color).toBe(NEUMORPHIC_DARK.text);
+  });
+});

--- a/__tests__/link-routing.test.ts
+++ b/__tests__/link-routing.test.ts
@@ -1,0 +1,106 @@
+import React from 'react';
+import { Alert, Linking, ScrollView, Text } from 'react-native';
+
+jest.mock('react-native-marked', () => ({
+  Renderer: class {
+    private key = 0;
+    getKey() {
+      this.key += 1;
+      return `key-${this.key}`;
+    }
+  },
+}));
+
+jest.mock('expo-image', () => ({ Image: () => null }));
+
+import { classifyHref } from '../src/utils/linkClassifier';
+import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
+
+describe('classifyHref', () => {
+  it('classifies anchor links using heading slug rules', () => {
+    expect(classifyHref('#Anchor Slug')).toEqual({ kind: 'anchor', target: 'anchor-slug' });
+  });
+
+  it('resolves sibling note links', () => {
+    expect(classifyHref('foo.md', 'notes/current.md')).toEqual({ kind: 'note', target: 'notes/foo.md' });
+    expect(classifyHref('./notes/foo.md', 'docs/current.md')).toEqual({ kind: 'note', target: 'docs/notes/foo.md' });
+  });
+
+  it('resolves parent-relative note links', () => {
+    expect(classifyHref('../shared/foo.md', 'notes/daily/today.md')).toEqual({ kind: 'note', target: 'notes/shared/foo.md' });
+  });
+
+  it('classifies web links', () => {
+    expect(classifyHref('https://example.com')).toEqual({ kind: 'web', target: 'https://example.com' });
+    expect(classifyHref('http://example.com')).toEqual({ kind: 'web', target: 'http://example.com' });
+  });
+
+  it('classifies mailto and tel links', () => {
+    expect(classifyHref('mailto:hello@example.com')).toEqual({ kind: 'mailto', target: 'hello@example.com' });
+    expect(classifyHref('tel:+15551234567')).toEqual({ kind: 'mailto', target: '+15551234567' });
+  });
+});
+
+describe('NotePreviewRenderer link routing', () => {
+  const openUrlSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
+  const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    openUrlSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  function createRenderer(overrides: Partial<ConstructorParameters<typeof NotePreviewRenderer>[0]> = {}) {
+    return new NotePreviewRenderer({
+      colors: { primary: '#2563eb', text: '#111', surfaceSecondary: '#eee' },
+      previewContent: '# Intro\nBody\n## Deep Link\nMore body',
+      previewScrollRef: { current: { scrollTo: jest.fn() } as unknown as ScrollView },
+      currentNotePath: 'notes/current.md',
+      onOpenNote: jest.fn(() => true),
+      ...overrides,
+    });
+  }
+
+  function pressLink(renderer: NotePreviewRenderer, href: string) {
+    const element = renderer.link(['label'], href) as React.ReactElement<React.ComponentProps<typeof Text>>;
+    (element.props as { onPress?: (event: unknown) => void }).onPress?.(undefined);
+  }
+
+  it('opens external web links with Linking', () => {
+    const renderer = createRenderer();
+    pressLink(renderer, 'https://example.com');
+
+    expect(openUrlSpy).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('routes note links through the note opener', () => {
+    const onOpenNote = jest.fn(() => true);
+    const renderer = createRenderer({ onOpenNote });
+    pressLink(renderer, './child.md');
+
+    expect(onOpenNote).toHaveBeenCalledWith('notes/child.md');
+    expect(openUrlSpy).not.toHaveBeenCalled();
+  });
+
+  it('alerts when linked note cannot be found', () => {
+    const renderer = createRenderer({ onOpenNote: jest.fn(() => false) });
+    pressLink(renderer, './missing.md');
+
+    expect(alertSpy).toHaveBeenCalledWith('Link target not found');
+  });
+
+  it('scrolls preview for anchor links', () => {
+    const scrollTo = jest.fn();
+    const renderer = createRenderer({
+      previewScrollRef: { current: { scrollTo } as unknown as ScrollView },
+      approxLinePx: 30,
+    });
+    pressLink(renderer, '#Deep Link');
+
+    expect(scrollTo).toHaveBeenCalledWith({ y: 60, animated: true });
+  });
+});

--- a/__tests__/neorg-null-guard.test.ts
+++ b/__tests__/neorg-null-guard.test.ts
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { NeorgContentParser } from '../src/services/NeorgContentParser';
+import { ErrorBoundary } from '../src/components/ui/ErrorBoundary';
+import { TestThemeProvider } from './ui/testThemeProvider';
+
+describe('Neorg null guard and ErrorBoundary', () => {
+  it('returns a structured error for null content', () => {
+    const result = NeorgContentParser.parseContent(null as unknown as string);
+
+    expect(result.success).toBe(false);
+    expect(result.blocks).toEqual([]);
+    expect(result.error).toBe('Invalid content: expected string');
+  });
+
+  it('returns a structured error for undefined content', () => {
+    const result = NeorgContentParser.parseContent(undefined as unknown as string);
+
+    expect(result.success).toBe(false);
+    expect(result.blocks).toEqual([]);
+    expect(result.error).toBe('Invalid content: expected string');
+  });
+
+  it('catches render errors and shows fallback UI', () => {
+    const Boom = () => {
+      throw new Error('boom');
+    };
+
+    const { getByText, queryByText } = render(
+      React.createElement(
+        TestThemeProvider,
+        null,
+        React.createElement(ErrorBoundary, { children: React.createElement(Boom) }),
+      ),
+    );
+
+    expect(getByText('Something went wrong')).toBeTruthy();
+    expect(getByText('Retry')).toBeTruthy();
+    expect(queryByText('boom')).toBeNull();
+  });
+
+  it('renders a custom fallback when provided', () => {
+    const Boom = () => {
+      throw new Error('boom');
+    };
+
+    const { getByText, queryByText } = render(
+      React.createElement(
+        TestThemeProvider,
+        null,
+        React.createElement(
+          ErrorBoundary,
+          {
+            fallback: React.createElement(Text, null, 'custom fallback'),
+            children: React.createElement(Boom),
+          },
+        ),
+      ),
+    );
+
+    expect(getByText('custom fallback')).toBeTruthy();
+    expect(queryByText('Something went wrong')).toBeNull();
+  });
+});

--- a/__tests__/note-color-coding.test.tsx
+++ b/__tests__/note-color-coding.test.tsx
@@ -1,0 +1,56 @@
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: { addEventListener: jest.fn(), fetch: jest.fn() },
+}));
+
+jest.mock('@expo/vector-icons', () => {
+  const { createElement } = require('react');
+  const { Text } = require('react-native');
+  return { Ionicons: ({ name }: any) => createElement(Text, null, name) };
+});
+
+jest.mock('../src/hooks/useResponsive', () => ({ useResponsive: () => ({ isTablet: false }) }));
+
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import NoteCard from '../src/components/NoteCard';
+import { Note } from '../src/models/Note';
+import { TestThemeProvider } from './ui/testThemeProvider';
+
+const buildNote = (overrides: Partial<Note> = {}): Note => ({
+  id: 'note-1',
+  title: 'Color note',
+  content: 'body',
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  ...overrides,
+});
+
+describe('NoteCard color coding', () => {
+  it('renders the mapped border color when note has a color', () => {
+    const { getByTestId } = render(
+      <TestThemeProvider>
+        <NoteCard note={buildNote({ color: 'purple' })} onPress={jest.fn()} />
+      </TestThemeProvider>,
+    );
+
+    const style = StyleSheet.flatten(getByTestId('note-card-note-1').props.style);
+    expect(style.borderColor).toBe('#8b5cf6');
+    expect(style.borderWidth).toBe(2);
+  });
+
+  it('renders without extra border when note has no color', () => {
+    const { getByTestId } = render(
+      <TestThemeProvider>
+        <NoteCard note={buildNote()} onPress={jest.fn()} />
+      </TestThemeProvider>,
+    );
+
+    const style = StyleSheet.flatten(getByTestId('note-card-note-1').props.style);
+    expect(style.borderColor).toBeUndefined();
+    expect(style.borderWidth).toBeUndefined();
+  });
+});

--- a/__tests__/offline-banner.test.tsx
+++ b/__tests__/offline-banner.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('../src/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: jest.fn(),
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      error: '#dc2626',
+    },
+  }),
+}));
+
+import { useNetworkStatus } from '../src/hooks/useNetworkStatus';
+import { OfflineBanner } from '../src/components/ui/OfflineBanner';
+
+const mockUseNetworkStatus = useNetworkStatus as jest.Mock;
+
+describe('OfflineBanner', () => {
+  it('renders when offline', () => {
+    mockUseNetworkStatus.mockReturnValue({
+      isConnected: false,
+      isInternetReachable: false,
+    });
+
+    const { getByText } = render(<OfflineBanner />);
+
+    expect(getByText("You're offline — changes won't sync")).toBeTruthy();
+  });
+
+  it('hides when online', () => {
+    mockUseNetworkStatus.mockReturnValue({
+      isConnected: true,
+      isInternetReachable: true,
+    });
+
+    const { queryByText } = render(<OfflineBanner />);
+
+    expect(queryByText("You're offline — changes won't sync")).toBeNull();
+  });
+});

--- a/__tests__/offline-gray-uncached.test.tsx
+++ b/__tests__/offline-gray-uncached.test.tsx
@@ -1,0 +1,160 @@
+var mockNavigate = jest.fn();
+
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: false, isInternetReachable: false }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+jest.mock('@shopify/flash-list', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const FlashList = React.forwardRef(({ data = [], renderItem }: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({ scrollToIndex: jest.fn() }));
+    return <View>{data.map((item: any, index: number) => renderItem({ item, index }))}</View>;
+  });
+  return { FlashList };
+});
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return React.forwardRef(({ children }: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({ close: jest.fn() }));
+    return <View>{children}</View>;
+  });
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const { createElement } = require('react');
+  const { Text } = require('react-native');
+  return { Ionicons: ({ name }: any) => createElement(Text, null, name) };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('../src/contexts/NoteContext', () => ({
+  useNotes: jest.fn(),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null } }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({ repositories: [] }),
+}));
+
+jest.mock('../src/contexts/ViewModeContext', () => ({
+  useViewMode: () => ({ viewMode: 'list', setViewMode: jest.fn() }),
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+jest.mock('../src/components/SearchBar', () => () => null);
+jest.mock('../src/components/GitHubActivityIndicator', () => ({ GitHubActivityIndicator: () => null }));
+jest.mock('../src/components/ui/OfflineBanner', () => ({ OfflineBanner: () => null }));
+jest.mock('../src/components/ui', () => ({ ScreenHeader: () => null }));
+jest.mock('../src/hooks/useResponsive', () => ({ useResponsive: () => ({ isTablet: false, maxContentWidth: 720 }) }));
+jest.mock('../src/hooks/useNetworkStatus', () => ({ useNetworkStatus: () => ({ isConnected: false, isInternetReachable: false }) }));
+jest.mock('../src/services/GitHubService', () => ({ GitHubService: { setToken: jest.fn() } }));
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    pendingCount: jest.fn(() => Promise.resolve(0)),
+    subscribe: jest.fn(() => jest.fn()),
+    drain: jest.fn(() => Promise.resolve({ succeeded: 0 })),
+  },
+}));
+jest.mock('../src/services/RepoPullService', () => ({ pullAllFromRepos: jest.fn() }));
+jest.mock('../src/services/ShareService', () => ({ ShareService: { isAvailable: jest.fn(() => false) } }));
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: { light: jest.fn(), medium: jest.fn(), selection: jest.fn(), success: jest.fn(), warning: jest.fn() },
+}));
+jest.mock('../src/stores/githubActivityStore', () => ({
+  githubActivity: { begin: jest.fn(), end: jest.fn() },
+}));
+
+import { Alert, StyleSheet } from 'react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import NoteCard from '../src/components/NoteCard';
+import NotesListScreen from '../src/screens/NotesListScreen';
+import { useNotes } from '../src/contexts/NoteContext';
+import { Note } from '../src/models/Note';
+import { NEUMORPHIC_LIGHT } from '../src/theme/tokens';
+import { TestThemeProvider } from './ui/testThemeProvider';
+
+const mockedUseNotes = useNotes as jest.MockedFunction<typeof useNotes>;
+
+const buildNote = (overrides: Partial<Note> = {}): Note => ({
+  id: 'note-1',
+  title: 'Offline note',
+  content: '',
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  ...overrides,
+});
+
+describe('offline gray uncached behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('grays out uncached notes offline and keeps online notes normal', () => {
+    const offlineRender = render(
+      <TestThemeProvider mode="light">
+        <NoteCard note={buildNote()} onPress={jest.fn()} isOffline isCached={false} />
+      </TestThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(offlineRender.getByTestId('note-card-note-1').props.style).opacity).toBe(0.5);
+    expect(StyleSheet.flatten(offlineRender.getByTestId('note-card-title-note-1').props.style).color).toBe(NEUMORPHIC_LIGHT.textSecondary);
+
+    offlineRender.unmount();
+
+    const onlineRender = render(
+      <TestThemeProvider mode="light">
+        <NoteCard note={buildNote()} onPress={jest.fn()} isOffline={false} isCached={false} />
+      </TestThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(onlineRender.getByTestId('note-card-note-1').props.style).opacity).toBe(1);
+    expect(StyleSheet.flatten(onlineRender.getByTestId('note-card-title-note-1').props.style).color).toBe(NEUMORPHIC_LIGHT.text);
+  });
+
+  it('blocks navigation for offline uncached notes', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined as never);
+    mockNavigate.mockClear();
+
+    mockedUseNotes.mockReturnValue({
+      notes: [buildNote()],
+      filteredNotes: [buildNote()],
+      isLoading: false,
+      searchQuery: '',
+      setSearchQuery: jest.fn(),
+      deleteNote: jest.fn(),
+      refreshNotes: jest.fn(),
+      togglePin: jest.fn(),
+      error: null,
+      createNote: jest.fn(),
+    } as any);
+
+    const { getByTestId, unmount } = render(
+      <TestThemeProvider mode="light">
+        <NotesListScreen />
+      </TestThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(getByTestId('note-card-note-1').props.style).opacity).toBe(0.5);
+
+    fireEvent.press(getByTestId('note-card-note-1'));
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledWith('Not available offline'));
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+    unmount();
+  });
+});

--- a/__tests__/renderer-pipeline.test.ts
+++ b/__tests__/renderer-pipeline.test.ts
@@ -1,0 +1,107 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+jest.mock('react-native-marked', () => ({
+  Renderer: class MockRenderer {
+    private key = 0;
+
+    getKey() {
+      this.key += 1;
+      return `mock-renderer-${this.key}`;
+    }
+  },
+}));
+
+jest.mock('expo-image', () => ({
+  Image: 'Image',
+}));
+
+import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
+import { createMemoizedNeorgInlineParser, parseNeorgInlineSegments } from '../src/components/NeorgRenderer';
+import { NeorgContentParser } from '../src/services/NeorgContentParser';
+
+function renderNode(node: React.ReactNode) {
+  return render(React.createElement(React.Fragment, null, node));
+}
+
+function createMarkdownRenderer() {
+  return new NotePreviewRenderer({
+    colors: {
+      primary: '#4f46e5',
+      text: '#111827',
+      surfaceSecondary: '#f3f4f6',
+    },
+  });
+}
+
+describe('renderer pipeline regression coverage', () => {
+  it('renders markdown fenced code language labels', () => {
+    const renderer = createMarkdownRenderer();
+    const node = renderer.code('const value = 1;', 'typescript', { padding: 12 }, { fontFamily: 'monospace' });
+    const { getByText } = renderNode(node);
+
+    expect(getByText('typescript')).toBeTruthy();
+    expect(getByText('const value = 1;')).toBeTruthy();
+  });
+
+  it('styles markdown inline code with monospace text and tinted background', () => {
+    const renderer = createMarkdownRenderer();
+    const node = renderer.codespan('inline()');
+    const { getByText } = renderNode(node);
+
+    const code = getByText('inline()');
+    const style = StyleSheet.flatten(code.props.style);
+
+    expect(style.fontFamily).toBe('monospace');
+    expect(style.backgroundColor).toBe('#f3f4f6');
+    expect(style.paddingHorizontal).toBe(4);
+    expect(style.borderRadius).toBe(4);
+  });
+
+  it('parses nested neorg emphasis without treating URLs as italic', () => {
+    const segments = parseNeorgInlineSegments('*outer *inner* outer* and https://x.com/path');
+
+    expect(segments).toEqual([
+      { type: 'bold', content: 'outer *inner* outer' },
+      { type: 'text', content: ' and https://x.com/path' },
+    ]);
+  });
+
+  it('captures neorg code block languages declared with =code.language', () => {
+    const result = NeorgContentParser.parseContent('=code.python\nprint("hi")\n=');
+
+    expect(result.success).toBe(true);
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks?.[0]).toMatchObject({
+      type: 'code',
+      code: { language: 'python', content: 'print("hi")' },
+    });
+  });
+
+  it('memoizes neorg inline parsing for unchanged text', () => {
+    const parser = jest.fn((text: string) => [{ type: 'text' as const, content: text }]);
+    const memoized = createMemoizedNeorgInlineParser(parser);
+
+    expect(memoized('cached inline text')).toEqual([{ type: 'text', content: 'cached inline text' }]);
+    expect(memoized('cached inline text')).toEqual([{ type: 'text', content: 'cached inline text' }]);
+
+    expect(parser).toHaveBeenCalledTimes(1);
+  });
+
+  it('derives list indentation from 4-space siblings and tabs', () => {
+    const input = ['- root', '    - four spaces', '        - eight spaces', '\t- tab indent'].join('\n');
+    const result = NeorgContentParser.parseContent(input);
+
+    expect(result.success).toBe(true);
+    expect(result.blocks?.[0]).toMatchObject({
+      type: 'list',
+      listItems: [
+        { text: 'root', indentLevel: 0 },
+        { text: 'four spaces', indentLevel: 1 },
+        { text: 'eight spaces', indentLevel: 2 },
+        { text: 'tab indent', indentLevel: 1 },
+      ],
+    });
+  });
+});

--- a/__tests__/save-loading-indicator.test.ts
+++ b/__tests__/save-loading-indicator.test.ts
@@ -1,0 +1,5 @@
+describe('save/loading indicator', () => {
+  it('passes', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/__tests__/save-loading-indicator.test.ts
+++ b/__tests__/save-loading-indicator.test.ts
@@ -1,5 +1,360 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockNavigation = {
+  goBack: jest.fn(),
+  navigate: jest.fn(),
+};
+
+const mockRouteParams = {
+  noteId: undefined,
+  initialTitle: 'Draft note',
+  initialContent: 'Draft content',
+  initialRepo: 'owner/repo',
+  initialBranch: 'main',
+  initialFormat: 'markdown',
+};
+
+const mockCreateNote = jest.fn();
+const mockUpdateNote = jest.fn();
+const mockDeleteNote = jest.fn();
+const mockRefreshNotes = jest.fn(async () => undefined);
+const mockTogglePin = jest.fn(async () => true);
+const mockSetSearchQuery = jest.fn();
+const mockSetViewMode = jest.fn();
+const mockUseNoteStore: any = jest.fn();
+mockUseNoteStore.getState = () => ({ error: 'Delete failed' });
+
+const mockNote = {
+  id: 'note-1',
+  title: 'First note',
+  content: 'Body',
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  format: 'markdown',
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => mockNavigation,
+  useRoute: () => ({ params: mockRouteParams }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('expo-image', () => ({ Image: () => null }));
+jest.mock('expo-image-picker', () => ({
+  MediaTypeOptions: { Images: 'Images' },
+  requestMediaLibraryPermissionsAsync: jest.fn(async () => ({ granted: true })),
+  launchImageLibraryAsync: jest.fn(async () => ({ canceled: true })),
+}));
+jest.mock('expo-speech', () => ({
+  speak: jest.fn(),
+  stop: jest.fn(),
+  isSpeakingAsync: jest.fn(async () => false),
+}));
+jest.mock('react-native-marked', () => ({ useMarkdown: jest.fn(() => []) }));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f4f4f4',
+      surfaceSecondary: '#e5e7eb',
+      primary: '#2563eb',
+      accent: '#2563eb',
+      text: '#111',
+      textSecondary: '#666',
+      border: '#ddd',
+      error: '#dc2626',
+    },
+    isDark: false,
+  }),
+  useTokens: () => ({
+    colors: {
+      surface: '#f4f4f4',
+      border: '#ddd',
+      accent: '#2563eb',
+      text: '#111',
+    },
+    radii: { pill: 999 },
+    spacing: { 2: 8, 3: 12 },
+    type: { sm: 12 },
+  }),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({ useAuth: () => ({ authState: { token: null } }) }));
+jest.mock('../src/contexts/RepoContext', () => ({ useRepos: () => ({ repositories: [{ path: 'owner/repo' }] }) }));
+jest.mock('../src/contexts/FolderContext', () => ({ useFolders: () => ({ folders: [] }) }));
+jest.mock('../src/contexts/CanvasContext', () => ({ useCanvases: () => ({ canvases: [] }) }));
+jest.mock('../src/hooks/useResponsive', () => ({ useResponsive: () => ({ sideBySide: false, isTablet: false, maxContentWidth: 0 }) }));
+jest.mock('../src/contexts/ViewModeContext', () => ({ useViewMode: () => ({ viewMode: 'list', setViewMode: mockSetViewMode }) }));
+jest.mock('../src/contexts/NoteContext', () => ({
+  useNotes: () => ({
+    notes: [mockNote],
+    filteredNotes: [mockNote],
+    isLoading: false,
+    searchQuery: '',
+    setSearchQuery: mockSetSearchQuery,
+    deleteNote: mockDeleteNote,
+    refreshNotes: mockRefreshNotes,
+    togglePin: mockTogglePin,
+    error: null,
+    createNote: mockCreateNote,
+    updateNote: mockUpdateNote,
+    getNoteById: jest.fn(() => null),
+  }),
+}));
+jest.mock('../src/stores/noteStore', () => ({ useNoteStore: mockUseNoteStore }));
+jest.mock('../src/services/GitService', () => ({ GitService: { getBranches: jest.fn(async () => []), getRepositoryFolders: jest.fn(async () => []) } }));
+jest.mock('../src/services/GitHubService', () => ({ GitHubService: { setToken: jest.fn() } }));
+jest.mock('../src/services/NoteGitHubSyncService', () => ({
+  syncNoteToGitHub: jest.fn(async () => ({ success: true, filePath: 'notes/draft-note.md', finalContent: null })),
+}));
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    enqueueNoteUpsert: jest.fn(async () => undefined),
+    pendingCount: jest.fn(async () => 0),
+    subscribe: jest.fn(() => jest.fn()),
+    drain: jest.fn(async () => ({ succeeded: 0 })),
+  },
+}));
+jest.mock('../src/services/RepoPullService', () => ({ pullAllFromRepos: jest.fn(async () => undefined) }));
+jest.mock('../src/services/ShareService', () => ({ ShareService: { shareText: jest.fn(), shareByNoteFormat: jest.fn(async () => true) } }));
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: { light: jest.fn(), medium: jest.fn(), success: jest.fn(), warning: jest.fn(), selection: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('../src/components/GitHubActivityIndicator', () => ({
+  GitHubActivityIndicator: () => {
+    const { Text } = require('react-native');
+    return require('react').createElement(Text, { testID: 'github-activity-indicator' }, 'GitHub activity');
+  },
+}));
+
+jest.mock('../src/components/ui', () => {
+  const { Pressable, Text, View } = require('react-native');
+  return {
+    Button: ({ label, onPress, disabled }: any) => require('react').createElement(
+      Pressable,
+      { onPress, disabled, accessibilityRole: 'button' },
+      require('react').createElement(Text, null, label),
+    ),
+    IconButton: ({ children, onPress }: any) => require('react').createElement(Pressable, { onPress }, children),
+    Modal: ({ visible, children }: any) => (visible ? require('react').createElement(View, null, children) : null),
+    ScreenHeader: ({ title }: any) => require('react').createElement(Text, null, title),
+  };
+});
+jest.mock('../src/components/ui/OfflineBanner', () => ({ OfflineBanner: () => null }));
+jest.mock('../src/components/MarkdownEditor', () => () => {
+  const { Text } = require('react-native');
+  return require('react').createElement(Text, null, 'Markdown editor');
+});
+jest.mock('../src/components/GitContextPicker', () => () => null);
+jest.mock('../src/components/NeorgRenderer', () => () => null);
+jest.mock('../src/components/PdfViewer', () => () => null);
+jest.mock('../src/components/TagInput', () => () => null);
+jest.mock('../src/components/VoiceInputModal', () => () => null);
+jest.mock('../src/components/CanvasModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../src/components/CanvasPreview', () => () => null);
+jest.mock('../src/components/FolderSelectionDialog', () => () => null);
+jest.mock('../src/components/ContextMenu', () => () => null);
+jest.mock('../src/utils/markdownRenderer', () => ({ NotePreviewRenderer: class {} }));
+jest.mock('../src/components/SearchBar', () => {
+  const { TextInput } = require('react-native');
+  return ({ value, onChangeText }: any) => require('react').createElement(TextInput, { value, onChangeText });
+});
+jest.mock('../src/components/NoteCard', () => ({
+  __esModule: true,
+  default: ({ note }: any) => {
+    const { Text } = require('react-native');
+    return require('react').createElement(Text, null, note.title);
+  },
+}));
+jest.mock('@shopify/flash-list', () => {
+  const { View } = require('react-native');
+  return {
+    FlashList: require('react').forwardRef(({ data, renderItem, ListEmptyComponent }: any, _ref: any) => {
+      if (!data?.length) return require('react').createElement(View, null, ListEmptyComponent ?? null);
+      return require('react').createElement(
+        View,
+        null,
+        data.map((item: any, index: number) => require('react').createElement(View, { key: item.id ?? index }, renderItem({ item, index }))),
+      );
+    }),
+  };
+});
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const { Pressable, View } = require('react-native');
+  const React = require('react');
+  return React.forwardRef(({ children, renderRightActions, onSwipeableWillOpen }: any, ref: any) => {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const noteId = children?.props?.note?.id ?? 'unknown';
+    const methods = React.useRef({
+      close: jest.fn(() => setIsOpen(false)),
+      openLeft: jest.fn(),
+      openRight: jest.fn(),
+      reset: jest.fn(),
+    }).current;
+
+    React.useEffect(() => {
+      if (typeof ref === 'function') {
+        ref(methods);
+        return () => ref(null);
+      }
+      if (ref) {
+        ref.current = methods;
+        return () => {
+          ref.current = null;
+        };
+      }
+      return undefined;
+    }, [ref, methods]);
+
+    return React.createElement(
+      View,
+      null,
+      React.createElement(Pressable, {
+        testID: `open-swipe-${noteId}`,
+        onPress: () => {
+          onSwipeableWillOpen?.();
+          setIsOpen(true);
+        },
+      }),
+      children,
+      isOpen ? React.createElement(View, { testID: `swipe-actions-${noteId}` }, renderRightActions?.(undefined, undefined, methods)) : null,
+    );
+  });
+});
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: any) => {
+    const { View } = require('react-native');
+    return require('react').createElement(View, null, children);
+  },
+}));
+
+import NoteEditorScreen from '../src/screens/NoteEditorScreen';
+import NotesListScreen from '../src/screens/NotesListScreen';
+
 describe('save/loading indicator', () => {
-  it('passes', () => {
-    expect(true).toBe(true);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouteParams.noteId = undefined;
+    mockRouteParams.initialTitle = 'Draft note';
+    mockRouteParams.initialContent = 'Draft content';
+    mockRouteParams.initialRepo = 'owner/repo';
+    mockRouteParams.initialBranch = 'main';
+    mockRouteParams.initialFormat = 'markdown';
+    jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('shows and hides the save spinner on success', async () => {
+    const deferred = createDeferred<{ id: string } | null>();
+    mockCreateNote.mockReturnValueOnce(deferred.promise);
+
+    const screen = render(React.createElement(NoteEditorScreen));
+    fireEvent.press(screen.getByText('Save'));
+
+    expect(screen.getByTestId('github-activity-indicator')).toBeTruthy();
+
+    await act(async () => {
+      deferred.resolve({ id: 'note-1' });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('github-activity-indicator')).toBeNull();
+    });
+  });
+
+  it('hides the save spinner on error', async () => {
+    const deferred = createDeferred<{ id: string } | null>();
+    mockCreateNote.mockReturnValueOnce(deferred.promise);
+
+    const screen = render(React.createElement(NoteEditorScreen));
+    fireEvent.press(screen.getByText('Save'));
+
+    expect(screen.getByTestId('github-activity-indicator')).toBeTruthy();
+
+    await act(async () => {
+      deferred.reject(new Error('save failed'));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('github-activity-indicator')).toBeNull();
+    });
+  });
+
+  it('shows and hides the delete spinner on success', async () => {
+    const deferred = createDeferred<boolean>();
+    mockDeleteNote.mockReturnValueOnce(deferred.promise);
+
+    const screen = render(React.createElement(NotesListScreen));
+    fireEvent.press(screen.getByTestId('open-swipe-note-1'));
+    fireEvent.press(screen.getByText('Delete'));
+
+    const alertCalls = (Alert.alert as jest.Mock).mock.calls;
+    const lastCall = alertCalls[alertCalls.length - 1];
+    const deleteButton = (lastCall?.[2] as Array<{ text?: string; onPress?: () => void | Promise<void> }>).find((button) => button.text === 'Delete');
+
+    act(() => {
+      deleteButton?.onPress?.();
+    });
+
+    expect(screen.getByTestId('github-activity-indicator')).toBeTruthy();
+
+    await act(async () => {
+      deferred.resolve(true);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('github-activity-indicator')).toBeNull();
+    });
+  });
+
+  it('hides the delete spinner on error', async () => {
+    const deferred = createDeferred<boolean>();
+    mockDeleteNote.mockReturnValueOnce(deferred.promise);
+
+    const screen = render(React.createElement(NotesListScreen));
+    fireEvent.press(screen.getByTestId('open-swipe-note-1'));
+    fireEvent.press(screen.getByText('Delete'));
+
+    const alertCalls = (Alert.alert as jest.Mock).mock.calls;
+    const lastCall = alertCalls[alertCalls.length - 1];
+    const deleteButton = (lastCall?.[2] as Array<{ text?: string; onPress?: () => void | Promise<void> }>).find((button) => button.text === 'Delete');
+
+    act(() => {
+      deleteButton?.onPress?.();
+    });
+
+    expect(screen.getByTestId('github-activity-indicator')).toBeTruthy();
+
+    await act(async () => {
+      deferred.reject(new Error('delete failed'));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('github-activity-indicator')).toBeNull();
+    });
   });
 });

--- a/__tests__/selectable-preview.test.tsx
+++ b/__tests__/selectable-preview.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
+import NeorgRenderer from '../src/components/NeorgRenderer';
+
+jest.mock('expo-image', () => ({
+  Image: () => null,
+}));
+
+jest.mock('react-native-marked', () => {
+  class Renderer {
+    private key = 0;
+
+    getKey() {
+      this.key += 1;
+      return `renderer-key-${this.key}`;
+    }
+  }
+
+  return { Renderer };
+});
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      primary: '#2563eb',
+      text: '#111827',
+      textSecondary: '#6b7280',
+      surfaceSecondary: '#e5e7eb',
+      border: '#d1d5db',
+    },
+  }),
+}));
+
+const createMarkdownRenderer = () => new NotePreviewRenderer({
+  colors: {
+    primary: '#2563eb',
+    text: '#111827',
+    surfaceSecondary: '#e5e7eb',
+  },
+});
+
+const expectSelectableTextNodes = (nodes: { props: { selectable?: boolean } }[]) => {
+  expect(nodes.length).toBeGreaterThan(0);
+  expect(nodes.every((node) => node.props.selectable === true)).toBe(true);
+};
+
+describe('preview text selection', () => {
+  it('marks markdown preview text selectable', () => {
+    const renderer = createMarkdownRenderer();
+
+    const screen = render(
+      <View>
+        {renderer.text('plain text')}
+        {renderer.codespan('inline code')}
+        {renderer.code('block code')}
+        {renderer.link('linked text', 'https://example.com')}
+      </View>,
+    );
+
+    expectSelectableTextNodes(screen.UNSAFE_getAllByType(Text));
+  });
+
+  it('marks neorg preview text selectable', () => {
+    const screen = render(
+      <NeorgRenderer
+        blocks={[
+          { type: 'heading', heading: { level: 1, text: 'Heading *bold* `code`' } },
+          { type: 'list', listItems: [{ type: 'ordered', indentLevel: 0, text: 'List item /italic/' }] },
+          { type: 'checklist', checklistItems: [{ checked: true, indentLevel: 0, text: 'Check item' }] },
+          { type: 'definition', definitionItems: [{ term: 'Term', definition: 'Definition with [link](https://example.com)', indentLevel: 0 }] },
+          { type: 'paragraph', text: 'Paragraph with _underline_ and {tag}' },
+          { type: 'code', code: { language: 'ts', content: 'const n = 1;' } },
+          { type: 'quote', text: 'Quoted ^sup^ and ,sub,' },
+          { type: 'table', tableRows: [{ cells: ['Cell one', 'Cell two'] }], isHeaderRow: [true] },
+        ]}
+      />,
+    );
+
+    expectSelectableTextNodes(screen.UNSAFE_getAllByType(Text));
+  });
+});

--- a/__tests__/swipe-delete.test.tsx
+++ b/__tests__/swipe-delete.test.tsx
@@ -21,6 +21,12 @@ const mockDeleteNote = jest.fn(async (id: string) => {
 const mockUseNoteStore: any = jest.fn();
 mockUseNoteStore.getState = () => ({ error: null });
 
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
 }));

--- a/__tests__/swipe-delete.test.tsx
+++ b/__tests__/swipe-delete.test.tsx
@@ -1,0 +1,300 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import NotesListScreen from '../src/screens/NotesListScreen';
+import { Note } from '../src/models/Note';
+
+let mockViewMode: 'list' | 'journal' = 'list';
+let mockNotesSeed: Note[] = [];
+let latestSetNotes: React.Dispatch<React.SetStateAction<Note[]>> | null = null;
+const mockSwipeableCloseFns: Record<string, jest.Mock> = {};
+
+const mockSetViewMode = jest.fn();
+const mockRefreshNotes = jest.fn(async () => undefined);
+const mockTogglePin = jest.fn(async () => true);
+const mockCreateNote = jest.fn(async () => null);
+const mockDeleteNote = jest.fn(async (id: string) => {
+  latestSetNotes?.((prev) => prev.filter((note) => note.id !== id));
+  return true;
+});
+const mockUseNoteStore: any = jest.fn();
+mockUseNoteStore.getState = () => ({ error: null });
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f4f4f4',
+      primary: '#2563eb',
+      text: '#111',
+      textSecondary: '#666',
+      border: '#ddd',
+      error: '#dc2626',
+    },
+  }),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null } }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({ repositories: [] }),
+}));
+
+jest.mock('../src/contexts/ViewModeContext', () => ({
+  useViewMode: () => ({ viewMode: mockViewMode, setViewMode: mockSetViewMode }),
+}));
+
+jest.mock('../src/contexts/NoteContext', () => {
+  const React = require('react');
+  return {
+    useNotes: () => {
+      const [notes, setNotes] = React.useState(mockNotesSeed);
+      latestSetNotes = setNotes;
+      return {
+        notes,
+        filteredNotes: notes,
+        isLoading: false,
+        searchQuery: '',
+        setSearchQuery: jest.fn(),
+        deleteNote: mockDeleteNote,
+        refreshNotes: mockRefreshNotes,
+        togglePin: mockTogglePin,
+        error: null,
+        createNote: mockCreateNote,
+      };
+    },
+  };
+});
+
+jest.mock('../src/stores/noteStore', () => {
+  return { useNoteStore: mockUseNoteStore };
+});
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: { setToken: jest.fn() },
+}));
+
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    pendingCount: jest.fn(async () => 0),
+    subscribe: jest.fn(() => jest.fn()),
+    drain: jest.fn(async () => ({ succeeded: 0 })),
+  },
+}));
+
+jest.mock('../src/services/RepoPullService', () => ({
+  pullAllFromRepos: jest.fn(async () => undefined),
+}));
+
+jest.mock('../src/services/ShareService', () => ({
+  ShareService: { shareText: jest.fn() },
+}));
+
+jest.mock('../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({ isTablet: false, maxContentWidth: 0 }),
+}));
+
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: {
+    light: jest.fn(),
+    medium: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    selection: jest.fn(),
+  },
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+
+jest.mock('../src/components/SearchBar', () => {
+  const { TextInput } = require('react-native');
+  return ({ value, onChangeText }: { value: string; onChangeText: (value: string) => void }) => (
+    <TextInput value={value} onChangeText={onChangeText} />
+  );
+});
+
+jest.mock('../src/components/ui', () => ({
+  ScreenHeader: ({ title }: { title: string }) => {
+    const { Text } = require('react-native');
+    return <Text>{title}</Text>;
+  },
+}));
+
+jest.mock('../src/components/NoteCard', () => ({
+  __esModule: true,
+  default: ({ note }: { note: Note }) => {
+    const { Text } = require('react-native');
+    return <Text>{note.title}</Text>;
+  },
+}));
+
+jest.mock('@shopify/flash-list', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    FlashList: React.forwardRef(({ data, renderItem, ListEmptyComponent }: any, _ref: any) => {
+      if (!data?.length) {
+        return <View>{ListEmptyComponent ?? null}</View>;
+      }
+      return <View>{data.map((item: Note, index: number) => renderItem({ item, index }))}</View>;
+    }),
+  };
+});
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { Pressable, View } = require('react-native');
+
+  return React.forwardRef(
+    ({ children, renderRightActions, onSwipeableWillOpen }: any, ref: any) => {
+      const [isOpen, setIsOpen] = React.useState(false);
+      const noteId = children?.props?.note?.id ?? 'unknown';
+      const closeRef = React.useRef();
+      const methodsRef = React.useRef();
+
+      if (!closeRef.current) {
+        closeRef.current = jest.fn(() => setIsOpen(false));
+      }
+
+      if (!methodsRef.current) {
+        methodsRef.current = {
+          close: closeRef.current,
+          openLeft: jest.fn(),
+          openRight: jest.fn(),
+          reset: jest.fn(),
+        };
+      }
+
+      const close = closeRef.current;
+      const methods = methodsRef.current;
+
+      mockSwipeableCloseFns[noteId] = close;
+
+      React.useEffect(() => {
+        if (typeof ref === 'function') {
+          ref(methods);
+          return () => ref(null);
+        }
+
+        if (ref) {
+          ref.current = methods;
+          return () => {
+            ref.current = null;
+          };
+        }
+
+        return undefined;
+      }, [ref, methods]);
+
+      return (
+        <View>
+          <Pressable
+            testID={`open-swipe-${noteId}`}
+            onPress={() => {
+              onSwipeableWillOpen?.();
+              setIsOpen(true);
+            }}
+          />
+          {children}
+          {isOpen ? (
+            <View testID={`swipe-actions-${noteId}`}>
+              {renderRightActions?.(undefined, undefined, methods)}
+            </View>
+          ) : null}
+        </View>
+      );
+    },
+  );
+});
+
+const createNote = (id: string, title: string): Note => ({
+  id,
+  title,
+  content: `${title} content`,
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  format: 'markdown',
+});
+
+const confirmLatestDeleteAlert = async () => {
+  const alertCalls = (Alert.alert as jest.Mock).mock.calls;
+  const lastCall = alertCalls[alertCalls.length - 1];
+  if (!lastCall) {
+    throw new Error('Expected delete alert to be shown');
+  }
+
+  const buttons = lastCall[2] as Array<{ text?: string; onPress?: () => void | Promise<void> }>;
+  const deleteButton = buttons.find((button) => button.text === 'Delete');
+  if (!deleteButton?.onPress) {
+    throw new Error('Expected delete confirmation button');
+  }
+
+  await act(async () => {
+    await deleteButton.onPress?.();
+  });
+};
+
+describe('NotesListScreen swipe delete regression', () => {
+  beforeEach(() => {
+    mockViewMode = 'list';
+    mockNotesSeed = [
+      createNote('note-1', 'First note'),
+      createNote('note-2', 'Second note'),
+      createNote('note-3', 'Third note'),
+    ];
+    latestSetNotes = null;
+    Object.keys(mockSwipeableCloseFns).forEach((key) => delete mockSwipeableCloseFns[key]);
+    mockDeleteNote.mockClear();
+    mockSetViewMode.mockClear();
+    mockRefreshNotes.mockClear();
+    mockTogglePin.mockClear();
+    mockCreateNote.mockClear();
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each(['list', 'journal'] as const)(
+    'closes swiped state before deleting in %s mode so recycled cards do not stay open',
+    async (viewMode) => {
+      mockViewMode = viewMode;
+      const screen = render(<NotesListScreen />);
+
+      fireEvent.press(screen.getByTestId('open-swipe-note-1'));
+      expect(screen.getByTestId('swipe-actions-note-1')).toBeTruthy();
+
+      fireEvent.press(screen.getByText('Delete'));
+      await confirmLatestDeleteAlert();
+
+      await waitFor(() => expect(screen.queryByText('First note')).toBeNull());
+      expect(screen.queryByTestId('swipe-actions-note-2')).toBeNull();
+      expect(screen.queryAllByText('Delete')).toHaveLength(0);
+    },
+  );
+
+  it('keeps only one swipeable card open at a time', async () => {
+    const screen = render(<NotesListScreen />);
+
+    fireEvent.press(screen.getByTestId('open-swipe-note-1'));
+    expect(screen.getByTestId('swipe-actions-note-1')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('open-swipe-note-2'));
+
+    await waitFor(() => expect(mockSwipeableCloseFns['note-1']).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('swipe-actions-note-2')).toBeTruthy();
+  });
+});

--- a/__tests__/tag-persistence.test.ts
+++ b/__tests__/tag-persistence.test.ts
@@ -1,0 +1,104 @@
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: {
+    fetch: jest.fn(async () => ({ isConnected: true, isInternetReachable: true })),
+    addEventListener: jest.fn(() => jest.fn()),
+  },
+}));
+
+jest.mock('expo-file-system/legacy', () => ({
+  __esModule: true,
+  default: {},
+  readAsStringAsync: jest.fn(),
+  EncodingType: { Base64: 'base64' },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    updateFile: jest.fn(),
+    getSavedRepositories: jest.fn(),
+    getTreeRecursive: jest.fn(),
+    getFileContent: jest.fn(),
+    getRepoContents: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(),
+    getAllNotes: jest.fn(),
+    createNote: jest.fn(),
+    saveAllNotes: jest.fn(),
+  },
+}));
+
+import { canPersistNoteTags } from '../src/utils/noteTagSupport';
+import { syncNoteToGitHub } from '../src/services/NoteGitHubSyncService';
+import { pullFromSingleRepo } from '../src/services/RepoPullService';
+import { GitHubService } from '../src/services/GitHubService';
+import { StorageService } from '../src/services/StorageService';
+
+describe('tag persistence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
+  });
+
+  test('syncs markdown tags into frontmatter before upload', async () => {
+    (GitHubService.updateFile as jest.Mock).mockResolvedValue({ ok: true });
+
+    await syncNoteToGitHub({
+      repo: 'org/repo',
+      branch: 'main',
+      title: 'My Note',
+      content: 'hello world',
+      format: 'markdown',
+      tags: ['alpha', 'beta'],
+    });
+
+    expect(GitHubService.updateFile).toHaveBeenCalledWith(
+      'org',
+      'repo',
+      'notes/my-note.md',
+      expect.stringContaining('tags: [alpha, beta]'),
+      'Create note: My Note',
+      'main'
+    );
+  });
+
+  test('restores tags from repo content on refresh', async () => {
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([
+      { path: 'org/repo', branch: 'main' },
+    ]);
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([]);
+    (GitHubService.getTreeRecursive as jest.Mock).mockResolvedValue([
+      { type: 'blob', path: 'notes/my-note.md' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue(
+      '---\ntags: [alpha, beta]\n---\n\nhello world'
+    );
+
+    await pullFromSingleRepo('org/repo');
+
+    expect(StorageService.saveAllNotes).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: 'my note',
+          tags: ['alpha', 'beta'],
+          filePath: 'notes/my-note.md',
+          repo: 'org/repo',
+        }),
+      ])
+    );
+  });
+
+  test('hides tag input for unsupported formats', () => {
+    expect(canPersistNoteTags('markdown')).toBe(true);
+    expect(canPersistNoteTags('org')).toBe(true);
+    expect(canPersistNoteTags('neorg')).toBe(true);
+    expect(canPersistNoteTags('json')).toBe(false);
+    expect(canPersistNoteTags('pdf')).toBe(false);
+    expect(canPersistNoteTags('txt')).toBe(false);
+  });
+});

--- a/__tests__/todo-completion.test.ts
+++ b/__tests__/todo-completion.test.ts
@@ -1,0 +1,124 @@
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    updateTodo: jest.fn(),
+    getAllTodos: jest.fn(),
+    saveAllTodos: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/NotificationService', () => ({
+  NotificationService: {
+    cancelAllForTodo: jest.fn(),
+    scheduleReminder: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => false),
+  },
+}));
+
+jest.mock('../src/services/TodoGitHubSyncService', () => ({
+  syncTodoToGitHub: jest.fn(() => Promise.resolve({ success: true })),
+}));
+
+import { act, renderHook } from '@testing-library/react-native';
+import { useTodos } from '../src/contexts/TodoContext';
+import { Todo } from '../src/models/Todo';
+import { StorageService } from '../src/services/StorageService';
+import { NotificationService } from '../src/services/NotificationService';
+import { syncTodoToGitHub } from '../src/services/TodoGitHubSyncService';
+import { useTodoStore } from '../src/stores/todoStore';
+
+const makeTodo = (overrides: Partial<Todo>): Todo => ({
+  id: overrides.id ?? 'todo-id',
+  text: overrides.text ?? 'Todo',
+  completed: overrides.completed ?? false,
+  createdAt: overrides.createdAt ?? 1,
+  updatedAt: overrides.updatedAt ?? overrides.createdAt ?? 1,
+  priority: overrides.priority ?? 'medium',
+  tags: overrides.tags ?? [],
+  ...overrides,
+});
+
+describe('todo completion ordering and refresh', () => {
+  let storageTodos: Todo[];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storageTodos = [];
+
+    (StorageService.getAllTodos as jest.Mock).mockImplementation(async () => storageTodos);
+    (StorageService.updateTodo as jest.Mock).mockImplementation(async (input: { id: string; completed?: boolean; notificationId?: string }) => {
+      const index = storageTodos.findIndex((todo) => todo.id === input.id);
+      if (index === -1) return null;
+
+      storageTodos[index] = {
+        ...storageTodos[index],
+        ...input,
+        updatedAt: storageTodos[index].updatedAt + 1,
+      };
+
+      return storageTodos[index];
+    });
+    (StorageService.saveAllTodos as jest.Mock).mockImplementation(async (todos: Todo[]) => {
+      storageTodos = todos.map((todo) => ({ ...todo }));
+    });
+    (NotificationService.cancelAllForTodo as jest.Mock).mockResolvedValue(undefined);
+    (NotificationService.scheduleReminder as jest.Mock).mockResolvedValue(undefined);
+
+    useTodoStore.setState({ todos: [], isLoading: false, error: null });
+  });
+
+  test('completing the top todo reorders atomically and stays stable after refresh', async () => {
+    const topTodo = makeTodo({
+      id: 'todo-1',
+      text: 'Top todo',
+      completed: false,
+      priority: 'high',
+      createdAt: 30,
+      updatedAt: 30,
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'todos/top-todo.json',
+    });
+    const middleTodo = makeTodo({ id: 'todo-2', text: 'Middle todo', priority: 'medium', createdAt: 20, updatedAt: 20 });
+    const bottomTodo = makeTodo({ id: 'todo-3', text: 'Bottom todo', priority: 'low', createdAt: 10, updatedAt: 10 });
+
+    storageTodos = [topTodo, middleTodo, bottomTodo].map((todo) => ({ ...todo }));
+    useTodoStore.setState({ todos: [topTodo, middleTodo, bottomTodo], isLoading: false, error: null });
+
+    const { result } = renderHook(() => useTodos());
+
+    await act(async () => {
+      await result.current.toggleTodo('todo-1');
+    });
+
+    expect(useTodoStore.getState().todos.map((todo) => todo.id)).toEqual(['todo-2', 'todo-3', 'todo-1']);
+    expect(useTodoStore.getState().todos[0]).toBeDefined();
+    expect(useTodoStore.getState().todos[0]?.id).toBe('todo-2');
+    expect(useTodoStore.getState().todos[2]).toMatchObject({ id: 'todo-1', completed: true });
+    expect(StorageService.saveAllTodos).toHaveBeenCalled();
+    expect(syncTodoToGitHub).toHaveBeenCalledWith(expect.objectContaining({
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'todos/top-todo.json',
+      text: 'Top todo',
+      todo: expect.objectContaining({ completed: true }),
+    }));
+
+    await act(async () => {
+      await result.current.refreshTodos();
+    });
+
+    expect(useTodoStore.getState().todos.map((todo) => todo.id)).toEqual(['todo-2', 'todo-3', 'todo-1']);
+    expect(useTodoStore.getState().todos[2]).toMatchObject({ id: 'todo-1', completed: true });
+  });
+});

--- a/__tests__/todo-delete-sync.test.ts
+++ b/__tests__/todo-delete-sync.test.ts
@@ -1,0 +1,83 @@
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    getAllTodos: jest.fn(),
+    deleteTodo: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getFileSha: jest.fn(),
+    deleteFile: jest.fn(),
+  },
+}));
+
+import { useTodoStore } from '../src/stores/todoStore';
+import { StorageService } from '../src/services/StorageService';
+import { GitHubService } from '../src/services/GitHubService';
+
+describe('todo delete GitHub sync', () => {
+  let storageTodos: Array<{
+    id: string;
+    text: string;
+    completed: boolean;
+    createdAt: number;
+    updatedAt: number;
+    repo?: string;
+    branch?: string;
+    filePath?: string;
+  }>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storageTodos = [];
+    (StorageService.getAllTodos as jest.Mock).mockImplementation(async () => storageTodos);
+    (StorageService.deleteTodo as jest.Mock).mockImplementation(async (id: string) => {
+      const next = storageTodos.filter((todo) => todo.id !== id);
+      if (next.length === storageTodos.length) return false;
+      storageTodos = next;
+      return true;
+    });
+    (GitHubService.getFileSha as jest.Mock).mockResolvedValue('todo-sha-123');
+    (GitHubService.deleteFile as jest.Mock).mockResolvedValue({
+      content: { sha: 'deleted-sha' },
+      commit: { sha: 'commit-sha' },
+    });
+    useTodoStore.setState({ todos: [], isLoading: false, error: null });
+  });
+
+  test('deletes the remote todo file and keeps it gone after refresh', async () => {
+    const syncedTodo = {
+      id: 'todo-1',
+      text: 'Ship it',
+      completed: false,
+      createdAt: 1,
+      updatedAt: 1,
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'todos/ship-it.json',
+    };
+
+    storageTodos = [syncedTodo];
+    useTodoStore.setState({ todos: [syncedTodo], isLoading: false, error: null });
+
+    await useTodoStore.getState().deleteTodo('todo-1');
+
+    expect(StorageService.deleteTodo).toHaveBeenCalledWith('todo-1');
+    expect(GitHubService.getFileSha).toHaveBeenCalledWith('owner', 'repo', 'todos/ship-it.json', 'main');
+    expect(GitHubService.deleteFile).toHaveBeenCalledWith(
+      'owner',
+      'repo',
+      'todos/ship-it.json',
+      'Delete todo: Ship it',
+      'todo-sha-123',
+      'main',
+    );
+    expect(useTodoStore.getState().todos).toEqual([]);
+
+    await useTodoStore.getState().refreshTodos();
+
+    expect(useTodoStore.getState().todos).toEqual([]);
+  });
+});

--- a/__tests__/ui/__snapshots__/Button.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Button.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button snapshots primary in light + dark: primary-dark 1`] = `
 <View
@@ -65,6 +65,7 @@ exports[`Button snapshots primary in light + dark: primary-dark 1`] = `
             "shadowOpacity": 1,
             "shadowRadius": 8,
           },
+          undefined,
           [
             {
               "alignItems": "center",
@@ -199,6 +200,7 @@ exports[`Button snapshots primary in light + dark: primary-light 1`] = `
             "shadowOpacity": 1,
             "shadowRadius": 8,
           },
+          undefined,
           [
             {
               "alignItems": "center",

--- a/__tests__/ui/__snapshots__/Card.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Card.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Card snapshots non-interactive light 1`] = `
 <View
@@ -17,6 +17,7 @@ exports[`Card snapshots non-interactive light 1`] = `
         "shadowOpacity": 1,
         "shadowRadius": 8,
       },
+      undefined,
       [
         {
           "padding": 16,

--- a/__tests__/ui/__snapshots__/Chip.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Chip.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Chip snapshots inactive + active: chip-active 1`] = `
 <View
@@ -17,6 +17,7 @@ exports[`Chip snapshots inactive + active: chip-active 1`] = `
         "shadowOpacity": 1,
         "shadowRadius": 4,
       },
+      undefined,
       [
         {
           "alignItems": "center",
@@ -87,6 +88,7 @@ exports[`Chip snapshots inactive + active: chip-inactive 1`] = `
         "shadowOpacity": 1,
         "shadowRadius": 4,
       },
+      undefined,
       [
         {
           "alignItems": "center",

--- a/__tests__/ui/__snapshots__/Group.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Group.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Group snapshots a 2-row group 1`] = `
 <View
@@ -41,6 +41,7 @@ exports[`Group snapshots a 2-row group 1`] = `
           "shadowOpacity": 1,
           "shadowRadius": 8,
         },
+        undefined,
         {
           "overflow": "hidden",
         },

--- a/__tests__/ui/__snapshots__/Surface.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Surface.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Surface snapshots a raised neumorphic Surface with a Text child 1`] = `
 <View
@@ -17,6 +17,7 @@ exports[`Surface snapshots a raised neumorphic Surface with a Text child 1`] = `
         "shadowOpacity": 1,
         "shadowRadius": 8,
       },
+      undefined,
       undefined,
     ]
   }

--- a/__tests__/ui/__snapshots__/Toggle.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Toggle.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toggle snapshots both states: toggle-off 1`] = `
 <View
@@ -54,6 +54,7 @@ exports[`Toggle snapshots both states: toggle-off 1`] = `
           "shadowOpacity": 1,
           "shadowRadius": 4,
         },
+        undefined,
         {
           "height": 30,
           "justifyContent": "center",
@@ -196,6 +197,7 @@ exports[`Toggle snapshots both states: toggle-on 1`] = `
           "shadowOpacity": 1,
           "shadowRadius": 4,
         },
+        undefined,
         {
           "height": 30,
           "justifyContent": "center",

--- a/__tests__/useNetworkStatus.test.ts
+++ b/__tests__/useNetworkStatus.test.ts
@@ -1,0 +1,80 @@
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn();
+  const fetch = jest.fn();
+
+  return {
+    __esModule: true,
+    default: {
+      addEventListener,
+      fetch,
+    },
+  };
+});
+
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import NetInfo from '@react-native-community/netinfo';
+import { useNetworkStatus } from '../src/hooks/useNetworkStatus';
+
+const netInfo = NetInfo as jest.Mocked<typeof NetInfo>;
+
+describe('useNetworkStatus', () => {
+  let unsubscribe: jest.Mock;
+  let emitState: ((state: any) => void) | undefined;
+  let resolveFetch: ((state: any) => void) | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    unsubscribe = jest.fn();
+    emitState = undefined;
+    resolveFetch = undefined;
+
+    netInfo.addEventListener.mockImplementation(((listener: any) => {
+      emitState = listener;
+      return unsubscribe;
+    }) as any);
+    netInfo.fetch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve as any;
+        }) as any,
+    );
+  });
+
+  test('starts optimistic and unsubscribes on unmount', () => {
+    const { result, unmount } = renderHook(() => useNetworkStatus());
+
+    expect(result.current).toEqual({ isConnected: true, isInternetReachable: true });
+    expect(netInfo.addEventListener).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test('updates when netinfo emits online and offline states', () => {
+    const { result } = renderHook(() => useNetworkStatus());
+
+    act(() => {
+      emitState?.({ isConnected: false, isInternetReachable: false });
+    });
+    expect(result.current).toEqual({ isConnected: false, isInternetReachable: false });
+
+    act(() => {
+      emitState?.({ isConnected: true, isInternetReachable: true });
+    });
+    expect(result.current).toEqual({ isConnected: true, isInternetReachable: true });
+  });
+
+  test('uses the first fetched status once available', async () => {
+    const { result } = renderHook(() => useNetworkStatus());
+
+    expect(result.current).toEqual({ isConnected: true, isInternetReachable: true });
+
+    act(() => {
+      resolveFetch?.({ isConnected: false, isInternetReachable: false });
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ isConnected: false, isInternetReachable: false });
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,10 @@ module.exports = {
     '**/?(*.)+(spec|test).{ts,tsx}',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '^expo-blur$': '<rootDir>/__mocks__/expo-blur.ts',
+    '^expo-file-system/legacy$': '<rootDir>/__mocks__/expo-file-system-legacy.ts',
+  },
   setupFiles: ['<rootDir>/jest.setup.ts'],
   transformIgnorePatterns: [
     'node_modules/(?!(react-native|@react-native|@react-navigation|expo|@expo|react-native-reanimated|@shopify)/)',

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,12 @@
 // Mocks for the @testing-library/react-native render path.
 
+jest.mock('expo-blur', () => {
+  const { View } = require('react-native');
+  return {
+    BlurView: View
+  };
+});
+
 // Minimal reanimated stub — official mock pulls in TS source that the
 // jest transform pipeline can't load. We only need the surface area used
 // by neumorphic primitives (useSharedValue, useAnimatedStyle, withSpring,

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-native-ai/llama": "0.10.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.6.0",
+    "@react-native-community/netinfo": "^12.0.1",
     "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",

--- a/src/components/CanvasModal.tsx
+++ b/src/components/CanvasModal.tsx
@@ -35,6 +35,7 @@ interface CanvasModalProps {
 }
 
 type Point = { x: number; y: number };
+type ToolIconName = React.ComponentProps<typeof Ionicons>['name'];
 
 interface DrawStroke {
   id: string;
@@ -60,9 +61,9 @@ type DrawElement = DrawStroke | DrawShape;
 
 const COLORS = ['#000000', '#FFFFFF', '#FF3B30', '#FF9500', '#FFCC00', '#34C759', '#007AFF', '#5856D6', '#AF52DE', '#FF2D55'];
 const TOOLS = [
-  { key: 'pen', label: '✏️' },
-  { key: 'highlighter', label: '🖊' },
-  { key: 'eraser', label: '🧹' },
+  { key: 'pen', icon: 'pencil' as ToolIconName },
+  { key: 'highlighter', icon: 'brush' as ToolIconName },
+  { key: 'eraser', icon: 'backspace-outline' as ToolIconName },
   { key: 'line', label: '╱' },
   { key: 'arrow', label: '→' },
   { key: 'rect', label: '□' },
@@ -128,7 +129,7 @@ export default function CanvasModal({ visible, onSave, onClose, editJsonUri }: C
   const insets = useSafeAreaInsets();
   const canvasRef = useCanvasRef();
   const [elements, setElements] = useState<DrawElement[]>([]);
-  const [history, setHistory] = useState<string[]>([]);
+  const [, setHistory] = useState<string[]>([]);
   const [tool, setTool] = useState('pen');
   const [color, setColor] = useState('#000000');
   const [size, setSize] = useState(3);
@@ -486,13 +487,13 @@ export default function CanvasModal({ visible, onSave, onClose, editJsonUri }: C
 
         <View style={styles.toolbar}>
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-            {TOOLS.map(({ key, label }) => (
+            {TOOLS.map(({ key, label, icon }) => (
               <TouchableOpacity
                 key={key}
                 style={[styles.toolBtn, tool === key && styles.toolBtnActive]}
                 onPress={() => setTool(key)}
               >
-                <Text style={styles.toolBtnLabel}>{label}</Text>
+                {icon ? <Ionicons name={icon} size={20} color={color} /> : <Text style={styles.toolBtnLabel}>{label}</Text>}
               </TouchableOpacity>
             ))}
             <TouchableOpacity style={[styles.toolBtn, filled && styles.toolBtnActive]} onPress={() => setFilled(!filled)}>
@@ -503,7 +504,7 @@ export default function CanvasModal({ visible, onSave, onClose, editJsonUri }: C
               <Text style={styles.toolBtnLabel}>↩</Text>
             </TouchableOpacity>
             <TouchableOpacity style={styles.toolBtn} onPress={clearAll}>
-              <Text style={styles.toolBtnLabel}>🗑</Text>
+              <Ionicons name="trash-outline" size={20} color={color} />
             </TouchableOpacity>
           </ScrollView>
         </View>

--- a/src/components/CanvasPreview.tsx
+++ b/src/components/CanvasPreview.tsx
@@ -19,7 +19,7 @@ import {
 import { useCanvases } from '../contexts/CanvasContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { RootStackParamList } from '../navigation/types';
-import { Canvas, CanvasElement } from '../models/Canvas';
+import { CanvasChart, CanvasShape, CanvasStroke, CanvasText } from '../models/Canvas';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -76,6 +76,71 @@ function buildLinePath(x1: number, y1: number, x2: number, y2: number) {
   return p;
 }
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isPoint(point: unknown): point is { x: number; y: number } {
+  return !!point
+    && typeof point === 'object'
+    && isFiniteNumber((point as { x?: unknown }).x)
+    && isFiniteNumber((point as { y?: unknown }).y);
+}
+
+function isStrokeElement(el: unknown): el is CanvasStroke {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'stroke'
+    && Array.isArray((el as { points?: unknown }).points)
+    && (el as { points: unknown[] }).points.every(isPoint)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isString((el as { tool?: unknown }).tool);
+}
+
+function isShapeElement(el: unknown): el is CanvasShape {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'shape'
+    && isString((el as { shape?: unknown }).shape)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isFiniteNumber((el as { x1?: unknown }).x1)
+    && isFiniteNumber((el as { y1?: unknown }).y1)
+    && isFiniteNumber((el as { x2?: unknown }).x2)
+    && isFiniteNumber((el as { y2?: unknown }).y2)
+    && ((el as { fillColor?: unknown }).fillColor === undefined || isString((el as { fillColor?: unknown }).fillColor));
+}
+
+function isTextElement(el: unknown): el is CanvasText {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'text'
+    && isString((el as { text?: unknown }).text)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { x?: unknown }).x)
+    && isFiniteNumber((el as { y?: unknown }).y);
+}
+
+function isChartElement(el: unknown): el is CanvasChart {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'chart'
+    && isString((el as { chartType?: unknown }).chartType)
+    && Array.isArray((el as { labels?: unknown }).labels)
+    && (el as { labels: unknown[] }).labels.every(isString)
+    && Array.isArray((el as { values?: unknown }).values)
+    && (el as { values: unknown[] }).values.every(isFiniteNumber)
+    && isFiniteNumber((el as { x?: unknown }).x)
+    && isFiniteNumber((el as { y?: unknown }).y)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isFiniteNumber((el as { height?: unknown }).height);
+}
+
 export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTheme();
@@ -111,17 +176,17 @@ export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
   }
 
   const scene = canvasData.scene;
-  const elements = scene?.elements ?? [];
-  const sceneWidth = scene?.width ?? 800;
-  const sceneHeight = scene?.height ?? 600;
+  const elements: unknown[] = Array.isArray(scene?.elements) ? scene.elements : [];
+  const sceneWidth = isFiniteNumber(scene?.width) && scene.width > 0 ? scene.width : 800;
+  const sceneHeight = isFiniteNumber(scene?.height) && scene.height > 0 ? scene.height : 600;
   const previewWidth = Dimensions.get('window').width - 32;
   const previewHeight = 140;
   const scaleX = previewWidth / sceneWidth;
   const scaleY = previewHeight / sceneHeight;
   const scale = Math.min(scaleX, scaleY);
 
-  const renderElement = (el: CanvasElement, idx: number) => {
-    if (el.type === 'stroke') {
+  const renderElement = (el: unknown, idx: number) => {
+    if (isStrokeElement(el)) {
       const path = buildStrokePath(el.points);
       if (!path) return null;
       const strokeColor = el.tool === 'highlighter' ? hexToRgba(el.color, 0.3) : el.color;
@@ -133,7 +198,7 @@ export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
       );
     }
 
-    if (el.type === 'shape') {
+    if (isShapeElement(el)) {
       const { x1, y1, x2, y2, shape, color: sColor, fillColor, width: sw } = el;
       const minX = Math.min(x1, x2);
       const minY = Math.min(y1, y2);
@@ -181,11 +246,11 @@ export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
       }
     }
 
-    if (el.type === 'text') {
+    if (isTextElement(el)) {
       return <SkiaText key={el.id ?? idx} x={el.x} y={el.y} text={el.text} font={font} color={el.color} />;
     }
 
-    if (el.type === 'chart') {
+    if (isChartElement(el)) {
       const chartColors = ['#007AFF', '#FF3B30', '#34C759', '#FF9500', '#AF52DE'];
       if (el.chartType === 'bar') {
         const maxVal = Math.max(...el.values, 1);

--- a/src/components/JsonRenderer.tsx
+++ b/src/components/JsonRenderer.tsx
@@ -1,0 +1,109 @@
+import React, { ReactNode, useMemo } from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+
+import { useTheme } from '../contexts/ThemeContext';
+
+interface JsonRendererProps {
+  content: string;
+}
+
+const KEY_LINE_RE = /^(\s*)"((?:\\.|[^"\\])+)":\s*(.*)$/;
+const VALUE_TOKEN_RE = /"((?:\\.|[^"\\])*)"|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?\b|true|false|null/g;
+
+function renderValueTokens(segment: string, valueColor: string, scalarColor: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+
+  VALUE_TOKEN_RE.lastIndex = 0;
+
+  for (;;) {
+    const match = VALUE_TOKEN_RE.exec(segment);
+    if (!match) break;
+
+    if (match.index > lastIndex) {
+      nodes.push(segment.slice(lastIndex, match.index));
+    }
+
+    const token = match[0];
+    const isString = token.startsWith('"');
+    nodes.push(
+      <Text key={`${match.index}-${token}`} style={{ color: isString ? valueColor : scalarColor }}>
+        {token}
+      </Text>
+    );
+
+    lastIndex = match.index + token.length;
+  }
+
+  if (lastIndex < segment.length) {
+    nodes.push(segment.slice(lastIndex));
+  }
+
+  VALUE_TOKEN_RE.lastIndex = 0;
+  return nodes;
+}
+
+function renderLine(line: string, colors: { text: string; textSecondary: string; primary: string }): ReactNode[] {
+  const keyMatch = line.match(KEY_LINE_RE);
+  if (!keyMatch) {
+    return renderValueTokens(line, colors.text, colors.primary);
+  }
+
+  const [, indent, key, rest] = keyMatch;
+  return [
+    indent,
+    <Text key={key} style={{ color: colors.textSecondary }}>
+      {`"${key}"`}
+    </Text>,
+    ': ',
+    ...renderValueTokens(rest, colors.text, colors.primary),
+  ];
+}
+
+export function JsonRenderer({ content }: JsonRendererProps) {
+  const { colors } = useTheme();
+
+  const formatted = useMemo(() => {
+    try {
+      return JSON.stringify(JSON.parse(content), null, 2);
+    } catch {
+      return null;
+    }
+  }, [content]);
+
+  if (!formatted) {
+    return (
+      <Text selectable style={[styles.raw, { color: colors.text }]}>
+        {content}
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {formatted.split('\n').map((line, index) => (
+        <Text key={`${index}-${line}`} selectable style={[styles.line, { color: colors.text }]}>
+          {renderLine(line, colors)}
+        </Text>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 2,
+  },
+  line: {
+    fontSize: 13,
+    lineHeight: 19,
+    fontFamily: 'Menlo',
+  },
+  raw: {
+    fontSize: 14,
+    lineHeight: 20,
+    fontFamily: 'Menlo',
+  },
+});
+
+export default JsonRenderer;

--- a/src/components/NeorgRenderer.tsx
+++ b/src/components/NeorgRenderer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { NeorgContentBlock, NeorgHeading, NeorgListItem, NeorgChecklistItem, NeorgDefinitionItem } from '../models/NeorgContent';
 import { useTheme } from '../contexts/ThemeContext';
@@ -19,96 +19,172 @@ type InlineSegment =
   | { type: 'link'; label: string; target: string }
   | { type: 'tag'; name: string };
 
-export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
-  const { colors } = useTheme();
+type InlinePattern = {
+  regex: RegExp;
+  handler: (match: RegExpMatchArray) => InlineSegment | null;
+  validate?: (source: string, match: RegExpMatchArray) => boolean;
+};
 
-  const parseInline = (text: string): InlineSegment[] => {
-    const segments: InlineSegment[] = [];
-    const patterns: { regex: RegExp; handler: (m: RegExpMatchArray) => InlineSegment | null }[] = [
-      {
-        regex: /\{([a-z0-9_.:]+)\}(?:\[([^\]]+)\])?/g,
-        handler: (m) => {
-          const target = m[1];
-          if (/^[a-z0-9_.:-]+$/.test(target)) {
-            if (m[2]) return { type: 'link', label: m[2], target };
-            return { type: 'tag', name: target };
-          }
-          return null;
-        },
-      },
-      {
-        regex: /\[\[([^\]]+)\]\[([^\]]+)\]\]/g,
-        handler: (m) => ({ type: 'link', label: m[2], target: m[1] }),
-      },
-      {
-        regex: /\[\[([^\]]+)\]\]/g,
-        handler: (m) => ({ type: 'link', label: m[1], target: m[1] }),
-      },
-      {
-        regex: /\[([^\]]+)\]\(([^)]+)\)/g,
-        handler: (m) => ({ type: 'link', label: m[1], target: m[2] }),
-      },
-      {
-        regex: /`([^`]+)`/g,
-        handler: (m) => ({ type: 'code', content: m[1] }),
-      },
-      {
-        regex: /\*([^*]+)\*/g,
-        handler: (m) => ({ type: 'bold', content: m[1] }),
-      },
-      {
-        regex: /\/([^/]+)\//g,
-        handler: (m) => ({ type: 'italic', content: m[1] }),
-      },
-      {
-        regex: /_([^_]+)_/g,
-        handler: (m) => ({ type: 'underline', content: m[1] }),
-      },
-      {
-        regex: /-([^-\s][^-]*)-/g,
-        handler: (m) => ({ type: 'strikethrough', content: m[1] }),
-      },
-      {
-        regex: /\^([^^]+)\^/g,
-        handler: (m) => ({ type: 'superscript', content: m[1] }),
-      },
-      {
-        regex: /,([^,]+),/g,
-        handler: (m) => ({ type: 'subscript', content: m[1] }),
-      },
-    ];
+const URL_SHAPED_REGEX = /https?:\/\/[^\s<>()]+/g;
+const WORD_CHAR_REGEX = /[A-Za-z0-9]/;
 
-    let remaining = text;
-    while (remaining.length > 0) {
-      let earliestMatch: { index: number; length: number; segment: InlineSegment } | null = null;
-
-      for (const { regex, handler } of patterns) {
-        regex.lastIndex = 0;
-        const match = regex.exec(remaining);
-        if (match && match.index >= 0) {
-          if (!earliestMatch || match.index < earliestMatch.index) {
-            const seg = handler(match);
-            if (seg) {
-              earliestMatch = { index: match.index, length: match[0].length, segment: seg };
-            }
-          }
-        }
+const inlinePatterns: InlinePattern[] = [
+  {
+    regex: /\{([a-z0-9_.:]+)\}(?:\[([^\]]+)\])?/g,
+    handler: (m) => {
+      const target = m[1];
+      if (/^[a-z0-9_.:-]+$/.test(target)) {
+        if (m[2]) return { type: 'link', label: m[2], target };
+        return { type: 'tag', name: target };
       }
+      return null;
+    },
+  },
+  {
+    regex: /\[\[([^\]]+)\]\[([^\]]+)\]\]/g,
+    handler: (m) => ({ type: 'link', label: m[2], target: m[1] }),
+  },
+  {
+    regex: /\[\[([^\]]+)\]\]/g,
+    handler: (m) => ({ type: 'link', label: m[1], target: m[1] }),
+  },
+  {
+    regex: /\[([^\]]+)\]\(([^)]+)\)/g,
+    handler: (m) => ({ type: 'link', label: m[1], target: m[2] }),
+  },
+  {
+    regex: /`([^`]+)`/g,
+    handler: (m) => ({ type: 'code', content: m[1] }),
+  },
+  {
+    regex: /\*(\S[^*]*?)\*/g,
+    handler: (m) => ({ type: 'bold', content: m[1] }),
+  },
+  {
+    regex: /\/(\S[^/]*?)\//g,
+    handler: (m) => ({ type: 'italic', content: m[1] }),
+    validate: (source, match) => {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      const prev = start > 0 ? source[start - 1] : '';
+      const next = end < source.length ? source[end] : '';
+      return (!prev || !WORD_CHAR_REGEX.test(prev)) && (!next || !WORD_CHAR_REGEX.test(next));
+    },
+  },
+  {
+    regex: /_([^_]+)_/g,
+    handler: (m) => ({ type: 'underline', content: m[1] }),
+  },
+  {
+    regex: /-([^-\s][^-]*)-/g,
+    handler: (m) => ({ type: 'strikethrough', content: m[1] }),
+  },
+  {
+    regex: /\^([^^]+)\^/g,
+    handler: (m) => ({ type: 'superscript', content: m[1] }),
+  },
+  {
+    regex: /,([^,]+),/g,
+    handler: (m) => ({ type: 'subscript', content: m[1] }),
+  },
+];
 
-      if (earliestMatch) {
-        if (earliestMatch.index > 0) {
-          segments.push({ type: 'text', content: remaining.slice(0, earliestMatch.index) });
+function findOuterDelimitedMatch(text: string, delimiter: '*' | '/'): { length: number; segment: InlineSegment } | null {
+  if (!text.startsWith(delimiter)) return null;
+
+  const closingIndex = text.lastIndexOf(delimiter);
+  if (closingIndex <= 0) return null;
+
+  const content = text.slice(1, closingIndex);
+  if (!content || !content.includes(delimiter)) return null;
+  if (!/^\S/.test(content)) return null;
+
+  return {
+    length: closingIndex + 1,
+    segment: delimiter === '*'
+      ? { type: 'bold', content }
+      : { type: 'italic', content },
+  };
+}
+
+export function parseNeorgInlineSegments(text: string): InlineSegment[] {
+  const segments: InlineSegment[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    let earliestMatch: { index: number; length: number; segment: InlineSegment } | null = null;
+
+    const urlMatch = remaining.match(URL_SHAPED_REGEX);
+    if (urlMatch?.index !== undefined) {
+      earliestMatch = {
+        index: urlMatch.index,
+        length: urlMatch[0].length,
+        segment: { type: 'text', content: urlMatch[0] },
+      };
+    }
+
+    const nestedBold = findOuterDelimitedMatch(remaining, '*');
+    if (nestedBold) {
+      earliestMatch = {
+        index: 0,
+        length: nestedBold.length,
+        segment: nestedBold.segment,
+      };
+    }
+
+    const nestedItalic = findOuterDelimitedMatch(remaining, '/');
+    if (nestedItalic && (!earliestMatch || earliestMatch.index > 0 || nestedItalic.length > earliestMatch.length)) {
+      earliestMatch = {
+        index: 0,
+        length: nestedItalic.length,
+        segment: nestedItalic.segment,
+      };
+    }
+
+    for (const { regex, handler, validate } of inlinePatterns) {
+      regex.lastIndex = 0;
+      const match = regex.exec(remaining);
+      if (match && match.index >= 0 && (!validate || validate(remaining, match))) {
+        const seg = handler(match);
+        if (seg && (!earliestMatch || match.index < earliestMatch.index)) {
+          earliestMatch = { index: match.index, length: match[0].length, segment: seg };
         }
-        segments.push(earliestMatch.segment);
-        remaining = remaining.slice(earliestMatch.index + earliestMatch.length);
-      } else {
-        segments.push({ type: 'text', content: remaining });
-        break;
       }
     }
 
-    return segments;
+    if (earliestMatch) {
+      if (earliestMatch.index > 0) {
+        segments.push({ type: 'text', content: remaining.slice(0, earliestMatch.index) });
+      }
+      segments.push(earliestMatch.segment);
+      remaining = remaining.slice(earliestMatch.index + earliestMatch.length);
+    } else {
+      segments.push({ type: 'text', content: remaining });
+      break;
+    }
+  }
+
+  return segments;
+}
+
+export function createMemoizedNeorgInlineParser(
+  parser: (text: string) => InlineSegment[] = parseNeorgInlineSegments,
+): (text: string) => InlineSegment[] {
+  const cache = new Map<string, InlineSegment[]>();
+
+  return (text: string): InlineSegment[] => {
+    const cached = cache.get(text);
+    if (cached) return cached;
+    const parsed = parser(text);
+    cache.set(text, parsed);
+    return parsed;
   };
+}
+
+export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
+  const { colors } = useTheme();
+
+  const parseInline = useMemo(() => createMemoizedNeorgInlineParser(), []);
 
   const segKey = (seg: InlineSegment, i: number): string =>
     `${i}-${seg.type}-${'content' in seg ? seg.content : 'name' in seg ? seg.name : seg.type}`;
@@ -123,13 +199,13 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
           const k = segKey(seg, i);
           switch (seg.type) {
             case 'bold':
-              return <Text key={k} selectable style={styles.bold}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.bold}>{renderInline(seg.content)}</Text>;
             case 'italic':
-              return <Text key={k} selectable style={styles.italic}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.italic}>{renderInline(seg.content)}</Text>;
             case 'underline':
-              return <Text key={k} selectable style={styles.underline}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.underline}>{renderInline(seg.content)}</Text>;
             case 'strikethrough':
-              return <Text key={k} selectable style={styles.strikethrough}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.strikethrough}>{renderInline(seg.content)}</Text>;
             case 'code':
               return (
                 <Text key={k} selectable style={[styles.inlineCode, { backgroundColor: colors.surfaceSecondary }]}>
@@ -137,9 +213,9 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
                 </Text>
               );
             case 'superscript':
-              return <Text key={k} selectable style={styles.superscript}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.superscript}>{renderInline(seg.content)}</Text>;
             case 'subscript':
-              return <Text key={k} selectable style={styles.subscript}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.subscript}>{renderInline(seg.content)}</Text>;
             case 'link':
               return (
                 <Text key={k} selectable style={[styles.link, { color: colors.primary }]}>

--- a/src/components/NeorgRenderer.tsx
+++ b/src/components/NeorgRenderer.tsx
@@ -123,37 +123,37 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
           const k = segKey(seg, i);
           switch (seg.type) {
             case 'bold':
-              return <Text key={k} style={styles.bold}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.bold}>{seg.content}</Text>;
             case 'italic':
-              return <Text key={k} style={styles.italic}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.italic}>{seg.content}</Text>;
             case 'underline':
-              return <Text key={k} style={styles.underline}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.underline}>{seg.content}</Text>;
             case 'strikethrough':
-              return <Text key={k} style={styles.strikethrough}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.strikethrough}>{seg.content}</Text>;
             case 'code':
               return (
-                <Text key={k} style={[styles.inlineCode, { backgroundColor: colors.surfaceSecondary }]}>
+                <Text key={k} selectable style={[styles.inlineCode, { backgroundColor: colors.surfaceSecondary }]}>
                   {seg.content}
                 </Text>
               );
             case 'superscript':
-              return <Text key={k} style={styles.superscript}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.superscript}>{seg.content}</Text>;
             case 'subscript':
-              return <Text key={k} style={styles.subscript}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.subscript}>{seg.content}</Text>;
             case 'link':
               return (
-                <Text key={k} style={[styles.link, { color: colors.primary }]}>
+                <Text key={k} selectable style={[styles.link, { color: colors.primary }]}>
                   {seg.label}
                 </Text>
               );
             case 'tag':
               return (
-                <Text key={k} style={[styles.tagBadge, { backgroundColor: colors.primary + '20', color: colors.primary }]}>
+                <Text key={k} selectable style={[styles.tagBadge, { backgroundColor: colors.primary + '20', color: colors.primary }]}>
                   {seg.name}
                 </Text>
               );
             default:
-              return <Text key={k}>{seg.content}</Text>;
+              return <Text key={k} selectable>{seg.content}</Text>;
           }
         })}
       </React.Fragment>
@@ -179,6 +179,7 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
     return (
       <Text
         key={`heading-${blockIndex}`}
+        selectable
         style={[
           styles.heading,
           { fontSize, color: colors.text, marginTop: heading.level === 1 ? 16 : 12 },
@@ -198,8 +199,8 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
       prefix = `${taskStatusIcon(item.status)} `;
     }
     return (
-      <View key={`list-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent }]}>
-        <Text style={[styles.listText, { color: colors.text }]}>
+      <View key={`list-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent }]}> 
+        <Text selectable style={[styles.listText, { color: colors.text }]}>
           {prefix}{renderInline(item.text)}
         </Text>
       </View>
@@ -209,8 +210,8 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
   const renderChecklistItem = (item: NeorgChecklistItem, blockIndex: number, itemIndex: number) => {
     const indent = item.indentLevel * 16;
     return (
-      <View key={`check-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent }]}>
-        <Text style={[styles.listText, { color: colors.text }]}>
+      <View key={`check-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent }]}> 
+        <Text selectable style={[styles.listText, { color: colors.text }]}>
           {item.checked ? '✓' : '○'} {renderInline(item.text)}
         </Text>
       </View>
@@ -220,12 +221,12 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
   const renderDefinitionItem = (item: NeorgDefinitionItem, blockIndex: number, itemIndex: number) => {
     const indent = item.indentLevel * 16;
     return (
-      <View key={`def-${blockIndex}-${itemIndex}`} style={[styles.definitionItem, { marginLeft: indent }]}>
-        <Text style={[styles.definitionTerm, { color: colors.primary }]}>
+      <View key={`def-${blockIndex}-${itemIndex}`} style={[styles.definitionItem, { marginLeft: indent }]}> 
+        <Text selectable style={[styles.definitionTerm, { color: colors.primary }]}> 
           {item.term}
         </Text>
         {item.definition ? (
-          <Text style={[styles.definitionText, { color: colors.text }]}>
+          <Text selectable style={[styles.definitionText, { color: colors.text }]}>
             {renderInline(item.definition)}
           </Text>
         ) : null}
@@ -234,19 +235,19 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
   };
 
   const renderParagraph = (text: string, blockIndex: number) => (
-    <Text key={`para-${blockIndex}`} style={[styles.paragraph, { color: colors.text }]}>
+    <Text key={`para-${blockIndex}`} selectable style={[styles.paragraph, { color: colors.text }]}>
       {renderInline(text)}
     </Text>
   );
 
   const renderCodeBlock = (code: { language?: string; content: string }, blockIndex: number) => (
-    <View key={`code-${blockIndex}`} style={[styles.codeBlock, { backgroundColor: colors.surfaceSecondary }]}>
-      {code.language && (
-        <Text style={[styles.codeLanguage, { color: colors.textSecondary }]}>{code.language}</Text>
-      )}
-      <Text style={[styles.codeContent, { color: colors.text }]}>{code.content}</Text>
-    </View>
-  );
+      <View key={`code-${blockIndex}`} style={[styles.codeBlock, { backgroundColor: colors.surfaceSecondary }]}>
+        {code.language && (
+          <Text selectable style={[styles.codeLanguage, { color: colors.textSecondary }]}>{code.language}</Text>
+        )}
+        <Text selectable style={[styles.codeContent, { color: colors.text }]}>{code.content}</Text>
+      </View>
+    );
 
   const renderTable = (block: NeorgContentBlock, blockIndex: number) => {
     if (!block.tableRows || block.tableRows.length === 0) return null;
@@ -266,6 +267,7 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
               {row.cells.map((cell, cellIdx) => (
                 <Text
                   key={`tc-${blockIndex}-${rowIdx}-${cellIdx}`}
+                  selectable
                   style={[
                     styles.tableCell,
                     { color: colors.text },
@@ -287,7 +289,7 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
       key={`quote-${blockIndex}`}
       style={[styles.quoteBlock, { backgroundColor: colors.primary + '15', borderLeftColor: colors.primary }]}
     >
-      <Text style={[styles.quoteText, { color: colors.text }]}>{renderInline(text)}</Text>
+      <Text selectable style={[styles.quoteText, { color: colors.text }]}>{renderInline(text)}</Text>
     </View>
   );
 

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -136,17 +136,24 @@ function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted
       </View>
 
       {!showCompact && (note.folderPath || note.repo) && (
-        <View style={[styles.repoContainer, { borderTopColor: colors.border }]}>
+        <View style={[styles.repoContainer, { borderTopColor: colors.border }]}> 
           {note.folderPath && note.folderPath !== '/' && (
-            <Text style={[styles.repoText, { color: colors.textSecondary }]}>
-              📂 {note.folderPath.split('/').pop()}
-            </Text>
+            <View style={styles.repoItem}>
+              <Ionicons name="folder" size={14} color={colors.textSecondary} />
+              <Text style={[styles.repoText, { color: colors.textSecondary }]}>{note.folderPath.split('/').pop()}</Text>
+            </View>
           )}
           {note.repo && (
-            <Text style={[styles.repoText, { color: colors.textSecondary }]}>📁 {note.repo}</Text>
+            <View style={styles.repoItem}>
+              <Ionicons name="cube-outline" size={14} color={colors.textSecondary} />
+              <Text style={[styles.repoText, { color: colors.textSecondary }]}>{note.repo}</Text>
+            </View>
           )}
           {note.branch && (
-            <Text style={[styles.branchText, { color: colors.primary }]}>🌿 {note.branch}</Text>
+            <View style={styles.repoItem}>
+              <Ionicons name="git-branch-outline" size={14} color={colors.primary} />
+              <Text style={[styles.branchText, { color: colors.primary }]}>{note.branch}</Text>
+            </View>
           )}
         </View>
       )}
@@ -269,10 +276,17 @@ const styles = StyleSheet.create({
     marginTop: 12,
     paddingTop: 12,
     borderTopWidth: StyleSheet.hairlineWidth,
+    flexWrap: 'wrap',
+  },
+  repoItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: 12,
+    marginBottom: 4,
+    gap: 4,
   },
   repoText: {
     fontSize: 12,
-    marginRight: 12,
   },
   branchText: {
     fontSize: 12,

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -47,13 +47,26 @@ interface NoteCardProps {
   compact?: boolean;
   highlighted?: boolean;
   variant?: 'default' | 'card';
+  isOffline?: boolean;
+  isCached?: boolean;
 }
 
-function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted = false, variant = 'default' }: NoteCardProps) {
+function NoteCardImpl({
+  note,
+  onPress,
+  onLongPress,
+  compact = false,
+  highlighted = false,
+  variant = 'default',
+  isOffline = false,
+  isCached = true,
+}: NoteCardProps) {
   const { colors, isDark } = useTheme();
   const { isTablet } = useResponsive();
   const isCard = variant === 'card';
   const showCompact = isCard ? false : compact;
+  const isOfflineUncached = isOffline && !isCached;
+  const titleColor = isOfflineUncached ? colors.textSecondary : colors.text;
   
   const checklistProgress = useMemo(() => {
     if (!hasChecklists(note.content)) return null;
@@ -68,12 +81,14 @@ function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted
           backgroundColor: colors.card,
           shadowColor: colors.shadow,
           shadowOpacity: isDark ? 0 : 0.1,
+          opacity: isOfflineUncached ? 0.5 : 1,
         },
         showCompact && styles.cardCompact,
         isCard && styles.cardVariant,
         isTablet && styles.cardTablet,
         highlighted && { borderWidth: 2, borderColor: colors.primary },
       ]}
+      testID={`note-card-${note.id}`}
       onPress={() => onPress(note)}
       onLongPress={() => onLongPress?.(note)}
       activeOpacity={0.7}
@@ -84,11 +99,19 @@ function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted
         </View>
       )}
       <View style={styles.header}>
-        <Text style={[styles.title, { color: colors.text }, showCompact && styles.titleCompact]} numberOfLines={showCompact ? 1 : 2}>
+        <Text
+          testID={`note-card-title-${note.id}`}
+          style={[styles.title, { color: titleColor }, showCompact && styles.titleCompact]}
+          numberOfLines={showCompact ? 1 : 2}
+        >
           {note.title || 'Untitled Note'}
         </Text>
         {!showCompact && (
-          <Text style={[styles.content, { color: colors.textSecondary }]} numberOfLines={isCard ? 3 : 2}>
+          <Text
+            testID={`note-card-content-${note.id}`}
+            style={[styles.content, { color: colors.textSecondary }]}
+            numberOfLines={isCard ? 3 : 2}
+          >
             {stripPreview(note.content, note.format) || 'No content'}
           </Text>
         )}

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -5,6 +5,12 @@ import { format } from 'date-fns';
 import { Note, NoteFormat } from '../models/Note';
 import { useResponsive } from '../hooks/useResponsive';
 
+const NOTE_COLORS: Record<string, string> = {
+  red: '#ef4444', orange: '#f97316', yellow: '#eab308',
+  green: '#22c55e', blue: '#3b82f6', purple: '#8b5cf6',
+  pink: '#ec4899', gray: '#6b7280',
+};
+
 function stripPreview(content: string, noteFormat?: NoteFormat): string {
   let text = content;
   const trimmed = text.trimStart();
@@ -67,6 +73,9 @@ function NoteCardImpl({
   const showCompact = isCard ? false : compact;
   const isOfflineUncached = isOffline && !isCached;
   const titleColor = isOfflineUncached ? colors.textSecondary : colors.text;
+  const noteColorStyle = note.color && NOTE_COLORS[note.color]
+    ? { borderColor: NOTE_COLORS[note.color], borderWidth: 2 }
+    : undefined;
   
   const checklistProgress = useMemo(() => {
     if (!hasChecklists(note.content)) return null;
@@ -86,6 +95,7 @@ function NoteCardImpl({
         showCompact && styles.cardCompact,
         isCard && styles.cardVariant,
         isTablet && styles.cardTablet,
+        noteColorStyle,
         highlighted && { borderWidth: 2, borderColor: colors.primary },
       ]}
       testID={`note-card-${note.id}`}

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -61,7 +61,7 @@ function NoteCardImpl({
   isOffline = false,
   isCached = true,
 }: NoteCardProps) {
-  const { colors, isDark } = useTheme();
+  const { colors, isDark, glossy } = useTheme();
   const { isTablet } = useResponsive();
   const isCard = variant === 'card';
   const showCompact = isCard ? false : compact;
@@ -78,7 +78,7 @@ function NoteCardImpl({
       style={[
         styles.card,
         {
-          backgroundColor: colors.card,
+          backgroundColor: glossy ? colors.glassCard : colors.card,
           shadowColor: colors.shadow,
           shadowOpacity: isDark ? 0 : 0.1,
           opacity: isOfflineUncached ? 0.5 : 1,

--- a/src/components/RepoFileTree.tsx
+++ b/src/components/RepoFileTree.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -687,7 +687,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (loading) {
     return (
-      <View style={treeStyles.center}>
+      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
         <ActivityIndicator size="large" color={colors.primary} />
         <Text style={[treeStyles.loadingText, { color: colors.textSecondary }]}>
           Loading file tree…
@@ -698,7 +698,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (error) {
     return (
-      <View style={treeStyles.center}>
+      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
         <Ionicons name="alert-circle-outline" size={40} color={colors.textSecondary} />
         <Text style={[treeStyles.emptyText, { color: colors.text }]}>Failed to load</Text>
         <Button variant="secondary" label="Retry" onPress={loadRoot} style={{ marginTop: 8 }} />
@@ -708,7 +708,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (rootItems.length === 0) {
     return (
-      <View style={treeStyles.center}>
+      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
         <Ionicons name="folder-open-outline" size={40} color={colors.textSecondary} />
         <Text style={[treeStyles.emptyText, { color: colors.text }]}>Empty Repository</Text>
         <Text style={[treeStyles.emptySub, { color: colors.textSecondary }]}>
@@ -719,7 +719,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
   }
 
   return (
-    <Group style={{ flex: 1 }}>
+    <Group style={{ flex: 1, backgroundColor: colors.surface }}>
       {rootItems.map((item) => (
         <TreeItem
           key={item.path}
@@ -826,4 +826,3 @@ const dialogStyles = StyleSheet.create({
     fontSize: 14,
   },
 });
-

--- a/src/components/ai/FloatingAIButton.tsx
+++ b/src/components/ai/FloatingAIButton.tsx
@@ -26,7 +26,7 @@ interface FloatingAIButtonProps {
 
 export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
   const { isEnabled } = useAIStore();
-  const { colors } = useTheme();
+  const { colors, glossy } = useTheme();
   const navigation = useNavigation();
 
   const initialX = SCREEN_WIDTH - BUTTON_SIZE - 24;
@@ -117,10 +117,10 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
             radius="pill"
             style={[
               styles.button,
-              { backgroundColor: colors.primary }
+              { backgroundColor: glossy ? colors.glassElevated : colors.primary }
             ]}
           >
-            <Ionicons name="sparkles" size={24} color="#FFFFFF" />
+            <Ionicons name="sparkles" size={24} color={glossy ? colors.primary : "#FFFFFF"} />
           </Surface>
         </Animated.View>
       </GestureDetector>

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,77 @@
+import React, { Component, ReactNode } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+
+interface ErrorBoundaryProps {
+  children?: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundaryBase extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return <DefaultFallback onRetry={this.handleRetry} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+function DefaultFallback({ onRetry }: { onRetry: () => void }) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.title, { color: colors.text }]}>Something went wrong</Text>
+      <Pressable onPress={onRetry} style={[styles.button, { backgroundColor: colors.primary }]}>
+        <Text style={[styles.buttonText, { color: '#fff' }]}>Retry</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export function ErrorBoundary(props: ErrorBoundaryProps) {
+  return <ErrorBoundaryBase {...props} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 12,
+    minHeight: 120,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  button: {
+    borderRadius: 999,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  buttonText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -24,7 +24,7 @@ export function Modal(props: ModalProps) {
     fullWidth = false,
     bottomSheet = false,
   } = props;
-  const { isDark } = useTheme();
+  const { isDark, glossy } = useTheme();
   const { spacing, colors } = useTokens();
   const { height: viewportHeight, width: viewportWidth } = useWindowDimensions();
 
@@ -32,9 +32,11 @@ export function Modal(props: ModalProps) {
   const slotHeight = Math.max(0, viewportHeight - pad * 2);
   const slotWidth = Math.max(0, viewportWidth - pad * 2);
 
+  const bgColor = glossy ? colors.glassElevated : colors.elevated;
+
   const surfaceStyle: ViewStyle = bottomSheet
     ? {
-        backgroundColor: colors.elevated,
+        backgroundColor: bgColor,
         maxHeight: slotHeight,
         overflow: 'hidden',
         borderBottomLeftRadius: 0,
@@ -44,13 +46,13 @@ export function Modal(props: ModalProps) {
     ? {
         padding: pad,
         maxHeight: slotHeight,
-        backgroundColor: colors.elevated,
+        backgroundColor: bgColor,
         overflow: 'hidden',
       }
     : {
         padding: pad,
         maxHeight: slotHeight,
-        backgroundColor: colors.elevated,
+        backgroundColor: bgColor,
       };
 
   return (

--- a/src/components/ui/OfflineBanner.tsx
+++ b/src/components/ui/OfflineBanner.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+import { useNetworkStatus } from '../../hooks/useNetworkStatus';
+import { useTheme } from '../../contexts/ThemeContext';
+
+export function OfflineBanner() {
+  const { isConnected } = useNetworkStatus();
+  const { colors } = useTheme();
+
+  if (isConnected) return null;
+
+  return (
+    <View
+      style={[
+        styles.banner,
+        { backgroundColor: `${colors.error}20`, borderColor: `${colors.error}33` },
+      ]}
+    >
+      <Text style={[styles.text, { color: colors.error }]}>You're offline — changes won't sync</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 14,
+    borderWidth: 1,
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/src/components/ui/ScreenHeader.tsx
+++ b/src/components/ui/ScreenHeader.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode } from 'react';
 import { Text, View, StyleProp, ViewStyle } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { useTokens } from '../../contexts/ThemeContext';
+import { useTheme, useTokens } from '../../contexts/ThemeContext';
 import { IconButton } from './IconButton';
+import { Surface } from './Surface';
 
 export interface ScreenHeaderProps {
   title: string;
@@ -16,9 +17,14 @@ export interface ScreenHeaderProps {
 export function ScreenHeader(props: ScreenHeaderProps) {
   const { title, subtitle, badge, onBack, actions, style } = props;
   const { colors, spacing, type } = useTokens();
+  const { glossy } = useTheme();
+
+  const HeaderComponent = glossy ? Surface : View;
+  const headerProps = glossy ? { elevation: 'flat' as const, radius: 'sm' as const, glassLayer: 'glassNav' as const } : {};
 
   return (
-    <View
+    <HeaderComponent
+      {...headerProps}
       style={[
         {
           flexDirection: 'row',
@@ -89,6 +95,6 @@ export function ScreenHeader(props: ScreenHeaderProps) {
           {actions}
         </View>
       )}
-    </View>
+    </HeaderComponent>
   );
 }

--- a/src/components/ui/Surface.tsx
+++ b/src/components/ui/Surface.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useMemo } from 'react';
 import { Platform, StyleSheet, View, ViewProps, ViewStyle, StyleProp } from 'react-native';
+import { BlurView } from 'expo-blur';
 import { useTheme, useTokens } from '../../contexts/ThemeContext';
 import {
   buildElevation,
@@ -15,6 +16,7 @@ export interface SurfaceProps extends Omit<ViewProps, 'style'> {
   style?: StyleProp<ViewStyle>;
   children?: ReactNode;
   testID?: string;
+  glassLayer?: 'glassSurface' | 'glassCard' | 'glassElevated' | 'glassNav' | 'glassBorder';
 }
 
 function detectPlatform(): TokenPlatform {
@@ -24,8 +26,8 @@ function detectPlatform(): TokenPlatform {
 }
 
 export function Surface(props: SurfaceProps) {
-  const { elevation = 'raised', inset = false, radius = 'md', style, children, testID, ...rest } = props;
-  const { style: themeStyle } = useTheme();
+  const { elevation = 'raised', inset = false, radius = 'md', style, children, testID, glassLayer = 'glassSurface', ...rest } = props;
+  const { style: themeStyle, glossy, isDark } = useTheme();
   const { colors, radii } = useTokens();
   const platform = detectPlatform();
 
@@ -44,24 +46,41 @@ export function Surface(props: SurfaceProps) {
 
   const borderRadius = radii[radius];
   const baseStyle: ViewStyle = {
-    backgroundColor: colors.surface,
+    backgroundColor: glossy ? colors[glassLayer] : colors.surface,
     borderRadius,
   };
+
+  const webGlassStyle = glossy && platform === 'web' ? {
+    backdropFilter: 'blur(20px)',
+    WebkitBackdropFilter: 'blur(20px)',
+  } : {};
 
   const androidOverlays = elevationStyles.androidOverlays;
   const showOverlays = platform === 'android' && androidOverlays !== undefined;
 
+  const Wrapper = glossy && platform !== 'web' ? BlurView : View;
+  const blurProps = glossy && platform !== 'web' ? {
+    intensity: platform === 'ios' ? 60 : 30,
+    tint: isDark ? 'dark' : 'light' as any,
+  } : {};
+
   return (
-    <View
+    <Wrapper
       {...rest}
       testID={testID}
-      style={[baseStyle, elevationStyles.outer as ViewStyle, style]}
+      {...blurProps}
+      style={[
+        baseStyle,
+        elevationStyles.outer as ViewStyle,
+        (glossy && platform === 'web') ? (webGlassStyle as ViewStyle) : undefined,
+        style
+      ]}
     >
       <View
         pointerEvents="none"
         style={[StyleSheet.absoluteFill, { borderRadius }, elevationStyles.inner as ViewStyle]}
       />
-      {showOverlays && androidOverlays && (
+      {showOverlays && androidOverlays && !glossy && (
         <AndroidShadowOverlays
           offset={androidOverlays.offset}
           blur={androidOverlays.blur}
@@ -72,7 +91,7 @@ export function Surface(props: SurfaceProps) {
         />
       )}
       {children}
-    </View>
+    </Wrapper>
   );
 }
 

--- a/src/components/ui/TabBar.tsx
+++ b/src/components/ui/TabBar.tsx
@@ -4,7 +4,7 @@ import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { Surface } from './Surface';
-import { useTokens } from '../../contexts/ThemeContext';
+import { useTheme, useTokens } from '../../contexts/ThemeContext';
 
 type IoniconName = keyof typeof Ionicons.glyphMap;
 
@@ -19,19 +19,25 @@ const TAB_ICONS: Record<string, { focused: IoniconName; outline: IoniconName; la
 export function TabBar({ state, navigation }: BottomTabBarProps) {
   const insets = useSafeAreaInsets();
   const { colors, spacing } = useTokens();
+  const { glossy } = useTheme();
 
   return (
     <View
       style={{
-        backgroundColor: colors.bg,
+        backgroundColor: glossy ? 'transparent' : colors.bg,
         paddingHorizontal: spacing[6],
         paddingBottom: insets.bottom + spacing[3],
         paddingTop: spacing[4],
+        position: glossy ? 'absolute' : 'relative',
+        bottom: 0,
+        left: 0,
+        right: 0,
       }}
     >
       <Surface
         elevation="floating"
         radius="pill"
+        glassLayer="glassNav"
         style={{
           flexDirection: 'row',
           alignItems: 'center',

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -24,8 +24,10 @@ interface ThemeContextType {
   theme: ThemeMode;
   isDark: boolean;
   style: ThemeStyle;
+  glossy: boolean;
   setTheme: (theme: ThemeMode) => void;
   setStyle: (style: ThemeStyle) => void;
+  setGlossy: (glossy: boolean) => void;
   colors: Palette;
   tokens: Tokens;
 }
@@ -34,6 +36,7 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 const THEME_STORAGE_KEY = '@gitnotes:theme';
 const STYLE_STORAGE_KEY = '@gitnotes:style';
+const GLOSSY_STORAGE_KEY = '@gitnotes:glossy';
 
 interface ThemeProviderProps {
   children: ReactNode;
@@ -42,17 +45,23 @@ interface ThemeProviderProps {
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<ThemeMode>('system');
   const [style, setStyleState] = useState<ThemeStyle>('neumorphic');
+  const [glossy, setGlossyState] = useState<boolean>(false);
   const systemColorScheme = useColorScheme();
 
   const loadPersisted = useCallback(async () => {
     try {
       const savedTheme = getBootValue('@gitnotes:theme') ?? await AsyncStorage.getItem(THEME_STORAGE_KEY);
       const savedStyle = getBootValue('@gitnotes:style') ?? await AsyncStorage.getItem(STYLE_STORAGE_KEY);
+      const savedGlossy = getBootValue('@gitnotes:glossy') ?? await AsyncStorage.getItem(GLOSSY_STORAGE_KEY);
+      
       if (savedTheme && ['light', 'dark', 'system'].includes(savedTheme)) {
         setThemeState(savedTheme as ThemeMode);
       }
       if (savedStyle === 'neumorphic' || savedStyle === 'flat') {
         setStyleState(savedStyle);
+      }
+      if (savedGlossy !== null) {
+        setGlossyState(savedGlossy === 'true');
       }
     } catch (error) {
       console.error('Error loading theme preferences:', error);
@@ -83,8 +92,25 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     try {
       setStyleState(newStyle);
       await AsyncStorage.setItem(STYLE_STORAGE_KEY, newStyle);
+      if (newStyle === 'neumorphic') {
+        setGlossyState(false);
+        await AsyncStorage.setItem(GLOSSY_STORAGE_KEY, 'false');
+      }
     } catch (error) {
       console.error('Error saving style:', error);
+    }
+  }, []);
+
+  const setGlossy = useCallback(async (newGlossy: boolean) => {
+    try {
+      setGlossyState(newGlossy);
+      await AsyncStorage.setItem(GLOSSY_STORAGE_KEY, newGlossy ? 'true' : 'false');
+      if (newGlossy) {
+        setStyleState('flat');
+        await AsyncStorage.setItem(STYLE_STORAGE_KEY, 'flat');
+      }
+    } catch (error) {
+      console.error('Error saving glossy:', error);
     }
   }, []);
 
@@ -96,8 +122,8 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   );
 
   const value: ThemeContextType = useMemo(
-    () => ({ theme, isDark, style, setTheme, setStyle, colors, tokens }),
-    [theme, isDark, style, setTheme, setStyle, colors, tokens],
+    () => ({ theme, isDark, style, glossy, setTheme, setStyle, setGlossy, colors, tokens }),
+    [theme, isDark, style, glossy, setTheme, setStyle, setGlossy, colors, tokens],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo } from 'react';
-import { Todo, TodoCreateInput, TodoUpdateInput } from '../models/Todo';
+import { Todo, TodoCreateInput, TodoUpdateInput, reorderTodos } from '../models/Todo';
 import { StorageService } from '../services/StorageService';
 import { NotificationService } from '../services/NotificationService';
 import { useTodoStore } from '../stores/todoStore';
+import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
 
 interface TodoContextValue {
   todos: Todo[];
@@ -110,7 +111,24 @@ export function useTodos(): TodoContextValue {
       console.warn('[TodoContext] Notification toggle handling failed:', err);
     }
 
-    useTodoStore.setState((s) => ({ todos: s.todos.map((t) => (t.id === id ? finalTodo : t)) }));
+    if (todo.repo) {
+      const syncResult = await syncTodoToGitHub({
+        repo: todo.repo,
+        branch: todo.branch,
+        filePath: todo.filePath,
+        text: finalTodo.text,
+        todo: finalTodo,
+      });
+      if (!syncResult.success) {
+        console.warn('[TodoContext] GitHub sync failed:', syncResult.error);
+      }
+    }
+
+    const nextTodos = reorderTodos(
+      useTodoStore.getState().todos.map((t) => (t.id === id ? finalTodo : t)),
+    );
+    await StorageService.saveAllTodos(nextTodos);
+    useTodoStore.setState({ todos: nextTodos });
     return true;
   }, []);
 

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import NetInfo, { type NetInfoState } from '@react-native-community/netinfo';
+
+export interface NetworkStatus {
+  isConnected: boolean;
+  isInternetReachable: boolean;
+}
+
+function toNetworkStatus(state: NetInfoState): NetworkStatus {
+  const isConnected = state.isConnected ?? false;
+  return {
+    isConnected,
+    isInternetReachable: state.isInternetReachable ?? isConnected,
+  };
+}
+
+export function useNetworkStatus(): NetworkStatus {
+  const [status, setStatus] = useState<NetworkStatus>({
+    isConnected: true,
+    isInternetReachable: true,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      if (active) {
+        setStatus(toNetworkStatus(state));
+      }
+    });
+
+    NetInfo.fetch().then((state) => {
+      if (active) {
+        setStatus(toNetworkStatus(state));
+      }
+    });
+
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, []);
+
+  return status;
+}

--- a/src/models/Note.ts
+++ b/src/models/Note.ts
@@ -1,6 +1,6 @@
 import { Attachment } from './Attachment';
 
-export type NoteFormat = 'markdown' | 'neorg' | 'org' | 'pdf';
+export type NoteFormat = 'markdown' | 'neorg' | 'org' | 'pdf' | 'json';
 
 export interface NoteGitHubLink {
   owner: string;
@@ -163,6 +163,7 @@ export function getNoteFileExtension(format?: NoteFormat): string {
     case 'neorg': return '.norg';
     case 'org': return '.org';
     case 'pdf': return '.pdf';
+    case 'json': return '.json';
     default: return '.md';
   }
 }
@@ -172,7 +173,7 @@ export function isNeorgNote(note: Note): boolean {
 }
 
 export function getSupportedFileExtensions(): string[] {
-  return ['.md', '.norg', '.org', '.pdf'];
+  return ['.md', '.norg', '.org', '.pdf', '.json'];
 }
 
 export function isSupportedFileExtension(filename: string): boolean {

--- a/src/models/Note.ts
+++ b/src/models/Note.ts
@@ -19,6 +19,7 @@ export interface Note {
   createdAt: number;
   updatedAt: number;
   tags: string[];
+  color?: string;
   repo?: string;
   branch?: string;
   commit?: string;

--- a/src/models/Todo.ts
+++ b/src/models/Todo.ts
@@ -106,6 +106,23 @@ export function applyTodoUpdate(existing: Todo, input: Partial<TodoUpdateInput>)
   };
 }
 
+const TODO_PRIORITY_ORDER: Record<TodoPriority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+export function compareTodos(a: Todo, b: Todo): number {
+  if (a.completed !== b.completed) return a.completed ? 1 : -1;
+  const priorityDiff = TODO_PRIORITY_ORDER[a.priority || 'medium'] - TODO_PRIORITY_ORDER[b.priority || 'medium'];
+  if (priorityDiff !== 0) return priorityDiff;
+  return b.createdAt - a.createdAt;
+}
+
+export function reorderTodos(todos: Todo[]): Todo[] {
+  return [...todos].sort(compareTodos);
+}
+
 export function slugifyTodoText(text: string): string {
   return text
     .toLowerCase()

--- a/src/screens/CanvasEditorScreen.tsx
+++ b/src/screens/CanvasEditorScreen.tsx
@@ -547,7 +547,7 @@ export default function CanvasEditorScreen() {
       });
 
       if (!syncResult.success) {
-        console.warn('[CanvasEditor] GitHub sync failed:', syncResult.error);
+        Alert.alert('Sync Failed', syncResult.error || 'Canvas changes were saved locally but could not sync to GitHub.');
       }
     }
 

--- a/src/screens/CanvasEditorScreen.tsx
+++ b/src/screens/CanvasEditorScreen.tsx
@@ -119,6 +119,110 @@ function buildLinePath(x1: number, y1: number, x2: number, y2: number): SkPath {
   return p;
 }
 
+const PAN_MARGIN = 80;
+
+export interface CanvasBounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+function expandBounds(bounds: CanvasBounds | null, x: number, y: number): CanvasBounds {
+  if (!bounds) {
+    return { minX: x, minY: y, maxX: x, maxY: y };
+  }
+
+  return {
+    minX: Math.min(bounds.minX, x),
+    minY: Math.min(bounds.minY, y),
+    maxX: Math.max(bounds.maxX, x),
+    maxY: Math.max(bounds.maxY, y),
+  };
+}
+
+export function getCanvasContentBounds(elements: CanvasElement[]): CanvasBounds | null {
+  'worklet';
+
+  let bounds: CanvasBounds | null = null;
+
+  for (const el of elements) {
+    if (el.type === 'stroke') {
+      for (const point of el.points) {
+        bounds = expandBounds(bounds, point.x - el.width / 2, point.y - el.width / 2);
+        bounds = expandBounds(bounds, point.x + el.width / 2, point.y + el.width / 2);
+      }
+      continue;
+    }
+
+    if (el.type === 'shape') {
+      const pad = el.width / 2;
+      bounds = expandBounds(bounds, Math.min(el.x1, el.x2) - pad, Math.min(el.y1, el.y2) - pad);
+      bounds = expandBounds(bounds, Math.max(el.x1, el.x2) + pad, Math.max(el.y1, el.y2) + pad);
+      continue;
+    }
+
+    if (el.type === 'text') {
+      const textWidth = Math.max(1, el.text.length * el.fontSize * 0.6);
+      bounds = expandBounds(bounds, el.x, el.y - el.fontSize);
+      bounds = expandBounds(bounds, el.x + textWidth, el.y);
+      continue;
+    }
+
+    if (el.type === 'chart') {
+      bounds = expandBounds(bounds, el.x, el.y);
+      bounds = expandBounds(bounds, el.x + el.width, el.y + el.height);
+    }
+  }
+
+  return bounds;
+}
+
+export function getCanvasFitTranslation(
+  bounds: CanvasBounds | null,
+  viewportWidth: number,
+  viewportHeight: number,
+  scaleValue: number,
+) {
+  'worklet';
+
+  if (!bounds) {
+    return { translateX: 0, translateY: 0 };
+  }
+
+  return {
+    translateX: viewportWidth / 2 - scaleValue * (bounds.minX + bounds.maxX) / 2,
+    translateY: viewportHeight / 2 - scaleValue * (bounds.minY + bounds.maxY) / 2,
+  };
+}
+
+export function clampCanvasTranslation(
+  translateX: number,
+  translateY: number,
+  scaleValue: number,
+  bounds: CanvasBounds | null,
+  viewportWidth: number,
+  viewportHeight: number,
+  margin = PAN_MARGIN,
+) {
+  'worklet';
+
+  if (!bounds) {
+    return { translateX, translateY };
+  }
+
+  const minTx = margin - scaleValue * bounds.maxX;
+  const maxTx = viewportWidth - margin - scaleValue * bounds.minX;
+  const minTy = margin - scaleValue * bounds.maxY;
+  const maxTy = viewportHeight - margin - scaleValue * bounds.minY;
+  const fit = getCanvasFitTranslation(bounds, viewportWidth, viewportHeight, scaleValue);
+
+  return {
+    translateX: minTx <= maxTx ? Math.min(maxTx, Math.max(minTx, translateX)) : fit.translateX,
+    translateY: minTy <= maxTy ? Math.min(maxTy, Math.max(minTy, translateY)) : fit.translateY,
+  };
+}
+
 export default function CanvasEditorScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<RouteType>();
@@ -163,6 +267,9 @@ export default function CanvasEditorScreen() {
   const savedTy = useSharedValue(0);
   const activeDrawingElement = useSharedValue<CanvasStroke | CanvasShape | null>(null);
   const activeStrokePath = useSharedValue(Skia.Path.Make().setIsVolatile(true));
+  const contentBounds = useMemo(() => getCanvasContentBounds(elements), [elements]);
+  const shouldAutoFitRef = useRef((existingCanvas?.scene?.elements?.length ?? 0) > 0);
+  const didAutoFitRef = useRef(false);
 
   const setZoom = useCallback(
     (next: number) => {
@@ -173,10 +280,14 @@ export default function CanvasEditorScreen() {
   );
 
   const resetView = useCallback(() => {
+    const next = canvasSize && contentBounds
+      ? getCanvasFitTranslation(contentBounds, canvasSize.width, canvasSize.height, 1)
+      : { translateX: 0, translateY: 0 };
+
     scale.value = withSpring(1, { mass: 0.5, damping: 14, stiffness: 200 });
-    translateX.value = withSpring(0, { mass: 0.5, damping: 14, stiffness: 200 });
-    translateY.value = withSpring(0, { mass: 0.5, damping: 14, stiffness: 200 });
-  }, [scale, translateX, translateY]);
+    translateX.value = withSpring(next.translateX, { mass: 0.5, damping: 14, stiffness: 200 });
+    translateY.value = withSpring(next.translateY, { mass: 0.5, damping: 14, stiffness: 200 });
+  }, [canvasSize, contentBounds, scale, translateX, translateY]);
 
   const canvasAnimStyle = useAnimatedStyle(() => ({
     transform: [
@@ -199,6 +310,16 @@ export default function CanvasEditorScreen() {
       }),
     [],
   );
+
+  useEffect(() => {
+    if (!canvasSize || !shouldAutoFitRef.current || didAutoFitRef.current || !contentBounds) return;
+
+    const next = getCanvasFitTranslation(contentBounds, canvasSize.width, canvasSize.height, 1);
+    scale.value = withSpring(1, { mass: 0.5, damping: 14, stiffness: 200 });
+    translateX.value = withSpring(next.translateX, { mass: 0.5, damping: 14, stiffness: 200 });
+    translateY.value = withSpring(next.translateY, { mass: 0.5, damping: 14, stiffness: 200 });
+    didAutoFitRef.current = true;
+  }, [canvasSize, contentBounds, scale, translateX, translateY]);
 
   const saveHistory = useCallback(() => {
     setHistory((prev) => {
@@ -486,9 +607,20 @@ export default function CanvasEditorScreen() {
         .onUpdate((e) => {
           'worklet';
           const next = savedScale.value * e.scale;
-          scale.value = Math.max(0.5, Math.min(4, next));
+          const nextScale = Math.max(0.5, Math.min(4, next));
+          scale.value = nextScale;
+          const clamped = clampCanvasTranslation(
+            translateX.value,
+            translateY.value,
+            nextScale,
+            contentBounds,
+            canvasSize?.width ?? 0,
+            canvasSize?.height ?? 0,
+          );
+          translateX.value = clamped.translateX;
+          translateY.value = clamped.translateY;
         }),
-    [scale, savedScale],
+    [scale, savedScale, contentBounds, canvasSize?.width, canvasSize?.height, translateX, translateY],
   );
 
   const twoFingerPan = useMemo(
@@ -503,10 +635,18 @@ export default function CanvasEditorScreen() {
         })
         .onUpdate((e) => {
           'worklet';
-          translateX.value = savedTx.value + e.translationX;
-          translateY.value = savedTy.value + e.translationY;
+          const clamped = clampCanvasTranslation(
+            savedTx.value + e.translationX,
+            savedTy.value + e.translationY,
+            scale.value,
+            contentBounds,
+            canvasSize?.width ?? 0,
+            canvasSize?.height ?? 0,
+          );
+          translateX.value = clamped.translateX;
+          translateY.value = clamped.translateY;
         }),
-    [translateX, translateY, savedTx, savedTy],
+    [translateX, translateY, savedTx, savedTy, scale, contentBounds, canvasSize?.width, canvasSize?.height],
   );
 
   const composedGesture = useMemo(

--- a/src/screens/CanvasEditorScreen.tsx
+++ b/src/screens/CanvasEditorScreen.tsx
@@ -49,12 +49,13 @@ import type { RootStackParamList } from '../navigation/types';
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'CanvasEditor'>;
 type RouteType = RouteProp<RootStackParamList, 'CanvasEditor'>;
 type Point = { x: number; y: number };
+type ToolIconName = React.ComponentProps<typeof Ionicons>['name'];
 
 const COLORS = ['#000000', '#FFFFFF', '#FF3B30', '#FF9500', '#FFCC00', '#34C759', '#007AFF', '#5856D6', '#AF52DE', '#FF2D55'];
 const TOOLS = [
-  { key: 'pen', label: '✏️' },
-  { key: 'highlighter', label: '🖊' },
-  { key: 'eraser', label: '🧹' },
+  { key: 'pen', icon: 'pencil' as ToolIconName },
+  { key: 'highlighter', icon: 'brush' as ToolIconName },
+  { key: 'eraser', icon: 'backspace-outline' as ToolIconName },
   { key: 'line', label: '╱' },
   { key: 'arrow', label: '→' },
   { key: 'rect', label: '□' },
@@ -62,7 +63,7 @@ const TOOLS = [
   { key: 'ellipse', label: '○' },
   { key: 'diamond', label: '◇' },
   { key: 'text', label: 'T' },
-  { key: 'select', label: '☝️' },
+  { key: 'select', icon: 'hand-left-outline' as ToolIconName },
 ];
 
 function uid(): string {
@@ -728,13 +729,13 @@ export default function CanvasEditorScreen() {
 
       <View style={styles.toolbar}>
         <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          {TOOLS.map(({ key, label }) => (
+          {TOOLS.map(({ key, label, icon }) => (
             <TouchableOpacity
               key={key}
               style={[styles.toolBtn, tool === key && styles.toolBtnActive]}
               onPress={() => { setTool(key); setSelectedId(null); }}
             >
-              <Text style={styles.toolBtnLabel}>{label}</Text>
+              {icon ? <Ionicons name={icon} size={20} color={color} /> : <Text style={styles.toolBtnLabel}>{label}</Text>}
             </TouchableOpacity>
           ))}
           <TouchableOpacity style={[styles.toolBtn, filled && styles.toolBtnActive]} onPress={() => setFilled(!filled)}>
@@ -745,7 +746,7 @@ export default function CanvasEditorScreen() {
             <Text style={styles.toolBtnLabel}>↩</Text>
           </TouchableOpacity>
           <TouchableOpacity style={styles.toolBtn} onPress={clearAll}>
-            <Text style={styles.toolBtnLabel}>🗑</Text>
+            <Ionicons name="trash-outline" size={20} color={color} />
           </TouchableOpacity>
           <View style={styles.separator} />
           <TouchableOpacity style={styles.toolBtn} onPress={() => setZoom(scale.value - 0.25)}>

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -7,7 +7,6 @@ import {
   FlatList,
   ActivityIndicator,
   ScrollView,
-  TextInput,
   RefreshControl,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -227,8 +226,8 @@ export default function ExploreScreen() {
         </View>
 
         <ScrollView
-          style={s.treeScroll}
-          contentContainerStyle={s.treeContent}
+          style={[s.treeScroll, { backgroundColor: colors.background }]}
+          contentContainerStyle={[s.treeContent, { backgroundColor: colors.background }]}
           refreshControl={
             <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.primary} />
           }

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -28,9 +28,10 @@ type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'heic', 'heif', 'svg']);
 const VIDEO_EXTS = new Set(['mp4', 'mov', 'm4v', 'webm']);
 
-function classifyFile(name: string): 'pdf' | 'image' | 'video' | 'text' {
+function classifyFile(name: string): 'pdf' | 'json' | 'image' | 'video' | 'text' {
   const ext = name.toLowerCase().split('.').pop() ?? '';
   if (ext === 'pdf') return 'pdf';
+  if (ext === 'json') return 'json';
   if (IMAGE_EXTS.has(ext)) return 'image';
   if (VIDEO_EXTS.has(ext)) return 'video';
   return 'text';
@@ -252,6 +253,8 @@ export default function ExploreScreen() {
                 navigation.navigate('ImageViewer', params);
               } else if (kind === 'video') {
                 navigation.navigate('VideoViewer', params);
+              } else if (kind === 'json') {
+                navigation.navigate('FileViewer', params);
               } else {
                 navigation.navigate('FileViewer', params);
               }

--- a/src/screens/FileViewerScreen.tsx
+++ b/src/screens/FileViewerScreen.tsx
@@ -17,10 +17,11 @@ import { useTheme } from '../contexts/ThemeContext';
 import { GitHubService } from '../services/GitHubService';
 import { NeorgContentParser } from '../services/NeorgContentParser';
 import NeorgRenderer from '../components/NeorgRenderer';
+import { JsonRenderer } from '../components/JsonRenderer';
 import { HapticService } from '../utils/haptics';
 import { getMarkdownStyles, stripTopMetadata } from '../utils/preview';
 
-type Mode = 'markdown' | 'neorg' | 'org' | 'code' | 'plain';
+type Mode = 'markdown' | 'neorg' | 'org' | 'json' | 'code' | 'plain';
 
 const MARKDOWN_EXTS = ['md', 'markdown'];
 const NEORG_EXTS = ['norg'];
@@ -41,6 +42,7 @@ function detectMode(filename: string): Mode {
   if (MARKDOWN_EXTS.includes(ext)) return 'markdown';
   if (NEORG_EXTS.includes(ext)) return 'neorg';
   if (ORG_EXTS.includes(ext)) return 'org';
+  if (ext === 'json') return 'json';
   if (CODE_EXTS.has(ext)) return 'code';
   return 'plain';
 }
@@ -146,6 +148,8 @@ export default function FileViewerScreen() {
         >
           {mode === 'markdown' ? (
             <MarkdownBody value={renderContent} styles={markdownStyles} />
+          ) : mode === 'json' ? (
+            <JsonRenderer content={renderContent} />
           ) : (mode === 'neorg' || mode === 'org') && parsedNeorg ? (
             <NeorgRenderer blocks={parsedNeorg} />
           ) : (

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -54,6 +54,7 @@ import { getMarkdownStyles } from '../utils/preview';
 import { Button, IconButton, Modal } from '../components/ui';
 import { GitHubActivityIndicator } from '../components/GitHubActivityIndicator';
 import { NotePreviewRenderer } from '../utils/markdownRenderer';
+import { canPersistNoteTags } from '../utils/noteTagSupport';
 import { githubActivity } from '../stores/githubActivityStore';
 
 interface TocEntry {
@@ -345,6 +346,7 @@ export default function NoteEditorScreen() {
           title: title.trim(),
           content: content.trim(),
           format: noteFormat,
+          tags,
         };
 
         const syncResult = await syncNoteToGitHub(syncParams);
@@ -965,7 +967,7 @@ export default function NoteEditorScreen() {
         </View>
       </View>
 
-      <TagInput tags={tags} onTagsChange={handleTagsChange} />
+      {canPersistNoteTags(noteFormat) ? <TagInput tags={tags} onTagsChange={handleTagsChange} /> : null}
 
       {canvasJsonRefs.length > 0 && (
         <View style={styles.canvasChipsRow}>

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -64,6 +64,10 @@ interface TocEntry {
 
 const APPROX_LINE_PX = 22;
 
+function normalizeNotePathForLookup(path: string): string {
+  return path.replace(/^\/+/, '').replace(/\/+/g, '/');
+}
+
 function extractTocFromMarkdown(content: string): TocEntry[] {
   const out: TocEntry[] = [];
   const lines = content.split('\n');
@@ -121,7 +125,7 @@ export default function NoteEditorScreen() {
   const { sideBySide } = useResponsive();
   const { noteId, format: initialFormat, initialTitle, initialContent, repo: initialRepo, branch: initialBranch, folderPath: initialFolderPath } = route.params || {};
 
-  const { getNoteById, createNote, updateNote } = useNotes();
+  const { notes, getNoteById, createNote, updateNote } = useNotes();
   const { canvases } = useCanvases();
 
   const [title, setTitle] = useState(initialTitle ?? '');
@@ -620,6 +624,23 @@ export default function NoteEditorScreen() {
 
   const previewScrollRef = useRef<ScrollView>(null);
 
+  const currentNotePath = useMemo(() => {
+    if (noteId) {
+      return notes.find((note) => note.id === noteId)?.filePath;
+    }
+    return folderPath && title.trim()
+      ? normalizeNotePathForLookup(`${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}`)
+      : undefined;
+  }, [folderPath, noteFormat, noteId, notes, title]);
+
+  const handleOpenLinkedNote = useCallback((targetPath: string) => {
+    const normalizedTargetPath = normalizeNotePathForLookup(targetPath);
+    const targetNote = notes.find((note) => note.filePath && normalizeNotePathForLookup(note.filePath) === normalizedTargetPath);
+    if (!targetNote?.id) return false;
+    navigation.navigate('NoteEditor', { noteId: targetNote.id });
+    return true;
+  }, [navigation, notes]);
+
   const notePreviewRenderer = useMemo(
     () =>
       new NotePreviewRenderer({
@@ -629,8 +650,10 @@ export default function NoteEditorScreen() {
         previewScrollRef,
         CanvasPreview,
         approxLinePx: APPROX_LINE_PX,
+        currentNotePath,
+        onOpenNote: handleOpenLinkedNote,
       }),
-    [colors, navigation, previewContent],
+    [colors, currentNotePath, handleOpenLinkedNote, navigation, previewContent],
   );
 
   const speakableContent = useMemo(() => {

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -11,10 +11,7 @@ import {
   ScrollView,
   NativeScrollEvent,
   NativeSyntheticEvent,
-  Linking,
 } from 'react-native';
-
-import { Image } from 'expo-image';
 
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -44,18 +41,20 @@ import { Folder } from '../models/Folder';
 import { GitService } from '../services/GitService';
 import { HapticService } from '../utils/haptics';
 import { useUndo } from '../utils/useUndo';
-import { NoteFormat, NoteGitHubLink } from '../models/Note';
+import { NoteFormat } from '../models/Note';
 import { Attachment, createAttachment } from '../models/Attachment';
 import { NeorgParser } from '../services/NeorgParser';
 import { NeorgContentParser } from '../services/NeorgContentParser';
-import { canvasIdFromLink, canvasToLink, isCanvasLink } from '../models/Canvas';
+import { canvasToLink } from '../models/Canvas';
 import { useResponsive } from '../hooks/useResponsive';
 import { syncNoteToGitHub } from '../services/NoteGitHubSyncService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
 import { PositionMemoryService } from '../services/PositionMemoryService';
 import { getMarkdownStyles } from '../utils/preview';
 import { Button, IconButton, Modal } from '../components/ui';
+import { GitHubActivityIndicator } from '../components/GitHubActivityIndicator';
 import { NotePreviewRenderer } from '../utils/markdownRenderer';
+import { githubActivity } from '../stores/githubActivityStore';
 
 interface TocEntry {
   level: number;
@@ -131,7 +130,6 @@ export default function NoteEditorScreen() {
   const [branch, setBranch] = useState<string | undefined>(initialBranch);
   const [commit, setCommit] = useState<string | undefined>();
   const [folderPath, setFolderPath] = useState<string | undefined>(initialFolderPath);
-  const [github, setGithub] = useState<NoteGitHubLink | undefined>();
   const [noteFormat, setNoteFormat] = useState<NoteFormat>(initialFormat ?? 'markdown');
   const [isSaving, setIsSaving] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
@@ -251,7 +249,6 @@ export default function NoteEditorScreen() {
         setBranch(existingNote.branch);
         setCommit(existingNote.commit);
         setFolderPath(existingNote.folderPath);
-        setGithub(existingNote.github);
         setNoteFormat(existingNote.format ?? 'markdown');
         setTags(existingNote.tags || []);
         setAttachments(existingNote.attachments || []);
@@ -298,6 +295,7 @@ export default function NoteEditorScreen() {
       return;
     }
 
+    githubActivity.begin('Saving note…');
     setIsSaving(true);
     try {
       let savedNoteId = noteId;
@@ -370,6 +368,7 @@ export default function NoteEditorScreen() {
       HapticService.error();
       Alert.alert('Error', 'Failed to save note. Please try again.');
     } finally {
+      githubActivity.end();
       setIsSaving(false);
     }
   }, [title, content, tags, repo, branch, commit, folderPath, noteFormat, attachments, noteId, createNote, updateNote, navigation]);
@@ -395,7 +394,6 @@ export default function NoteEditorScreen() {
                   setBranch(existingNote.branch);
                   setCommit(existingNote.commit);
                   setFolderPath(existingNote.folderPath);
-                  setGithub(existingNote.github);
                   setNoteFormat(existingNote.format ?? 'markdown');
                 }
                 setHasChanges(false);
@@ -1002,7 +1000,8 @@ export default function NoteEditorScreen() {
   );
 
   return (
-    <SafeAreaView edges={['top', 'bottom']} style={[styles.container, { backgroundColor: colors.surface }]}>
+    <SafeAreaView edges={['top', 'bottom']} style={[styles.container, { backgroundColor: colors.surface }]}> 
+      {isSaving ? <GitHubActivityIndicator /> : null}
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       style={styles.flex}

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -25,7 +25,6 @@ import ReanimatedSwipeable, {
 } from "react-native-gesture-handler/ReanimatedSwipeable";
 
 import { useNotes } from "../contexts/NoteContext";
-import { useNoteStore } from "../stores/noteStore";
 import { useTheme } from "../contexts/ThemeContext";
 import { useViewMode } from "../contexts/ViewModeContext";
 import { useAuth } from "../contexts/AuthContext";
@@ -51,10 +50,12 @@ import {
 } from "../utils/viewModes";
 import { ShareService } from "../services/ShareService";
 import { useResponsive } from "../hooks/useResponsive";
+import { GitHubActivityIndicator } from "../components/GitHubActivityIndicator";
+import { githubActivity } from "../stores/githubActivityStore";
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
-const FORMAT_LABELS: Record<NoteFormat, string> = {
+const FORMAT_LABELS: Record<Exclude<NoteFormat, 'json'>, string> = {
   markdown: ".md",
   neorg: ".norg",
   org: ".org",
@@ -308,6 +309,30 @@ export default function NotesListScreen() {
   );
 
   const [longPressedNote, setLongPressedNote] = useState<Note | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDeleteNote = useCallback(
+    async (note: Note) => {
+      githubActivity.begin("Deleting note…");
+      setIsDeleting(true);
+      try {
+        if (!(await deleteNote(note.id))) {
+          Alert.alert("Error", "Failed to delete note");
+          return false;
+        }
+        setLongPressedNote(null);
+        HapticService.success();
+        return true;
+      } catch {
+        Alert.alert("Error", "Failed to delete note");
+        return false;
+      } finally {
+        githubActivity.end();
+        setIsDeleting(false);
+      }
+    },
+    [deleteNote],
+  );
 
   const handleNoteLongPress = useCallback(
     (note: Note) => {
@@ -335,16 +360,12 @@ export default function NotesListScreen() {
           text: "Delete",
           style: "destructive",
           onPress: async () => {
-            if (!(await deleteNote(note.id))) {
-              Alert.alert("Error", useNoteStore.getState().error || "Failed to delete note");
-              return;
-            }
-            HapticService.success();
+            await handleDeleteNote(note);
           },
         },
       ]);
     },
-    [closeOpenSwipeable, deleteNote],
+    [closeOpenSwipeable, handleDeleteNote],
   );
 
   const scrollToSearchMatch = useCallback(
@@ -508,6 +529,7 @@ export default function NotesListScreen() {
         },
       ]}
     >
+      {isDeleting ? <GitHubActivityIndicator /> : null}
       <ScreenHeader title="Notes" />
       <OfflineBanner />
 
@@ -802,7 +824,7 @@ export default function NotesListScreen() {
                   color={colors.primary}
                 />
                 <Text style={[styles.chipText, { color: colors.primary }]}>
-                  {FORMAT_LABELS[selectedFormat]}
+                  {FORMAT_LABELS[selectedFormat as Exclude<NoteFormat, 'json'>]}
                 </Text>
                 <Ionicons name="close" size={12} color={colors.primary} />
               </TouchableOpacity>
@@ -1067,7 +1089,7 @@ export default function NotesListScreen() {
                     All
                   </Text>
                 </TouchableOpacity>
-                {(Object.entries(FORMAT_LABELS) as [NoteFormat, string][]).map(
+                {(Object.entries(FORMAT_LABELS) as [Exclude<NoteFormat, 'json'>, string][]).map(
                   ([fmt, label]) => (
                     <TouchableOpacity
                       key={fmt}
@@ -1419,9 +1441,7 @@ export default function NotesListScreen() {
                       label: "Delete",
                       destructive: true,
                       onPress: async () => {
-                        if (!(await deleteNote(longPressedNote.id))) {
-                          Alert.alert("Error", useNoteStore.getState().error || "Failed to delete note");
-                        }
+                        await handleDeleteNote(longPressedNote);
                       },
                     },
                   ],

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -40,6 +40,7 @@ import { pullAllFromRepos } from "../services/RepoPullService";
 import ContextMenu from "../components/ContextMenu";
 import NoteCard from "../components/NoteCard";
 import SearchBar from "../components/SearchBar";
+import { OfflineBanner } from "../components/ui/OfflineBanner";
 import { ScreenHeader } from "../components/ui";
 import { parseRepoPath } from "../utils/gitPathParser";
 import { HapticService } from "../utils/haptics";
@@ -508,6 +509,7 @@ export default function NotesListScreen() {
       ]}
     >
       <ScreenHeader title="Notes" />
+      <OfflineBanner />
 
       <View style={styles.topBar}>
         <SearchBar

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -50,6 +50,7 @@ import {
 } from "../utils/viewModes";
 import { ShareService } from "../services/ShareService";
 import { useResponsive } from "../hooks/useResponsive";
+import { useNetworkStatus } from "../hooks/useNetworkStatus";
 import { GitHubActivityIndicator } from "../components/GitHubActivityIndicator";
 import { githubActivity } from "../stores/githubActivityStore";
 
@@ -80,6 +81,7 @@ export default function NotesListScreen() {
   } = useNotes();
   const { viewMode, setViewMode } = useViewMode();
   const { isTablet, maxContentWidth } = useResponsive();
+  const { isConnected } = useNetworkStatus();
   const { repositories } = useRepos();
   const listRef = useRef<FlashListRef<Note>>(null);
   const swipeableRefs = useRef<
@@ -290,6 +292,11 @@ export default function NotesListScreen() {
 
   const handleNotePress = useCallback(
     (note: Note) => {
+      if (isConnected === false && !note.content?.trim()) {
+        Alert.alert("Not available offline");
+        return;
+      }
+
       if (note.format === "pdf" && note.repo && note.filePath) {
         const info = parseRepoPath(note.repo);
         if (info) {
@@ -305,7 +312,7 @@ export default function NotesListScreen() {
       }
       navigation.navigate("NoteEditor", { noteId: note.id });
     },
-    [navigation],
+    [isConnected, navigation],
   );
 
   const [longPressedNote, setLongPressedNote] = useState<Note | null>(null);
@@ -455,6 +462,8 @@ export default function NotesListScreen() {
           onPress={handleNotePress}
           onLongPress={handleNoteLongPress}
           highlighted={hasActiveSearch && index === currentSearchMatchIndex}
+          isOffline={isConnected === false}
+          isCached={!!note.content?.trim()}
         />
       </ReanimatedSwipeable>
     ),

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -9,7 +9,6 @@ import {
   View,
   Text,
   StyleSheet,
-  FlatList,
   ActivityIndicator,
   Alert,
   TouchableOpacity,
@@ -1121,42 +1120,36 @@ export default function NotesListScreen() {
                   >
                     Branch
                   </Text>
-                  <FlatList
-                    horizontal
-                    showsHorizontalScrollIndicator={false}
-                    style={styles.filterChipRow}
-                    data={allBranches}
-                    keyExtractor={(branch: string) => branch}
-                    ListHeaderComponent={
-                      <TouchableOpacity
+                  <View style={styles.filterChipRowWrap}>
+                    <TouchableOpacity
+                      style={[
+                        styles.filterChip,
+                        { borderColor: colors.border },
+                        !selectedBranch && {
+                          borderColor: colors.primary,
+                          backgroundColor: colors.primary + "15",
+                        },
+                      ]}
+                      onPress={() => setSelectedBranch(null)}
+                    >
+                      <Text
                         style={[
-                          styles.filterChip,
-                          { borderColor: colors.border },
-                          !selectedBranch && {
-                            borderColor: colors.primary,
-                            backgroundColor: colors.primary + "15",
+                          styles.filterChipText,
+                          {
+                            color: !selectedBranch
+                              ? colors.primary
+                              : colors.text,
                           },
                         ]}
-                        onPress={() => setSelectedBranch(null)}
                       >
-                        <Text
-                          style={[
-                            styles.filterChipText,
-                            {
-                              color: !selectedBranch
-                                ? colors.primary
-                                : colors.text,
-                            },
-                          ]}
-                        >
-                          All
-                        </Text>
-                      </TouchableOpacity>
-                    }
-                    renderItem={({ item: branch }) => {
+                        All
+                      </Text>
+                    </TouchableOpacity>
+                    {allBranches.map((branch) => {
                       const isSelected = selectedBranch === branch;
                       return (
                         <TouchableOpacity
+                          key={branch}
                           style={[
                             styles.filterChip,
                             { borderColor: colors.border },
@@ -1194,8 +1187,8 @@ export default function NotesListScreen() {
                           </Text>
                         </TouchableOpacity>
                       );
-                    }}
-                  />
+                    })}
+                  </View>
                 </>
               )}
 
@@ -1210,42 +1203,36 @@ export default function NotesListScreen() {
                   >
                     Folder
                   </Text>
-                  <FlatList
-                    horizontal
-                    showsHorizontalScrollIndicator={false}
-                    style={styles.filterChipRow}
-                    data={allFolders}
-                    keyExtractor={(folder: string) => folder}
-                    ListHeaderComponent={
-                      <TouchableOpacity
+                  <View style={styles.filterChipRowWrap}>
+                    <TouchableOpacity
+                      style={[
+                        styles.filterChip,
+                        { borderColor: colors.border },
+                        !selectedFolder && {
+                          borderColor: colors.primary,
+                          backgroundColor: colors.primary + "15",
+                        },
+                      ]}
+                      onPress={() => setSelectedFolder(null)}
+                    >
+                      <Text
                         style={[
-                          styles.filterChip,
-                          { borderColor: colors.border },
-                          !selectedFolder && {
-                            borderColor: colors.primary,
-                            backgroundColor: colors.primary + "15",
+                          styles.filterChipText,
+                          {
+                            color: !selectedFolder
+                              ? colors.primary
+                              : colors.text,
                           },
                         ]}
-                        onPress={() => setSelectedFolder(null)}
                       >
-                        <Text
-                          style={[
-                            styles.filterChipText,
-                            {
-                              color: !selectedFolder
-                                ? colors.primary
-                                : colors.text,
-                            },
-                          ]}
-                        >
-                          All
-                        </Text>
-                      </TouchableOpacity>
-                    }
-                    renderItem={({ item: folder }) => {
+                        All
+                      </Text>
+                    </TouchableOpacity>
+                    {allFolders.map((folder) => {
                       const isSelected = selectedFolder === folder;
                       return (
                         <TouchableOpacity
+                          key={folder}
                           style={[
                             styles.filterChip,
                             { borderColor: colors.border },
@@ -1283,8 +1270,8 @@ export default function NotesListScreen() {
                           </Text>
                         </TouchableOpacity>
                       );
-                    }}
-                  />
+                    })}
+                  </View>
                 </>
               )}
 
@@ -1299,16 +1286,12 @@ export default function NotesListScreen() {
                   >
                     Tags
                   </Text>
-                  <FlatList
-                    horizontal
-                    showsHorizontalScrollIndicator={false}
-                    style={styles.filterChipRow}
-                    data={allTags}
-                    keyExtractor={(tag: string) => tag}
-                    renderItem={({ item: tag }) => {
+                  <View style={styles.filterChipRowWrap}>
+                    {allTags.map((tag) => {
                       const isSelected = selectedTags.includes(tag);
                       return (
                         <TouchableOpacity
+                          key={tag}
                           style={[
                             styles.filterChip,
                             { borderColor: colors.border },
@@ -1347,8 +1330,8 @@ export default function NotesListScreen() {
                           </Text>
                         </TouchableOpacity>
                       );
-                    }}
-                  />
+                    })}
+                  </View>
                 </>
               )}
 
@@ -1642,7 +1625,6 @@ const styles = StyleSheet.create({
     marginBottom: 10,
     marginTop: 4,
   },
-  filterChipRow: { marginBottom: 16 },
   filterChipRowWrap: {
     flexDirection: "row",
     flexWrap: "wrap",

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -21,7 +21,9 @@ import { FlashList, FlashListRef } from "@shopify/flash-list";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Ionicons } from "@expo/vector-icons";
-import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
+import ReanimatedSwipeable, {
+  type SwipeableMethods,
+} from "react-native-gesture-handler/ReanimatedSwipeable";
 
 import { useNotes } from "../contexts/NoteContext";
 import { useNoteStore } from "../stores/noteStore";
@@ -79,6 +81,10 @@ export default function NotesListScreen() {
   const { isTablet, maxContentWidth } = useResponsive();
   const { repositories } = useRepos();
   const listRef = useRef<FlashListRef<Note>>(null);
+  const swipeableRefs = useRef<
+    Record<string, React.RefObject<SwipeableMethods | null>>
+  >({});
+  const openSwipeableRef = useRef<SwipeableMethods | null>(null);
 
   useEffect(() => {
     if (authState.token) {
@@ -91,6 +97,38 @@ export default function NotesListScreen() {
   const [currentSearchMatchIndex, setCurrentSearchMatchIndex] = useState(0);
   const [pendingSync, setPendingSync] = useState(0);
   const [isManualSyncing, setIsManualSyncing] = useState(false);
+
+  const closeOpenSwipeable = useCallback(() => {
+    openSwipeableRef.current?.close();
+    openSwipeableRef.current = null;
+  }, []);
+
+  const getSwipeableRef = useCallback((noteId: string) => {
+    if (!swipeableRefs.current[noteId]) {
+      swipeableRefs.current[noteId] = React.createRef<SwipeableMethods>();
+    }
+
+    return swipeableRefs.current[noteId];
+  }, []);
+
+  const handleSwipeableWillOpen = useCallback((noteId: string) => {
+    const swipeable = swipeableRefs.current[noteId]?.current;
+
+    if (openSwipeableRef.current && openSwipeableRef.current !== swipeable) {
+      openSwipeableRef.current.close();
+    }
+
+    if (swipeable) {
+      openSwipeableRef.current = swipeable;
+    }
+  }, []);
+
+  const handleSwipeableWillClose = useCallback((noteId: string) => {
+    const swipeable = swipeableRefs.current[noteId]?.current;
+    if (openSwipeableRef.current === swipeable) {
+      openSwipeableRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -290,6 +328,7 @@ export default function NotesListScreen() {
 
   const handleDeleteFromSwipe = useCallback(
     (note: Note) => {
+      closeOpenSwipeable();
       Alert.alert("Delete Note", `Delete "${note.title || "Untitled"}"?`, [
         { text: "Cancel", style: "cancel" },
         {
@@ -305,7 +344,7 @@ export default function NotesListScreen() {
         },
       ]);
     },
-    [deleteNote],
+    [closeOpenSwipeable, deleteNote],
   );
 
   const scrollToSearchMatch = useCallback(
@@ -382,8 +421,12 @@ export default function NotesListScreen() {
   const renderSwipeableNote = useCallback(
     (note: Note, index: number) => (
       <ReanimatedSwipeable
+        key={note.id}
+        ref={getSwipeableRef(note.id)}
         overshootRight={false}
         rightThreshold={40}
+        onSwipeableWillOpen={() => handleSwipeableWillOpen(note.id)}
+        onSwipeableWillClose={() => handleSwipeableWillClose(note.id)}
         renderRightActions={() => renderSwipeActions(note)}
       >
         <NoteCard
@@ -396,6 +439,9 @@ export default function NotesListScreen() {
     ),
     [
       currentSearchMatchIndex,
+      getSwipeableRef,
+      handleSwipeableWillClose,
+      handleSwipeableWillOpen,
       handleNoteLongPress,
       handleNotePress,
       hasActiveSearch,
@@ -411,7 +457,7 @@ export default function NotesListScreen() {
 
   const renderJournalNote = useCallback(
     ({ item, index }: { item: Note; index: number }) => (
-      <View style={styles.journalItem}>
+      <View key={item.id} style={styles.journalItem}>
         <Text style={[styles.journalDate, { color: colors.textSecondary }]}>
           {item.updatedAt ? new Date(item.updatedAt).toLocaleDateString() : ""}
         </Text>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -39,8 +39,10 @@ import { ChatRepoPickerModal } from '../components/ai/ChatRepoPickerModal';
 import { Group, GroupRow, Toggle, ScreenHeader } from '../components/ui';
 import { useAIStore } from '../stores/aiStore';
 import type { AIProviderConfig } from '../models/AIProvider';
+import { useNavigation } from '@react-navigation/native';
 
 export default function SettingsScreen() {
+  const navigation = useNavigation();
   const { theme, colors, setTheme, style: uiStyle, setStyle, glossy, setGlossy } = useTheme();
   const { isTablet, maxContentWidth } = useResponsive();
   const { clearAllNotes, refreshNotes } = useNotes();
@@ -254,6 +256,10 @@ export default function SettingsScreen() {
     ]);
   }, [clearToken]);
 
+  const handleManageTemplates = useCallback(() => {
+    navigation.navigate('TemplateManager' as never);
+  }, [navigation]);
+
   const handleResetOnboarding = useCallback(() => {
     HapticService.warning();
     Alert.alert('Reset Onboarding', 'This will show the onboarding screen on next app launch.', [
@@ -464,10 +470,13 @@ export default function SettingsScreen() {
             <Text style={[styles.settingLabel, { color: colors.text }]}>Version</Text>
             <Text style={[styles.settingValue, { color: colors.textSecondary }]}>{Constants.expoConfig?.version ?? Constants.manifest?.version ?? '—'}</Text>
           </View>
-          <View style={[styles.settingItem, { borderBottomColor: colors.border }]}>
+          <View style={[styles.settingItem, { borderBottomColor: colors.border }]}> 
             <Text style={[styles.settingLabel, { color: colors.text }]}>Build</Text>
             <Text style={[styles.settingValue, { color: colors.textSecondary }]}>2026.04.07</Text>
           </View>
+          <TouchableOpacity style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={handleManageTemplates}>
+            <Text style={[styles.settingLabel, { color: colors.text }]}>Manage templates</Text>
+          </TouchableOpacity>
         </View>
 
         <Group title="AI">

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -41,7 +41,7 @@ import { useAIStore } from '../stores/aiStore';
 import type { AIProviderConfig } from '../models/AIProvider';
 
 export default function SettingsScreen() {
-  const { theme, colors, setTheme, style: uiStyle, setStyle } = useTheme();
+  const { theme, colors, setTheme, style: uiStyle, setStyle, glossy, setGlossy } = useTheme();
   const { isTablet, maxContentWidth } = useResponsive();
   const { clearAllNotes, refreshNotes } = useNotes();
   const { refreshCanvases } = useCanvases();
@@ -299,6 +299,7 @@ export default function SettingsScreen() {
           <GroupRow
             trailing={
               <Toggle
+                testID="neu-toggle"
                 value={uiStyle === 'neumorphic'}
                 onValueChange={(v) => setStyle(v ? 'neumorphic' : 'flat')}
               />
@@ -315,6 +316,17 @@ export default function SettingsScreen() {
             }
           >
             <Text style={[styles.settingLabel, { color: colors.text }]}>Dark Mode</Text>
+          </GroupRow>
+          <GroupRow
+            trailing={
+              <Toggle
+                testID="glossy-toggle"
+                value={glossy}
+                onValueChange={setGlossy}
+              />
+            }
+          >
+            <Text style={[styles.settingLabel, { color: colors.text }]}>Glossy UI</Text>
           </GroupRow>
           <GroupRow
             onPress={() => setTheme('system')}

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -20,7 +20,7 @@ import { format, isToday, isTomorrow, isPast } from 'date-fns';
 
 import { useTodos } from '../contexts/TodoContext';
 import { useTheme } from '../contexts/ThemeContext';
-import { Todo, TodoPriority, PRIORITY_COLORS, PRIORITY_LABELS, REMINDER_OPTIONS, slugifyTodoText } from '../models/Todo';
+import { Todo, TodoPriority, PRIORITY_COLORS, PRIORITY_LABELS, REMINDER_OPTIONS, slugifyTodoText, reorderTodos } from '../models/Todo';
 import { HapticService } from '../utils/haptics';
 import { useResponsive } from '../hooks/useResponsive';
 import GitContextPicker from '../components/GitContextPicker';
@@ -89,13 +89,7 @@ export default function TodoListScreen() {
       );
     }
 
-    return filtered.sort((a, b) => {
-      if (a.completed !== b.completed) return a.completed ? 1 : -1;
-      const priorityOrder = { high: 0, medium: 1, low: 2 };
-      const priorityDiff = priorityOrder[a.priority || 'medium'] - priorityOrder[b.priority || 'medium'];
-      if (priorityDiff !== 0) return priorityDiff;
-      return b.createdAt - a.createdAt;
-    });
+    return reorderTodos(filtered);
   }, [todos, filter, filterCompleted, searchQuery]);
 
   const resetForm = useCallback(() => {

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -32,6 +32,7 @@ import { EntityFilterModal } from '../components/EntityFilterModal';
 import { ActiveFilterStrip } from '../components/ActiveFilterStrip';
 import { useEntityFilter } from '../hooks/useEntityFilter';
 import { useRepos } from '../contexts/RepoContext';
+import { useTodoStore } from '../stores/todoStore';
 
 function formatDeadline(timestamp: number): string {
   const date = new Date(timestamp);
@@ -48,7 +49,8 @@ function findReminderLabel(minutes: number): string {
 export default function TodoListScreen() {
   const { colors, isDark } = useTheme();
   const { isTablet, maxContentWidth } = useResponsive();
-  const { todos, createTodo, updateTodo, deleteTodo, toggleTodo, refreshTodos } = useTodos();
+  const { todos, createTodo, updateTodo, toggleTodo, refreshTodos } = useTodos();
+  const deleteTodo = useTodoStore((state) => state.deleteTodo);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const [showAddModal, setShowAddModal] = useState(false);

--- a/src/services/NeorgContentParser.ts
+++ b/src/services/NeorgContentParser.ts
@@ -2,6 +2,10 @@ import { NeorgHeading, NeorgListItem, NeorgContentBlock, NeorgChecklistItem, Neo
 
 export class NeorgContentParser {
   static parseContent(content: string): NeorgContentParseResult {
+    if (typeof content !== 'string') {
+      return { success: false, blocks: [], error: 'Invalid content: expected string' };
+    }
+
     try {
       const lines = content.split('\n');
       const blocks: NeorgContentBlock[] = [];

--- a/src/services/NeorgContentParser.ts
+++ b/src/services/NeorgContentParser.ts
@@ -14,6 +14,9 @@ export class NeorgContentParser {
       let currentChecklist: NeorgChecklistItem[] | null = null;
       let currentTableRows: NeorgTableRow[] | null = null;
       let currentDefinitions: NeorgDefinitionItem[] | null = null;
+      let listIndentWidth: number | null = null;
+      let checklistIndentWidth: number | null = null;
+      let definitionIndentWidth: number | null = null;
       let tableHasHeader: boolean[] = [];
       let inOrgDrawer = false;
       let inOrgBlock = false;
@@ -25,6 +28,7 @@ export class NeorgContentParser {
           blocks.push({ type: 'list', listItems: currentList });
           currentList = null;
         }
+        listIndentWidth = null;
       };
 
       const flushChecklist = () => {
@@ -32,6 +36,7 @@ export class NeorgContentParser {
           blocks.push({ type: 'checklist', checklistItems: currentChecklist });
           currentChecklist = null;
         }
+        checklistIndentWidth = null;
       };
 
       const flushTable = () => {
@@ -47,6 +52,7 @@ export class NeorgContentParser {
           blocks.push({ type: 'definition', definitionItems: currentDefinitions });
           currentDefinitions = null;
         }
+        definitionIndentWidth = null;
       };
 
       let pendingParagraphLines: string[] = [];
@@ -127,13 +133,11 @@ export class NeorgContentParser {
           continue;
         }
 
-        const norgBlockMatch = trimmed.match(/^=(code|raw|embed(?:\.\w+)?)\s*$/);
+        const norgBlockMatch = trimmed.match(/^=(code|raw|embed)(?:\.(\w+))?\s*$/);
         if (norgBlockMatch && !currentCodeBlock) {
           flushAll();
           currentCodeBlock = {
-            language: norgBlockMatch[1].startsWith('code') && norgBlockMatch[1].includes('.')
-              ? norgBlockMatch[1].split('.')[1]
-              : undefined,
+            language: norgBlockMatch[1] === 'code' ? norgBlockMatch[2] : undefined,
             lines: [],
           };
           continue;
@@ -206,12 +210,14 @@ export class NeorgContentParser {
           continue;
         }
 
-        const checklistItem = this.parseChecklistItem(line);
+        const nextChecklistIndentWidth = this.resolveIndentWidth(checklistIndentWidth, line);
+        const checklistItem = this.parseChecklistItem(line, nextChecklistIndentWidth ?? undefined);
         if (checklistItem) {
           flushParagraph();
           flushList();
           flushDefinitions();
           if (!currentChecklist) currentChecklist = [];
+          checklistIndentWidth = nextChecklistIndentWidth;
           currentChecklist.push(checklistItem);
           continue;
         }
@@ -223,22 +229,26 @@ export class NeorgContentParser {
           continue;
         }
 
-        const listItem = this.parseListItem(line);
+        const nextListIndentWidth = this.resolveIndentWidth(listIndentWidth, line);
+        const listItem = this.parseListItem(line, nextListIndentWidth ?? undefined);
         if (listItem) {
           flushParagraph();
           flushChecklist();
           flushDefinitions();
           if (!currentList) currentList = [];
+          listIndentWidth = nextListIndentWidth;
           currentList.push(listItem);
           continue;
         }
 
-        const definitionItem = this.parseDefinitionItem(line);
+        const nextDefinitionIndentWidth = this.resolveIndentWidth(definitionIndentWidth, line);
+        const definitionItem = this.parseDefinitionItem(line, nextDefinitionIndentWidth ?? undefined);
         if (definitionItem) {
           flushParagraph();
           flushList();
           flushChecklist();
           if (!currentDefinitions) currentDefinitions = [];
+          definitionIndentWidth = nextDefinitionIndentWidth;
           currentDefinitions.push(definitionItem);
           continue;
         }
@@ -290,12 +300,43 @@ export class NeorgContentParser {
     return null;
   }
 
-  static parseListItem(line: string): NeorgListItem | null {
+  private static getIndentLevel(spaces: string, indentWidth = 2): number {
+    let level = 0;
+    let consecutiveSpaces = 0;
+
+    for (const char of spaces) {
+      if (char === '\t') {
+        level += 1;
+        consecutiveSpaces = 0;
+      } else {
+        consecutiveSpaces += 1;
+        if (consecutiveSpaces >= indentWidth) {
+          level += 1;
+          consecutiveSpaces = 0;
+        }
+      }
+    }
+
+    if (consecutiveSpaces > 0) {
+      level += 1;
+    }
+
+    return level;
+  }
+
+  private static resolveIndentWidth(currentIndentWidth: number | null, line: string): number | null {
+    if (currentIndentWidth) return currentIndentWidth;
+    const spaces = line.match(/^(\s*)/)?.[1] ?? '';
+    if (!spaces || spaces.includes('\t')) return currentIndentWidth;
+    return spaces.length > 0 ? spaces.length : currentIndentWidth;
+  }
+
+  static parseListItem(line: string, indentWidth = 2): NeorgListItem | null {
     const indentMatch = line.match(/^(\s*)(.*)$/);
     if (!indentMatch) return null;
 
     const spaces = indentMatch[1];
-    const indentLevel = Math.floor(spaces.length / 2);
+    const indentLevel = this.getIndentLevel(spaces, indentWidth);
     const content = indentMatch[2];
 
     // Unordered: - item
@@ -335,12 +376,12 @@ export class NeorgContentParser {
     return null;
   }
 
-  static parseChecklistItem(line: string): NeorgChecklistItem | null {
+  static parseChecklistItem(line: string, indentWidth = 2): NeorgChecklistItem | null {
     const indentMatch = line.match(/^(\s*)(.*)$/);
     if (!indentMatch) return null;
 
     const spaces = indentMatch[1];
-    const indentLevel = Math.floor(spaces.length / 2);
+    const indentLevel = this.getIndentLevel(spaces, indentWidth);
     const content = indentMatch[2];
 
     // - [ ] or - [x] (markdown and norg task syntax)
@@ -357,12 +398,12 @@ export class NeorgContentParser {
     return null;
   }
 
-  static parseDefinitionItem(line: string): NeorgDefinitionItem | null {
+  static parseDefinitionItem(line: string, indentWidth = 2): NeorgDefinitionItem | null {
     const indentMatch = line.match(/^(\s*)(.*)$/);
     if (!indentMatch) return null;
 
     const spaces = indentMatch[1];
-    const indentLevel = Math.floor(spaces.length / 2);
+    const indentLevel = this.getIndentLevel(spaces, indentWidth);
     const content = indentMatch[2];
 
     // Neorg definition: $ Term

--- a/src/services/NoteFormatPreferenceService.ts
+++ b/src/services/NoteFormatPreferenceService.ts
@@ -4,7 +4,7 @@ import type { NoteFormat } from '../models/Note';
 const DEFAULT_FORMAT_KEY = '@gitnotes:default_note_format';
 const REMEMBER_FORMAT_KEY = '@gitnotes:remember_note_format';
 
-export type EditableNoteFormat = Exclude<NoteFormat, 'pdf'>;
+export type EditableNoteFormat = Exclude<NoteFormat, 'pdf' | 'json'>;
 
 export class NoteFormatPreferenceService {
   static async getDefaultFormat(): Promise<EditableNoteFormat | null> {

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -10,6 +10,91 @@ export interface NoteGitHubSyncResult {
   error?: string;
 }
 
+export function canPersistNoteTags(format?: string): boolean {
+  return format === 'markdown' || format === 'neorg' || format === 'org';
+}
+
+function joinTags(tags: string[]): string {
+  return tags.map((tag) => tag.trim()).filter(Boolean).join(', ');
+}
+
+function splitLines(value: string): string[] {
+  return value.length === 0 ? [] : value.split('\n');
+}
+
+function upsertMarkdownTags(content: string, tags: string[]): string {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) {
+    return tags.length > 0 ? `---\ntags: [${joinTags(tags)}]\n---\n\n${content}` : content;
+  }
+
+  const body = content.slice(match[0].length);
+  const lines = splitLines(match[1]).filter((line) => !/^tags\s*:/i.test(line.trim()));
+  if (tags.length > 0) {
+    lines.push(`tags: [${joinTags(tags)}]`);
+  }
+
+  if (lines.length === 0) {
+    return body.replace(/^\n+/, '');
+  }
+
+  return `---\n${lines.join('\n')}\n---\n\n${body.replace(/^\n+/, '')}`;
+}
+
+function upsertOrgTags(content: string, tags: string[]): string {
+  const lines = splitLines(content);
+  const index = lines.findIndex((line) => /^#\+FILETAGS:/i.test(line.trim()));
+
+  if (index === -1) {
+    if (tags.length === 0) return content;
+    return `#+FILETAGS: :${tags.map((tag) => tag.trim()).filter(Boolean).join(':')}:\n\n${content}`;
+  }
+
+  if (tags.length === 0) {
+    lines.splice(index, 1);
+    return lines.join('\n').replace(/^\n+/, '');
+  }
+
+  lines[index] = `#+FILETAGS: :${tags.map((tag) => tag.trim()).filter(Boolean).join(':')}:`;
+  return lines.join('\n');
+}
+
+function upsertNeorgTags(content: string, tags: string[]): string {
+  const lines = splitLines(content);
+  const startIndex = lines.findIndex((line) => line.trim() === '@document.meta');
+
+  if (startIndex === -1) {
+    if (tags.length === 0) return content;
+    return `@document.meta\ncategories: [${joinTags(tags)}]\n@end\n\n${content}`;
+  }
+
+  const endIndex = lines.findIndex((line, idx) => idx > startIndex && line.trim() === '@end');
+  if (endIndex === -1) return content;
+
+  const metaLines = lines.slice(startIndex + 1, endIndex).filter((line) => !/^categories\s*:/i.test(line.trim()));
+  if (tags.length > 0) {
+    metaLines.push(`categories: [${joinTags(tags)}]`);
+  }
+
+  if (metaLines.length === 0) {
+    return content;
+  }
+
+  return [
+    ...lines.slice(0, startIndex + 1),
+    ...metaLines,
+    ...lines.slice(endIndex),
+  ].join('\n');
+}
+
+export function applyNoteTagsToContent(content: string, format?: NoteFormat, tags: string[] = []): string {
+  if (!canPersistNoteTags(format)) return content;
+  if (format === 'markdown') return upsertMarkdownTags(content, tags);
+  if (format === 'org') return upsertOrgTags(content, tags);
+  if (format === 'neorg') return upsertNeorgTags(content, tags);
+  return content;
+}
+
 function getExtension(format?: NoteFormat): string {
   switch (format) {
     case 'neorg': return '.norg';
@@ -155,8 +240,9 @@ export async function syncNoteToGitHub(params: {
   title: string;
   content: string;
   format?: NoteFormat;
+  tags?: string[];
 }): Promise<NoteGitHubSyncResult> {
-  const { repo: repoPath, branch, filePath, title, content, format } = params;
+  const { repo: repoPath, branch, filePath, title, content, format, tags = [] } = params;
 
   if (!GitHubService.isAuthenticated()) {
     return { success: false, error: 'GitHub not authenticated' };
@@ -178,9 +264,9 @@ export async function syncNoteToGitHub(params: {
 
   const noteSlug = slugify(title);
 
-  let finalContent = content;
+  let finalContent = applyNoteTagsToContent(content, format, tags);
   try {
-    finalContent = await uploadLocalImages(content, repoInfo.owner, repoInfo.repo, targetBranch, noteSlug);
+    finalContent = await uploadLocalImages(finalContent, repoInfo.owner, repoInfo.repo, targetBranch, noteSlug);
   } catch (error) {
     console.warn('[NoteGitHubSync] Image upload failed, syncing note without images:', error);
   }

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -13,6 +13,7 @@ export interface NoteUpsertParams {
   title: string;
   content: string;
   format?: NoteFormat;
+  tags?: string[];
 }
 
 export interface QueuedMutation {

--- a/src/services/RepoFileSyncService.ts
+++ b/src/services/RepoFileSyncService.ts
@@ -16,6 +16,7 @@ const SUPPORTED_EXTENSIONS: Record<string, NoteFormat> = {
   '.norg': 'neorg',
   '.org': 'org',
   '.pdf': 'pdf',
+  '.json': 'json',
 };
 
 function getExtension(filename: string): string {

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -163,53 +163,43 @@ async function pullCanvasesFromRepo(
     const files = await fetchDirectoryFiles(owner, repo, 'canvases', branch);
     if (files.length === 0) return 0;
 
-    // Single read → mutate in memory → single write. Previous code re-read
-    // and re-wrote inside each iteration which lost interleaved edits when
-    // pulls ran in parallel (Promise.all in pullAllFromRepos).
-    const allCanvases = await StorageService.getAllCanvases();
-    let dirty = false;
+    await StorageService.mutateCanvases((allCanvases) => {
+      for (const file of files) {
+        if (!file.path.endsWith('.json')) continue;
 
-    for (const file of files) {
-      if (!file.path.endsWith('.json')) continue;
+        let scene: CanvasScene;
+        try {
+          scene = JSON.parse(file.content);
+        } catch {
+          continue;
+        }
 
-      let scene: CanvasScene;
-      try {
-        scene = JSON.parse(file.content);
-      } catch {
-        continue;
-      }
+        const titleFromPath = file.path
+          .replace(/^canvases\//, '')
+          .replace(/\.json$/, '')
+          .replace(/-/g, ' ');
 
-      const titleFromPath = file.path
-        .replace(/^canvases\//, '')
-        .replace(/\.json$/, '')
-        .replace(/-/g, ' ');
-
-      const idx = allCanvases.findIndex((c) => c.filePath === file.path);
-      if (idx !== -1) {
-        const existing = allCanvases[idx];
-        if (JSON.stringify(existing.scene) !== JSON.stringify(scene)) {
-          allCanvases[idx] = updateCanvas(existing, { scene });
-          dirty = true;
+        const idx = allCanvases.findIndex((c) => c.filePath === file.path);
+        if (idx !== -1) {
+          const existing = allCanvases[idx];
+          if (JSON.stringify(existing.scene) !== JSON.stringify(scene)) {
+            allCanvases[idx] = updateCanvas(existing, { scene });
+            pulled++;
+          }
+        } else {
+          allCanvases.push(
+            createCanvas({
+              title: titleFromPath,
+              scene,
+              repo: repoPath,
+              branch,
+              filePath: file.path,
+            }),
+          );
           pulled++;
         }
-      } else {
-        allCanvases.push(
-          createCanvas({
-            title: titleFromPath,
-            scene,
-            repo: repoPath,
-            branch,
-            filePath: file.path,
-          }),
-        );
-        dirty = true;
-        pulled++;
       }
-    }
-
-    if (dirty) {
-      await StorageService.saveAllCanvases(allCanvases);
-    }
+    });
   } catch {
     console.warn(`[RepoPullService] Failed to pull canvases from ${owner}/${repo}`);
   }

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -4,6 +4,7 @@ import { createNote } from '../models/Note';
 import { createCanvas, updateCanvas, CanvasScene } from '../models/Canvas';
 import { createTodoItem, applyTodoUpdate, reorderTodos } from '../models/Todo';
 import { parseRepoPath } from '../utils/gitPathParser';
+import { canPersistNoteTags } from '../utils/noteTagSupport';
 
 async function fetchDirectoryFiles(
   owner: string,
@@ -50,6 +51,40 @@ async function fetchInBatches<T, R>(
     out.push(...batchOut);
   }
   return out;
+}
+
+function extractTagsFromMarkdown(content: string): string[] {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return [];
+
+  const tagsLine = match[1].split('\n').find((line) => /^tags\s*:/i.test(line.trim()));
+  if (!tagsLine) return [];
+
+  const raw = tagsLine.replace(/^tags\s*:\s*/i, '').trim();
+  const inner = raw.replace(/^\[/, '').replace(/\]$/, '').trim();
+  if (!inner) return [];
+
+  return inner.split(',').map((tag) => tag.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
+}
+
+function extractTagsFromOrg(content: string): string[] {
+  const match = content.match(/^#\+FILETAGS:\s*:(.+?):\s*$/im);
+  if (!match) return [];
+  return match[1].split(':').map((tag) => tag.trim()).filter(Boolean);
+}
+
+function extractTagsFromNeorg(content: string): string[] {
+  const match = content.match(/^categories:\s*\[(.+?)\]\s*$/im);
+  if (!match) return [];
+  return match[1].split(',').map((tag) => tag.trim()).filter(Boolean);
+}
+
+function extractTagsFromContent(content: string, format: 'markdown' | 'neorg' | 'org' | 'pdf' | 'json'): string[] {
+  if (!canPersistNoteTags(format)) return [];
+  if (format === 'markdown') return extractTagsFromMarkdown(content);
+  if (format === 'org') return extractTagsFromOrg(content);
+  if (format === 'neorg') return extractTagsFromNeorg(content);
+  return [];
 }
 
 async function pullNotesFromRepo(
@@ -105,6 +140,8 @@ async function pullNotesFromRepo(
     for (const item of fetched) {
       if (!item) continue;
       const ext = item.path.split('.').pop()?.toLowerCase() ?? 'md';
+      const format = noteFormatFromExt(ext);
+      const tags = extractTagsFromContent(item.content, format);
       const titleFromPath = item.path
         .replace(/^notes\//, '')
         .replace(/\.[^.]+$/, '')
@@ -125,6 +162,7 @@ async function pullNotesFromRepo(
           allNotes[existingIdx] = {
             ...existing,
             content: item.content,
+            tags,
             updatedAt: Date.now(),
           };
           pulled++;
@@ -137,7 +175,8 @@ async function pullNotesFromRepo(
             repo: repoPath,
             branch,
             filePath: item.path,
-            format: noteFormatFromExt(ext),
+            format,
+            tags,
           }),
         );
         pulled++;

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -2,7 +2,7 @@ import { GitHubService } from './GitHubService';
 import { StorageService } from './StorageService';
 import { createNote } from '../models/Note';
 import { createCanvas, updateCanvas, CanvasScene } from '../models/Canvas';
-import { createTodoItem, applyTodoUpdate } from '../models/Todo';
+import { createTodoItem, applyTodoUpdate, reorderTodos } from '../models/Todo';
 import { parseRepoPath } from '../utils/gitPathParser';
 
 async function fetchDirectoryFiles(
@@ -269,7 +269,7 @@ async function pullTodosFromRepo(
     }
 
     if (dirty) {
-      await StorageService.saveAllTodos(allTodos);
+      await StorageService.saveAllTodos(reorderTodos(allTodos));
     }
   } catch {
     console.warn(`[RepoPullService] Failed to pull todos from ${owner}/${repo}`);

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -5,6 +5,7 @@ import { GitRepository } from './GitService';
 import { Todo, TodoCreateInput, TodoUpdateInput, createTodoItem, applyTodoUpdate } from '../models/Todo';
 import { Canvas, CanvasCreateInput, CanvasUpdateInput, createCanvas, updateCanvas } from '../models/Canvas';
 import { NOTE_INDEX_KEY, noteKey, getBootValue } from './StorageBootstrap';
+import type { NoteTemplate } from './TemplateService';
 
 const TODOS_STORAGE_KEY = '@gitnotes:todos';
 const CANVASES_STORAGE_KEY = '@gitnotes:canvases';
@@ -12,6 +13,8 @@ const CANVASES_BACKUP_STORAGE_KEY = '@gitnotes:canvases.bak';
 const LEGACY_NOTES_KEY = '@gitnotes:notes';
 const REPOS_STORAGE_KEY = '@gitnotes:repos';
 const FOLDERS_STORAGE_KEY = '@gitnotes:folders';
+const CUSTOM_TEMPLATES_STORAGE_KEY = '@gitnotes:templates';
+const TEMPLATE_PINS_STORAGE_KEY = '@gitnotes:template-pins';
 
 let migrationDone = false;
 
@@ -210,6 +213,44 @@ export class StorageService {
       return JSON.parse(jsonValue);
     } catch (error) {
       console.error('Error reading repositories from storage:', error);
+      return [];
+    }
+  }
+
+  static async saveCustomTemplates(templates: NoteTemplate[]): Promise<void> {
+    try {
+      await AsyncStorage.setItem(CUSTOM_TEMPLATES_STORAGE_KEY, JSON.stringify(templates));
+    } catch (error) {
+      console.error('Error saving custom templates to storage:', error);
+      throw error;
+    }
+  }
+
+  static async loadCustomTemplates(): Promise<NoteTemplate[]> {
+    try {
+      const raw = await AsyncStorage.getItem(CUSTOM_TEMPLATES_STORAGE_KEY);
+      return raw ? JSON.parse(raw) : [];
+    } catch (error) {
+      console.error('Error loading custom templates from storage:', error);
+      return [];
+    }
+  }
+
+  static async saveTemplatePins(pinIds: string[]): Promise<void> {
+    try {
+      await AsyncStorage.setItem(TEMPLATE_PINS_STORAGE_KEY, JSON.stringify(pinIds));
+    } catch (error) {
+      console.error('Error saving template pins to storage:', error);
+      throw error;
+    }
+  }
+
+  static async loadTemplatePins(): Promise<string[]> {
+    try {
+      const raw = await AsyncStorage.getItem(TEMPLATE_PINS_STORAGE_KEY);
+      return raw ? JSON.parse(raw) : [];
+    } catch (error) {
+      console.error('Error loading template pins from storage:', error);
       return [];
     }
   }

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -3,11 +3,12 @@ import { Note, NoteCreateInput, NoteUpdateInput, createNote, updateNote } from '
 import { Folder, FolderCreateInput, createFolder, updateFolder } from '../models/Folder';
 import { GitRepository } from './GitService';
 import { Todo, TodoCreateInput, TodoUpdateInput, createTodoItem, applyTodoUpdate } from '../models/Todo';
-import { Canvas, CanvasCreateInput, CanvasUpdateInput, createCanvas, updateCanvas, sortCanvasesByUpdated } from '../models/Canvas';
+import { Canvas, CanvasCreateInput, CanvasUpdateInput, createCanvas, updateCanvas } from '../models/Canvas';
 import { NOTE_INDEX_KEY, noteKey, getBootValue } from './StorageBootstrap';
 
 const TODOS_STORAGE_KEY = '@gitnotes:todos';
 const CANVASES_STORAGE_KEY = '@gitnotes:canvases';
+const CANVASES_BACKUP_STORAGE_KEY = '@gitnotes:canvases.bak';
 const LEGACY_NOTES_KEY = '@gitnotes:notes';
 const REPOS_STORAGE_KEY = '@gitnotes:repos';
 const FOLDERS_STORAGE_KEY = '@gitnotes:folders';
@@ -38,6 +39,47 @@ async function migrateFromBlob(): Promise<void> {
 }
 
 export class StorageService {
+  private static canvasWriteQueue: Promise<void> = Promise.resolve();
+
+  private static enqueueCanvasWrite<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.canvasWriteQueue.catch(() => undefined).then(operation);
+    this.canvasWriteQueue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  private static async readAllCanvasesRaw(): Promise<Canvas[]> {
+    try {
+      const boot = getBootValue('@gitnotes:canvases');
+      const json = boot ?? await AsyncStorage.getItem(CANVASES_STORAGE_KEY);
+      return json ? JSON.parse(json) : [];
+    } catch (error) {
+      console.error('Error reading canvases from storage:', error);
+      return [];
+    }
+  }
+
+  private static async backupCanvasBlob(): Promise<void> {
+    const current = await AsyncStorage.getItem(CANVASES_STORAGE_KEY);
+    if (current !== null) {
+      await AsyncStorage.setItem(CANVASES_BACKUP_STORAGE_KEY, current);
+    }
+  }
+
+  static async mutateCanvases<T>(mutator: (canvases: Canvas[]) => Promise<T> | T): Promise<T> {
+    return this.enqueueCanvasWrite(async () => {
+      const canvases = await this.readAllCanvasesRaw();
+      const result = await mutator(canvases);
+      try {
+        await this.backupCanvasBlob();
+        await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify(canvases));
+      } catch (error) {
+        console.error('Error saving canvases to storage:', error);
+        throw error;
+      }
+      return result;
+    });
+  }
+
   static async getAllNotes(): Promise<Note[]> {
     await migrateFromBlob();
     try {
@@ -323,22 +365,20 @@ export class StorageService {
   }
 
   static async getAllCanvases(): Promise<Canvas[]> {
-    try {
-      const boot = getBootValue('@gitnotes:canvases');
-      const json = boot ?? await AsyncStorage.getItem(CANVASES_STORAGE_KEY);
-      return json ? JSON.parse(json) : [];
-    } catch {
-      return [];
-    }
+    await this.canvasWriteQueue;
+    return this.readAllCanvasesRaw();
   }
 
   static async saveAllCanvases(canvases: Canvas[]): Promise<void> {
-    try {
-      await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify(canvases));
-    } catch (error) {
-      console.error('Error saving canvases to storage:', error);
-      throw error;
-    }
+    await this.enqueueCanvasWrite(async () => {
+      try {
+        await this.backupCanvasBlob();
+        await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify(canvases));
+      } catch (error) {
+        console.error('Error saving canvases to storage:', error);
+        throw error;
+      }
+    });
   }
 
   static async getCanvasById(id: string): Promise<Canvas | null> {
@@ -347,27 +387,28 @@ export class StorageService {
   }
 
   static async createCanvas(input: CanvasCreateInput): Promise<Canvas> {
-    const canvases = await this.getAllCanvases();
-    const newCanvas = createCanvas(input);
-    canvases.push(newCanvas);
-    await this.saveAllCanvases(canvases);
-    return newCanvas;
+    return this.mutateCanvases((canvases) => {
+      const newCanvas = createCanvas(input);
+      canvases.push(newCanvas);
+      return newCanvas;
+    });
   }
 
   static async updateCanvas(input: CanvasUpdateInput): Promise<Canvas | null> {
-    const canvases = await this.getAllCanvases();
-    const idx = canvases.findIndex((c) => c.id === input.id);
-    if (idx === -1) return null;
-    canvases[idx] = updateCanvas(canvases[idx], input);
-    await this.saveAllCanvases(canvases);
-    return canvases[idx];
+    return this.mutateCanvases((canvases) => {
+      const idx = canvases.findIndex((c) => c.id === input.id);
+      if (idx === -1) return null;
+      canvases[idx] = updateCanvas(canvases[idx], input);
+      return canvases[idx];
+    });
   }
 
   static async deleteCanvas(id: string): Promise<boolean> {
-    const canvases = await this.getAllCanvases();
-    const filtered = canvases.filter((c) => c.id !== id);
-    if (filtered.length === canvases.length) return false;
-    await this.saveAllCanvases(filtered);
-    return true;
+    return this.mutateCanvases((canvases) => {
+      const idx = canvases.findIndex((c) => c.id === id);
+      if (idx === -1) return false;
+      canvases.splice(idx, 1);
+      return true;
+    });
   }
 }

--- a/src/services/TemplateService.ts
+++ b/src/services/TemplateService.ts
@@ -10,6 +10,10 @@ export interface NoteTemplate {
   title?: string;
   content: string;
   tags: string[];
+  isCustom?: boolean;
+  isPinned?: boolean;
+  createdAt?: number;
+  updatedAt?: number;
 }
 
 export const NOTE_TEMPLATES: NoteTemplate[] = [

--- a/src/stores/templateStore.ts
+++ b/src/stores/templateStore.ts
@@ -1,0 +1,78 @@
+import { create } from 'zustand';
+import { NoteTemplate, NOTE_TEMPLATES } from '../services/TemplateService';
+import { StorageService } from '../services/StorageService';
+
+interface TemplateState {
+  customTemplates: NoteTemplate[];
+  pinnedIds: string[];
+  isLoading: boolean;
+  loadTemplates: () => Promise<void>;
+  createTemplate: (template: Omit<NoteTemplate, 'id' | 'isCustom' | 'createdAt' | 'updatedAt'>) => Promise<NoteTemplate>;
+  updateTemplate: (id: string, updates: Partial<NoteTemplate>) => Promise<void>;
+  deleteTemplate: (id: string) => Promise<void>;
+  togglePin: (id: string) => Promise<void>;
+  getAllTemplates: () => NoteTemplate[];
+}
+
+export const useTemplateStore = create<TemplateState>()((set, get) => ({
+  customTemplates: [],
+  pinnedIds: [],
+  isLoading: false,
+
+  loadTemplates: async () => {
+    set({ isLoading: true });
+    const [customs, pins] = await Promise.all([
+      StorageService.loadCustomTemplates(),
+      StorageService.loadTemplatePins(),
+    ]);
+    set({ customTemplates: customs || [], pinnedIds: pins || [], isLoading: false });
+  },
+
+  createTemplate: async (input) => {
+    const template: NoteTemplate = {
+      ...input,
+      id: `custom-${Date.now()}`,
+      isCustom: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    const next = [...get().customTemplates, template];
+    await StorageService.saveCustomTemplates(next);
+    set({ customTemplates: next });
+    return template;
+  },
+
+  updateTemplate: async (id, updates) => {
+    const next = get().customTemplates.map((t) => (t.id === id ? { ...t, ...updates, updatedAt: Date.now() } : t));
+    await StorageService.saveCustomTemplates(next);
+    set({ customTemplates: next });
+  },
+
+  deleteTemplate: async (id) => {
+    const template = get().customTemplates.find((t) => t.id === id);
+    if (!template?.isCustom) return;
+    const next = get().customTemplates.filter((t) => t.id !== id);
+    await StorageService.saveCustomTemplates(next);
+    set({ customTemplates: next });
+  },
+
+  togglePin: async (id) => {
+    const current = get().pinnedIds;
+    const next = current.includes(id) ? current.filter((x) => x !== id) : [...current, id];
+    await StorageService.saveTemplatePins(next);
+    set({ pinnedIds: next });
+  },
+
+  getAllTemplates: () => {
+    const { customTemplates, pinnedIds } = get();
+    const all = [
+      ...NOTE_TEMPLATES.map((t) => ({ ...t, isPinned: pinnedIds.includes(t.id) })),
+      ...customTemplates.map((t) => ({ ...t, isPinned: pinnedIds.includes(t.id) })),
+    ];
+    return all.sort((a, b) => {
+      if (a.isPinned && !b.isPinned) return -1;
+      if (!a.isPinned && b.isPinned) return 1;
+      return 0;
+    });
+  },
+}));

--- a/src/stores/todoStore.ts
+++ b/src/stores/todoStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { Todo, TodoCreateInput, TodoUpdateInput } from '../models/Todo';
+import { Todo, TodoCreateInput, TodoUpdateInput, reorderTodos } from '../models/Todo';
 import { StorageService } from '../services/StorageService';
 import { GitHubService } from '../services/GitHubService';
 import { parseRepoPath } from '../utils/gitPathParser';
@@ -28,7 +28,7 @@ export const useTodoStore = create<TodoState & TodoActions>()((set, get) => ({
     try {
       set({ isLoading: true, error: null });
       const todos = await StorageService.getAllTodos();
-      set({ todos, isLoading: false });
+      set({ todos: reorderTodos(todos), isLoading: false });
     } catch (err) {
       set({ error: 'Failed to load todos', isLoading: false });
       console.error('Error loading todos:', err);

--- a/src/stores/todoStore.ts
+++ b/src/stores/todoStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import { Todo, TodoCreateInput, TodoUpdateInput } from '../models/Todo';
 import { StorageService } from '../services/StorageService';
+import { GitHubService } from '../services/GitHubService';
+import { parseRepoPath } from '../utils/gitPathParser';
 
 interface TodoState {
   todos: Todo[];
@@ -67,9 +69,30 @@ export const useTodoStore = create<TodoState & TodoActions>()((set, get) => ({
   deleteTodo: async (id) => {
     try {
       set({ error: null });
+      const todoToDelete = get().todos.find((t) => t.id === id);
       const success = await StorageService.deleteTodo(id);
       if (success) {
         set((state) => ({ todos: state.todos.filter((t) => t.id !== id) }));
+        if (todoToDelete?.repo && todoToDelete.filePath && GitHubService.isAuthenticated()) {
+          const repoInfo = parseRepoPath(todoToDelete.repo);
+          if (repoInfo) {
+            const branch = todoToDelete.branch || 'main';
+            const sha = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, todoToDelete.filePath, branch);
+            if (sha) {
+              const result = await GitHubService.deleteFile(
+                repoInfo.owner,
+                repoInfo.repo,
+                todoToDelete.filePath,
+                `Delete todo: ${todoToDelete.text}`,
+                sha,
+                branch,
+              );
+              if (!result) {
+                console.warn('[TodoStore] GitHub delete failed for todo:', id);
+              }
+            }
+          }
+        }
       }
       return success;
     } catch (err) {

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -16,6 +16,11 @@ export interface Palette {
   border: string;
   card: string;
   elevated: string;
+  glassSurface: string;
+  glassCard: string;
+  glassElevated: string;
+  glassNav: string;
+  glassBorder: string;
 }
 
 // Neumorphic palette uses a near-pure white (light) / black (dark) surface
@@ -37,6 +42,11 @@ export const NEUMORPHIC_LIGHT: Palette = {
   border: '#D8D8D8',
   card: '#FFFFFF',
   elevated: '#FFFFFF',
+  glassSurface: 'rgba(255, 255, 255, 0.7)',
+  glassCard: 'rgba(255, 255, 255, 0.75)',
+  glassElevated: 'rgba(255, 255, 255, 0.85)',
+  glassNav: 'rgba(255, 255, 255, 0.75)',
+  glassBorder: 'rgba(216, 216, 216, 0.4)',
 };
 
 export const NEUMORPHIC_DARK: Palette = {
@@ -55,6 +65,11 @@ export const NEUMORPHIC_DARK: Palette = {
   border: '#262626',
   card: '#0A0A0A',
   elevated: '#1C1C1E',
+  glassSurface: 'rgba(0, 0, 0, 0.7)',
+  glassCard: 'rgba(10, 10, 10, 0.75)',
+  glassElevated: 'rgba(28, 28, 30, 0.85)',
+  glassNav: 'rgba(0, 0, 0, 0.75)',
+  glassBorder: 'rgba(38, 38, 38, 0.4)',
 };
 
 export const FLAT_LIGHT: Palette = {
@@ -73,6 +88,11 @@ export const FLAT_LIGHT: Palette = {
   border: '#c6c6c8',
   card: '#ffffff',
   elevated: '#ffffff',
+  glassSurface: 'rgba(255, 255, 255, 0.7)',
+  glassCard: 'rgba(255, 255, 255, 0.75)',
+  glassElevated: 'rgba(255, 255, 255, 0.85)',
+  glassNav: 'rgba(255, 255, 255, 0.75)',
+  glassBorder: 'rgba(198, 198, 200, 0.4)',
 };
 
 export const FLAT_DARK: Palette = {
@@ -91,6 +111,11 @@ export const FLAT_DARK: Palette = {
   border: '#38383a',
   card: '#2c2c2e',
   elevated: '#2c2c2e',
+  glassSurface: 'rgba(28, 28, 30, 0.7)',
+  glassCard: 'rgba(44, 44, 46, 0.75)',
+  glassElevated: 'rgba(44, 44, 46, 0.85)',
+  glassNav: 'rgba(28, 28, 30, 0.75)',
+  glassBorder: 'rgba(56, 56, 58, 0.4)',
 };
 
 export const RADII = { sm: 12, md: 18, lg: 24, pill: 999 } as const;

--- a/src/utils/linkClassifier.ts
+++ b/src/utils/linkClassifier.ts
@@ -1,0 +1,71 @@
+export type LinkKind = 'anchor' | 'note' | 'web' | 'mailto';
+
+export interface ClassifiedHref {
+  kind: LinkKind;
+  target: string;
+}
+
+function slugifyFragment(fragment: string): string {
+  return decodeURIComponent(fragment)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function normalizePath(path: string): string {
+  const isAbsolute = path.startsWith('/');
+  const parts = path.split('/');
+  const normalized: string[] = [];
+
+  for (const part of parts) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      if (normalized.length > 0) normalized.pop();
+      continue;
+    }
+    normalized.push(part);
+  }
+
+  const joined = normalized.join('/');
+  return isAbsolute ? `/${joined}` : joined;
+}
+
+function dirname(path: string): string {
+  const normalized = normalizePath(path);
+  const lastSlash = normalized.lastIndexOf('/');
+  if (lastSlash < 0) return '';
+  return normalized.slice(0, lastSlash);
+}
+
+function resolveNotePath(href: string, currentNotePath?: string): string {
+  if (href.startsWith('/')) {
+    return normalizePath(href).replace(/^\//, '');
+  }
+
+  const baseDir = currentNotePath ? dirname(currentNotePath) : '';
+  return normalizePath(baseDir ? `${baseDir}/${href}` : href);
+}
+
+export function classifyHref(href: string, currentNotePath?: string): ClassifiedHref | null {
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('#')) {
+    return { kind: 'anchor', target: slugifyFragment(trimmed.slice(1)) };
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return { kind: 'web', target: trimmed };
+  }
+
+  if (/^(mailto|tel):/i.test(trimmed)) {
+    return { kind: 'mailto', target: trimmed.replace(/^(mailto|tel):/i, '') };
+  }
+
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && /\.(md|norg|org|pdf|json)$/i.test(trimmed)) {
+    return { kind: 'note', target: resolveNotePath(trimmed, currentNotePath) };
+  }
+
+  return null;
+}

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -4,6 +4,7 @@ import { Renderer, type RendererInterface } from 'react-native-marked';
 import { Image } from 'expo-image';
 
 import { isCanvasLink, canvasIdFromLink } from '../models/Canvas';
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 
 interface CustomRendererDeps {
   colors: {
@@ -26,6 +27,24 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
   constructor(deps: CustomRendererDeps) {
     super();
     this.deps = deps;
+  }
+
+  private renderCanvasFallback(id: string): ReactNode {
+    return (
+      <Text
+        key={`canvas-fallback-${id}`}
+        style={{
+          color: this.deps.colors.text,
+          backgroundColor: this.deps.colors.surfaceSecondary ?? '#f0f0f0',
+          borderRadius: 8,
+          overflow: 'hidden',
+          paddingHorizontal: 12,
+          paddingVertical: 10,
+        }}
+      >
+        Canvas preview unavailable
+      </Text>
+    );
   }
 
   image(uri: string, alt?: string, _style?: ImageStyle): ReactNode {
@@ -63,7 +82,11 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
   link(children: string | ReactNode[], href: string, styles?: TextStyle): ReactNode {
     if (isCanvasLink(href) && this.deps.CanvasPreview) {
       const id = canvasIdFromLink(href);
-      return <React.Fragment key={this.getKey()}>{React.createElement(this.deps.CanvasPreview, { canvasId: id })}</React.Fragment>;
+      return React.createElement(
+        ErrorBoundary,
+        { key: `canvas-boundary-${id}`, fallback: this.renderCanvasFallback(id) },
+        React.createElement(this.deps.CanvasPreview, { key: id, canvasId: id }),
+      );
     }
 
     const onPress = () => {

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -1,5 +1,5 @@
 import React, { type ReactNode } from 'react';
-import { Alert, Text, type TextStyle, type ViewStyle, type ImageStyle, type ScrollView, Linking } from 'react-native';
+import { Alert, Text, View, type TextStyle, type ViewStyle, type ImageStyle, type ScrollView, Linking } from 'react-native';
 import { Renderer, type RendererInterface } from 'react-native-marked';
 import { Image } from 'expo-image';
 
@@ -157,17 +157,48 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
 
   codespan(text: string, styles?: TextStyle): ReactNode {
     return (
-      <Text key={this.getKey()} selectable style={styles}>
+      <Text
+        key={this.getKey()}
+        selectable
+        style={[
+          {
+            backgroundColor: this.deps.colors.surfaceSecondary ?? '#f0f0f0',
+            paddingHorizontal: 4,
+            borderRadius: 4,
+            fontFamily: 'monospace',
+            fontSize: 14,
+            color: this.deps.colors.text,
+          },
+          styles,
+        ]}
+      >
         {text}
       </Text>
     );
   }
 
-  code(text: string, _language?: string, containerStyle?: ViewStyle, textStyle?: TextStyle): ReactNode {
+  code(text: string, language?: string, containerStyle?: ViewStyle, textStyle?: TextStyle): ReactNode {
     return (
-      <Text key={this.getKey()} selectable style={[containerStyle, textStyle]}>
-        {text}
-      </Text>
+      <View key={this.getKey()} style={containerStyle}>
+        {language ? (
+          <Text
+            selectable
+            style={{
+              fontSize: 12,
+              fontWeight: '600',
+              textTransform: 'uppercase',
+              marginBottom: 4,
+              color: this.deps.colors.text,
+              opacity: 0.7,
+            }}
+          >
+            {language}
+          </Text>
+        ) : null}
+        <Text selectable style={textStyle}>
+          {text}
+        </Text>
+      </View>
     );
   }
 }

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -1,10 +1,11 @@
 import React, { type ReactNode } from 'react';
-import { Text, type TextStyle, type ViewStyle, type ImageStyle, type ScrollView, Linking } from 'react-native';
+import { Alert, Text, type TextStyle, type ViewStyle, type ImageStyle, type ScrollView, Linking } from 'react-native';
 import { Renderer, type RendererInterface } from 'react-native-marked';
 import { Image } from 'expo-image';
 
 import { isCanvasLink, canvasIdFromLink } from '../models/Canvas';
 import { ErrorBoundary } from '../components/ui/ErrorBoundary';
+import { classifyHref } from './linkClassifier';
 
 interface CustomRendererDeps {
   colors: {
@@ -19,6 +20,8 @@ interface CustomRendererDeps {
   previewScrollRef?: React.RefObject<ScrollView | null>;
   CanvasPreview?: React.ComponentType<{ canvasId: string }>;
   approxLinePx?: number;
+  currentNotePath?: string;
+  onOpenNote?: (path: string) => boolean;
 }
 
 export class NotePreviewRenderer extends Renderer implements RendererInterface {
@@ -92,15 +95,20 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
 
     const onPress = () => {
       if (!href) return;
-      if (href.startsWith('note:')) {
-        const id = href.slice('note:'.length);
-        if (id && this.deps.navigation) {
-          this.deps.navigation.navigate('NoteEditor', { noteId: id });
+      const classified = classifyHref(href, this.deps.currentNotePath);
+      if (!classified) {
+        Linking.openURL(href).catch(() => {});
+        return;
+      }
+      if (classified.kind === 'note') {
+        const opened = this.deps.onOpenNote?.(classified.target) ?? false;
+        if (!opened) {
+          Alert.alert('Link target not found');
         }
         return;
       }
-      if (href.startsWith('#')) {
-        const slug = href.slice(1).toLowerCase();
+      if (classified.kind === 'anchor') {
+        const slug = classified.target;
         const content = this.deps.previewContent ?? '';
         const target = content
           .split('\n')
@@ -118,6 +126,10 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
           const px = this.deps.approxLinePx ?? 22;
           this.deps.previewScrollRef.current.scrollTo({ y: target * px, animated: true });
         }
+        return;
+      }
+      if (classified.kind === 'web' || classified.kind === 'mailto') {
+        Linking.openURL(href).catch(() => {});
         return;
       }
       Linking.openURL(href).catch(() => {});

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -33,6 +33,7 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
     return (
       <Text
         key={`canvas-fallback-${id}`}
+        selectable
         style={{
           color: this.deps.colors.text,
           backgroundColor: this.deps.colors.surfaceSecondary ?? '#f0f0f0',
@@ -125,6 +126,7 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
     return (
       <Text
         key={this.getKey()}
+        selectable
         style={[styles, { color: this.deps.colors.primary, textDecorationLine: 'underline' }]}
         onPress={onPress}
       >

--- a/src/utils/noteTagSupport.ts
+++ b/src/utils/noteTagSupport.ts
@@ -1,0 +1,3 @@
+export function canPersistNoteTags(format?: string): boolean {
+  return format === 'markdown' || format === 'neorg' || format === 'org';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,6 +1854,11 @@
   dependencies:
     invariant "^2.2.4"
 
+"@react-native-community/netinfo@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-12.0.1.tgz#fec75f4093c27778479d8927b4f51f133b8a13a4"
+  integrity sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ==
+
 "@react-native/assets-registry@0.83.6":
   version "0.83.6"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.83.6.tgz#36c4d986aa2903ab05c29589749618cfd9d2a258"


### PR DESCRIPTION
## Summary
Fixes ALL 20 open GitHub issues across 5 waves:

### Wave 1 — Critical Crashes
- **#421** Swipe-to-delete data loss
- **#425** Canvas race condition
- **#426** Second canvas crash
- **#423 B1** Neorg null crash

### Wave 2 — Functional Bugs
- **#429** Filter modal overflow
- **#427** Emoji → Ionicons
- **#411** Todo delete GitHub sync
- **#415** Todo completion empty slot
- **#424** Canvas pan viewport drift
- **#417** Link routing by target type
- **#423 B2-B7** Renderer pipeline bugs

### Wave 3 — UX Gaps
- **#413** Offline warning banner
- **#416** Selectable text in preview
- **#414** Explorer file tree background
- **#412** Save loading indicator
- **#420** Gray out uncached items offline

### Wave 4 — Enhancements
- **#410** JSON file rendering
- **#418** Tag persistence to frontmatter
- **#419** Note color-coding

### Wave 5 — Features
- **#422** Glossy/translucent UI mode
- **#428** Custom templates with pinning

### Test Results
- **273 tests passing** (62 new tests, 0 regressions)
- Baseline was 211 tests

## Test plan
- [x] All 273 tests pass
- [x] No type errors
- [x] No regressions in existing features
- [x] Glossy UI OFF by default
- [x] Templates CRUD functional