### PR TITLE
feat(ui): add offline warning banner (#413) + test mocks

### DIFF
--- a/.sisyphus/notepads/fix-all-github-issues/learnings.md
+++ b/.sisyphus/notepads/fix-all-github-issues/learnings.md
@@ -1,0 +1,3 @@
+## Learnings
+- Offline banners can stay lightweight by reading `useNetworkStatus` directly and returning `null` when connected.
+- For UI tests, mocking theme/network hooks is enough; no provider setup is needed for a simple present/hidden assertion.

--- a/__tests__/filter-modal-overflow.test.tsx
+++ b/__tests__/filter-modal-overflow.test.tsx
@@ -1,6 +1,12 @@
 import { TouchableOpacity } from 'react-native';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
 import NotesListScreen from '../src/screens/NotesListScreen';
 import { Note } from '../src/models/Note';
 

--- a/__tests__/offline-banner-todos-explore.test.tsx
+++ b/__tests__/offline-banner-todos-explore.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+// Mock netinfo at the source so any indirect import resolves.
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+// Hook-level mock — easier to flip per test than driving NetInfo events.
+jest.mock('../src/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: jest.fn(),
+}));
+
+import { useNetworkStatus } from '../src/hooks/useNetworkStatus';
+
+const mockUseNetworkStatus = useNetworkStatus as jest.Mock;
+
+const setOnline = () =>
+  mockUseNetworkStatus.mockReturnValue({ isConnected: true, isInternetReachable: true });
+const setOffline = () =>
+  mockUseNetworkStatus.mockReturnValue({ isConnected: false, isInternetReachable: false });
+
+const BANNER_TEXT = "You're offline — changes won't sync";
+
+// ---------- Shared theme + navigation mocks ----------
+const mockColorProxy = new Proxy(
+  {
+    background: '#fff',
+    surface: '#f4f4f4',
+    surfaceSecondary: '#e5e7eb',
+    surfaceTertiary: '#d1d5db',
+    primary: '#2563eb',
+    accent: '#2563eb',
+    text: '#111827',
+    textSecondary: '#6b7280',
+    border: '#d1d5db',
+    error: '#dc2626',
+    success: '#16a34a',
+  },
+  {
+    get(target, key: string) {
+      return key in target ? (target as Record<string, string>)[key] : '#111827';
+    },
+  },
+);
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: mockColorProxy, isDark: false }),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({ isTablet: false, maxContentWidth: 0 }),
+}));
+
+jest.mock('../src/components/SearchBar', () => {
+  const { TextInput } = require('react-native');
+  return ({ value, onChangeText }: { value: string; onChangeText: (value: string) => void }) => (
+    <TextInput value={value} onChangeText={onChangeText} />
+  );
+});
+
+jest.mock('../src/components/ui', () => {
+  const { Text, TouchableOpacity } = require('react-native');
+  return {
+    ScreenHeader: ({ title }: { title: string }) => <Text>{title}</Text>,
+    IconButton: ({ children, onPress }: any) => (
+      <TouchableOpacity onPress={onPress}>{children}</TouchableOpacity>
+    ),
+  };
+});
+
+// ---------- TodoListScreen-specific mocks ----------
+jest.mock('../src/contexts/TodoContext', () => ({
+  useTodos: () => ({
+    todos: [],
+    createTodo: jest.fn(),
+    updateTodo: jest.fn(),
+    toggleTodo: jest.fn(),
+    refreshTodos: jest.fn(async () => undefined),
+  }),
+}));
+
+jest.mock('../src/stores/todoStore', () => ({
+  useTodoStore: (selector: any) => selector({ deleteTodo: jest.fn() }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  // Pre-seed a repo so ExploreScreen skips its mount-time refresh effect
+  // (avoids spurious act() warnings without affecting banner visibility).
+  useRepos: () => ({
+    repositories: [{ id: 1, name: 'r', path: 'github:owner/r', branch: 'main' }],
+    refreshRepos: jest.fn(async () => undefined),
+  }),
+}));
+
+jest.mock('../src/hooks/useEntityFilter', () => ({
+  useEntityFilter: () => ({
+    applyFilters: (items: any[]) => items,
+    activeCount: 0,
+    state: {},
+    setRepo: jest.fn(),
+    setBranch: jest.fn(),
+    setFolder: jest.fn(),
+    setTags: jest.fn(),
+    clear: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/components/EntityFilterModal', () => ({
+  EntityFilterModal: () => null,
+}));
+
+jest.mock('../src/components/ActiveFilterStrip', () => ({
+  ActiveFilterStrip: () => null,
+}));
+
+jest.mock('../src/components/GitContextPicker', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../src/services/TodoGitHubSyncService', () => ({
+  syncTodoToGitHub: jest.fn(async () => ({ success: true })),
+}));
+
+jest.mock('../src/services/RepoPullService', () => ({
+  pullAllFromRepos: jest.fn(async () => undefined),
+}));
+
+jest.mock('@react-native-community/datetimepicker', () => () => null);
+
+// ---------- ExploreScreen-specific mocks ----------
+jest.mock('../src/components/RepoFileTree', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+// FlashList — render items inline so screens render without virtualization.
+jest.mock('@shopify/flash-list', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    FlashList: React.forwardRef(({ data, renderItem, ListEmptyComponent }: any, _ref: any) => {
+      if (!data?.length) {
+        return <View>{ListEmptyComponent ?? null}</View>;
+      }
+      return <View>{data.map((item: any, index: number) => renderItem({ item, index }))}</View>;
+    }),
+  };
+});
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return React.forwardRef(({ children }: any, _ref: any) => <View>{children}</View>);
+});
+
+import TodoListScreen from '../src/screens/TodoListScreen';
+import ExploreScreen from '../src/screens/ExploreScreen';
+
+describe('OfflineBanner mounted on TodoListScreen and ExploreScreen', () => {
+  describe('TodoListScreen', () => {
+    it('renders banner when offline', () => {
+      setOffline();
+      const { getByText } = render(<TodoListScreen />);
+      expect(getByText(BANNER_TEXT)).toBeTruthy();
+    });
+
+    it('hides banner when online', () => {
+      setOnline();
+      const { queryByText } = render(<TodoListScreen />);
+      expect(queryByText(BANNER_TEXT)).toBeNull();
+    });
+  });
+
+  describe('ExploreScreen', () => {
+    it('renders banner when offline', () => {
+      setOffline();
+      const { getByText } = render(<ExploreScreen />);
+      expect(getByText(BANNER_TEXT)).toBeTruthy();
+    });
+
+    it('hides banner when online', () => {
+      setOnline();
+      const { queryByText } = render(<ExploreScreen />);
+      expect(queryByText(BANNER_TEXT)).toBeNull();
+    });
+  });
+});

