### PR TITLE
feat(ui): add glossy/translucent UI mode toggle (#422)

### DIFF
--- a/__mocks__/expo-blur.ts
+++ b/__mocks__/expo-blur.ts
@@ -1,0 +1,7 @@
+const { View } = require('react-native');
+
+module.exports = {
+  __esModule: true,
+  BlurView: View,
+  default: View,
+};

--- a/__mocks__/expo-file-system-legacy.ts
+++ b/__mocks__/expo-file-system-legacy.ts
@@ -1,0 +1,6 @@
+module.exports = {
+  __esModule: true,
+  EncodingType: { Base64: 'base64' },
+  readAsStringAsync: jest.fn(),
+  default: {},
+};

--- a/__tests__/glossy-ui.test.tsx
+++ b/__tests__/glossy-ui.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { ThemeProvider, useTheme } from '../src/contexts/ThemeContext';
+import { Surface } from '../src/components/ui/Surface';
+import SettingsScreen from '../src/screens/SettingsScreen';
+import { NavigationContainer } from '@react-navigation/native';
+import { AuthProvider } from '../src/contexts/AuthContext';
+import { NoteProvider } from '../src/contexts/NoteContext';
+import { RepoProvider } from '../src/contexts/RepoContext';
+import { CanvasProvider } from '../src/contexts/CanvasContext';
+import { TodoProvider } from '../src/contexts/TodoContext';
+import { View, Text } from 'react-native';
+
+// Mock AsyncStorage
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+jest.mock('@react-native-community/netinfo', () => ({
+  useNetInfo: () => ({ isConnected: true, isInternetReachable: true }),
+  addEventListener: jest.fn(),
+  fetch: jest.fn(() => Promise.resolve({ isConnected: true })),
+}));
+
+// Mock expo-blur
+jest.mock('expo-blur', () => {
+  const { View } = require('react-native');
+  return {
+    BlurView: (props: any) => <View {...props} testID="blur-view" />
+  };
+});
+
+jest.mock('expo-image', () => ({
+  Image: () => null,
+}));
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+}));
+
+jest.mock('expo-constants', () => ({
+  expoConfig: { version: '1.0.0' },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('expo-file-system/legacy', () => ({
+  readAsStringAsync: jest.fn(),
+  writeAsStringAsync: jest.fn(),
+  deleteAsync: jest.fn(),
+  makeDirectoryAsync: jest.fn(),
+  getInfoAsync: jest.fn(),
+}));
+
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+}));
+
+// Mock hooks
+jest.mock('../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    isTablet: false,
+    maxContentWidth: 600,
+  }),
+}));
+
+const renderWithProviders = (component: React.ReactElement) => {
+  return render(
+    <ThemeProvider>
+      <AuthProvider>
+        <RepoProvider>
+          <NoteProvider>
+            <CanvasProvider>
+              <TodoProvider>
+                <NavigationContainer>
+                  {component}
+                </NavigationContainer>
+              </TodoProvider>
+            </CanvasProvider>
+          </NoteProvider>
+        </RepoProvider>
+      </AuthProvider>
+    </ThemeProvider>
+  );
+};
+
+const TestConsumer = () => {
+  const { glossy, setGlossy, style, setStyle } = useTheme();
+  return (
+    <View>
+      <Text testID="glossy-val">{String(glossy)}</Text>
+      <Text testID="style-val">{style}</Text>
+    </View>
+  );
+};
+
+describe('Glossy UI mode', () => {
+  it('is OFF by default and turning it ON disables Neumorphic', async () => {
+    const { getByTestId, getByText } = renderWithProviders(
+      <>
+        <TestConsumer />
+        <SettingsScreen />
+      </>
+    );
+
+    // Initial state: default is flat or neumorphic (neumorphic typically), glossy false
+    await waitFor(() => {
+      expect(getByTestId('glossy-val').props.children).toBe('false');
+    });
+
+    // Toggle Glossy ON
+    const glossyToggle = getByTestId('glossy-toggle');
+    fireEvent(glossyToggle, 'valueChange', true);
+
+    await waitFor(() => {
+      expect(getByTestId('glossy-val').props.children).toBe('true');
+      expect(getByTestId('style-val').props.children).toBe('flat'); // Neumorphic disabled
+    });
+    
+    // Toggle Neumorphic ON
+    const neuToggle = getByTestId('neu-toggle');
+    fireEvent(neuToggle, 'valueChange', true);
+    
+    await waitFor(() => {
+      expect(getByTestId('style-val').props.children).toBe('neumorphic');
+      expect(getByTestId('glossy-val').props.children).toBe('false'); // Glossy disabled
+    });
+  });
+
+  it('renders BlurView when glossy is ON', async () => {
+    const { getByTestId, queryByTestId, getAllByTestId } = render(
+      <ThemeProvider>
+        <TestSurface />
+      </ThemeProvider>
+    );
+
+    // Initial glossy false
+    expect(queryByTestId('blur-view')).toBeNull();
+    
+    // Check after toggling
+    fireEvent.press(getByTestId('toggle-btn'));
+    
+    await waitFor(() => {
+      expect(getAllByTestId('blur-view').length).toBeGreaterThan(0);
+    });
+  });
+});
+
+const TestSurface = () => {
+  const { setGlossy, glossy } = useTheme();
+  return (
+    <View>
+      <Surface testID="test-surface" />
+      {glossy && <Surface testID="test-surface-2" />}
+      <Text testID="toggle-btn" onPress={() => setGlossy(true)}>Toggle</Text>
+    </View>
+  );
+};

