### PR TITLE
fix(ui): enable text selection in note preview (#416)

### DIFF
--- a/.sisyphus/notepads/wave3-ux/learnings.md
+++ b/.sisyphus/notepads/wave3-ux/learnings.md
@@ -1,0 +1,3 @@
+- Markdown preview text selection needs to cover link text too; links can stay pressable and selectable together.
+- For nested Neorg inline rendering, setting selectable on every Text node is the safest way to keep copy/paste working across headings, lists, tables, quotes, and inline styles.
+- RNTL `UNSAFE_getAllByType(Text)` is enough to verify selectable props on rendered preview text without adding UI-specific assertions.

--- a/__tests__/file-tree-bg.test.tsx
+++ b/__tests__/file-tree-bg.test.tsx
@@ -1,0 +1,74 @@
+import { StyleSheet } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+
+import { Group } from '../src/components/ui';
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#111111',
+      surface: '#222222',
+      primary: '#2563eb',
+      text: '#f9fafb',
+      textSecondary: '#9ca3af',
+      border: '#374151',
+    },
+  }),
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    getRepoContents: jest.fn().mockResolvedValue([
+      { name: 'notes.md', path: 'notes.md', type: 'file', sha: 'abc', size: 12 },
+    ]),
+    getFileContent: jest.fn(),
+    getFileSha: jest.fn(),
+    moveFile: jest.fn(),
+    deleteFile: jest.fn(),
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+jest.mock('../src/components/ui', () => {
+  const ReactMock = require('react');
+  const { View: RNView, Text: RNText } = require('react-native');
+  const { forwardRef } = ReactMock;
+
+  const passthrough = (Component: any = RNView) =>
+    forwardRef(({ children, style, ...props }: any, ref: any) => (
+      <Component ref={ref} style={style} {...props}>
+        {children}
+      </Component>
+    ));
+
+  return {
+    Group: passthrough(RNView),
+    GroupRow: passthrough(RNView),
+    Modal: ({ children }: any) => <RNView>{children}</RNView>,
+    Input: forwardRef((props: any, ref: any) => <RNView ref={ref} {...props} />),
+    Button: ({ label }: any) => <RNText>{label}</RNText>,
+  };
+});
+
+import RepoFileTree from '../src/components/RepoFileTree';
+
+const isBlackBg = (value: unknown) =>
+  value === '#000' || value === '#000000' || value === 'black';
+
+describe('file tree backgrounds', () => {
+  it('uses theme colors instead of black backgrounds', async () => {
+    const screen = render(<RepoFileTree owner="acme" repo="notes" />);
+
+    await waitFor(() => expect(screen.queryAllByText('notes.md').length).toBeGreaterThan(0));
+
+    const group = screen.UNSAFE_getByType(Group);
+    const styles = StyleSheet.flatten(group.props.style);
+
+    expect(isBlackBg(styles?.backgroundColor)).toBe(false);
+    expect(styles?.backgroundColor).toBe('#222222');
+  });
+});

--- a/__tests__/selectable-preview.test.tsx
+++ b/__tests__/selectable-preview.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
+import NeorgRenderer from '../src/components/NeorgRenderer';
+
+jest.mock('expo-image', () => ({
+  Image: () => null,
+}));
+
+jest.mock('react-native-marked', () => {
+  class Renderer {
+    private key = 0;
+
+    getKey() {
+      this.key += 1;
+      return `renderer-key-${this.key}`;
+    }
+  }
+
+  return { Renderer };
+});
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      primary: '#2563eb',
+      text: '#111827',
+      textSecondary: '#6b7280',
+      surfaceSecondary: '#e5e7eb',
+      border: '#d1d5db',
+    },
+  }),
+}));
+
+const createMarkdownRenderer = () => new NotePreviewRenderer({
+  colors: {
+    primary: '#2563eb',
+    text: '#111827',
+    surfaceSecondary: '#e5e7eb',
+  },
+});
+
+const expectSelectableTextNodes = (nodes: { props: { selectable?: boolean } }[]) => {
+  expect(nodes.length).toBeGreaterThan(0);
+  expect(nodes.every((node) => node.props.selectable === true)).toBe(true);
+};
+
+describe('preview text selection', () => {
+  it('marks markdown preview text selectable', () => {
+    const renderer = createMarkdownRenderer();
+
+    const screen = render(
+      <View>
+        {renderer.text('plain text')}
+        {renderer.codespan('inline code')}
+        {renderer.code('block code')}
+        {renderer.link('linked text', 'https://example.com')}
+      </View>,
+    );
+
+    expectSelectableTextNodes(screen.UNSAFE_getAllByType(Text));
+  });
+
+  it('marks neorg preview text selectable', () => {
+    const screen = render(
+      <NeorgRenderer
+        blocks={[
+          { type: 'heading', heading: { level: 1, text: 'Heading *bold* `code`' } },
+          { type: 'list', listItems: [{ type: 'ordered', indentLevel: 0, text: 'List item /italic/' }] },
+          { type: 'checklist', checklistItems: [{ checked: true, indentLevel: 0, text: 'Check item' }] },
+          { type: 'definition', definitionItems: [{ term: 'Term', definition: 'Definition with [link](https://example.com)', indentLevel: 0 }] },
+          { type: 'paragraph', text: 'Paragraph with _underline_ and {tag}' },
+          { type: 'code', code: { language: 'ts', content: 'const n = 1;' } },
+          { type: 'quote', text: 'Quoted ^sup^ and ,sub,' },
+          { type: 'table', tableRows: [{ cells: ['Cell one', 'Cell two'] }], isHeaderRow: [true] },
+        ]}
+      />,
+    );
+
+    expectSelectableTextNodes(screen.UNSAFE_getAllByType(Text));
+  });
+});