--- a/__tests__/offline-banner.test.tsx
+++ b/__tests__/offline-banner.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('../src/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: jest.fn(),
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      error: '#dc2626',
+    },
+  }),
+}));
+
+import { useNetworkStatus } from '../src/hooks/useNetworkStatus';
+import { OfflineBanner } from '../src/components/ui/OfflineBanner';
+
+const mockUseNetworkStatus = useNetworkStatus as jest.Mock;
+
+describe('OfflineBanner', () => {
+  it('renders when offline', () => {
+    mockUseNetworkStatus.mockReturnValue({
+      isConnected: false,
+      isInternetReachable: false,
+    });
+
+    const { getByText } = render(<OfflineBanner />);
+
+    expect(getByText("You're offline — changes won't sync")).toBeTruthy();
+  });
+
+  it('hides when online', () => {
+    mockUseNetworkStatus.mockReturnValue({
+      isConnected: true,
+      isInternetReachable: true,
+    });
+
+    const { queryByText } = render(<OfflineBanner />);
+
+    expect(queryByText("You're offline — changes won't sync")).toBeNull();
+  });
+});

--- a/__tests__/swipe-delete.test.tsx
+++ b/__tests__/swipe-delete.test.tsx
@@ -21,6 +21,12 @@ const mockDeleteNote = jest.fn(async (id: string) => {
 const mockUseNoteStore: any = jest.fn();
 mockUseNoteStore.getState = () => ({ error: null });
 
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
 }));

