### PR TITLE
fix(ui): fix explorer file tree background theming (#414)

### DIFF
--- a/__tests__/file-tree-bg.test.tsx
+++ b/__tests__/file-tree-bg.test.tsx
@@ -1,0 +1,74 @@
+import { StyleSheet } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+
+import { Group } from '../src/components/ui';
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#111111',
+      surface: '#222222',
+      primary: '#2563eb',
+      text: '#f9fafb',
+      textSecondary: '#9ca3af',
+      border: '#374151',
+    },
+  }),
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    getRepoContents: jest.fn().mockResolvedValue([
+      { name: 'notes.md', path: 'notes.md', type: 'file', sha: 'abc', size: 12 },
+    ]),
+    getFileContent: jest.fn(),
+    getFileSha: jest.fn(),
+    moveFile: jest.fn(),
+    deleteFile: jest.fn(),
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+jest.mock('../src/components/ui', () => {
+  const ReactMock = require('react');
+  const { View: RNView, Text: RNText } = require('react-native');
+  const { forwardRef } = ReactMock;
+
+  const passthrough = (Component: any = RNView) =>
+    forwardRef(({ children, style, ...props }: any, ref: any) => (
+      <Component ref={ref} style={style} {...props}>
+        {children}
+      </Component>
+    ));
+
+  return {
+    Group: passthrough(RNView),
+    GroupRow: passthrough(RNView),
+    Modal: ({ children }: any) => <RNView>{children}</RNView>,
+    Input: forwardRef((props: any, ref: any) => <RNView ref={ref} {...props} />),
+    Button: ({ label }: any) => <RNText>{label}</RNText>,
+  };
+});
+
+import RepoFileTree from '../src/components/RepoFileTree';
+
+const isBlackBg = (value: unknown) =>
+  value === '#000' || value === '#000000' || value === 'black';
+
+describe('file tree backgrounds', () => {
+  it('uses theme colors instead of black backgrounds', async () => {
+    const screen = render(<RepoFileTree owner="acme" repo="notes" />);
+
+    await waitFor(() => expect(screen.queryAllByText('notes.md').length).toBeGreaterThan(0));
+
+    const group = screen.UNSAFE_getByType(Group);
+    const styles = StyleSheet.flatten(group.props.style);
+
+    expect(isBlackBg(styles?.backgroundColor)).toBe(false);
+    expect(styles?.backgroundColor).toBe('#222222');
+  });
+});

--- a/src/components/RepoFileTree.tsx
+++ b/src/components/RepoFileTree.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -687,7 +687,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (loading) {
     return (
-      <View style={treeStyles.center}>
+      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
         <ActivityIndicator size="large" color={colors.primary} />
         <Text style={[treeStyles.loadingText, { color: colors.textSecondary }]}>
           Loading file tree…
@@ -698,7 +698,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (error) {
     return (
-      <View style={treeStyles.center}>
+      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
         <Ionicons name="alert-circle-outline" size={40} color={colors.textSecondary} />
         <Text style={[treeStyles.emptyText, { color: colors.text }]}>Failed to load</Text>
         <Button variant="secondary" label="Retry" onPress={loadRoot} style={{ marginTop: 8 }} />
@@ -708,7 +708,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (rootItems.length === 0) {
     return (
-      <View style={treeStyles.center}>
+      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
         <Ionicons name="folder-open-outline" size={40} color={colors.textSecondary} />
         <Text style={[treeStyles.emptyText, { color: colors.text }]}>Empty Repository</Text>
         <Text style={[treeStyles.emptySub, { color: colors.textSecondary }]}>
@@ -719,7 +719,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
   }
 
   return (
-    <Group style={{ flex: 1 }}>
+    <Group style={{ flex: 1, backgroundColor: colors.surface }}>
       {rootItems.map((item) => (
         <TreeItem
           key={item.path}
@@ -826,4 +826,3 @@ const dialogStyles = StyleSheet.create({
     fontSize: 14,
   },
 });
-

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -7,7 +7,6 @@ import {
   FlatList,
   ActivityIndicator,
   ScrollView,
-  TextInput,
   RefreshControl,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -231,8 +230,8 @@ export default function ExploreScreen() {
         <OfflineBanner />
 
         <ScrollView
-          style={s.treeScroll}
-          contentContainerStyle={s.treeContent}
+          style={[s.treeScroll, { backgroundColor: colors.background }]}
+          contentContainerStyle={[s.treeContent, { backgroundColor: colors.background }]}
           refreshControl={
             <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.primary} />
           }


### PR DESCRIPTION
## Summary
- File tree background respects theme tokens (no hard-coded color)

> **Stacked PR**: part of the Wave 3 chain. Base will retarget to `main` once predecessor PRs land. Merge prerequisites: all Wave 1+2 PRs (#443-#447, #449-#451) into `main` first; then this stack merges in order.

Closes #414

## Test plan
- [x] `yarn test __tests__/file-tree-bg.test.tsx` — pass
- [x] `yarn ts:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)