### PR TITLE
fix(canvas): clamp pan viewport to prevent content drift (#424)

### DIFF
--- a/.sisyphus/notepads/wave3-ux/decisions.md
+++ b/.sisyphus/notepads/wave3-ux/decisions.md
@@ -1,0 +1,2 @@
+- Kept the canvas pan/fit logic inside `CanvasEditorScreen` as exported pure helpers so the screen and unit test stay in sync without changing the canvas data model.
+- Used the same fit-to-content translation for initial auto-fit and the reset button so both flows center existing content consistently.

--- a/.sisyphus/notepads/wave3-ux/issues.md
+++ b/.sisyphus/notepads/wave3-ux/issues.md
@@ -1,0 +1,1 @@
+- The canvas screen now has several gesture worklet closures that depend on viewport size and bounds; any future gesture refactor should keep those dependencies explicit so clamping stays correct after layout changes.

--- a/.sisyphus/notepads/wave3-ux/learnings.md
+++ b/.sisyphus/notepads/wave3-ux/learnings.md
@@ -1,3 +1,5 @@
 - Markdown preview text selection needs to cover link text too; links can stay pressable and selectable together.
 - For nested Neorg inline rendering, setting selectable on every Text node is the safest way to keep copy/paste working across headings, lists, tables, quotes, and inline styles.
 - RNTL `UNSAFE_getAllByType(Text)` is enough to verify selectable props on rendered preview text without adding UI-specific assertions.
+- Canvas viewport clamping is easiest when the content bbox and fit-to-center translation are pure helpers shared by the gesture worklets and reset/open flows.
+- The pan clamp needs to be scale-aware; clamping against screen-space bbox edges keeps at least the requested margin visible after pinch zoom.

--- a/__tests__/canvas-pan-clamp.test.ts
+++ b/__tests__/canvas-pan-clamp.test.ts
@@ -1,0 +1,84 @@
+import React from 'react';
+import type { CanvasElement } from '../src/models/Canvas';
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('@react-navigation/native', () => ({ useNavigation: () => ({}), useRoute: () => ({ params: {} }) }));
+jest.mock('@react-navigation/native-stack', () => ({}));
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: () => null,
+  Gesture: {
+    Pan: () => ({
+      maxPointers: () => ({
+        onStart: () => ({
+          onChange: () => ({
+            onEnd: () => ({}),
+          }),
+        }),
+      }),
+      minPointers: () => ({
+        averageTouches: () => ({
+          onStart: () => ({
+            onUpdate: () => ({}),
+          }),
+        }),
+      }),
+    }),
+    Pinch: () => ({
+      onStart: () => ({
+        onUpdate: () => ({}),
+      }),
+    }),
+    Simultaneous: () => ({}),
+  },
+  GestureHandlerRootView: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: {},
+  runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+  useAnimatedStyle: () => ({}),
+  useDerivedValue: (fn: () => unknown) => ({ value: fn() }),
+  useSharedValue: (value: unknown) => ({ value }),
+  withSpring: (value: unknown) => value,
+}));
+jest.mock('@shopify/react-native-skia', () => ({
+  Canvas: () => null,
+  Path: () => null,
+  Rect: () => null,
+  Oval: () => null,
+  RoundedRect: () => null,
+  Fill: () => null,
+  Group: () => null,
+  Skia: { Path: { Make: () => ({ moveTo: () => {}, lineTo: () => {}, close: () => {}, rewind: () => {}, setIsVolatile: () => ({}) }) } },
+  matchFont: () => ({}),
+  Text: () => null,
+}));
+jest.mock('../src/contexts/CanvasContext', () => ({ useCanvases: () => ({ getCanvasById: () => undefined, createCanvas: async () => undefined, updateCanvas: async () => undefined }) }));
+jest.mock('../src/contexts/ThemeContext', () => ({ useTheme: () => ({ colors: { background: '#fff', border: '#ddd', surface: '#fff', text: '#111', textSecondary: '#666', primary: '#2563eb' } }) }));
+jest.mock('../src/components/GitContextPicker', () => () => null);
+jest.mock('../src/services/CanvasGitHubSyncService', () => ({ syncCanvasToGitHub: async () => ({ success: true }) }));
+
+import { clampCanvasTranslation, getCanvasContentBounds, getCanvasFitTranslation } from '../src/screens/CanvasEditorScreen';
+
+describe('canvas pan clamp helpers', () => {
+  const elements: CanvasElement[] = [
+    { type: 'stroke', id: 'stroke-1', tool: 'pen', color: '#000', width: 8, points: [{ x: 20, y: 40 }, { x: 60, y: 10 }] },
+    { type: 'shape', id: 'shape-1', shape: 'rect', color: '#111', width: 4, x1: -30, y1: 80, x2: 0, y2: 100 },
+    { type: 'chart', id: 'chart-1', chartType: 'bar', title: 'Sales', labels: ['A'], values: [1], x: 200, y: 300, width: 50, height: 60 },
+  ];
+
+  it('computes a bounding box across mixed canvas elements', () => {
+    expect(getCanvasContentBounds(elements)).toEqual({ minX: -32, minY: 6, maxX: 250, maxY: 360 });
+  });
+
+  it('centers non-empty content in the viewport for auto-fit/reset', () => {
+    expect(getCanvasFitTranslation({ minX: -32, minY: 6, maxX: 250, maxY: 360 }, 400, 400, 1)).toEqual({ translateX: 91, translateY: 17 });
+  });
+
+  it('clamps pan translation so at least 80px stays visible', () => {
+    const bounds = { minX: -32, minY: 6, maxX: 250, maxY: 360 };
+
+    expect(clampCanvasTranslation(-500, -500, 1, bounds, 400, 400)).toEqual({ translateX: -170, translateY: -280 });
+    expect(clampCanvasTranslation(-500, -900, 2, bounds, 400, 400)).toEqual({ translateX: -420, translateY: -640 });
+  });
+});

