### PR TITLE
fix(canvas): serialize storage writes to prevent race condition (#425)

### DIFF
--- a/__tests__/canvas-race.test.ts
+++ b/__tests__/canvas-race.test.ts
@@ -1,0 +1,179 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  let store: Record<string, string> = {};
+  let blockNextCanvasWrite = false;
+  let blockedCanvasWrite: {
+    promise: Promise<void>;
+    release: () => void;
+    started: Promise<void>;
+    markStarted: () => void;
+  } | null = null;
+
+  const createBlockedWrite = () => {
+    let release = () => {};
+    let markStarted = () => {};
+    const promise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    return { promise, release, started, markStarted };
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (key: string) => (key in store ? store[key] : null)),
+      setItem: jest.fn(async (key: string, value: string) => {
+        if (key === '@gitnotes:canvases' && blockNextCanvasWrite) {
+          blockNextCanvasWrite = false;
+          blockedCanvasWrite = createBlockedWrite();
+          blockedCanvasWrite.markStarted();
+          await blockedCanvasWrite.promise;
+          blockedCanvasWrite = null;
+        }
+        store[key] = value;
+      }),
+      removeItem: jest.fn(async (key: string) => {
+        delete store[key];
+      }),
+      multiGet: jest.fn(async (keys: string[]) => keys.map((key) => [key, key in store ? store[key] : null])),
+      multiSet: jest.fn(async (pairs: [string, string][]) => {
+        for (const [key, value] of pairs) {
+          store[key] = value;
+        }
+      }),
+      multiRemove: jest.fn(async (keys: string[]) => {
+        for (const key of keys) {
+          delete store[key];
+        }
+      }),
+      clear: jest.fn(async () => {
+        store = {};
+      }),
+      __reset: () => {
+        blockedCanvasWrite?.release();
+        store = {};
+        blockNextCanvasWrite = false;
+        blockedCanvasWrite = null;
+      },
+      __blockNextCanvasWrite: () => {
+        blockNextCanvasWrite = true;
+      },
+      __waitForBlockedCanvasWrite: async () => {
+        for (let attempt = 0; attempt < 20 && !blockedCanvasWrite; attempt += 1) {
+          await Promise.resolve();
+        }
+        if (!blockedCanvasWrite) {
+          throw new Error('No blocked canvas write in progress');
+        }
+        await blockedCanvasWrite.started;
+      },
+      __releaseBlockedCanvasWrite: () => {
+        blockedCanvasWrite?.release();
+      },
+    },
+  };
+});
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getTreeRecursive: jest.fn(async () => []),
+    getRepoContents: jest.fn(async (_owner: string, _repo: string, dirPath: string) => {
+      if (dirPath !== 'canvases') return [];
+      return [{ type: 'file', path: 'canvases/remote-canvas.json', download_url: 'https://example.com/remote-canvas.json' }];
+    }),
+    getFileContent: jest.fn(async (_owner: string, _repo: string, path: string) => {
+      if (path !== 'canvases/remote-canvas.json') return null;
+      return JSON.stringify({
+        version: 1,
+        width: 640,
+        height: 480,
+        background: '#FFFFFF',
+        elements: [
+          {
+            type: 'text',
+            id: 'remote-text',
+            text: 'remote',
+            x: 16,
+            y: 24,
+            fontSize: 18,
+            color: '#000000',
+          },
+        ],
+      });
+    }),
+  },
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createCanvas } from '../src/models/Canvas';
+import { pullFromSingleRepo } from '../src/services/RepoPullService';
+import { StorageService } from '../src/services/StorageService';
+
+const CANVASES_STORAGE_KEY = '@gitnotes:canvases';
+const CANVASES_BACKUP_STORAGE_KEY = '@gitnotes:canvases.bak';
+
+type AsyncStorageMock = {
+  __reset: () => void;
+  __blockNextCanvasWrite: () => void;
+  __waitForBlockedCanvasWrite: () => Promise<void>;
+  __releaseBlockedCanvasWrite: () => void;
+};
+
+describe('canvas storage race handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage as unknown as AsyncStorageMock).__reset();
+  });
+
+  test('concurrent local save and repo pull preserve both changes', async () => {
+    const localCanvas = createCanvas({
+      title: 'Local canvas',
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'canvases/local-canvas.json',
+    });
+
+    await StorageService.saveAllCanvases([localCanvas]);
+    await StorageService.saveRepositories([{ id: 'repo-1', name: 'repo', path: 'owner/repo', branch: 'main' }]);
+
+    (AsyncStorage as unknown as AsyncStorageMock).__blockNextCanvasWrite();
+
+    const updatePromise = StorageService.updateCanvas({ id: localCanvas.id, title: 'Local canvas edited' });
+    await (AsyncStorage as unknown as AsyncStorageMock).__waitForBlockedCanvasWrite();
+
+    const pullPromise = pullFromSingleRepo('owner/repo');
+
+    (AsyncStorage as unknown as AsyncStorageMock).__releaseBlockedCanvasWrite();
+
+    const [updatedCanvas, pullResult] = await Promise.all([updatePromise, pullPromise]);
+    const canvases = await StorageService.getAllCanvases();
+
+    expect(updatedCanvas?.title).toBe('Local canvas edited');
+    expect(pullResult.canvases).toBe(1);
+    expect(canvases).toHaveLength(2);
+    expect(canvases.find((canvas) => canvas.id === localCanvas.id)?.title).toBe('Local canvas edited');
+    expect(canvases.find((canvas) => canvas.filePath === 'canvases/remote-canvas.json')?.scene.elements).toHaveLength(1);
+  });
+
+  test('malformed canvas JSON returns [] instead of throwing', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await AsyncStorage.setItem(CANVASES_STORAGE_KEY, '{not json');
+
+    await expect(StorageService.getAllCanvases()).resolves.toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error reading canvases from storage:', expect.any(Error));
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('canvas writes keep a backup of the previous blob', async () => {
+    await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify([{ id: 'old-canvas' }]));
+
+    await StorageService.saveAllCanvases([createCanvas({ title: 'New canvas' })]);
+
+    await expect(AsyncStorage.getItem(CANVASES_BACKUP_STORAGE_KEY)).resolves.toBe(JSON.stringify([{ id: 'old-canvas' }]));
+  });
+});

