### PR TITLE
fix(todos): fix completion empty slot and refresh bugs (#415)

### DIFF
--- a/.sisyphus/notepads/fix-all-github-issues/decisions.md
+++ b/.sisyphus/notepads/fix-all-github-issues/decisions.md
@@ -1,0 +1,3 @@
+## Decisions
+- Shared todo ordering now lives in `src/models/Todo.ts` via `compareTodos`/`reorderTodos` so the screen, store refresh path, and repo pull path all use one stable ordering rule.
+- Todo completion now persists the reordered list after toggle and syncs repo-backed todos to GitHub before refreshes, which keeps pull-to-refresh from reintroducing stale completion state.

--- a/.sisyphus/notepads/fix-all-github-issues/learnings.md
+++ b/.sisyphus/notepads/fix-all-github-issues/learnings.md
@@ -1,3 +1,5 @@
 ## Learnings
 - Offline banners can stay lightweight by reading `useNetworkStatus` directly and returning `null` when connected.
 - For UI tests, mocking theme/network hooks is enough; no provider setup is needed for a simple present/hidden assertion.
+- Todo completion has to persist the same sorted order used by the list UI; otherwise refresh can reload a stale top-of-list ordering and cause visible reflow glitches.
+- Toggling a repo-backed todo must sync its updated `completed` state back to GitHub, or the next pull will overwrite the local completion state.

--- a/__tests__/todo-completion.test.ts
+++ b/__tests__/todo-completion.test.ts
@@ -1,0 +1,124 @@
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    updateTodo: jest.fn(),
+    getAllTodos: jest.fn(),
+    saveAllTodos: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/NotificationService', () => ({
+  NotificationService: {
+    cancelAllForTodo: jest.fn(),
+    scheduleReminder: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => false),
+  },
+}));
+
+jest.mock('../src/services/TodoGitHubSyncService', () => ({
+  syncTodoToGitHub: jest.fn(() => Promise.resolve({ success: true })),
+}));
+
+import { act, renderHook } from '@testing-library/react-native';
+import { useTodos } from '../src/contexts/TodoContext';
+import { Todo } from '../src/models/Todo';
+import { StorageService } from '../src/services/StorageService';
+import { NotificationService } from '../src/services/NotificationService';
+import { syncTodoToGitHub } from '../src/services/TodoGitHubSyncService';
+import { useTodoStore } from '../src/stores/todoStore';
+
+const makeTodo = (overrides: Partial<Todo>): Todo => ({
+  id: overrides.id ?? 'todo-id',
+  text: overrides.text ?? 'Todo',
+  completed: overrides.completed ?? false,
+  createdAt: overrides.createdAt ?? 1,
+  updatedAt: overrides.updatedAt ?? overrides.createdAt ?? 1,
+  priority: overrides.priority ?? 'medium',
+  tags: overrides.tags ?? [],
+  ...overrides,
+});
+
+describe('todo completion ordering and refresh', () => {
+  let storageTodos: Todo[];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storageTodos = [];
+
+    (StorageService.getAllTodos as jest.Mock).mockImplementation(async () => storageTodos);
+    (StorageService.updateTodo as jest.Mock).mockImplementation(async (input: { id: string; completed?: boolean; notificationId?: string }) => {
+      const index = storageTodos.findIndex((todo) => todo.id === input.id);
+      if (index === -1) return null;
+
+      storageTodos[index] = {
+        ...storageTodos[index],
+        ...input,
+        updatedAt: storageTodos[index].updatedAt + 1,
+      };
+
+      return storageTodos[index];
+    });
+    (StorageService.saveAllTodos as jest.Mock).mockImplementation(async (todos: Todo[]) => {
+      storageTodos = todos.map((todo) => ({ ...todo }));
+    });
+    (NotificationService.cancelAllForTodo as jest.Mock).mockResolvedValue(undefined);
+    (NotificationService.scheduleReminder as jest.Mock).mockResolvedValue(undefined);
+
+    useTodoStore.setState({ todos: [], isLoading: false, error: null });
+  });
+
+  test('completing the top todo reorders atomically and stays stable after refresh', async () => {
+    const topTodo = makeTodo({
+      id: 'todo-1',
+      text: 'Top todo',
+      completed: false,
+      priority: 'high',
+      createdAt: 30,
+      updatedAt: 30,
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'todos/top-todo.json',
+    });
+    const middleTodo = makeTodo({ id: 'todo-2', text: 'Middle todo', priority: 'medium', createdAt: 20, updatedAt: 20 });
+    const bottomTodo = makeTodo({ id: 'todo-3', text: 'Bottom todo', priority: 'low', createdAt: 10, updatedAt: 10 });
+
+    storageTodos = [topTodo, middleTodo, bottomTodo].map((todo) => ({ ...todo }));
+    useTodoStore.setState({ todos: [topTodo, middleTodo, bottomTodo], isLoading: false, error: null });
+
+    const { result } = renderHook(() => useTodos());
+
+    await act(async () => {
+      await result.current.toggleTodo('todo-1');
+    });
+
+    expect(useTodoStore.getState().todos.map((todo) => todo.id)).toEqual(['todo-2', 'todo-3', 'todo-1']);
+    expect(useTodoStore.getState().todos[0]).toBeDefined();
+    expect(useTodoStore.getState().todos[0]?.id).toBe('todo-2');
+    expect(useTodoStore.getState().todos[2]).toMatchObject({ id: 'todo-1', completed: true });
+    expect(StorageService.saveAllTodos).toHaveBeenCalled();
+    expect(syncTodoToGitHub).toHaveBeenCalledWith(expect.objectContaining({
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'todos/top-todo.json',
+      text: 'Top todo',
+      todo: expect.objectContaining({ completed: true }),
+    }));
+
+    await act(async () => {
+      await result.current.refreshTodos();
+    });
+
+    expect(useTodoStore.getState().todos.map((todo) => todo.id)).toEqual(['todo-2', 'todo-3', 'todo-1']);
+    expect(useTodoStore.getState().todos[2]).toMatchObject({ id: 'todo-1', completed: true });
+  });
+});