--- a/__tests__/searchbar-glossy.test.tsx
+++ b/__tests__/searchbar-glossy.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { ThemeProvider, useTheme } from '../src/contexts/ThemeContext';
+import SearchBar from '../src/components/SearchBar';
+
+// Mock AsyncStorage
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+// Mock expo-blur — render a View tagged so tests can detect it
+jest.mock('expo-blur', () => {
+  const { View } = require('react-native');
+  return {
+    BlurView: (props: any) => <View {...props} testID="blur-view" />,
+  };
+});
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+const GlossyController = ({ initialGlossy }: { initialGlossy: boolean }) => {
+  const { setGlossy } = useTheme();
+  React.useEffect(() => {
+    setGlossy(initialGlossy);
+  }, [initialGlossy, setGlossy]);
+  return null;
+};
+
+const renderWithTheme = (component: React.ReactElement, glossy: boolean) =>
+  render(
+    <ThemeProvider>
+      <GlossyController initialGlossy={glossy} />
+      {component}
+    </ThemeProvider>
+  );
+
+describe('SearchBar glossy mode', () => {
+  it('does not render BlurView when glossy is OFF', async () => {
+    const { queryByTestId } = renderWithTheme(
+      <SearchBar value="" onChangeText={() => {}} />,
+      false
+    );
+
+    // Wait one tick for ThemeProvider initialization to complete
+    await waitFor(() => {
+      expect(queryByTestId('blur-view')).toBeNull();
+    });
+  });
+
+  it('renders BlurView when glossy is ON', async () => {
+    const { getAllByTestId } = renderWithTheme(
+      <SearchBar value="" onChangeText={() => {}} />,
+      true
+    );
+
+    await waitFor(() => {
+      expect(getAllByTestId('blur-view').length).toBeGreaterThan(0);
+    });
+  });
+
+});

--- a/__tests__/ui/__snapshots__/Button.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Button.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button snapshots primary in light + dark: primary-dark 1`] = `
 <View
@@ -65,6 +65,7 @@ exports[`Button snapshots primary in light + dark: primary-dark 1`] = `
             "shadowOpacity": 1,
             "shadowRadius": 8,
           },
+          undefined,
           [
             {
               "alignItems": "center",
@@ -199,6 +200,7 @@ exports[`Button snapshots primary in light + dark: primary-light 1`] = `
             "shadowOpacity": 1,
             "shadowRadius": 8,
           },
