### PR TITLE
feat(home): bento Recent + Quick Access shelf for pinned items

### DIFF
--- a/__tests__/recentItems.test.ts
+++ b/__tests__/recentItems.test.ts
@@ -1,0 +1,146 @@
+import { bentoSizeForIndex, buildPinnedFeed, buildRecentFeed } from '../src/utils/recentItems';
+import type { Note } from '../src/models/Note';
+import type { Canvas } from '../src/models/Canvas';
+
+function makeNote(overrides: Partial<Note>): Note {
+  return {
+    id: overrides.id ?? `n-${Math.random()}`,
+    title: overrides.title ?? 'note',
+    content: overrides.content ?? '',
+    createdAt: overrides.createdAt ?? 0,
+    updatedAt: overrides.updatedAt ?? 0,
+    tags: overrides.tags ?? [],
+    format: overrides.format,
+    isPinned: overrides.isPinned,
+    repo: overrides.repo,
+    branch: overrides.branch,
+    filePath: overrides.filePath,
+    folderPath: overrides.folderPath,
+  };
+}
+
+function makeCanvas(overrides: Partial<Canvas>): Canvas {
+  return {
+    id: overrides.id ?? `c-${Math.random()}`,
+    title: overrides.title ?? 'canvas',
+    scene: overrides.scene ?? { version: 1, width: 100, height: 100, background: '#fff', elements: [] },
+    folderPath: overrides.folderPath,
+    repo: overrides.repo,
+    branch: overrides.branch,
+    filePath: overrides.filePath,
+    tags: overrides.tags ?? [],
+    createdAt: overrides.createdAt ?? 0,
+    updatedAt: overrides.updatedAt ?? 0,
+  };
+}
+
+describe('buildRecentFeed', () => {
+  it('returns empty when no inputs', () => {
+    expect(buildRecentFeed([], [])).toEqual([]);
+  });
+
+  it('mixes notes / documents / canvases sorted by updatedAt desc', () => {
+    const items = buildRecentFeed(
+      [
+        makeNote({ id: 'n1', updatedAt: 100 }),
+        makeNote({ id: 'd1', updatedAt: 300, format: 'pdf' }),
+      ],
+      [makeCanvas({ id: 'c1', updatedAt: 200 })],
+    );
+    expect(items.map((i) => `${i.kind}:${i.data.id}`)).toEqual([
+      'document:d1',
+      'canvas:c1',
+      'note:n1',
+    ]);
+  });
+
+  it('excludes pinned notes by default', () => {
+    const items = buildRecentFeed(
+      [
+        makeNote({ id: 'pinned', updatedAt: 500, isPinned: true }),
+        makeNote({ id: 'fresh', updatedAt: 100 }),
+      ],
+      [],
+    );
+    expect(items.map((i) => i.data.id)).toEqual(['fresh']);
+  });
+
+  it('keeps pinned items when excludePinned is false', () => {
+    const items = buildRecentFeed(
+      [
+        makeNote({ id: 'pinned', updatedAt: 500, isPinned: true }),
+        makeNote({ id: 'fresh', updatedAt: 100 }),
+      ],
+      [],
+      { excludePinned: false },
+    );
+    expect(items.map((i) => i.data.id)).toEqual(['pinned', 'fresh']);
+  });
+
+  it('respects limit', () => {
+    const items = buildRecentFeed(
+      [
+        makeNote({ id: 'a', updatedAt: 3 }),
+        makeNote({ id: 'b', updatedAt: 2 }),
+        makeNote({ id: 'c', updatedAt: 1 }),
+      ],
+      [],
+      { limit: 2 },
+    );
+    expect(items.map((i) => i.data.id)).toEqual(['a', 'b']);
+  });
+
+  it('marks pdf notes as document kind, others as note', () => {
+    const [pdf, md] = buildRecentFeed(
+      [
+        makeNote({ id: 'pdf', updatedAt: 2, format: 'pdf' }),
+        makeNote({ id: 'md', updatedAt: 1, format: 'markdown' }),
+      ],
+      [],
+    );
+    expect(pdf.kind).toBe('document');
+    expect(md.kind).toBe('note');
+  });
+});
+
+describe('buildPinnedFeed', () => {
+  it('returns empty when nothing is pinned', () => {
+    expect(buildPinnedFeed([makeNote({ id: 'a' })], [])).toEqual([]);
+  });
+
+  it('returns only pinned notes, sorted by updatedAt desc', () => {
+    const items = buildPinnedFeed(
+      [
+        makeNote({ id: 'p1', updatedAt: 100, isPinned: true }),
+        makeNote({ id: 'free', updatedAt: 200 }),
+        makeNote({ id: 'p2', updatedAt: 300, isPinned: true }),
+      ],
+      [],
+    );
+    expect(items.map((i) => i.data.id)).toEqual(['p2', 'p1']);
+  });
+
+  it('caps to limit', () => {
+    const items = buildPinnedFeed(
+      [
+        makeNote({ id: 'a', updatedAt: 3, isPinned: true }),
+        makeNote({ id: 'b', updatedAt: 2, isPinned: true }),
+        makeNote({ id: 'c', updatedAt: 1, isPinned: true }),
+      ],
+      [],
+      2,
+    );
+    expect(items).toHaveLength(2);
+    expect(items[0].data.id).toBe('a');
+  });
+});
+
+describe('bentoSizeForIndex', () => {
+  it('maps 0 to large, 1-2 to medium, rest to small', () => {
+    expect(bentoSizeForIndex(0)).toBe('large');
+    expect(bentoSizeForIndex(1)).toBe('medium');
+    expect(bentoSizeForIndex(2)).toBe('medium');
+    expect(bentoSizeForIndex(3)).toBe('small');
+    expect(bentoSizeForIndex(99)).toBe('small');
+  });
+});

