### PR TITLE
fix(canvas): prevent crash when adding second canvas to note (#426)

### DIFF
--- a/__tests__/canvas-multi-embed.test.tsx
+++ b/__tests__/canvas-multi-embed.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
+
+jest.mock('expo-image', () => ({
+  Image: () => null,
+}));
+
+jest.mock('react-native-marked', () => {
+  class Renderer {
+    private key = 0;
+
+    getKey() {
+      this.key += 1;
+      return `renderer-key-${this.key}`;
+    }
+  }
+
+  return { Renderer };
+});
+
+const createRenderer = (CanvasPreview: React.ComponentType<{ canvasId: string }>) => new NotePreviewRenderer({
+  colors: {
+    primary: '#2563eb',
+    text: '#111827',
+    surfaceSecondary: '#e5e7eb',
+  },
+  CanvasPreview,
+});
+
+describe('canvas multi-embed regression', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders two canvas embeds without crashing', () => {
+    const renderer = createRenderer(({ canvasId }) => <Text testID={`canvas-${canvasId}`}>{canvasId}</Text>);
+
+    const screen = render(
+      <View>
+        {renderer.link([], 'canvas:canvas-1')}
+        {renderer.link([], 'canvas:canvas-2')}
+      </View>,
+    );
+
+    expect(screen.getByTestId('canvas-canvas-1')).toBeTruthy();
+    expect(screen.getByTestId('canvas-canvas-2')).toBeTruthy();
+  });
+
+  it('assigns stable unique keys to each canvas preview', () => {
+    const renderer = createRenderer(({ canvasId }) => <Text>{canvasId}</Text>);
+
+    const firstNode = renderer.link([], 'canvas:canvas-1') as React.ReactElement<{ children: React.ReactNode }>;
+    const secondNode = renderer.link([], 'canvas:canvas-2') as React.ReactElement<{ children: React.ReactNode }>;
+    const firstPreview = React.Children.only(firstNode.props.children) as React.ReactElement;
+    const secondPreview = React.Children.only(secondNode.props.children) as React.ReactElement;
+
+    expect(firstNode.key).toBe('canvas-boundary-canvas-1');
+    expect(secondNode.key).toBe('canvas-boundary-canvas-2');
+    expect(firstPreview.key).toBe('canvas-1');
+    expect(secondPreview.key).toBe('canvas-2');
+  });
+
+  it('shows a placeholder when canvas preview rendering throws', () => {
+    const renderer = createRenderer(({ canvasId }) => {
+      if (canvasId === 'canvas-2') {
+        throw new Error('Skia init failed');
+      }
+
+      return <Text testID={`canvas-${canvasId}`}>{canvasId}</Text>;
+    });
+
+    const screen = render(
+      <View>
+        {renderer.link([], 'canvas:canvas-1')}
+        {renderer.link([], 'canvas:canvas-2')}
+      </View>,
+    );
+
+    expect(screen.getByTestId('canvas-canvas-1')).toBeTruthy();
+    expect(screen.getByText('Canvas preview unavailable')).toBeTruthy();
+  });
+});

--- a/src/components/CanvasPreview.tsx
+++ b/src/components/CanvasPreview.tsx
@@ -19,7 +19,7 @@ import {
 import { useCanvases } from '../contexts/CanvasContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { RootStackParamList } from '../navigation/types';
-import { Canvas, CanvasElement } from '../models/Canvas';
+import { CanvasChart, CanvasShape, CanvasStroke, CanvasText } from '../models/Canvas';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -76,6 +76,71 @@ function buildLinePath(x1: number, y1: number, x2: number, y2: number) {
   return p;
 }
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isPoint(point: unknown): point is { x: number; y: number } {
+  return !!point
+    && typeof point === 'object'
+    && isFiniteNumber((point as { x?: unknown }).x)
+    && isFiniteNumber((point as { y?: unknown }).y);
+}
+
+function isStrokeElement(el: unknown): el is CanvasStroke {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'stroke'
+    && Array.isArray((el as { points?: unknown }).points)
+    && (el as { points: unknown[] }).points.every(isPoint)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isString((el as { tool?: unknown }).tool);
+}
+
+function isShapeElement(el: unknown): el is CanvasShape {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'shape'
+    && isString((el as { shape?: unknown }).shape)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isFiniteNumber((el as { x1?: unknown }).x1)
+    && isFiniteNumber((el as { y1?: unknown }).y1)
+    && isFiniteNumber((el as { x2?: unknown }).x2)
+    && isFiniteNumber((el as { y2?: unknown }).y2)
+    && ((el as { fillColor?: unknown }).fillColor === undefined || isString((el as { fillColor?: unknown }).fillColor));
+}
+
+function isTextElement(el: unknown): el is CanvasText {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'text'
+    && isString((el as { text?: unknown }).text)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { x?: unknown }).x)
+    && isFiniteNumber((el as { y?: unknown }).y);
+}
+
+function isChartElement(el: unknown): el is CanvasChart {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'chart'
+    && isString((el as { chartType?: unknown }).chartType)
+    && Array.isArray((el as { labels?: unknown }).labels)
+    && (el as { labels: unknown[] }).labels.every(isString)
+    && Array.isArray((el as { values?: unknown }).values)
+    && (el as { values: unknown[] }).values.every(isFiniteNumber)
+    && isFiniteNumber((el as { x?: unknown }).x)
+    && isFiniteNumber((el as { y?: unknown }).y)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isFiniteNumber((el as { height?: unknown }).height);
+}
+
 export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTheme();