+          undefined,
           [
             {
               "alignItems": "center",

--- a/__tests__/ui/__snapshots__/Card.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Card.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Card snapshots non-interactive light 1`] = `
 <View
@@ -17,6 +17,7 @@ exports[`Card snapshots non-interactive light 1`] = `
         "shadowOpacity": 1,
         "shadowRadius": 8,
       },
+      undefined,
       [
         {
           "padding": 16,

--- a/__tests__/ui/__snapshots__/Chip.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Chip.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Chip snapshots inactive + active: chip-active 1`] = `
 <View
@@ -17,6 +17,7 @@ exports[`Chip snapshots inactive + active: chip-active 1`] = `
         "shadowOpacity": 1,
         "shadowRadius": 4,
       },
+      undefined,
       [
         {
           "alignItems": "center",
@@ -87,6 +88,7 @@ exports[`Chip snapshots inactive + active: chip-inactive 1`] = `
         "shadowOpacity": 1,
         "shadowRadius": 4,
       },
+      undefined,
       [
         {
           "alignItems": "center",

--- a/__tests__/ui/__snapshots__/Group.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Group.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Group snapshots a 2-row group 1`] = `
 <View
@@ -41,6 +41,7 @@ exports[`Group snapshots a 2-row group 1`] = `
           "shadowOpacity": 1,
           "shadowRadius": 8,
         },
+        undefined,
         {
           "overflow": "hidden",
         },

--- a/__tests__/ui/__snapshots__/Surface.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Surface.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Surface snapshots a raised neumorphic Surface with a Text child 1`] = `
 <View
@@ -17,6 +17,7 @@ exports[`Surface snapshots a raised neumorphic Surface with a Text child 1`] = `
         "shadowOpacity": 1,
         "shadowRadius": 8,
       },
+      undefined,
       undefined,
     ]
   }

--- a/__tests__/ui/__snapshots__/Toggle.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Toggle.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toggle snapshots both states: toggle-off 1`] = `
 <View
@@ -54,6 +54,7 @@ exports[`Toggle snapshots both states: toggle-off 1`] = `
           "shadowOpacity": 1,
           "shadowRadius": 4,
         },