--- a/src/components/home/BentoRecent.tsx
+++ b/src/components/home/BentoRecent.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { BentoTile } from './BentoTile';
+import type { RecentItem } from '../../utils/recentItems';
+
+interface Props {
+  items: RecentItem[];
+  onOpen: (item: RecentItem) => void;
+}
+
+/**
+ * Bento layout for the Home screen "Recent" feed.
+ *
+ * Phone (single column logical width):
+ *   [        large        ]
+ *   [ medium ] [ medium  ]
+ *   [ small  ] [ small   ]
+ *   ...
+ *
+ * Tablet (wider): the medium and small rows show two tiles per row but
+ * each tile is roomier. Layout intent is the same; sizing is taller.
+ */
+export function BentoRecent({ items, onOpen }: Props) {
+  const { colors } = useTheme();
+  if (items.length === 0) return null;
+
+  const [first, ...rest] = items;
+  const mediums = rest.slice(0, 2);
+  const smalls = rest.slice(2);
+
+  const smallRows: RecentItem[][] = [];
+  for (let i = 0; i < smalls.length; i += 2) {
+    smallRows.push(smalls.slice(i, i + 2));
+  }
+
+  return (
+    <View style={styles.section}>
+      <Text style={[styles.heading, { color: colors.textSecondary }]}>Recent</Text>
+      <View style={styles.column}>
+        <BentoTile item={first} size="large" onPress={() => onOpen(first)} />
+        {mediums.length > 0 ? (
+          <View style={styles.row}>
+            {mediums.map((item) => (
+              <View key={`${item.kind}-${item.data.id}`} style={styles.cell}>
+                <BentoTile item={item} size="medium" onPress={() => onOpen(item)} />
+              </View>
+            ))}
+            {mediums.length === 1 ? <View style={styles.cell} /> : null}
+          </View>
+        ) : null}
+        {smallRows.map((row, idx) => (
+          <View key={`small-row-${idx}`} style={styles.row}>
+            {row.map((item) => (
+              <View key={`${item.kind}-${item.data.id}`} style={styles.cell}>
+                <BentoTile item={item} size="small" onPress={() => onOpen(item)} />
+              </View>
+            ))}
+            {row.length === 1 ? <View style={styles.cell} /> : null}
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginTop: 8,
+    marginBottom: 16,
+  },
+  heading: {
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    marginBottom: 10,
+    paddingHorizontal: 4,
+  },
+  column: {
+    gap: 12,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  cell: {
+    flex: 1,
+  },
+});
+
+export default BentoRecent;

--- a/src/components/home/BentoTile.tsx
+++ b/src/components/home/BentoTile.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../../contexts/ThemeContext';
+import type { RecentItem, BentoSize } from '../../utils/recentItems';
+
+interface Props {
+  item: RecentItem;
+  size: BentoSize;
+  onPress: () => void;
+}
+
+function relativeTime(ms: number): string {
+  const diff = Date.now() - ms;
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return 'just now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+function iconFor(kind: RecentItem['kind']): keyof typeof Ionicons.glyphMap {
+  if (kind === 'canvas') return 'easel-outline';
+  if (kind === 'document') return 'document-text-outline';
+  return 'reader-outline';
+}
+
+function titleFor(item: RecentItem): string {
+  if (item.kind === 'canvas') return item.data.title || 'Untitled Canvas';
+  const note = item.data;
+  if (note.title) return note.title;
+  if (item.kind === 'document' && note.filePath) {
+    return note.filePath.split('/').pop() ?? 'Document';
+  }
+  return 'Untitled';
+}
+
+function subtitleFor(item: RecentItem): string {
+  if (item.kind === 'canvas') {
+    const n = item.data.scene?.elements?.length ?? 0;
+    return `${n} ${n === 1 ? 'element' : 'elements'} · ${relativeTime(item.updatedAt)}`;
+  }
+  if (item.kind === 'document') {
+    return item.data.filePath ?? `PDF · ${relativeTime(item.updatedAt)}`;
+  }
+  return relativeTime(item.updatedAt);
+}
+
+export function BentoTile({ item, size, onPress }: Props) {
+  const { colors } = useTheme();
+  const isLarge = size === 'large';
+  const isMedium = size === 'medium';
+
+  const accentByKind: Record<RecentItem['kind'], string> = {
+    note: colors.primary,
+    document: colors.accent,
+    canvas: colors.accent,
+  };
+  const accent = accentByKind[item.kind];
+
+  const heightFor: Record<BentoSize, number> = { large: 168, medium: 124, small: 84 };
+  const padding: Record<BentoSize, number> = { large: 18, medium: 14, small: 12 };
+  const titleSize: Record<BentoSize, number> = { large: 18, medium: 15, small: 13 };
+  const subSize: Record<BentoSize, number> = { large: 13, medium: 12, small: 11 };
+  const iconSize: Record<BentoSize, number> = { large: 28, medium: 22, small: 18 };
+  const radius: Record<BentoSize, number> = { large: 20, medium: 16, small: 14 };
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.tile,
+        {
+          backgroundColor: colors.surface,
+          borderColor: colors.border,
+          height: heightFor[size],
+          padding: padding[size],
+          borderRadius: radius[size],
+          opacity: pressed ? 0.92 : 1,
+          transform: [{ scale: pressed ? 0.985 : 1 }],
+        },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={`${item.kind} ${titleFor(item)}`}
+    >
+      <View style={[styles.badge, { backgroundColor: accent + '1F' }]}>
+        <Ionicons name={iconFor(item.kind)} size={iconSize[size]} color={accent} />
+      </View>
+      {item.pinned ? (
+        <View style={[styles.pin, { backgroundColor: colors.background }]}>
+          <Ionicons name="pin" size={11} color={accent} />
+        </View>
+      ) : null}
+      <View style={styles.spacer} />
+      <Text style={[styles.title, { color: colors.text, fontSize: titleSize[size] }]} numberOfLines={isLarge ? 3 : isMedium ? 2 : 1}>
+        {titleFor(item)}
+      </Text>
+      <Text style={[styles.subtitle, { color: colors.textSecondary, fontSize: subSize[size] }]} numberOfLines={1}>
+        {subtitleFor(item)}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  tile: {
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+  },
+  badge: {
+    width: 38,
+    height: 38,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pin: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  spacer: { flex: 1 },
+  title: {
+    fontWeight: '700',
+    letterSpacing: -0.2,
+  },
+  subtitle: {
+    fontWeight: '500',
+    marginTop: 2,
+  },
+});
+
+export default BentoTile;

--- a/src/components/home/QuickAccessShelf.tsx
+++ b/src/components/home/QuickAccessShelf.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../../contexts/ThemeContext';
+import type { RecentItem } from '../../utils/recentItems';
+
+interface Props {
+  items: RecentItem[];
+  onOpen: (item: RecentItem) => void;
+}
+
+function iconFor(kind: RecentItem['kind']): keyof typeof Ionicons.glyphMap {
+  if (kind === 'canvas') return 'easel';
+  if (kind === 'document') return 'document-text';
+  return 'reader';
+}
+
+function titleFor(item: RecentItem): string {
+  if (item.kind === 'canvas') return item.data.title || 'Untitled Canvas';
+  const note = item.data;
+  if (note.title) return note.title;
+  if (item.kind === 'document' && note.filePath) {
+    return note.filePath.split('/').pop() ?? 'Document';
+  }
+  return 'Untitled';
+}
+
+export function QuickAccessShelf({ items, onOpen }: Props) {
+  const { colors } = useTheme();
+  if (items.length === 0) return null;
+
+  return (
+    <View style={styles.section}>
+      <View style={styles.headerRow}>
+        <Ionicons name="pin" size={14} color={colors.textSecondary} />
+        <Text style={[styles.heading, { color: colors.textSecondary }]}>Quick access</Text>
+      </View>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.row}
+      >
+        {items.map((item) => {
+          const accent = item.kind === 'note' ? colors.primary : colors.accent;
+          return (
+            <Pressable
+              key={`${item.kind}-${item.data.id}`}
+              onPress={() => onOpen(item)}
+              style={({ pressed }) => [
+                styles.card,
+                {
+                  backgroundColor: colors.surface,
+                  borderColor: colors.border,
+                  opacity: pressed ? 0.92 : 1,
+                  transform: [{ scale: pressed ? 0.98 : 1 }],
+                },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Pinned ${item.kind} ${titleFor(item)}`}
+            >
+              <View style={[styles.badge, { backgroundColor: accent + '1F' }]}>
+                <Ionicons name={iconFor(item.kind)} size={16} color={accent} />
+              </View>
+              <Text
+                style={[styles.title, { color: colors.text }]}
+                numberOfLines={2}
+              >
+                {titleFor(item)}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginTop: 4,
+    marginBottom: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 8,
+    paddingHorizontal: 4,
+  },
+  heading: {
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  row: {
+    gap: 10,
+    paddingRight: 12,
+  },
+  card: {
+    width: 148,
+    minHeight: 88,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 12,
+    gap: 8,
+    justifyContent: 'space-between',
+  },
+  badge: {
+    width: 28,
+    height: 28,
+    borderRadius: 9,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 13,
+    fontWeight: '600',
+    letterSpacing: -0.1,
+  },
+});
+
+export default QuickAccessShelf;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -9,14 +9,17 @@ import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useNotes } from '../contexts/NoteContext';
 import { useCanvases } from '../contexts/CanvasContext';
-import { Note, NoteFormat } from '../models/Note';
+import { NoteFormat } from '../models/Note';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { HapticService } from '../utils/haptics';
 import TemplateSelector from '../components/TemplateSelector';
 import { NoteTemplate } from '../services/TemplateService';
 import { NoteFormatPreferenceService } from '../services/NoteFormatPreferenceService';
 import { useResponsive } from '../hooks/useResponsive';
-import { Button, Card, Modal, Group, GroupRow, ScreenHeader } from '../components/ui';
+import { Button, Card, Modal, ScreenHeader } from '../components/ui';
+import { BentoRecent } from '../components/home/BentoRecent';
+import { QuickAccessShelf } from '../components/home/QuickAccessShelf';
+import { buildPinnedFeed, buildRecentFeed, RecentItem } from '../utils/recentItems';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 type EditableNoteFormat = Exclude<NoteFormat, 'pdf'>;
@@ -26,75 +29,6 @@ const FORMAT_OPTIONS: { label: string; value: EditableNoteFormat; ext: string }[
   { label: 'Org Mode', value: 'org', ext: '.org' },
   { label: 'Neorg', value: 'neorg', ext: '.norg' },
 ];
-
-function stripFormatting(content: string, format?: NoteFormat): string {
-  const stripTopMetadata = (raw: string): string => {
-    if (format === 'neorg') {
-      const trimmed = raw.trimStart();
-      if (!trimmed.startsWith('@document.meta')) return raw;
-      const lines = raw.split('\n');
-      if (!lines[0]?.trim().startsWith('@document.meta')) return raw;
-      const endIndex = lines.findIndex((line, idx) => idx > 0 && line.trim() === '@end');
-      if (endIndex === -1) return raw;
-      return lines.slice(endIndex + 1).join('\n').trimStart();
-    }
-
-    if (format === 'org') {
-      const lines = raw.split('\n');
-      let i = 0;
-      while (i < lines.length && /^\s*#\+[A-Za-z0-9_]+:\s*.*$/.test(lines[i])) {
-        i++;
-      }
-      while (i < lines.length && lines[i].trim() === '') {
-        i++;
-      }
-      return i > 0 ? lines.slice(i).join('\n') : raw;
-    }
-
-    const trimmed = raw.trimStart();
-    if (!trimmed.startsWith('---\n')) return raw;
-    const lines = trimmed.split('\n');
-    if (lines[0] !== '---') return raw;
-    const closingIndex = lines.findIndex((line, idx) => idx > 0 && line.trim() === '---');
-    if (closingIndex === -1) return raw;
-    return lines.slice(closingIndex + 1).join('\n').trimStart();
-  };
-
-  const normalized = stripTopMetadata(content);
-
-  return normalized
-    // Remove markdown headings
-    .replace(/^#{1,6}\s+/gm, '')
-    // Remove bold/italic
-    .replace(/\*{1,2}([^*]+)\*{1,2}/g, '$1')
-    .replace(/_{1,2}([^_]+)_{1,2}/g, '$1')
-    // Remove org headings
-    .replace(/^\*{1,6}\s+/gm, '')
-    // Remove neorg headings
-    .replace(/^\*{1,6}\s+/gm, '')
-    // Remove markdown links
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    // Remove code blocks
-    .replace(/`{1,3}[^`]*`{1,3}/g, '')
-    // Remove blockquotes
-    .replace(/^>\s*/gm, '')
-    // Collapse whitespace/newlines
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-function relativeTime(ms: number): string {
-  const diff = Date.now() - ms;
-  const sec = Math.floor(diff / 1000);
-  if (sec < 60) return 'just now';
-  const min = Math.floor(sec / 60);
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}h ago`;
-  const day = Math.floor(hr / 24);
-  if (day < 7) return `${day}d ago`;
-  return new Date(ms).toLocaleDateString();
-}
 
 export default function HomeScreen() {
   const navigation = useNavigation<NavigationProp>();
@@ -158,9 +92,19 @@ export default function HomeScreen() {
     });
   }, [navigation]);
 
-  const openItem = useCallback(
-    (note: Note) => () => {
-      if (note.format === 'pdf' && note.repo && note.filePath) {
+  const recentLimit = isTablet ? 12 : 7;
+  const pinnedLimit = isTablet ? 12 : 6;
+  const recentItems = buildRecentFeed(notes, canvases, { excludePinned: true, limit: recentLimit });
+  const pinnedItems = buildPinnedFeed(notes, canvases, pinnedLimit);
+
+  const handleOpenRecentItem = useCallback(
+    (item: RecentItem) => {
+      if (item.kind === 'canvas') {
+        navigation.navigate('CanvasEditor', { canvasId: item.data.id });
+        return;
+      }
+      const note = item.data;
+      if (item.kind === 'document' && note.repo && note.filePath) {
         const info = parseRepoPath(note.repo);
         if (info) {
           navigation.navigate('PdfViewer', {
@@ -175,13 +119,8 @@ export default function HomeScreen() {
       }
       navigation.navigate('NoteEditor', { noteId: note.id });
     },
-    [navigation]
+    [navigation],
   );
-
-  const recentLimit = isTablet ? 6 : 3;
-  const recentNotes = notes.filter((n) => n.format !== 'pdf').slice(0, recentLimit);
-  const recentDocuments = notes.filter((n) => n.format === 'pdf').slice(0, recentLimit);
-  const recentCanvases = canvases.slice(0, recentLimit);
 
   return (
     <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: colors.background }]}>
@@ -249,74 +188,8 @@ export default function HomeScreen() {
         </View>
       </View>
 
-      {recentCanvases.length > 0 && (
-        <View style={{ marginTop: 8, marginBottom: 16 }}>
-          <Group title="Recent Canvases">
-            {recentCanvases.map((canvas) => (
-              <GroupRow
-                key={canvas.id}
-                onPress={() => navigation.navigate('CanvasEditor', { canvasId: canvas.id })}
-                leading={<Ionicons name="easel-outline" size={20} color={colors.accent} />}
-                trailing={(
-                  <Text style={[styles.recentNotePreview, { color: colors.textSecondary }]} numberOfLines={1}>
-                    {relativeTime(canvas.updatedAt)}
-                  </Text>
-                )}
-              >
-                <Text style={[styles.recentNoteTitle, { color: colors.text }]} numberOfLines={1}>
-                  {canvas.title || 'Untitled Canvas'}
-                </Text>
-                <Text style={[styles.recentNotePreview, { color: colors.textSecondary }]} numberOfLines={1}>
-                  {canvas.scene?.elements?.length ?? 0} elements
-                </Text>
-              </GroupRow>
-            ))}
-          </Group>
-        </View>
-      )}
-
-      {recentNotes.length > 0 && (
-        <View style={{ marginTop: 8, marginBottom: 16 }}>
-          <Group title="Recent Notes">
-            {recentNotes.map((note) => (
-              <GroupRow
-                key={note.id}
-                onPress={openItem(note)}
-                trailing={note.repo ? <Ionicons name="code-slash" size={14} color={colors.textSecondary} /> : undefined}
-              >
-                <Text style={[styles.recentNoteTitle, { color: colors.text }]} numberOfLines={1}>
-                  {note.title || 'Untitled'}
-                </Text>
-                <Text style={[styles.recentNotePreview, { color: colors.textSecondary }]} numberOfLines={1}>
-                  {stripFormatting(note.content, note.format).substring(0, 60) || 'No content'}
-                </Text>
-              </GroupRow>
-            ))}
-          </Group>
-        </View>
-      )}
-
-      {recentDocuments.length > 0 && (
-        <View style={{ marginTop: 8 }}>
-          <Group title="Recent Documents">
-            {recentDocuments.map((note) => (
-              <GroupRow
-                key={note.id}
-                onPress={openItem(note)}
-                leading={<Ionicons name="document-text" size={22} color={colors.accent} />}
-                trailing={note.repo ? <Ionicons name="code-slash" size={14} color={colors.textSecondary} /> : undefined}
-              >
-                <Text style={[styles.recentNoteTitle, { color: colors.text }]} numberOfLines={1}>
-                  {note.title || (note.filePath ?? 'Document').split('/').pop()}
-                </Text>
-                <Text style={[styles.recentNotePreview, { color: colors.textSecondary }]} numberOfLines={1}>
-                  {note.filePath ?? 'PDF'}
-                </Text>
-              </GroupRow>
-            ))}
-          </Group>
-        </View>
-      )}
+      <QuickAccessShelf items={pinnedItems} onOpen={handleOpenRecentItem} />
+      <BentoRecent items={recentItems} onOpen={handleOpenRecentItem} />
 
       <Modal visible={showFormatPicker} onRequestClose={handleFormatPickerClose} fullWidth>
         <Text style={[styles.modalTitle, { color: colors.text }]}>Choose Note Format</Text>

--- a/src/utils/recentItems.ts
+++ b/src/utils/recentItems.ts
@@ -1,0 +1,117 @@
+import type { Note } from '../models/Note';
+import type { Canvas } from '../models/Canvas';
+
+/**
+ * Discriminated union covering every entity type that can appear in the
+ * Home screen "Recent" feed. Use the `kind` discriminant to render the
+ * right tile + route to the right viewer.
+ */
+export type RecentItem =
+  | { kind: 'note'; data: Note; updatedAt: number; pinned: boolean }
+  | { kind: 'document'; data: Note; updatedAt: number; pinned: boolean }
+  | { kind: 'canvas'; data: Canvas; updatedAt: number; pinned: boolean };
+
+export interface BuildRecentFeedOptions {
+  /** Drop items where `isPinned` is true (they belong in Quick Access). */
+  excludePinned?: boolean;
+  /** Cap the returned list. Defaults to no cap. */
+  limit?: number;
+}
+
+function noteIsPinned(note: Note): boolean {
+  return note.isPinned === true;
+}
+
+// Canvases / Todos may not yet have an `isPinned` field (waiting on
+// model updates). Treat them as not-pinned via duck typing so this util
+// keeps working once that field lands without another edit here.
+function maybePinned(item: { isPinned?: boolean }): boolean {
+  return item.isPinned === true;
+}
+
+export function buildRecentFeed(
+  notes: readonly Note[],
+  canvases: readonly Canvas[],
+  options: BuildRecentFeedOptions = {},
+): RecentItem[] {
+  const { excludePinned = true, limit } = options;
+
+  const items: RecentItem[] = [];
+
+  for (const note of notes) {
+    const pinned = noteIsPinned(note);
+    if (excludePinned && pinned) continue;
+    items.push({
+      kind: note.format === 'pdf' ? 'document' : 'note',
+      data: note,
+      updatedAt: note.updatedAt,
+      pinned,
+    });
+  }
+
+  for (const canvas of canvases) {
+    const pinned = maybePinned(canvas as unknown as { isPinned?: boolean });
+    if (excludePinned && pinned) continue;
+    items.push({
+      kind: 'canvas',
+      data: canvas,
+      updatedAt: canvas.updatedAt,
+      pinned,
+    });
+  }
+
+  items.sort((a, b) => b.updatedAt - a.updatedAt);
+
+  if (limit !== undefined) return items.slice(0, limit);
+  return items;
+}
+
+/**
+ * Pinned items across notes (and canvases / todos once those gain the
+ * field). Sorted by `updatedAt` desc.
+ */
+export function buildPinnedFeed(
+  notes: readonly Note[],
+  canvases: readonly Canvas[],
+  limit?: number,
+): RecentItem[] {
+  const items: RecentItem[] = [];
+
+  for (const note of notes) {
+    if (!noteIsPinned(note)) continue;
+    items.push({
+      kind: note.format === 'pdf' ? 'document' : 'note',
+      data: note,
+      updatedAt: note.updatedAt,
+      pinned: true,
+    });
+  }
+
+  for (const canvas of canvases) {
+    if (!maybePinned(canvas as unknown as { isPinned?: boolean })) continue;
+    items.push({
+      kind: 'canvas',
+      data: canvas,
+      updatedAt: canvas.updatedAt,
+      pinned: true,
+    });
+  }
+
+  items.sort((a, b) => b.updatedAt - a.updatedAt);
+
+  if (limit !== undefined) return items.slice(0, limit);
+  return items;
+}
+
+/** Bento sizing variants. */
+export type BentoSize = 'large' | 'medium' | 'small';
+
+/**
+ * Map an index in the recent-feed array to a bento tile size.
+ * Index 0 => large, 1-2 => medium, 3+ => small.
+ */
+export function bentoSizeForIndex(index: number): BentoSize {
+  if (index === 0) return 'large';
+  if (index < 3) return 'medium';
+  return 'small';
+}


### PR DESCRIPTION
Closes #441.

Replaces the three flat Recent Canvases / Recent Notes / Recent Documents sections on \`HomeScreen\` with two unified surfaces — a bento-style **Recent** feed mixing all item types in updated-at order, and a **Quick Access** shelf for pinned items above it.

## Recent (bento)

- New \`buildRecentFeed\` util merges notes + canvases (and PDFs as a \`document\` kind), sorts by \`updatedAt\` desc, and excludes pinned items by default so they live exclusively in Quick Access.
- \`BentoTile\` renders \`large\` / \`medium\` / \`small\` variants with a type badge (note / document / canvas), pin marker, title, and contextual subtitle (relative time for notes, element count for canvases).
- \`BentoRecent\` lays out the items:
  - Index 0 → **large** tile, full width
  - 1-2 → **medium**, two per row
  - 3+ → **small**, two per row
  - Tablet: limit bumps from 7 → 12 items.

## Quick Access

- New \`buildPinnedFeed\` gathers items where \`isPinned === true\`. Today only \`Note\` has the field — canvases and todos light up automatically once they gain \`isPinned\` in the follow-up (intentionally deferred — see below).
- \`QuickAccessShelf\` is a horizontal-scroll row of compact pinned cards.
- **Hidden entirely when nothing is pinned** — no empty state, no \"Pin items here\" placeholder. Per the conditional rule from #441.

## Conditional rendering matrix

| State | Quick Access | Recent |
|-------|--------------|--------|
| 0 pinned, 0 recent | hidden | hidden |
| 0 pinned, N recent | hidden | bento renders |
| M pinned, 0 recent | renders | hidden |
| M pinned, N recent | both render | both render |

## Why canvas/todo pin model is deferred

Other agent's in-flight PR #440 already touches \`src/models/Todo.ts\`, \`src/models/Note.ts\`, \`src/screens/CanvasEditorScreen.tsx\`, \`src/screens/TodoListScreen.tsx\`, and \`src/stores/todoStore.ts\`. Adding \`isPinned\` + \`togglePin\` + long-press menu entries on top right now would conflict on every one of those files.

This PR ships the home-page redesign cleanly (zero overlap with #440 — HomeScreen + new home/* components + new utils file). Once #440 lands, a small follow-up adds \`isPinned\` to Canvas + Todo models + a Pin/Unpin entry in their long-press menus + the badge in CanvasCard / TodoRow. \`buildPinnedFeed\` already accepts canvases and silently picks up the field via duck typing — no change needed here.

## Files

- New: \`src/utils/recentItems.ts\` — \`RecentItem\` discriminated union, \`buildRecentFeed\`, \`buildPinnedFeed\`, \`bentoSizeForIndex\`
- New: \`src/components/home/BentoTile.tsx\` — three size variants, type badge, pin badge
- New: \`src/components/home/BentoRecent.tsx\` — large + 2 medium + N small layout
- New: \`src/components/home/QuickAccessShelf.tsx\` — horizontal shelf of pinned cards
- Edit: \`src/screens/HomeScreen.tsx\` — replaces the three Group/GroupRow sections (lines 252-318 in main) with \`<QuickAccessShelf />\` and \`<BentoRecent />\`. Also drops the now-dead \`stripFormatting\` and \`relativeTime\` helpers (the bento tile has its own time formatter).

## Test plan

- [x] \`yarn ts:check\` clean
- [x] \`yarn test\` — 221 passed, 24 suites, 9 snapshots (10 new \`recentItems\` tests)
- [ ] Manual: Home renders nothing in either section on a fresh install
- [ ] Manual: With one note, Recent shows a single large tile, no Quick Access
- [ ] Manual: Pin a note → Quick Access appears, that note no longer in Recent
- [ ] Manual: Mix notes + a PDF + a canvas → bento shows largest = most recent, type badges differ
- [ ] Manual: Tablet width → recent limit increases, layout still readable
- [ ] Manual: Tap any tile → routes to NoteEditor / CanvasEditor / PdfViewer correctly

## Non-goals

- Drag-to-reorder pinned items
- User-customizable bento layout
- PDF first-page thumbnail (icon for now)
- Animated tile entrance

🤖 Generated with [Claude Code](https://claude.com/claude-code)