--- a/src/components/NeorgRenderer.tsx
+++ b/src/components/NeorgRenderer.tsx
@@ -123,37 +123,37 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
           const k = segKey(seg, i);
           switch (seg.type) {
             case 'bold':
-              return <Text key={k} style={styles.bold}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.bold}>{seg.content}</Text>;
             case 'italic':
-              return <Text key={k} style={styles.italic}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.italic}>{seg.content}</Text>;
             case 'underline':
-              return <Text key={k} style={styles.underline}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.underline}>{seg.content}</Text>;
             case 'strikethrough':
-              return <Text key={k} style={styles.strikethrough}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.strikethrough}>{seg.content}</Text>;
             case 'code':
               return (
-                <Text key={k} style={[styles.inlineCode, { backgroundColor: colors.surfaceSecondary }]}>
+                <Text key={k} selectable style={[styles.inlineCode, { backgroundColor: colors.surfaceSecondary }]}>
                   {seg.content}
                 </Text>
               );
             case 'superscript':
-              return <Text key={k} style={styles.superscript}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.superscript}>{seg.content}</Text>;
             case 'subscript':
-              return <Text key={k} style={styles.subscript}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.subscript}>{seg.content}</Text>;
             case 'link':
               return (
-                <Text key={k} style={[styles.link, { color: colors.primary }]}>
+                <Text key={k} selectable style={[styles.link, { color: colors.primary }]}>
                   {seg.label}
                 </Text>
               );
             case 'tag':
               return (
-                <Text key={k} style={[styles.tagBadge, { backgroundColor: colors.primary + '20', color: colors.primary }]}>
+                <Text key={k} selectable style={[styles.tagBadge, { backgroundColor: colors.primary + '20', color: colors.primary }]}>
                   {seg.name}
                 </Text>
               );
             default:
-              return <Text key={k}>{seg.content}</Text>;
+              return <Text key={k} selectable>{seg.content}</Text>;
           }
         })}
       </React.Fragment>