--- a/src/screens/CanvasEditorScreen.tsx
+++ b/src/screens/CanvasEditorScreen.tsx
@@ -547,7 +547,7 @@ export default function CanvasEditorScreen() {
       });
 
       if (!syncResult.success) {
-        console.warn('[CanvasEditor] GitHub sync failed:', syncResult.error);
+        Alert.alert('Sync Failed', syncResult.error || 'Canvas changes were saved locally but could not sync to GitHub.');
       }
     }
 

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -163,53 +163,43 @@ async function pullCanvasesFromRepo(
     const files = await fetchDirectoryFiles(owner, repo, 'canvases', branch);
     if (files.length === 0) return 0;
 
-    // Single read → mutate in memory → single write. Previous code re-read
-    // and re-wrote inside each iteration which lost interleaved edits when
-    // pulls ran in parallel (Promise.all in pullAllFromRepos).
-    const allCanvases = await StorageService.getAllCanvases();
-    let dirty = false;
+    await StorageService.mutateCanvases((allCanvases) => {
+      for (const file of files) {
+        if (!file.path.endsWith('.json')) continue;
 
-    for (const file of files) {
-      if (!file.path.endsWith('.json')) continue;
+        let scene: CanvasScene;
+        try {
+          scene = JSON.parse(file.content);
+        } catch {
+          continue;
+        }
 
-      let scene: CanvasScene;
-      try {
-        scene = JSON.parse(file.content);
-      } catch {
-        continue;
-      }
+        const titleFromPath = file.path
+          .replace(/^canvases\//, '')
+          .replace(/\.json$/, '')
+          .replace(/-/g, ' ');
 
-      const titleFromPath = file.path
-        .replace(/^canvases\//, '')
-        .replace(/\.json$/, '')
-        .replace(/-/g, ' ');
-
-      const idx = allCanvases.findIndex((c) => c.filePath === file.path);
-      if (idx !== -1) {
-        const existing = allCanvases[idx];
-        if (JSON.stringify(existing.scene) !== JSON.stringify(scene)) {
-          allCanvases[idx] = updateCanvas(existing, { scene });
-          dirty = true;
+        const idx = allCanvases.findIndex((c) => c.filePath === file.path);
+        if (idx !== -1) {
+          const existing = allCanvases[idx];
+          if (JSON.stringify(existing.scene) !== JSON.stringify(scene)) {
+            allCanvases[idx] = updateCanvas(existing, { scene });
+            pulled++;
+          }
+        } else {
+          allCanvases.push(
+            createCanvas({
+              title: titleFromPath,
+              scene,
+              repo: repoPath,
+              branch,
+              filePath: file.path,
+            }),
+          );
           pulled++;
         }
-      } else {
-        allCanvases.push(
-          createCanvas({
-            title: titleFromPath,
-            scene,
-            repo: repoPath,
-            branch,
-            filePath: file.path,
-          }),
-        );
-        dirty = true;
-        pulled++;
       }
-    }
-
-    if (dirty) {
-      await StorageService.saveAllCanvases(allCanvases);
-    }
+    });
   } catch {
     console.warn(`[RepoPullService] Failed to pull canvases from ${owner}/${repo}`);
   }

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -3,11 +3,12 @@ import { Note, NoteCreateInput, NoteUpdateInput, createNote, updateNote } from '
 import { Folder, FolderCreateInput, createFolder, updateFolder } from '../models/Folder';
 import { GitRepository } from './GitService';
 import { Todo, TodoCreateInput, TodoUpdateInput, createTodoItem, applyTodoUpdate } from '../models/Todo';
-import { Canvas, CanvasCreateInput, CanvasUpdateInput, createCanvas, updateCanvas, sortCanvasesByUpdated } from '../models/Canvas';
+import { Canvas, CanvasCreateInput, CanvasUpdateInput, createCanvas, updateCanvas } from '../models/Canvas';
 import { NOTE_INDEX_KEY, noteKey, getBootValue } from './StorageBootstrap';
 
 const TODOS_STORAGE_KEY = '@gitnotes:todos';
 const CANVASES_STORAGE_KEY = '@gitnotes:canvases';
+const CANVASES_BACKUP_STORAGE_KEY = '@gitnotes:canvases.bak';
 const LEGACY_NOTES_KEY = '@gitnotes:notes';
 const REPOS_STORAGE_KEY = '@gitnotes:repos';
 const FOLDERS_STORAGE_KEY = '@gitnotes:folders';
@@ -38,6 +39,47 @@ async function migrateFromBlob(): Promise<void> {
 }
 
 export class StorageService {
+  private static canvasWriteQueue: Promise<void> = Promise.resolve();
+
+  private static enqueueCanvasWrite<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.canvasWriteQueue.catch(() => undefined).then(operation);
+    this.canvasWriteQueue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  private static async readAllCanvasesRaw(): Promise<Canvas[]> {
+    try {
+      const boot = getBootValue('@gitnotes:canvases');
+      const json = boot ?? await AsyncStorage.getItem(CANVASES_STORAGE_KEY);
+      return json ? JSON.parse(json) : [];
+    } catch (error) {
+      console.error('Error reading canvases from storage:', error);
+      return [];
+    }
+  }
+
+  private static async backupCanvasBlob(): Promise<void> {
+    const current = await AsyncStorage.getItem(CANVASES_STORAGE_KEY);
+    if (current !== null) {
+      await AsyncStorage.setItem(CANVASES_BACKUP_STORAGE_KEY, current);
+    }
+  }
+
+  static async mutateCanvases<T>(mutator: (canvases: Canvas[]) => Promise<T> | T): Promise<T> {
+    return this.enqueueCanvasWrite(async () => {
+      const canvases = await this.readAllCanvasesRaw();
+      const result = await mutator(canvases);
+      try {
+        await this.backupCanvasBlob();
+        await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify(canvases));
+      } catch (error) {
+        console.error('Error saving canvases to storage:', error);
+        throw error;
+      }
+      return result;
+    });
+  }
+
   static async getAllNotes(): Promise<Note[]> {
     await migrateFromBlob();
     try {
@@ -323,22 +365,20 @@ export class StorageService {
   }
 
   static async getAllCanvases(): Promise<Canvas[]> {
-    try {
-      const boot = getBootValue('@gitnotes:canvases');
-      const json = boot ?? await AsyncStorage.getItem(CANVASES_STORAGE_KEY);
-      return json ? JSON.parse(json) : [];
-    } catch {
-      return [];
-    }
+    await this.canvasWriteQueue;
+    return this.readAllCanvasesRaw();
   }
 
   static async saveAllCanvases(canvases: Canvas[]): Promise<void> {
-    try {
-      await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify(canvases));
-    } catch (error) {
-      console.error('Error saving canvases to storage:', error);
-      throw error;
-    }
+    await this.enqueueCanvasWrite(async () => {
+      try {
+        await this.backupCanvasBlob();
+        await AsyncStorage.setItem(CANVASES_STORAGE_KEY, JSON.stringify(canvases));
+      } catch (error) {
+        console.error('Error saving canvases to storage:', error);
+        throw error;
+      }
+    });
   }
 
   static async getCanvasById(id: string): Promise<Canvas | null> {
@@ -347,27 +387,28 @@ export class StorageService {
   }
 
   static async createCanvas(input: CanvasCreateInput): Promise<Canvas> {
-    const canvases = await this.getAllCanvases();
-    const newCanvas = createCanvas(input);
-    canvases.push(newCanvas);
-    await this.saveAllCanvases(canvases);
-    return newCanvas;
+    return this.mutateCanvases((canvases) => {
+      const newCanvas = createCanvas(input);
+      canvases.push(newCanvas);
+      return newCanvas;
+    });
   }
 
   static async updateCanvas(input: CanvasUpdateInput): Promise<Canvas | null> {
-    const canvases = await this.getAllCanvases();
-    const idx = canvases.findIndex((c) => c.id === input.id);
-    if (idx === -1) return null;
-    canvases[idx] = updateCanvas(canvases[idx], input);
-    await this.saveAllCanvases(canvases);
-    return canvases[idx];
+    return this.mutateCanvases((canvases) => {
+      const idx = canvases.findIndex((c) => c.id === input.id);
+      if (idx === -1) return null;
+      canvases[idx] = updateCanvas(canvases[idx], input);
+      return canvases[idx];
+    });
   }
 
   static async deleteCanvas(id: string): Promise<boolean> {
-    const canvases = await this.getAllCanvases();
-    const filtered = canvases.filter((c) => c.id !== id);
-    if (filtered.length === canvases.length) return false;
-    await this.saveAllCanvases(filtered);
-    return true;
+    return this.mutateCanvases((canvases) => {
+      const idx = canvases.findIndex((c) => c.id === id);
+      if (idx === -1) return false;
+      canvases.splice(idx, 1);
+      return true;
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Promise-chained write queue in `StorageService` so canvas read-modify-write never interleaves
- `RepoPullService` uses `mutateCanvases()` for atomic pull merges
- Backup canvas blob before writes; surface sync failures via Alert

Closes #425

## Test plan
- [x] `yarn test __tests__/canvas-race.test.ts` — 3/3 pass
- [x] `yarn ts:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)