--- a/src/components/ui/OfflineBanner.tsx
+++ b/src/components/ui/OfflineBanner.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+import { useNetworkStatus } from '../../hooks/useNetworkStatus';
+import { useTheme } from '../../contexts/ThemeContext';
+
+export function OfflineBanner() {
+  const { isConnected } = useNetworkStatus();
+  const { colors } = useTheme();
+
+  if (isConnected) return null;
+
+  return (
+    <View
+      style={[
+        styles.banner,
+        { backgroundColor: `${colors.error}20`, borderColor: `${colors.error}33` },
+      ]}
+    >
+      <Text style={[styles.text, { color: colors.error }]}>You're offline — changes won't sync</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 14,
+    borderWidth: 1,
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -22,6 +22,7 @@ import { parseRepoPath } from '../utils/gitPathParser';
 import RepoFileTree, { TreeNode } from '../components/RepoFileTree';
 import { RootStackParamList } from '../navigation/types';
 import { ScreenHeader } from '../components/ui';
+import { OfflineBanner } from '../components/ui/OfflineBanner';
 import SearchBar from '../components/SearchBar';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
@@ -128,6 +129,7 @@ export default function ExploreScreen() {
     return (
       <SafeAreaView style={[s.container, { backgroundColor: colors.background }]} edges={['top', 'bottom']}>
         <ScreenHeader title="Explore" />
+        <OfflineBanner />
         <View style={{ paddingHorizontal: 16, paddingBottom: 12 }}>
           <SearchBar
             value={repoSearch}
@@ -170,6 +172,7 @@ export default function ExploreScreen() {
     return (
       <SafeAreaView style={[s.container, { backgroundColor: colors.background }]} edges={['top', 'bottom']}>
         <ScreenHeader title={selectedRepo.name} onBack={handleBack} />
+        <OfflineBanner />
 
         <View style={[s.detailCard, { backgroundColor: colors.surface, borderColor: colors.border + '30' }]}>
           <View style={s.detailTop}>
@@ -225,6 +228,7 @@ export default function ExploreScreen() {
           </View>
           <View style={s.headerBtnPlaceholder} />
         </View>
+        <OfflineBanner />
 
         <ScrollView
           style={s.treeScroll}

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -40,6 +40,7 @@ import { pullAllFromRepos } from "../services/RepoPullService";
 import ContextMenu from "../components/ContextMenu";
 import NoteCard from "../components/NoteCard";
 import SearchBar from "../components/SearchBar";
+import { OfflineBanner } from "../components/ui/OfflineBanner";
 import { ScreenHeader } from "../components/ui";
 import { parseRepoPath } from "../utils/gitPathParser";
 import { HapticService } from "../utils/haptics";
@@ -508,6 +509,7 @@ export default function NotesListScreen() {
       ]}
     >
       <ScreenHeader title="Notes" />
+      <OfflineBanner />
 
       <View style={styles.topBar}>
         <SearchBar

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -27,6 +27,7 @@ import GitContextPicker from '../components/GitContextPicker';
 import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
 import { pullAllFromRepos } from '../services/RepoPullService';
 import { IconButton, ScreenHeader } from '../components/ui';
+import { OfflineBanner } from '../components/ui/OfflineBanner';
 import SearchBar from '../components/SearchBar';
 import { EntityFilterModal } from '../components/EntityFilterModal';
 import { ActiveFilterStrip } from '../components/ActiveFilterStrip';
@@ -440,6 +441,7 @@ export default function TodoListScreen() {
           </>
         }
       />
+      <OfflineBanner />
 
       <View style={{ paddingHorizontal: 16, paddingBottom: 12 }}>
         <SearchBar


### PR DESCRIPTION
## Summary
- New `OfflineBanner` component shown when device is offline
- Uses `useNetworkStatus` hook from #444
- Includes follow-up commit adding netinfo mock to swipe-delete and filter-modal tests so they keep passing once `NotesListScreen` imports the banner

> **Stacked PR**: part of the Wave 3 chain. Base will retarget to `main` once predecessor PRs land. Merge prerequisites: all Wave 1+2 PRs (#443-#447, #449-#451) into `main` first; then this stack merges in order.

Closes #413

## Test plan
- [x] `yarn test __tests__/offline-banner.test.tsx` — pass
- [x] `yarn ts:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)