@@ -111,17 +176,17 @@ export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
   }
 
   const scene = canvasData.scene;
-  const elements = scene?.elements ?? [];
-  const sceneWidth = scene?.width ?? 800;
-  const sceneHeight = scene?.height ?? 600;
+  const elements: unknown[] = Array.isArray(scene?.elements) ? scene.elements : [];
+  const sceneWidth = isFiniteNumber(scene?.width) && scene.width > 0 ? scene.width : 800;
+  const sceneHeight = isFiniteNumber(scene?.height) && scene.height > 0 ? scene.height : 600;
   const previewWidth = Dimensions.get('window').width - 32;
   const previewHeight = 140;
   const scaleX = previewWidth / sceneWidth;
   const scaleY = previewHeight / sceneHeight;
   const scale = Math.min(scaleX, scaleY);
 
-  const renderElement = (el: CanvasElement, idx: number) => {
-    if (el.type === 'stroke') {
+  const renderElement = (el: unknown, idx: number) => {
+    if (isStrokeElement(el)) {
       const path = buildStrokePath(el.points);
       if (!path) return null;
       const strokeColor = el.tool === 'highlighter' ? hexToRgba(el.color, 0.3) : el.color;
@@ -133,7 +198,7 @@ export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
       );
     }
 
-    if (el.type === 'shape') {
+    if (isShapeElement(el)) {
       const { x1, y1, x2, y2, shape, color: sColor, fillColor, width: sw } = el;
       const minX = Math.min(x1, x2);
       const minY = Math.min(y1, y2);
@@ -181,11 +246,11 @@ export default function CanvasPreview({ canvasId }: CanvasPreviewProps) {
       }
     }
 
-    if (el.type === 'text') {
+    if (isTextElement(el)) {
       return <SkiaText key={el.id ?? idx} x={el.x} y={el.y} text={el.text} font={font} color={el.color} />;
     }
 
-    if (el.type === 'chart') {
+    if (isChartElement(el)) {
       const chartColors = ['#007AFF', '#FF3B30', '#34C759', '#FF9500', '#AF52DE'];
       if (el.chartType === 'bar') {
         const maxVal = Math.max(...el.values, 1);

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -4,6 +4,7 @@ import { Renderer, type RendererInterface } from 'react-native-marked';
 import { Image } from 'expo-image';
 
 import { isCanvasLink, canvasIdFromLink } from '../models/Canvas';
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 
 interface CustomRendererDeps {
   colors: {
@@ -26,6 +27,24 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
   constructor(deps: CustomRendererDeps) {
     super();
     this.deps = deps;
+  }
+
+  private renderCanvasFallback(id: string): ReactNode {
+    return (
+      <Text
+        key={`canvas-fallback-${id}`}
+        style={{
+          color: this.deps.colors.text,
+          backgroundColor: this.deps.colors.surfaceSecondary ?? '#f0f0f0',
+          borderRadius: 8,
+          overflow: 'hidden',
+          paddingHorizontal: 12,
+          paddingVertical: 10,
+        }}
+      >
+        Canvas preview unavailable
+      </Text>
+    );
   }
 
   image(uri: string, alt?: string, _style?: ImageStyle): ReactNode {
@@ -63,7 +82,11 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
   link(children: string | ReactNode[], href: string, styles?: TextStyle): ReactNode {
     if (isCanvasLink(href) && this.deps.CanvasPreview) {
       const id = canvasIdFromLink(href);
-      return <React.Fragment key={this.getKey()}>{React.createElement(this.deps.CanvasPreview, { canvasId: id })}</React.Fragment>;
+      return React.createElement(
+        ErrorBoundary,
+        { key: `canvas-boundary-${id}`, fallback: this.renderCanvasFallback(id) },
+        React.createElement(this.deps.CanvasPreview, { key: id, canvasId: id }),
+      );
     }
 
     const onPress = () => {


### PR DESCRIPTION
## Summary
- Add stable `key={id}` to `CanvasPreview` createElement (prevents React key collision on multi-embed)
- Wrap canvas embeds in `ErrorBoundary` so Skia init failures degrade to placeholder
- Validate element shapes before rendering to guard malformed storage data

> **Stacked PR**: based on \`fix/423-renderer-null-crash\` (which introduces \`ErrorBoundary\`). Will rebase to \`main\` after that PR merges.

Closes #426

## Test plan
- [x] \`yarn test __tests__/canvas-multi-embed.test.tsx\` — 3/3 pass
- [x] \`yarn ts:check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)