--- a/src/screens/CanvasEditorScreen.tsx
+++ b/src/screens/CanvasEditorScreen.tsx
@@ -119,6 +119,110 @@ function buildLinePath(x1: number, y1: number, x2: number, y2: number): SkPath {
   return p;
 }
 
+const PAN_MARGIN = 80;
+
+export interface CanvasBounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+function expandBounds(bounds: CanvasBounds | null, x: number, y: number): CanvasBounds {
+  if (!bounds) {
+    return { minX: x, minY: y, maxX: x, maxY: y };
+  }
+
+  return {
+    minX: Math.min(bounds.minX, x),
+    minY: Math.min(bounds.minY, y),
+    maxX: Math.max(bounds.maxX, x),
+    maxY: Math.max(bounds.maxY, y),
+  };
+}
+
+export function getCanvasContentBounds(elements: CanvasElement[]): CanvasBounds | null {
+  'worklet';
+
+  let bounds: CanvasBounds | null = null;
+
+  for (const el of elements) {
+    if (el.type === 'stroke') {
+      for (const point of el.points) {
+        bounds = expandBounds(bounds, point.x - el.width / 2, point.y - el.width / 2);
+        bounds = expandBounds(bounds, point.x + el.width / 2, point.y + el.width / 2);
+      }
+      continue;
+    }
+
+    if (el.type === 'shape') {
+      const pad = el.width / 2;
+      bounds = expandBounds(bounds, Math.min(el.x1, el.x2) - pad, Math.min(el.y1, el.y2) - pad);
+      bounds = expandBounds(bounds, Math.max(el.x1, el.x2) + pad, Math.max(el.y1, el.y2) + pad);
+      continue;
+    }
+
+    if (el.type === 'text') {
+      const textWidth = Math.max(1, el.text.length * el.fontSize * 0.6);
+      bounds = expandBounds(bounds, el.x, el.y - el.fontSize);
+      bounds = expandBounds(bounds, el.x + textWidth, el.y);
+      continue;
+    }
+
+    if (el.type === 'chart') {
+      bounds = expandBounds(bounds, el.x, el.y);
+      bounds = expandBounds(bounds, el.x + el.width, el.y + el.height);
+    }
+  }
+
+  return bounds;
+}
+
+export function getCanvasFitTranslation(
+  bounds: CanvasBounds | null,
+  viewportWidth: number,
+  viewportHeight: number,
+  scaleValue: number,
+) {
+  'worklet';
+
+  if (!bounds) {
+    return { translateX: 0, translateY: 0 };
+  }
+
+  return {
+    translateX: viewportWidth / 2 - scaleValue * (bounds.minX + bounds.maxX) / 2,
+    translateY: viewportHeight / 2 - scaleValue * (bounds.minY + bounds.maxY) / 2,
+  };
+}
+
+export function clampCanvasTranslation(
+  translateX: number,
+  translateY: number,
+  scaleValue: number,
+  bounds: CanvasBounds | null,
+  viewportWidth: number,
+  viewportHeight: number,
+  margin = PAN_MARGIN,
+) {
+  'worklet';
+
+  if (!bounds) {
+    return { translateX, translateY };
+  }
+
+  const minTx = margin - scaleValue * bounds.maxX;
+  const maxTx = viewportWidth - margin - scaleValue * bounds.minX;
+  const minTy = margin - scaleValue * bounds.maxY;
+  const maxTy = viewportHeight - margin - scaleValue * bounds.minY;
+  const fit = getCanvasFitTranslation(bounds, viewportWidth, viewportHeight, scaleValue);
+
+  return {
+    translateX: minTx <= maxTx ? Math.min(maxTx, Math.max(minTx, translateX)) : fit.translateX,
+    translateY: minTy <= maxTy ? Math.min(maxTy, Math.max(minTy, translateY)) : fit.translateY,
+  };
+}
+
 export default function CanvasEditorScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<RouteType>();
