### PR TITLE
feat(ui): gray out uncached items in offline mode (#420)

### DIFF
--- a/__tests__/offline-gray-uncached.test.tsx
+++ b/__tests__/offline-gray-uncached.test.tsx
@@ -1,0 +1,160 @@
+var mockNavigate = jest.fn();
+
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: false, isInternetReachable: false }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+jest.mock('@shopify/flash-list', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const FlashList = React.forwardRef(({ data = [], renderItem }: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({ scrollToIndex: jest.fn() }));
+    return <View>{data.map((item: any, index: number) => renderItem({ item, index }))}</View>;
+  });
+  return { FlashList };
+});
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return React.forwardRef(({ children }: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({ close: jest.fn() }));
+    return <View>{children}</View>;
+  });
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const { createElement } = require('react');
+  const { Text } = require('react-native');
+  return { Ionicons: ({ name }: any) => createElement(Text, null, name) };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('../src/contexts/NoteContext', () => ({
+  useNotes: jest.fn(),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null } }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({ repositories: [] }),
+}));
+
+jest.mock('../src/contexts/ViewModeContext', () => ({
+  useViewMode: () => ({ viewMode: 'list', setViewMode: jest.fn() }),
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+jest.mock('../src/components/SearchBar', () => () => null);
+jest.mock('../src/components/GitHubActivityIndicator', () => ({ GitHubActivityIndicator: () => null }));
+jest.mock('../src/components/ui/OfflineBanner', () => ({ OfflineBanner: () => null }));
+jest.mock('../src/components/ui', () => ({ ScreenHeader: () => null }));
+jest.mock('../src/hooks/useResponsive', () => ({ useResponsive: () => ({ isTablet: false, maxContentWidth: 720 }) }));
+jest.mock('../src/hooks/useNetworkStatus', () => ({ useNetworkStatus: () => ({ isConnected: false, isInternetReachable: false }) }));
+jest.mock('../src/services/GitHubService', () => ({ GitHubService: { setToken: jest.fn() } }));
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    pendingCount: jest.fn(() => Promise.resolve(0)),
+    subscribe: jest.fn(() => jest.fn()),
+    drain: jest.fn(() => Promise.resolve({ succeeded: 0 })),
+  },
+}));
+jest.mock('../src/services/RepoPullService', () => ({ pullAllFromRepos: jest.fn() }));
+jest.mock('../src/services/ShareService', () => ({ ShareService: { isAvailable: jest.fn(() => false) } }));
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: { light: jest.fn(), medium: jest.fn(), selection: jest.fn(), success: jest.fn(), warning: jest.fn() },
+}));
+jest.mock('../src/stores/githubActivityStore', () => ({
+  githubActivity: { begin: jest.fn(), end: jest.fn() },
+}));
+
+import { Alert, StyleSheet } from 'react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import NoteCard from '../src/components/NoteCard';
+import NotesListScreen from '../src/screens/NotesListScreen';
+import { useNotes } from '../src/contexts/NoteContext';
+import { Note } from '../src/models/Note';
+import { NEUMORPHIC_LIGHT } from '../src/theme/tokens';
+import { TestThemeProvider } from './ui/testThemeProvider';
+
+const mockedUseNotes = useNotes as jest.MockedFunction<typeof useNotes>;
+
+const buildNote = (overrides: Partial<Note> = {}): Note => ({
+  id: 'note-1',
+  title: 'Offline note',
+  content: '',
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  ...overrides,
+});
+
+describe('offline gray uncached behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('grays out uncached notes offline and keeps online notes normal', () => {
+    const offlineRender = render(
+      <TestThemeProvider mode="light">
+        <NoteCard note={buildNote()} onPress={jest.fn()} isOffline isCached={false} />
+      </TestThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(offlineRender.getByTestId('note-card-note-1').props.style).opacity).toBe(0.5);
+    expect(StyleSheet.flatten(offlineRender.getByTestId('note-card-title-note-1').props.style).color).toBe(NEUMORPHIC_LIGHT.textSecondary);
+
+    offlineRender.unmount();
+
+    const onlineRender = render(
+      <TestThemeProvider mode="light">
+        <NoteCard note={buildNote()} onPress={jest.fn()} isOffline={false} isCached={false} />
+      </TestThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(onlineRender.getByTestId('note-card-note-1').props.style).opacity).toBe(1);
+    expect(StyleSheet.flatten(onlineRender.getByTestId('note-card-title-note-1').props.style).color).toBe(NEUMORPHIC_LIGHT.text);
+  });
+
+  it('blocks navigation for offline uncached notes', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined as never);
+    mockNavigate.mockClear();
+
+    mockedUseNotes.mockReturnValue({
+      notes: [buildNote()],
+      filteredNotes: [buildNote()],
+      isLoading: false,
+      searchQuery: '',
+      setSearchQuery: jest.fn(),
+      deleteNote: jest.fn(),
+      refreshNotes: jest.fn(),
+      togglePin: jest.fn(),
+      error: null,
+      createNote: jest.fn(),
+    } as any);
+
+    const { getByTestId, unmount } = render(
+      <TestThemeProvider mode="light">
+        <NotesListScreen />
+      </TestThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(getByTestId('note-card-note-1').props.style).opacity).toBe(0.5);
+
+    fireEvent.press(getByTestId('note-card-note-1'));
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledWith('Not available offline'));
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+    unmount();
+  });
+});

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -47,13 +47,26 @@ interface NoteCardProps {
   compact?: boolean;
   highlighted?: boolean;
   variant?: 'default' | 'card';
+  isOffline?: boolean;
+  isCached?: boolean;
 }
 
