### PR TITLE
fix(notes): prevent swipe-to-delete from opening adjacent card (#421)

### DIFF
--- a/__tests__/swipe-delete.test.tsx
+++ b/__tests__/swipe-delete.test.tsx
@@ -1,0 +1,300 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import NotesListScreen from '../src/screens/NotesListScreen';
+import { Note } from '../src/models/Note';
+
+let mockViewMode: 'list' | 'journal' = 'list';
+let mockNotesSeed: Note[] = [];
+let latestSetNotes: React.Dispatch<React.SetStateAction<Note[]>> | null = null;
+const mockSwipeableCloseFns: Record<string, jest.Mock> = {};
+
+const mockSetViewMode = jest.fn();
+const mockRefreshNotes = jest.fn(async () => undefined);
+const mockTogglePin = jest.fn(async () => true);
+const mockCreateNote = jest.fn(async () => null);
+const mockDeleteNote = jest.fn(async (id: string) => {
+  latestSetNotes?.((prev) => prev.filter((note) => note.id !== id));
+  return true;
+});
+const mockUseNoteStore: any = jest.fn();
+mockUseNoteStore.getState = () => ({ error: null });
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f4f4f4',
+      primary: '#2563eb',
+      text: '#111',
+      textSecondary: '#666',
+      border: '#ddd',
+      error: '#dc2626',
+    },
+  }),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null } }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({ repositories: [] }),
+}));
+
+jest.mock('../src/contexts/ViewModeContext', () => ({
+  useViewMode: () => ({ viewMode: mockViewMode, setViewMode: mockSetViewMode }),
+}));
+
+jest.mock('../src/contexts/NoteContext', () => {
+  const React = require('react');
+  return {
+    useNotes: () => {
+      const [notes, setNotes] = React.useState(mockNotesSeed);
+      latestSetNotes = setNotes;
+      return {
+        notes,
+        filteredNotes: notes,
+        isLoading: false,
+        searchQuery: '',
+        setSearchQuery: jest.fn(),
+        deleteNote: mockDeleteNote,
+        refreshNotes: mockRefreshNotes,
+        togglePin: mockTogglePin,
+        error: null,
+        createNote: mockCreateNote,
+      };
+    },
+  };
+});
+
+jest.mock('../src/stores/noteStore', () => {
+  return { useNoteStore: mockUseNoteStore };
+});
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: { setToken: jest.fn() },
+}));
+
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    pendingCount: jest.fn(async () => 0),
+    subscribe: jest.fn(() => jest.fn()),
+    drain: jest.fn(async () => ({ succeeded: 0 })),
+  },
+}));
+
+jest.mock('../src/services/RepoPullService', () => ({
+  pullAllFromRepos: jest.fn(async () => undefined),
+}));
+
+jest.mock('../src/services/ShareService', () => ({
+  ShareService: { shareText: jest.fn() },
+}));
+
+jest.mock('../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({ isTablet: false, maxContentWidth: 0 }),
+}));
+
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: {
+    light: jest.fn(),
+    medium: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    selection: jest.fn(),
+  },
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+
+jest.mock('../src/components/SearchBar', () => {
+  const { TextInput } = require('react-native');
+  return ({ value, onChangeText }: { value: string; onChangeText: (value: string) => void }) => (
+    <TextInput value={value} onChangeText={onChangeText} />
+  );
+});
+
+jest.mock('../src/components/ui', () => ({
+  ScreenHeader: ({ title }: { title: string }) => {
+    const { Text } = require('react-native');
+    return <Text>{title}</Text>;
+  },
+}));
+
+jest.mock('../src/components/NoteCard', () => ({
+  __esModule: true,
+  default: ({ note }: { note: Note }) => {
+    const { Text } = require('react-native');
+    return <Text>{note.title}</Text>;
+  },
+}));
+
+jest.mock('@shopify/flash-list', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    FlashList: React.forwardRef(({ data, renderItem, ListEmptyComponent }: any, _ref: any) => {
+      if (!data?.length) {
+        return <View>{ListEmptyComponent ?? null}</View>;
+      }
+      return <View>{data.map((item: Note, index: number) => renderItem({ item, index }))}</View>;
+    }),
+  };
+});
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { Pressable, View } = require('react-native');
+
+  return React.forwardRef(
+    ({ children, renderRightActions, onSwipeableWillOpen }: any, ref: any) => {
+      const [isOpen, setIsOpen] = React.useState(false);
+      const noteId = children?.props?.note?.id ?? 'unknown';
+      const closeRef = React.useRef();
+      const methodsRef = React.useRef();
+
+      if (!closeRef.current) {
+        closeRef.current = jest.fn(() => setIsOpen(false));
+      }
+
+      if (!methodsRef.current) {
+        methodsRef.current = {
+          close: closeRef.current,
+          openLeft: jest.fn(),
+          openRight: jest.fn(),
+          reset: jest.fn(),
+        };
+      }
+
+      const close = closeRef.current;
+      const methods = methodsRef.current;
+
+      mockSwipeableCloseFns[noteId] = close;
+
+      React.useEffect(() => {
+        if (typeof ref === 'function') {
+          ref(methods);
+          return () => ref(null);
+        }
+
+        if (ref) {
+          ref.current = methods;
+          return () => {
+            ref.current = null;
+          };
+        }
+
+        return undefined;
+      }, [ref, methods]);
+
+      return (
+        <View>
+          <Pressable
+            testID={`open-swipe-${noteId}`}
+            onPress={() => {
+              onSwipeableWillOpen?.();
+              setIsOpen(true);
+            }}
+          />
+          {children}
+          {isOpen ? (
+            <View testID={`swipe-actions-${noteId}`}>
+              {renderRightActions?.(undefined, undefined, methods)}
+            </View>
+          ) : null}
+        </View>
+      );
+    },
+  );
+});
+
+const createNote = (id: string, title: string): Note => ({
+  id,
+  title,
+  content: `${title} content`,
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  format: 'markdown',
+});
+
+const confirmLatestDeleteAlert = async () => {
+  const alertCalls = (Alert.alert as jest.Mock).mock.calls;
+  const lastCall = alertCalls[alertCalls.length - 1];
+  if (!lastCall) {
+    throw new Error('Expected delete alert to be shown');
+  }
+
+  const buttons = lastCall[2] as Array<{ text?: string; onPress?: () => void | Promise<void> }>;
+  const deleteButton = buttons.find((button) => button.text === 'Delete');
+  if (!deleteButton?.onPress) {
+    throw new Error('Expected delete confirmation button');
+  }
+
+  await act(async () => {
+    await deleteButton.onPress?.();
+  });
+};
+
+describe('NotesListScreen swipe delete regression', () => {
+  beforeEach(() => {
+    mockViewMode = 'list';
+    mockNotesSeed = [
+      createNote('note-1', 'First note'),
+      createNote('note-2', 'Second note'),
+      createNote('note-3', 'Third note'),
+    ];
+    latestSetNotes = null;
+    Object.keys(mockSwipeableCloseFns).forEach((key) => delete mockSwipeableCloseFns[key]);
+    mockDeleteNote.mockClear();
+    mockSetViewMode.mockClear();
+    mockRefreshNotes.mockClear();
+    mockTogglePin.mockClear();
+    mockCreateNote.mockClear();
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each(['list', 'journal'] as const)(
+    'closes swiped state before deleting in %s mode so recycled cards do not stay open',
+    async (viewMode) => {
+      mockViewMode = viewMode;
+      const screen = render(<NotesListScreen />);
+
+      fireEvent.press(screen.getByTestId('open-swipe-note-1'));
+      expect(screen.getByTestId('swipe-actions-note-1')).toBeTruthy();
+
+      fireEvent.press(screen.getByText('Delete'));
+      await confirmLatestDeleteAlert();
+
+      await waitFor(() => expect(screen.queryByText('First note')).toBeNull());
+      expect(screen.queryByTestId('swipe-actions-note-2')).toBeNull();
+      expect(screen.queryAllByText('Delete')).toHaveLength(0);
+    },
+  );
+
+  it('keeps only one swipeable card open at a time', async () => {
+    const screen = render(<NotesListScreen />);
+
+    fireEvent.press(screen.getByTestId('open-swipe-note-1'));
+    expect(screen.getByTestId('swipe-actions-note-1')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('open-swipe-note-2'));
+
+    await waitFor(() => expect(mockSwipeableCloseFns['note-1']).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('swipe-actions-note-2')).toBeTruthy();
+  });
+});

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -21,7 +21,9 @@ import { FlashList, FlashListRef } from "@shopify/flash-list";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Ionicons } from "@expo/vector-icons";
-import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
+import ReanimatedSwipeable, {
+  type SwipeableMethods,
+} from "react-native-gesture-handler/ReanimatedSwipeable";
 
 import { useNotes } from "../contexts/NoteContext";
 import { useNoteStore } from "../stores/noteStore";
@@ -79,6 +81,10 @@ export default function NotesListScreen() {
   const { isTablet, maxContentWidth } = useResponsive();
   const { repositories } = useRepos();
   const listRef = useRef<FlashListRef<Note>>(null);
+  const swipeableRefs = useRef<
+    Record<string, React.RefObject<SwipeableMethods | null>>
+  >({});
+  const openSwipeableRef = useRef<SwipeableMethods | null>(null);
 
   useEffect(() => {
     if (authState.token) {
@@ -91,6 +97,38 @@ export default function NotesListScreen() {
   const [currentSearchMatchIndex, setCurrentSearchMatchIndex] = useState(0);
   const [pendingSync, setPendingSync] = useState(0);
   const [isManualSyncing, setIsManualSyncing] = useState(false);
+
+  const closeOpenSwipeable = useCallback(() => {
+    openSwipeableRef.current?.close();
+    openSwipeableRef.current = null;
+  }, []);
+
+  const getSwipeableRef = useCallback((noteId: string) => {
+    if (!swipeableRefs.current[noteId]) {
+      swipeableRefs.current[noteId] = React.createRef<SwipeableMethods>();
+    }
+
+    return swipeableRefs.current[noteId];
+  }, []);
+
+  const handleSwipeableWillOpen = useCallback((noteId: string) => {
+    const swipeable = swipeableRefs.current[noteId]?.current;
+
+    if (openSwipeableRef.current && openSwipeableRef.current !== swipeable) {
+      openSwipeableRef.current.close();
+    }
+
+    if (swipeable) {
+      openSwipeableRef.current = swipeable;
+    }
+  }, []);
+
+  const handleSwipeableWillClose = useCallback((noteId: string) => {
+    const swipeable = swipeableRefs.current[noteId]?.current;
+    if (openSwipeableRef.current === swipeable) {
+      openSwipeableRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -290,6 +328,7 @@ export default function NotesListScreen() {
 
   const handleDeleteFromSwipe = useCallback(
     (note: Note) => {
+      closeOpenSwipeable();
       Alert.alert("Delete Note", `Delete "${note.title || "Untitled"}"?`, [
         { text: "Cancel", style: "cancel" },
         {
@@ -305,7 +344,7 @@ export default function NotesListScreen() {
         },
       ]);
     },
-    [deleteNote],
+    [closeOpenSwipeable, deleteNote],
   );
 
   const scrollToSearchMatch = useCallback(
@@ -382,8 +421,12 @@ export default function NotesListScreen() {
   const renderSwipeableNote = useCallback(
     (note: Note, index: number) => (
       <ReanimatedSwipeable
+        key={note.id}
+        ref={getSwipeableRef(note.id)}
         overshootRight={false}
         rightThreshold={40}
+        onSwipeableWillOpen={() => handleSwipeableWillOpen(note.id)}
+        onSwipeableWillClose={() => handleSwipeableWillClose(note.id)}
         renderRightActions={() => renderSwipeActions(note)}
       >
         <NoteCard
@@ -396,6 +439,9 @@ export default function NotesListScreen() {
     ),
     [
       currentSearchMatchIndex,
+      getSwipeableRef,
+      handleSwipeableWillClose,
+      handleSwipeableWillOpen,
       handleNoteLongPress,
       handleNotePress,
       hasActiveSearch,
@@ -411,7 +457,7 @@ export default function NotesListScreen() {
 
   const renderJournalNote = useCallback(
     ({ item, index }: { item: Note; index: number }) => (
-      <View style={styles.journalItem}>
+      <View key={item.id} style={styles.journalItem}>
         <Text style={[styles.journalDate, { color: colors.textSecondary }]}>
           {item.updatedAt ? new Date(item.updatedAt).toLocaleDateString() : ""}
         </Text>


### PR DESCRIPTION
## Summary
- Track currently-open Swipeable in `NotesListScreen`; auto-close prior card when another opens
- Close swipeable before showing delete confirm so adjacent FlashList-recycled card never inherits open state
- Same fix applied to journal renderer

Closes #421

## Test plan
- [x] `yarn test __tests__/swipe-delete.test.tsx` — 3/3 pass
- [x] `yarn ts:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)