+        undefined,
         {
           "height": 30,
           "justifyContent": "center",
@@ -196,6 +197,7 @@ exports[`Toggle snapshots both states: toggle-on 1`] = `
           "shadowOpacity": 1,
           "shadowRadius": 4,
         },
+        undefined,
         {
           "height": 30,
           "justifyContent": "center",

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,10 @@ module.exports = {
     '**/?(*.)+(spec|test).{ts,tsx}',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '^expo-blur$': '<rootDir>/__mocks__/expo-blur.ts',
+    '^expo-file-system/legacy$': '<rootDir>/__mocks__/expo-file-system-legacy.ts',
+  },
   setupFiles: ['<rootDir>/jest.setup.ts'],
   transformIgnorePatterns: [
     'node_modules/(?!(react-native|@react-native|@react-navigation|expo|@expo|react-native-reanimated|@shopify)/)',

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,12 @@
 // Mocks for the @testing-library/react-native render path.
 
+jest.mock('expo-blur', () => {
+  const { View } = require('react-native');
+  return {
+    BlurView: View
+  };
+});
+
 // Minimal reanimated stub — official mock pulls in TS source that the
 // jest transform pipeline can't load. We only need the surface area used
 // by neumorphic primitives (useSharedValue, useAnimatedStyle, withSpring,

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -48,3 +48,17 @@ jest.mock('@react-native-async-storage/async-storage', () => {
     },
   };
 });
+
+jest.mock('react-native-safe-area-context', () => {
+  const { View } = require('react-native');
+  const insets = { top: 0, right: 0, bottom: 0, left: 0 };
+  const frame = { x: 0, y: 0, width: 0, height: 0 };
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+    SafeAreaConsumer: ({ children }: { children: (i: typeof insets) => React.ReactNode }) => children(insets),
+    SafeAreaView: View,
+    useSafeAreaInsets: () => insets,
+    useSafeAreaFrame: () => frame,
+    initialWindowMetrics: { insets, frame },
+  };
+});

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -50,7 +50,7 @@ interface NoteCardProps {
 }
 
 function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted = false, variant = 'default' }: NoteCardProps) {
-  const { colors, isDark } = useTheme();
+  const { colors, isDark, glossy } = useTheme();
   const { isTablet } = useResponsive();
   const isCard = variant === 'card';
   const showCompact = isCard ? false : compact;
@@ -65,7 +65,7 @@ function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted
       style={[
         styles.card,
         {
-          backgroundColor: colors.card,
+          backgroundColor: glossy ? colors.glassCard : colors.card,
           shadowColor: colors.shadow,
           shadowOpacity: isDark ? 0 : 0.1,
         },

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -10,6 +10,7 @@ interface SearchBarProps {
   placeholder?: string;
   onClear?: () => void;
   style?: StyleProp<ViewStyle>;
+  testID?: string;
 }
 
 export default function SearchBar({
@@ -18,8 +19,9 @@ export default function SearchBar({
   placeholder = 'Search notes...',
   onClear,
   style,
+  testID,
 }: SearchBarProps) {
-  const { colors } = useTheme();
+  const { colors, glossy } = useTheme();
 
   const handleClear = () => {
     onChangeText('');
@@ -35,6 +37,8 @@ export default function SearchBar({
       autoCorrect={false}
       autoCapitalize="none"
       containerStyle={style}
+      glassLayer={glossy ? 'glassNav' : undefined}
+      surfaceTestID={testID}
       leading={<Ionicons name="search" size={20} color={colors.textSecondary} />}
       trailing={
         value.length > 0 ? (

--- a/src/components/ai/FloatingAIButton.tsx
+++ b/src/components/ai/FloatingAIButton.tsx
@@ -26,7 +26,7 @@ interface FloatingAIButtonProps {
 
 export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
   const { isEnabled } = useAIStore();
-  const { colors } = useTheme();
+  const { colors, glossy } = useTheme();
   const navigation = useNavigation();
 
   const initialX = SCREEN_WIDTH - BUTTON_SIZE - 24;
@@ -47,7 +47,9 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
           translateY.value = y;
           savedTranslateX.value = x;
           savedTranslateY.value = y;
-        } catch (e) {}
+        } catch (e) {
+          console.warn('Failed to restore FAB position:', e);
+        }
       }
     });
   }, [translateX, translateY, savedTranslateX, savedTranslateY]);
@@ -117,10 +119,10 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
             radius="pill"
             style={[
               styles.button,
-              { backgroundColor: colors.primary }
+              { backgroundColor: glossy ? colors.glassElevated : colors.primary }
             ]}
           >
-            <Ionicons name="sparkles" size={24} color="#FFFFFF" />
+            <Ionicons name="sparkles" size={24} color={glossy ? colors.primary : "#FFFFFF"} />
           </Surface>
         </Animated.View>
       </GestureDetector>

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, ReactNode, useState } from 'react';
 import { StyleProp, TextInput, TextInputProps, TextStyle, View, ViewStyle } from 'react-native';
-import { Surface } from './Surface';
+import { Surface, SurfaceProps } from './Surface';
 import { useTokens } from '../../contexts/ThemeContext';
 
 export interface InputProps extends Omit<TextInputProps, 'style'> {
@@ -9,6 +9,8 @@ export interface InputProps extends Omit<TextInputProps, 'style'> {
   containerStyle?: StyleProp<ViewStyle>;
   inputStyle?: StyleProp<TextStyle>;
   multilineMinHeight?: number;
+  glassLayer?: SurfaceProps['glassLayer'];
+  surfaceTestID?: string;
 }
 
 export const Input = forwardRef<TextInput, InputProps>(function Input(props, ref) {
@@ -22,6 +24,8 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(props, ref
     onFocus,
     onBlur,
     placeholderTextColor,
+    glassLayer,
+    surfaceTestID,
     ...textInputProps
   } = props;
   const { colors, spacing, type } = useTokens();
@@ -32,6 +36,8 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(props, ref
       elevation="subtle"
       radius="md"
       inset
+      glassLayer={glassLayer}
+      testID={surfaceTestID}
       style={[
         {
           flexDirection: 'row',

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -24,7 +24,7 @@ export function Modal(props: ModalProps) {
     fullWidth = false,
     bottomSheet = false,
   } = props;
-  const { isDark } = useTheme();
+  const { isDark, glossy } = useTheme();
   const { spacing, colors } = useTokens();
   const { height: viewportHeight, width: viewportWidth } = useWindowDimensions();
 
@@ -32,9 +32,11 @@ export function Modal(props: ModalProps) {
   const slotHeight = Math.max(0, viewportHeight - pad * 2);
   const slotWidth = Math.max(0, viewportWidth - pad * 2);
 
+  const bgColor = glossy ? colors.glassElevated : colors.elevated;
+
   const surfaceStyle: ViewStyle = bottomSheet
     ? {
-        backgroundColor: colors.elevated,
+        backgroundColor: bgColor,
         maxHeight: slotHeight,
         overflow: 'hidden',
         borderBottomLeftRadius: 0,
@@ -44,13 +46,13 @@ export function Modal(props: ModalProps) {
     ? {
         padding: pad,
         maxHeight: slotHeight,
-        backgroundColor: colors.elevated,
+        backgroundColor: bgColor,
         overflow: 'hidden',
       }
     : {
         padding: pad,
         maxHeight: slotHeight,
-        backgroundColor: colors.elevated,
+        backgroundColor: bgColor,
       };
 
   return (

--- a/src/components/ui/ScreenHeader.tsx
+++ b/src/components/ui/ScreenHeader.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode } from 'react';
 import { Text, View, StyleProp, ViewStyle } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { useTokens } from '../../contexts/ThemeContext';
+import { useTheme, useTokens } from '../../contexts/ThemeContext';
 import { IconButton } from './IconButton';
+import { Surface } from './Surface';
 
 export interface ScreenHeaderProps {
   title: string;
@@ -16,9 +17,14 @@ export interface ScreenHeaderProps {
 export function ScreenHeader(props: ScreenHeaderProps) {
   const { title, subtitle, badge, onBack, actions, style } = props;
   const { colors, spacing, type } = useTokens();
+  const { glossy } = useTheme();
+
+  const HeaderComponent = glossy ? Surface : View;
+  const headerProps = glossy ? { elevation: 'flat' as const, radius: 'sm' as const, glassLayer: 'glassNav' as const } : {};
 
   return (
-    <View
+    <HeaderComponent
+      {...headerProps}
       style={[
         {
           flexDirection: 'row',
@@ -89,6 +95,6 @@ export function ScreenHeader(props: ScreenHeaderProps) {
           {actions}
         </View>
       )}
-    </View>
+    </HeaderComponent>
   );
 }

--- a/src/components/ui/Surface.tsx
+++ b/src/components/ui/Surface.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useMemo } from 'react';
 import { Platform, StyleSheet, View, ViewProps, ViewStyle, StyleProp } from 'react-native';
+import { BlurView } from 'expo-blur';
 import { useTheme, useTokens } from '../../contexts/ThemeContext';
 import {
   buildElevation,
@@ -15,6 +16,7 @@ export interface SurfaceProps extends Omit<ViewProps, 'style'> {
   style?: StyleProp<ViewStyle>;
   children?: ReactNode;
   testID?: string;
+  glassLayer?: 'glassSurface' | 'glassCard' | 'glassElevated' | 'glassNav' | 'glassBorder';
 }
 
 function detectPlatform(): TokenPlatform {
@@ -24,8 +26,8 @@ function detectPlatform(): TokenPlatform {
 }
 
 export function Surface(props: SurfaceProps) {
-  const { elevation = 'raised', inset = false, radius = 'md', style, children, testID, ...rest } = props;
-  const { style: themeStyle } = useTheme();
+  const { elevation = 'raised', inset = false, radius = 'md', style, children, testID, glassLayer = 'glassSurface', ...rest } = props;
+  const { style: themeStyle, glossy, isDark } = useTheme();
   const { colors, radii } = useTokens();
   const platform = detectPlatform();
 
@@ -44,24 +46,41 @@ export function Surface(props: SurfaceProps) {
 
   const borderRadius = radii[radius];
   const baseStyle: ViewStyle = {
-    backgroundColor: colors.surface,
+    backgroundColor: glossy ? colors[glassLayer] : colors.surface,
     borderRadius,
   };
+
+  const webGlassStyle = glossy && platform === 'web' ? {
+    backdropFilter: 'blur(20px)',
+    WebkitBackdropFilter: 'blur(20px)',
+  } : {};
 
   const androidOverlays = elevationStyles.androidOverlays;
   const showOverlays = platform === 'android' && androidOverlays !== undefined;
 
+  const Wrapper = glossy && platform !== 'web' ? BlurView : View;
+  const blurProps = glossy && platform !== 'web' ? {
+    intensity: platform === 'ios' ? 60 : 30,
+    tint: isDark ? 'dark' : 'light' as any,
+  } : {};
+
   return (
-    <View
+    <Wrapper
       {...rest}
       testID={testID}
-      style={[baseStyle, elevationStyles.outer as ViewStyle, style]}
+      {...blurProps}
+      style={[
+        baseStyle,
+        elevationStyles.outer as ViewStyle,
+        (glossy && platform === 'web') ? (webGlassStyle as ViewStyle) : undefined,
+        style
+      ]}
     >
       <View
         pointerEvents="none"
         style={[StyleSheet.absoluteFill, { borderRadius }, elevationStyles.inner as ViewStyle]}
       />
-      {showOverlays && androidOverlays && (
+      {showOverlays && androidOverlays && !glossy && (
         <AndroidShadowOverlays
           offset={androidOverlays.offset}
           blur={androidOverlays.blur}
@@ -72,7 +91,7 @@ export function Surface(props: SurfaceProps) {
         />
       )}
       {children}
-    </View>
+    </Wrapper>
   );
 }
 

--- a/src/components/ui/TabBar.tsx
+++ b/src/components/ui/TabBar.tsx
@@ -4,7 +4,7 @@ import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { Surface } from './Surface';
-import { useTokens } from '../../contexts/ThemeContext';
+import { useTheme, useTokens } from '../../contexts/ThemeContext';
 
 type IoniconName = keyof typeof Ionicons.glyphMap;
 
@@ -19,19 +19,25 @@ const TAB_ICONS: Record<string, { focused: IoniconName; outline: IoniconName; la
 export function TabBar({ state, navigation }: BottomTabBarProps) {
   const insets = useSafeAreaInsets();
   const { colors, spacing } = useTokens();
+  const { glossy } = useTheme();
 
   return (
     <View
       style={{
-        backgroundColor: colors.bg,
+        backgroundColor: glossy ? 'transparent' : colors.bg,
         paddingHorizontal: spacing[6],
         paddingBottom: insets.bottom + spacing[3],
         paddingTop: spacing[4],
+        position: glossy ? 'absolute' : 'relative',
+        bottom: 0,
+        left: 0,
+        right: 0,
       }}
     >
       <Surface
         elevation="floating"
         radius="pill"
+        glassLayer="glassNav"
         style={{
           flexDirection: 'row',
           alignItems: 'center',

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -24,8 +24,10 @@ interface ThemeContextType {
   theme: ThemeMode;
   isDark: boolean;
   style: ThemeStyle;
+  glossy: boolean;
   setTheme: (theme: ThemeMode) => void;
   setStyle: (style: ThemeStyle) => void;
+  setGlossy: (glossy: boolean) => void;
   colors: Palette;
   tokens: Tokens;
 }
@@ -34,6 +36,7 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 const THEME_STORAGE_KEY = '@gitnotes:theme';
 const STYLE_STORAGE_KEY = '@gitnotes:style';
+const GLOSSY_STORAGE_KEY = '@gitnotes:glossy';
 
 interface ThemeProviderProps {
   children: ReactNode;
@@ -64,6 +67,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   // ThemeProvider without calling bootstrapStorage first).
   const [theme, setThemeState] = useState<ThemeMode>(readBootTheme);
   const [style, setStyleState] = useState<ThemeStyle>(readBootStyle);
+  const [glossy, setGlossyState] = useState<boolean>(false);
   const systemColorScheme = useColorScheme();
 
   const loadPersisted = useCallback(async () => {
@@ -79,6 +83,10 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         if (savedStyle === 'neumorphic' || savedStyle === 'flat') {
           setStyleState(savedStyle);
         }
+      }
+      const savedGlossy = await AsyncStorage.getItem(GLOSSY_STORAGE_KEY);
+      if (savedGlossy !== null) {
+        setGlossyState(savedGlossy === 'true');
       }
     } catch (error) {
       console.error('Error loading theme preferences:', error);
@@ -109,8 +117,25 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     try {
       setStyleState(newStyle);
       await AsyncStorage.setItem(STYLE_STORAGE_KEY, newStyle);
+      if (newStyle === 'neumorphic') {
+        setGlossyState(false);
+        await AsyncStorage.setItem(GLOSSY_STORAGE_KEY, 'false');
+      }
     } catch (error) {
       console.error('Error saving style:', error);
+    }
+  }, []);
+
+  const setGlossy = useCallback(async (newGlossy: boolean) => {
+    try {
+      setGlossyState(newGlossy);
+      await AsyncStorage.setItem(GLOSSY_STORAGE_KEY, newGlossy ? 'true' : 'false');
+      if (newGlossy) {
+        setStyleState('flat');
+        await AsyncStorage.setItem(STYLE_STORAGE_KEY, 'flat');
+      }
+    } catch (error) {
+      console.error('Error saving glossy:', error);
     }
   }, []);
 
@@ -122,8 +147,8 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   );
 
   const value: ThemeContextType = useMemo(
-    () => ({ theme, isDark, style, setTheme, setStyle, colors, tokens }),
-    [theme, isDark, style, setTheme, setStyle, colors, tokens],
+    () => ({ theme, isDark, style, glossy, setTheme, setStyle, setGlossy, colors, tokens }),
+    [theme, isDark, style, glossy, setTheme, setStyle, setGlossy, colors, tokens],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -44,7 +44,7 @@ import { useAIStore } from '../stores/aiStore';
 import type { AIProviderConfig } from '../models/AIProvider';
 
 export default function SettingsScreen() {
-  const { theme, colors, setTheme, style: uiStyle, setStyle } = useTheme();
+  const { theme, colors, setTheme, style: uiStyle, setStyle, glossy, setGlossy } = useTheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { isTablet, maxContentWidth } = useResponsive();
   const { clearAllNotes, refreshNotes } = useNotes();
@@ -336,6 +336,7 @@ export default function SettingsScreen() {
           <GroupRow
             trailing={
               <Toggle
+                testID="neu-toggle"
                 value={uiStyle === 'neumorphic'}
                 onValueChange={(v) => setStyle(v ? 'neumorphic' : 'flat')}
               />
@@ -352,6 +353,17 @@ export default function SettingsScreen() {
             }
           >
             <Text style={[styles.settingLabel, { color: colors.text }]}>Dark Mode</Text>
+          </GroupRow>
+          <GroupRow
+            trailing={
+              <Toggle
+                testID="glossy-toggle"
+                value={glossy}
+                onValueChange={setGlossy}
+              />
+            }
+          >
+            <Text style={[styles.settingLabel, { color: colors.text }]}>Glossy UI</Text>
           </GroupRow>
           <GroupRow
             onPress={() => setTheme('system')}

--- a/src/services/StorageBootstrap.ts
+++ b/src/services/StorageBootstrap.ts
@@ -12,6 +12,7 @@ const STARTUP_KEYS = [
   '@gitnotes:todos',
   '@gitnotes:canvases',
   '@gitnotes:theme',
+  '@gitnotes:glossy',
   '@gitnotes:style',
   '@gitnotes:viewMode',
   '@gitnotes:auth_token',

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -16,6 +16,11 @@ export interface Palette {
   border: string;
   card: string;
   elevated: string;
+  glassSurface: string;
+  glassCard: string;
+  glassElevated: string;
+  glassNav: string;
+  glassBorder: string;
 }
 
 // Neumorphic palette uses a near-pure white (light) / black (dark) surface
@@ -37,6 +42,11 @@ export const NEUMORPHIC_LIGHT: Palette = {
   border: '#D8D8D8',
   card: '#FFFFFF',
   elevated: '#FFFFFF',
+  glassSurface: 'rgba(255, 255, 255, 0.7)',
+  glassCard: 'rgba(255, 255, 255, 0.75)',
+  glassElevated: 'rgba(255, 255, 255, 0.85)',
+  glassNav: 'rgba(255, 255, 255, 0.75)',
+  glassBorder: 'rgba(216, 216, 216, 0.4)',
 };
 
 export const NEUMORPHIC_DARK: Palette = {
@@ -55,6 +65,11 @@ export const NEUMORPHIC_DARK: Palette = {
   border: '#262626',
   card: '#0A0A0A',
   elevated: '#1C1C1E',
+  glassSurface: 'rgba(0, 0, 0, 0.7)',
+  glassCard: 'rgba(10, 10, 10, 0.75)',
+  glassElevated: 'rgba(28, 28, 30, 0.85)',
+  glassNav: 'rgba(0, 0, 0, 0.75)',
+  glassBorder: 'rgba(38, 38, 38, 0.4)',
 };
 
 export const FLAT_LIGHT: Palette = {
@@ -73,6 +88,11 @@ export const FLAT_LIGHT: Palette = {
   border: '#c6c6c8',
   card: '#ffffff',
   elevated: '#ffffff',
+  glassSurface: 'rgba(255, 255, 255, 0.7)',
+  glassCard: 'rgba(255, 255, 255, 0.75)',
+  glassElevated: 'rgba(255, 255, 255, 0.85)',
+  glassNav: 'rgba(255, 255, 255, 0.75)',
+  glassBorder: 'rgba(198, 198, 200, 0.4)',
 };
 
 export const FLAT_DARK: Palette = {
@@ -91,6 +111,11 @@ export const FLAT_DARK: Palette = {
   border: '#38383a',
   card: '#2c2c2e',
   elevated: '#2c2c2e',
+  glassSurface: 'rgba(28, 28, 30, 0.7)',
+  glassCard: 'rgba(44, 44, 46, 0.75)',
+  glassElevated: 'rgba(44, 44, 46, 0.85)',
+  glassNav: 'rgba(28, 28, 30, 0.75)',
+  glassBorder: 'rgba(56, 56, 58, 0.4)',
 };
 
 export const RADII = { sm: 12, md: 18, lg: 24, pill: 999 } as const;


### PR DESCRIPTION
## Summary
- Optional glossy/translucent UI mode using `expo-blur`
- OFF by default — user enables in Settings, persisted to `@gitnotes:glossy`
- Adds `@gitnotes:glossy` to bootstrap startup keys for type-safe storage

> **Stacked PR**: continues the Wave 3 chain. Base will retarget to `main` once predecessors land. Merge prerequisites: all Wave 1+2 PRs (#443-#447, #449-#451) and Wave 3 chain PRs (#452-#460) into `main` first.

Closes #422

## Test plan
- [x] `yarn test __tests__/glossy-ui.test.tsx` — pass
- [x] `yarn ts:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)