-function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted = false, variant = 'default' }: NoteCardProps) {
+function NoteCardImpl({
+  note,
+  onPress,
+  onLongPress,
+  compact = false,
+  highlighted = false,
+  variant = 'default',
+  isOffline = false,
+  isCached = true,
+}: NoteCardProps) {
   const { colors, isDark } = useTheme();
   const { isTablet } = useResponsive();
   const isCard = variant === 'card';
   const showCompact = isCard ? false : compact;
+  const isOfflineUncached = isOffline && !isCached;
+  const titleColor = isOfflineUncached ? colors.textSecondary : colors.text;
   
   const checklistProgress = useMemo(() => {
     if (!hasChecklists(note.content)) return null;
@@ -68,12 +81,14 @@ function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted
           backgroundColor: colors.card,
           shadowColor: colors.shadow,
           shadowOpacity: isDark ? 0 : 0.1,
+          opacity: isOfflineUncached ? 0.5 : 1,
         },
         showCompact && styles.cardCompact,
         isCard && styles.cardVariant,
         isTablet && styles.cardTablet,
         highlighted && { borderWidth: 2, borderColor: colors.primary },
       ]}
+      testID={`note-card-${note.id}`}
       onPress={() => onPress(note)}
       onLongPress={() => onLongPress?.(note)}
       activeOpacity={0.7}
@@ -84,11 +99,19 @@ function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted
         </View>
       )}
       <View style={styles.header}>
-        <Text style={[styles.title, { color: colors.text }, showCompact && styles.titleCompact]} numberOfLines={showCompact ? 1 : 2}>
+        <Text
+          testID={`note-card-title-${note.id}`}
+          style={[styles.title, { color: titleColor }, showCompact && styles.titleCompact]}
+          numberOfLines={showCompact ? 1 : 2}
+        >
           {note.title || 'Untitled Note'}
         </Text>
         {!showCompact && (
-          <Text style={[styles.content, { color: colors.textSecondary }]} numberOfLines={isCard ? 3 : 2}>
+          <Text
+            testID={`note-card-content-${note.id}`}
+            style={[styles.content, { color: colors.textSecondary }]}
+            numberOfLines={isCard ? 3 : 2}
+          >
             {stripPreview(note.content, note.format) || 'No content'}
           </Text>
         )}

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -50,6 +50,7 @@ import {
 } from "../utils/viewModes";
 import { ShareService } from "../services/ShareService";
 import { useResponsive } from "../hooks/useResponsive";
+import { useNetworkStatus } from "../hooks/useNetworkStatus";
 import { GitHubActivityIndicator } from "../components/GitHubActivityIndicator";
 import { githubActivity } from "../stores/githubActivityStore";
 
@@ -80,6 +81,7 @@ export default function NotesListScreen() {
   } = useNotes();
   const { viewMode, setViewMode } = useViewMode();
   const { isTablet, maxContentWidth } = useResponsive();
+  const { isConnected } = useNetworkStatus();
   const { repositories } = useRepos();
   const listRef = useRef<FlashListRef<Note>>(null);
   const swipeableRefs = useRef<
@@ -290,6 +292,11 @@ export default function NotesListScreen() {
 
   const handleNotePress = useCallback(
     (note: Note) => {
+      if (isConnected === false && !note.content?.trim()) {
+        Alert.alert("Not available offline");
+        return;
+      }
+
       if (note.format === "pdf" && note.repo && note.filePath) {
         const info = parseRepoPath(note.repo);
         if (info) {
@@ -305,7 +312,7 @@ export default function NotesListScreen() {
       }
       navigation.navigate("NoteEditor", { noteId: note.id });
     },
-    [navigation],
+    [isConnected, navigation],
   );
 
   const [longPressedNote, setLongPressedNote] = useState<Note | null>(null);
@@ -455,6 +462,8 @@ export default function NotesListScreen() {
           onPress={handleNotePress}
           onLongPress={handleNoteLongPress}
           highlighted={hasActiveSearch && index === currentSearchMatchIndex}
+          isOffline={isConnected === false}
+          isCached={!!note.content?.trim()}
         />
       </ReanimatedSwipeable>
     ),


### PR DESCRIPTION
## Summary
- `NoteCard` accepts `isOffline`/`isCached` props; dims when offline + uncached
- `NotesListScreen` blocks navigation for offline+uncached items with a toast

> **Stacked PR**: part of the Wave 3 chain. Base will retarget to `main` once predecessor PRs land. Merge prerequisites: all Wave 1+2 PRs (#443-#447, #449-#451) into `main` first; then this stack merges in order.

Closes #420

## Test plan
- [x] `yarn test __tests__/offline-gray-uncached.test.tsx` — pass
- [x] `yarn ts:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)