@@ -163,6 +267,9 @@ export default function CanvasEditorScreen() {
   const savedTy = useSharedValue(0);
   const activeDrawingElement = useSharedValue<CanvasStroke | CanvasShape | null>(null);
   const activeStrokePath = useSharedValue(Skia.Path.Make().setIsVolatile(true));
+  const contentBounds = useMemo(() => getCanvasContentBounds(elements), [elements]);
+  const shouldAutoFitRef = useRef((existingCanvas?.scene?.elements?.length ?? 0) > 0);
+  const didAutoFitRef = useRef(false);
 
   const setZoom = useCallback(
     (next: number) => {
@@ -173,10 +280,14 @@ export default function CanvasEditorScreen() {
   );
 
   const resetView = useCallback(() => {
+    const next = canvasSize && contentBounds
+      ? getCanvasFitTranslation(contentBounds, canvasSize.width, canvasSize.height, 1)
+      : { translateX: 0, translateY: 0 };
+
     scale.value = withSpring(1, { mass: 0.5, damping: 14, stiffness: 200 });
-    translateX.value = withSpring(0, { mass: 0.5, damping: 14, stiffness: 200 });
-    translateY.value = withSpring(0, { mass: 0.5, damping: 14, stiffness: 200 });
-  }, [scale, translateX, translateY]);
+    translateX.value = withSpring(next.translateX, { mass: 0.5, damping: 14, stiffness: 200 });
+    translateY.value = withSpring(next.translateY, { mass: 0.5, damping: 14, stiffness: 200 });
+  }, [canvasSize, contentBounds, scale, translateX, translateY]);
 
   const canvasAnimStyle = useAnimatedStyle(() => ({
     transform: [
@@ -199,6 +310,16 @@ export default function CanvasEditorScreen() {
       }),
     [],
   );
+
+  useEffect(() => {
+    if (!canvasSize || !shouldAutoFitRef.current || didAutoFitRef.current || !contentBounds) return;
+
+    const next = getCanvasFitTranslation(contentBounds, canvasSize.width, canvasSize.height, 1);
+    scale.value = withSpring(1, { mass: 0.5, damping: 14, stiffness: 200 });
+    translateX.value = withSpring(next.translateX, { mass: 0.5, damping: 14, stiffness: 200 });
+    translateY.value = withSpring(next.translateY, { mass: 0.5, damping: 14, stiffness: 200 });
+    didAutoFitRef.current = true;
+  }, [canvasSize, contentBounds, scale, translateX, translateY]);
 
   const saveHistory = useCallback(() => {
     setHistory((prev) => {
@@ -486,9 +607,20 @@ export default function CanvasEditorScreen() {
         .onUpdate((e) => {
           'worklet';
           const next = savedScale.value * e.scale;
-          scale.value = Math.max(0.5, Math.min(4, next));
+          const nextScale = Math.max(0.5, Math.min(4, next));
+          scale.value = nextScale;
+          const clamped = clampCanvasTranslation(
+            translateX.value,
+            translateY.value,
+            nextScale,
+            contentBounds,
+            canvasSize?.width ?? 0,
+            canvasSize?.height ?? 0,
+          );
+          translateX.value = clamped.translateX;
+          translateY.value = clamped.translateY;
         }),
-    [scale, savedScale],
+    [scale, savedScale, contentBounds, canvasSize?.width, canvasSize?.height, translateX, translateY],
   );
 
   const twoFingerPan = useMemo(
@@ -503,10 +635,18 @@ export default function CanvasEditorScreen() {
         })
         .onUpdate((e) => {
           'worklet';
-          translateX.value = savedTx.value + e.translationX;
-          translateY.value = savedTy.value + e.translationY;
+          const clamped = clampCanvasTranslation(
+            savedTx.value + e.translationX,
+            savedTy.value + e.translationY,
+            scale.value,
+            contentBounds,
+            canvasSize?.width ?? 0,
+            canvasSize?.height ?? 0,
+          );
+          translateX.value = clamped.translateX;
+          translateY.value = clamped.translateY;
         }),
-    [translateX, translateY, savedTx, savedTy],
+    [translateX, translateY, savedTx, savedTy, scale, contentBounds, canvasSize?.width, canvasSize?.height],
   );
 
   const composedGesture = useMemo(


### PR DESCRIPTION
## Summary
- Clamp pan offset to canvas bounds; bounds-aware reset

> **Note**: supersedes earlier #448 (closed). This is the chain-ordered version.

> **Stacked PR**: part of the Wave 3 chain. Base will retarget to `main` once predecessor PRs land. Merge prerequisites: all Wave 1+2 PRs (#443-#447, #449-#451) into `main` first; then this stack merges in order.

Closes #424

## Test plan
- [x] `yarn test __tests__/canvas-pan-clamp.test.ts` — pass
- [x] `yarn ts:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)