--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo } from 'react';
-import { Todo, TodoCreateInput, TodoUpdateInput } from '../models/Todo';
+import { Todo, TodoCreateInput, TodoUpdateInput, reorderTodos } from '../models/Todo';
 import { StorageService } from '../services/StorageService';
 import { NotificationService } from '../services/NotificationService';
 import { useTodoStore } from '../stores/todoStore';
+import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
 
 interface TodoContextValue {
   todos: Todo[];
@@ -110,7 +111,24 @@ export function useTodos(): TodoContextValue {
       console.warn('[TodoContext] Notification toggle handling failed:', err);
     }
 
-    useTodoStore.setState((s) => ({ todos: s.todos.map((t) => (t.id === id ? finalTodo : t)) }));
+    if (todo.repo) {
+      const syncResult = await syncTodoToGitHub({
+        repo: todo.repo,
+        branch: todo.branch,
+        filePath: todo.filePath,
+        text: finalTodo.text,
+        todo: finalTodo,
+      });
+      if (!syncResult.success) {
+        console.warn('[TodoContext] GitHub sync failed:', syncResult.error);
+      }
+    }
+
+    const nextTodos = reorderTodos(
+      useTodoStore.getState().todos.map((t) => (t.id === id ? finalTodo : t)),
+    );
+    await StorageService.saveAllTodos(nextTodos);
+    useTodoStore.setState({ todos: nextTodos });
     return true;
   }, []);
 

--- a/src/models/Todo.ts
+++ b/src/models/Todo.ts
@@ -106,6 +106,23 @@ export function applyTodoUpdate(existing: Todo, input: Partial<TodoUpdateInput>)
   };
 }
 
