### PR TITLE
chore: add netinfo dependency + useNetworkStatus hook

### DIFF
--- a/__tests__/useNetworkStatus.test.ts
+++ b/__tests__/useNetworkStatus.test.ts
@@ -1,0 +1,80 @@
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn();
+  const fetch = jest.fn();
+
+  return {
+    __esModule: true,
+    default: {
+      addEventListener,
+      fetch,
+    },
+  };
+});
+
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import NetInfo from '@react-native-community/netinfo';
+import { useNetworkStatus } from '../src/hooks/useNetworkStatus';
+
+const netInfo = NetInfo as jest.Mocked<typeof NetInfo>;
+
+describe('useNetworkStatus', () => {
+  let unsubscribe: jest.Mock;
+  let emitState: ((state: any) => void) | undefined;
+  let resolveFetch: ((state: any) => void) | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    unsubscribe = jest.fn();
+    emitState = undefined;
+    resolveFetch = undefined;
+
+    netInfo.addEventListener.mockImplementation(((listener: any) => {
+      emitState = listener;
+      return unsubscribe;
+    }) as any);
+    netInfo.fetch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve as any;
+        }) as any,
+    );
+  });
+
+  test('starts optimistic and unsubscribes on unmount', () => {
+    const { result, unmount } = renderHook(() => useNetworkStatus());
+
+    expect(result.current).toEqual({ isConnected: true, isInternetReachable: true });
+    expect(netInfo.addEventListener).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test('updates when netinfo emits online and offline states', () => {
+    const { result } = renderHook(() => useNetworkStatus());
+
+    act(() => {
+      emitState?.({ isConnected: false, isInternetReachable: false });
+    });
+    expect(result.current).toEqual({ isConnected: false, isInternetReachable: false });
+
+    act(() => {
+      emitState?.({ isConnected: true, isInternetReachable: true });
+    });
+    expect(result.current).toEqual({ isConnected: true, isInternetReachable: true });
+  });
+
+  test('uses the first fetched status once available', async () => {
+    const { result } = renderHook(() => useNetworkStatus());
+
+    expect(result.current).toEqual({ isConnected: true, isInternetReachable: true });
+
+    act(() => {
+      resolveFetch?.({ isConnected: false, isInternetReachable: false });
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ isConnected: false, isInternetReachable: false });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-native-ai/llama": "0.10.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.6.0",
+    "@react-native-community/netinfo": "^12.0.1",
     "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import NetInfo, { type NetInfoState } from '@react-native-community/netinfo';
+
+export interface NetworkStatus {
+  isConnected: boolean;
+  isInternetReachable: boolean;
+}
+
+function toNetworkStatus(state: NetInfoState): NetworkStatus {
+  const isConnected = state.isConnected ?? false;
+  return {
+    isConnected,
+    isInternetReachable: state.isInternetReachable ?? isConnected,
+  };
+}
+
+export function useNetworkStatus(): NetworkStatus {
+  const [status, setStatus] = useState<NetworkStatus>({
+    isConnected: true,
+    isInternetReachable: true,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      if (active) {
+        setStatus(toNetworkStatus(state));
+      }
+    });
+
+    NetInfo.fetch().then((state) => {
+      if (active) {
+        setStatus(toNetworkStatus(state));
+      }
+    });
+
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, []);
+
+  return status;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,6 +1854,11 @@
   dependencies:
     invariant "^2.2.4"
 
+"@react-native-community/netinfo@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-12.0.1.tgz#fec75f4093c27778479d8927b4f51f133b8a13a4"
+  integrity sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ==
+
 "@react-native/assets-registry@0.83.6":
   version "0.83.6"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.83.6.tgz#36c4d986aa2903ab05c29589749618cfd9d2a258"


### PR DESCRIPTION
## Summary
- Add `@react-native-community/netinfo`
- New `src/hooks/useNetworkStatus.ts` — subscribes to NetInfo, returns `{ isConnected, isInternetReachable }`
- Foundation for #413 (offline banner) and #420 (gray-out uncached)

## Test plan
- [x] `yarn test __tests__/useNetworkStatus.test.ts` — 3/3 pass
- [x] `yarn ts:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)