### PR TITLE
fix(theme): use bootstrap cache on first render to avoid light-mode flash

### DIFF
--- a/__tests__/themeContextHydration.test.tsx
+++ b/__tests__/themeContextHydration.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { ThemeProvider, useTheme } from '../src/contexts/ThemeContext';
+import { bootstrapStorage, clearBootCache } from '../src/services/StorageBootstrap';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// Project's jest setup mocks AsyncStorage with getItem/setItem/removeItem only.
+// bootstrapStorage uses multiGet — supply it here so the lazy-init path can run.
+beforeAll(() => {
+  if (typeof (AsyncStorage as unknown as { multiGet?: unknown }).multiGet !== 'function') {
+    (AsyncStorage as unknown as { multiGet: (keys: string[]) => Promise<[string, string | null][]> }).multiGet =
+      async (keys: string[]) => {
+        const out: [string, string | null][] = [];
+        for (const k of keys) {
+          out.push([k, await AsyncStorage.getItem(k)]);
+        }
+        return out;
+      };
+  }
+});
+
+function ThemeProbe() {
+  const { theme, isDark, style } = useTheme();
+  return <Text testID="probe">{`theme=${theme} dark=${isDark ? '1' : '0'} style=${style}`}</Text>;
+}
+
+beforeEach(async () => {
+  clearBootCache();
+  await AsyncStorage.clear?.();
+});
+
+describe('ThemeProvider initial paint', () => {
+  it('uses bootstrap cache values on first render so the first frame matches the persisted theme', async () => {
+    await AsyncStorage.setItem('@gitnotes:theme', 'dark');
+    await AsyncStorage.setItem('@gitnotes:style', 'flat');
+    await bootstrapStorage();
+
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    // First synchronous render must reflect the saved theme/style — no
+    // need to flush effects. This is what prevents the light-mode flash.
+    expect(getByTestId('probe').props.children).toBe('theme=dark dark=1 style=flat');
+  });
+
+  it('falls back to system theme when no persisted value is in the boot cache', async () => {
+    await bootstrapStorage();
+
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(getByTestId('probe').props.children).toMatch(/theme=system/);
+  });
+});

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -39,20 +39,46 @@ interface ThemeProviderProps {
   children: ReactNode;
 }
 
+function readBootTheme(): ThemeMode {
+  const v = getBootValue('@gitnotes:theme');
+  if (v === 'light' || v === 'dark' || v === 'system') return v;
+  return 'system';
+}
+
+function readBootStyle(): ThemeStyle {
+  const v = getBootValue('@gitnotes:style');
+  if (v === 'neumorphic' || v === 'flat') return v;
+  return 'neumorphic';
+}
+
 export function ThemeProvider({ children }: ThemeProviderProps) {
-  const [theme, setThemeState] = useState<ThemeMode>('system');
-  const [style, setStyleState] = useState<ThemeStyle>('neumorphic');
+  // Lazy-init from the storage bootstrap cache so the very first paint
+  // uses the persisted theme. Without this, the initial render uses the
+  // 'system' default and `useColorScheme()` may return null on cold
+  // start, leaving the first frame in light mode. Surfaces with cached
+  // subtree state (custom TabBar, NavigationContainer chrome) end up
+  // briefly mismatched with the rest of the app.
+  //
+  // Falls back to AsyncStorage in loadPersisted for the rare case where
+  // the bootstrap cache is missing the key (e.g. tests mounting
+  // ThemeProvider without calling bootstrapStorage first).
+  const [theme, setThemeState] = useState<ThemeMode>(readBootTheme);
+  const [style, setStyleState] = useState<ThemeStyle>(readBootStyle);
   const systemColorScheme = useColorScheme();
 
   const loadPersisted = useCallback(async () => {
     try {
-      const savedTheme = getBootValue('@gitnotes:theme') ?? await AsyncStorage.getItem(THEME_STORAGE_KEY);
-      const savedStyle = getBootValue('@gitnotes:style') ?? await AsyncStorage.getItem(STYLE_STORAGE_KEY);
-      if (savedTheme && ['light', 'dark', 'system'].includes(savedTheme)) {
-        setThemeState(savedTheme as ThemeMode);
+      if (getBootValue('@gitnotes:theme') === undefined) {
+        const savedTheme = await AsyncStorage.getItem(THEME_STORAGE_KEY);
+        if (savedTheme === 'light' || savedTheme === 'dark' || savedTheme === 'system') {
+          setThemeState(savedTheme);
+        }
       }
-      if (savedStyle === 'neumorphic' || savedStyle === 'flat') {
-        setStyleState(savedStyle);
+      if (getBootValue('@gitnotes:style') === undefined) {
+        const savedStyle = await AsyncStorage.getItem(STYLE_STORAGE_KEY);
+        if (savedStyle === 'neumorphic' || savedStyle === 'flat') {
+          setStyleState(savedStyle);
+        }
       }
     } catch (error) {
       console.error('Error loading theme preferences:', error);


### PR DESCRIPTION
## Bug

On first open, TabBar (and any NavigationContainer-managed chrome) briefly renders in **light mode** while the body content renders dark, when the user has chosen the dark theme.

## Root cause

\`ThemeProvider\` initialized state to \`theme = 'system'\` in \`useState\` and only applied the persisted value inside a \`useEffect\`:

\`\`\`tsx
const [theme, setThemeState] = useState<ThemeMode>('system');
// ...
useEffect(() => { loadPersisted(); }, [loadPersisted]);
\`\`\`

Combined with React Native's \`useColorScheme()\` returning \`null\` on the first sync render (cold-start behavior), the very first paint always landed on \"light\":

- theme = 'system' (default)
- isDark = (\`useColorScheme()\` === 'dark') → \`null === 'dark'\` → \`false\` → light

Then once \`loadPersisted\` finished, isDark flipped true and everything re-rendered dark. Most surfaces caught up cleanly, but the TabBar / nav chrome lagged by a frame because they sit inside cached subtrees (Surface elevation memo, NavigationContainer's internal theme application). The result was a momentary light bar against a dark body.

## Fix

\`bootstrapStorage()\` already prefetches \`@gitnotes:theme\` and \`@gitnotes:style\` synchronously into an in-memory cache before \`ThemeProvider\` mounts (\`StorageBootstrap.ts:14-15\`). Lazy-init the \`useState\` calls from \`getBootValue\` so the **first** render uses the persisted theme directly:

\`\`\`tsx
const [theme, setThemeState] = useState<ThemeMode>(readBootTheme);
const [style, setStyleState] = useState<ThemeStyle>(readBootStyle);
\`\`\`

The old AsyncStorage fallback in \`loadPersisted\` stays, but only fires when the boot cache is missing the key (tests that mount the provider without calling \`bootstrapStorage\` first).

## Test plan

- [x] \`yarn ts:check\` clean
- [x] \`yarn test\` — 213 passed, 24 suites (2 new tests in \`themeContextHydration.test.tsx\` cover lazy init from boot cache + fallback to system default)
- [ ] Manual: cold-start the app with theme set to dark — TabBar paints dark on the first frame, no flash
- [ ] Manual: cold-start with theme = 'system' on a dark device — same, no flash
- [ ] Manual: clear app data, fresh install — defaults to system, no regression

## Why not a hydration gate?

Considered blocking children behind a \`hasHydrated\` flag. Rejected — adds an extra blank frame on every cold start even when theme is already correct (e.g. system = light, default theme = system, no persisted override). The lazy-init fix is zero-cost when the cache is warm and degrades to the previous behavior when it's not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)