+const TODO_PRIORITY_ORDER: Record<TodoPriority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+export function compareTodos(a: Todo, b: Todo): number {
+  if (a.completed !== b.completed) return a.completed ? 1 : -1;
+  const priorityDiff = TODO_PRIORITY_ORDER[a.priority || 'medium'] - TODO_PRIORITY_ORDER[b.priority || 'medium'];
+  if (priorityDiff !== 0) return priorityDiff;
+  return b.createdAt - a.createdAt;
+}
+
+export function reorderTodos(todos: Todo[]): Todo[] {
+  return [...todos].sort(compareTodos);
+}
+
 export function slugifyTodoText(text: string): string {
   return text
     .toLowerCase()

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -20,7 +20,7 @@ import { format, isToday, isTomorrow, isPast } from 'date-fns';
 
 import { useTodos } from '../contexts/TodoContext';
 import { useTheme } from '../contexts/ThemeContext';
-import { Todo, TodoPriority, PRIORITY_COLORS, PRIORITY_LABELS, REMINDER_OPTIONS, slugifyTodoText } from '../models/Todo';
+import { Todo, TodoPriority, PRIORITY_COLORS, PRIORITY_LABELS, REMINDER_OPTIONS, slugifyTodoText, reorderTodos } from '../models/Todo';
 import { HapticService } from '../utils/haptics';
 import { useResponsive } from '../hooks/useResponsive';
 import GitContextPicker from '../components/GitContextPicker';
@@ -90,13 +90,7 @@ export default function TodoListScreen() {
       );
     }
 
-    return filtered.sort((a, b) => {
-      if (a.completed !== b.completed) return a.completed ? 1 : -1;
-      const priorityOrder = { high: 0, medium: 1, low: 2 };
-      const priorityDiff = priorityOrder[a.priority || 'medium'] - priorityOrder[b.priority || 'medium'];
-      if (priorityDiff !== 0) return priorityDiff;
-      return b.createdAt - a.createdAt;
-    });
+    return reorderTodos(filtered);
   }, [todos, filter, filterCompleted, searchQuery]);
 
   const resetForm = useCallback(() => {

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -2,7 +2,7 @@ import { GitHubService } from './GitHubService';
 import { StorageService } from './StorageService';
 import { createNote } from '../models/Note';
 import { createCanvas, updateCanvas, CanvasScene } from '../models/Canvas';
-import { createTodoItem, applyTodoUpdate } from '../models/Todo';
+import { createTodoItem, applyTodoUpdate, reorderTodos } from '../models/Todo';
 import { parseRepoPath } from '../utils/gitPathParser';
 
 async function fetchDirectoryFiles(
@@ -269,7 +269,7 @@ async function pullTodosFromRepo(
     }
 
     if (dirty) {
-      await StorageService.saveAllTodos(allTodos);
+      await StorageService.saveAllTodos(reorderTodos(allTodos));
     }
   } catch {
     console.warn(`[RepoPullService] Failed to pull todos from ${owner}/${repo}`);

--- a/src/stores/todoStore.ts
+++ b/src/stores/todoStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { Todo, TodoCreateInput, TodoUpdateInput } from '../models/Todo';
+import { Todo, TodoCreateInput, TodoUpdateInput, reorderTodos } from '../models/Todo';
 import { StorageService } from '../services/StorageService';
 import { GitHubService } from '../services/GitHubService';
 import { parseRepoPath } from '../utils/gitPathParser';
@@ -28,7 +28,7 @@ export const useTodoStore = create<TodoState & TodoActions>()((set, get) => ({
     try {
       set({ isLoading: true, error: null });
       const todos = await StorageService.getAllTodos();
-      set({ todos, isLoading: false });
+      set({ todos: reorderTodos(todos), isLoading: false });
     } catch (err) {
       set({ error: 'Failed to load todos', isLoading: false });
       console.error('Error loading todos:', err);


### PR DESCRIPTION
## Summary
- Fix the empty slot left after marking a todo complete
- Fix refresh path so completed todos show correct state after pull

> **Stacked PR**: part of the Wave 3 chain. Base will retarget to `main` once predecessor PRs land. Merge prerequisites: all Wave 1+2 PRs (#443-#447, #449-#451) into `main` first; then this stack merges in order.

Closes #415

## Test plan
- [x] `yarn test __tests__/todo-completion.test.ts` — pass
- [x] `yarn ts:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)