@@ -179,6 +179,7 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
     return (
       <Text
         key={`heading-${blockIndex}`}
+        selectable
         style={[
           styles.heading,
           { fontSize, color: colors.text, marginTop: heading.level === 1 ? 16 : 12 },
@@ -198,8 +199,8 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
       prefix = `${taskStatusIcon(item.status)} `;
     }
     return (
-      <View key={`list-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent }]}>
-        <Text style={[styles.listText, { color: colors.text }]}>
+      <View key={`list-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent }]}> 
+        <Text selectable style={[styles.listText, { color: colors.text }]}>
           {prefix}{renderInline(item.text)}
         </Text>
       </View>
@@ -209,8 +210,8 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
   const renderChecklistItem = (item: NeorgChecklistItem, blockIndex: number, itemIndex: number) => {
     const indent = item.indentLevel * 16;
     return (
-      <View key={`check-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent }]}>
-        <Text style={[styles.listText, { color: colors.text }]}>
+      <View key={`check-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent }]}> 
+        <Text selectable style={[styles.listText, { color: colors.text }]}>
           {item.checked ? '✓' : '○'} {renderInline(item.text)}
         </Text>
       </View>
@@ -220,12 +221,12 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
   const renderDefinitionItem = (item: NeorgDefinitionItem, blockIndex: number, itemIndex: number) => {
     const indent = item.indentLevel * 16;
     return (
-      <View key={`def-${blockIndex}-${itemIndex}`} style={[styles.definitionItem, { marginLeft: indent }]}>
-        <Text style={[styles.definitionTerm, { color: colors.primary }]}>
+      <View key={`def-${blockIndex}-${itemIndex}`} style={[styles.definitionItem, { marginLeft: indent }]}> 
+        <Text selectable style={[styles.definitionTerm, { color: colors.primary }]}> 
           {item.term}
         </Text>
         {item.definition ? (
-          <Text style={[styles.definitionText, { color: colors.text }]}>
+          <Text selectable style={[styles.definitionText, { color: colors.text }]}>
             {renderInline(item.definition)}
           </Text>
         ) : null}
@@ -234,19 +235,19 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
   };
 
   const renderParagraph = (text: string, blockIndex: number) => (
-    <Text key={`para-${blockIndex}`} style={[styles.paragraph, { color: colors.text }]}>
+    <Text key={`para-${blockIndex}`} selectable style={[styles.paragraph, { color: colors.text }]}>
       {renderInline(text)}
     </Text>
   );
 
   const renderCodeBlock = (code: { language?: string; content: string }, blockIndex: number) => (
-    <View key={`code-${blockIndex}`} style={[styles.codeBlock, { backgroundColor: colors.surfaceSecondary }]}>
-      {code.language && (
-        <Text style={[styles.codeLanguage, { color: colors.textSecondary }]}>{code.language}</Text>
-      )}
-      <Text style={[styles.codeContent, { color: colors.text }]}>{code.content}</Text>
-    </View>
-  );
+      <View key={`code-${blockIndex}`} style={[styles.codeBlock, { backgroundColor: colors.surfaceSecondary }]}>
+        {code.language && (
+          <Text selectable style={[styles.codeLanguage, { color: colors.textSecondary }]}>{code.language}</Text>
+        )}
+        <Text selectable style={[styles.codeContent, { color: colors.text }]}>{code.content}</Text>
+      </View>
+    );
 
   const renderTable = (block: NeorgContentBlock, blockIndex: number) => {
     if (!block.tableRows || block.tableRows.length === 0) return null;
@@ -266,6 +267,7 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
               {row.cells.map((cell, cellIdx) => (
                 <Text
                   key={`tc-${blockIndex}-${rowIdx}-${cellIdx}`}
+                  selectable
                   style={[
                     styles.tableCell,
                     { color: colors.text },
@@ -287,7 +289,7 @@ export default function NeorgRenderer({ blocks }: NeorgRendererProps) {
       key={`quote-${blockIndex}`}
       style={[styles.quoteBlock, { backgroundColor: colors.primary + '15', borderLeftColor: colors.primary }]}
     >
-      <Text style={[styles.quoteText, { color: colors.text }]}>{renderInline(text)}</Text>
+      <Text selectable style={[styles.quoteText, { color: colors.text }]}>{renderInline(text)}</Text>
     </View>
   );
 

--- a/src/components/RepoFileTree.tsx
+++ b/src/components/RepoFileTree.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -687,7 +687,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (loading) {
     return (
-      <View style={treeStyles.center}>
+      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
         <ActivityIndicator size="large" color={colors.primary} />
         <Text style={[treeStyles.loadingText, { color: colors.textSecondary }]}>
           Loading file tree…
@@ -698,7 +698,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (error) {
     return (
-      <View style={treeStyles.center}>
+      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
         <Ionicons name="alert-circle-outline" size={40} color={colors.textSecondary} />
         <Text style={[treeStyles.emptyText, { color: colors.text }]}>Failed to load</Text>
         <Button variant="secondary" label="Retry" onPress={loadRoot} style={{ marginTop: 8 }} />
@@ -708,7 +708,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (rootItems.length === 0) {
     return (
-      <View style={treeStyles.center}>
+      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
         <Ionicons name="folder-open-outline" size={40} color={colors.textSecondary} />
         <Text style={[treeStyles.emptyText, { color: colors.text }]}>Empty Repository</Text>
         <Text style={[treeStyles.emptySub, { color: colors.textSecondary }]}>
@@ -719,7 +719,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
   }
 
   return (
-    <Group style={{ flex: 1 }}>
+    <Group style={{ flex: 1, backgroundColor: colors.surface }}>
       {rootItems.map((item) => (
         <TreeItem
           key={item.path}
@@ -826,4 +826,3 @@ const dialogStyles = StyleSheet.create({
     fontSize: 14,
   },
 });
-

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -7,7 +7,6 @@ import {
   FlatList,
   ActivityIndicator,
   ScrollView,
-  TextInput,
   RefreshControl,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -231,8 +230,8 @@ export default function ExploreScreen() {
         <OfflineBanner />
 
         <ScrollView
-          style={s.treeScroll}
-          contentContainerStyle={s.treeContent}
+          style={[s.treeScroll, { backgroundColor: colors.background }]}
+          contentContainerStyle={[s.treeContent, { backgroundColor: colors.background }]}
           refreshControl={
             <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.primary} />
           }

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -33,6 +33,7 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
     return (
       <Text
         key={`canvas-fallback-${id}`}
+        selectable
         style={{
           color: this.deps.colors.text,
           backgroundColor: this.deps.colors.surfaceSecondary ?? '#f0f0f0',
@@ -125,6 +126,7 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
     return (
       <Text
         key={this.getKey()}
+        selectable
         style={[styles, { color: this.deps.colors.primary, textDecorationLine: 'underline' }]}
         onPress={onPress}
       >


### PR DESCRIPTION
## Summary
- Enable text selection in markdown/neorg preview rendering

> **Stacked PR**: part of the Wave 3 chain. Base will retarget to `main` once predecessor PRs land. Merge prerequisites: all Wave 1+2 PRs (#443-#447, #449-#451) into `main` first; then this stack merges in order.

Closes #416

## Test plan
- [x] `yarn test __tests__/selectable-preview.test.tsx` — pass
- [x] `yarn ts:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)