### PR TITLE
feat(viewer): render JSON files with formatted tree view (#410) [recovery]

### DIFF
--- a/__tests__/Note.test.ts
+++ b/__tests__/Note.test.ts
@@ -173,7 +173,7 @@ describe('format helpers', () => {
   });
 
   test('getSupportedFileExtensions / isSupportedFileExtension', () => {
-    expect(getSupportedFileExtensions()).toEqual(['.md', '.norg', '.org', '.pdf']);
+    expect(getSupportedFileExtensions()).toEqual(['.md', '.norg', '.org', '.pdf', '.json']);
     expect(isSupportedFileExtension('a.md')).toBe(true);
     expect(isSupportedFileExtension('A.PDF')).toBe(true);
     expect(isSupportedFileExtension('a.txt')).toBe(false);

--- a/__tests__/json-renderer.test.tsx
+++ b/__tests__/json-renderer.test.tsx
@@ -1,0 +1,45 @@
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import { JsonRenderer } from '../src/components/JsonRenderer';
+import { NEUMORPHIC_DARK, NEUMORPHIC_LIGHT } from '../src/theme/tokens';
+import { TestThemeProvider } from './ui/testThemeProvider';
+
+describe('JsonRenderer', () => {
+  it('renders formatted JSON with themed syntax colors', () => {
+    const { getByText, toJSON } = render(
+      <TestThemeProvider mode="light">
+        <JsonRenderer content='{"name":"GitNotes","count":2,"enabled":true,"nested":{"slug":"wave"}}' />
+      </TestThemeProvider>,
+    );
+    const tree = toJSON();
+
+    const key = getByText('"name"');
+    const value = getByText('"GitNotes"');
+    const number = getByText('2');
+
+    expect(StyleSheet.flatten(key.props.style).color).toBe(NEUMORPHIC_LIGHT.textSecondary);
+    expect(StyleSheet.flatten(value.props.style).color).toBe(NEUMORPHIC_LIGHT.text);
+    expect(StyleSheet.flatten(number.props.style).color).toBe(NEUMORPHIC_LIGHT.primary);
+    expect((tree as { children?: Array<{ children?: unknown[] }> } | null)?.children?.[1]?.children?.[0]).toBe('  ');
+  });
+
+  it('uses dark theme colors and falls back to raw text for malformed JSON', () => {
+    const raw = '{"oops": }';
+    const { getByText } = render(
+      <TestThemeProvider mode="dark">
+        <JsonRenderer content={raw} />
+      </TestThemeProvider>,
+    );
+
+    expect(getByText(raw)).toBeTruthy();
+    expect(StyleSheet.flatten(getByText(raw).props.style).color).toBe(NEUMORPHIC_DARK.text);
+  });
+});

--- a/__tests__/save-loading-indicator.test.ts
+++ b/__tests__/save-loading-indicator.test.ts
@@ -1,0 +1,5 @@
+describe('save/loading indicator', () => {
+  it('passes', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/components/JsonRenderer.tsx
+++ b/src/components/JsonRenderer.tsx
@@ -1,0 +1,109 @@
+import React, { ReactNode, useMemo } from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+
+import { useTheme } from '../contexts/ThemeContext';
+
+interface JsonRendererProps {
+  content: string;
+}
+
+const KEY_LINE_RE = /^(\s*)"((?:\\.|[^"\\])+)":\s*(.*)$/;
+const VALUE_TOKEN_RE = /"((?:\\.|[^"\\])*)"|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?\b|true|false|null/g;
+
+function renderValueTokens(segment: string, valueColor: string, scalarColor: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+
+  VALUE_TOKEN_RE.lastIndex = 0;
+
+  for (;;) {
+    const match = VALUE_TOKEN_RE.exec(segment);
+    if (!match) break;
+
+    if (match.index > lastIndex) {
+      nodes.push(segment.slice(lastIndex, match.index));
+    }
+
+    const token = match[0];
+    const isString = token.startsWith('"');
+    nodes.push(
+      <Text key={`${match.index}-${token}`} style={{ color: isString ? valueColor : scalarColor }}>
+        {token}
+      </Text>
+    );
+
+    lastIndex = match.index + token.length;
+  }
+
+  if (lastIndex < segment.length) {
+    nodes.push(segment.slice(lastIndex));
+  }
+
+  VALUE_TOKEN_RE.lastIndex = 0;
+  return nodes;
+}
+
+function renderLine(line: string, colors: { text: string; textSecondary: string; primary: string }): ReactNode[] {
+  const keyMatch = line.match(KEY_LINE_RE);
+  if (!keyMatch) {
+    return renderValueTokens(line, colors.text, colors.primary);
+  }
+
+  const [, indent, key, rest] = keyMatch;
+  return [
+    indent,
+    <Text key={key} style={{ color: colors.textSecondary }}>
+      {`"${key}"`}
+    </Text>,
+    ': ',
+    ...renderValueTokens(rest, colors.text, colors.primary),
+  ];
+}
+
+export function JsonRenderer({ content }: JsonRendererProps) {
+  const { colors } = useTheme();
+
+  const formatted = useMemo(() => {
+    try {
+      return JSON.stringify(JSON.parse(content), null, 2);
+    } catch {
+      return null;
+    }
+  }, [content]);
+
+  if (!formatted) {
+    return (
+      <Text selectable style={[styles.raw, { color: colors.text }]}>
+        {content}
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {formatted.split('\n').map((line, index) => (
+        <Text key={`${index}-${line}`} selectable style={[styles.line, { color: colors.text }]}>
+          {renderLine(line, colors)}
+        </Text>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 2,
+  },
+  line: {
+    fontSize: 13,
+    lineHeight: 19,
+    fontFamily: 'Menlo',
+  },
+  raw: {
+    fontSize: 14,
+    lineHeight: 20,
+    fontFamily: 'Menlo',
+  },
+});
+
+export default JsonRenderer;

--- a/src/models/Note.ts
+++ b/src/models/Note.ts
@@ -1,6 +1,6 @@
 import { Attachment } from './Attachment';
 
-export type NoteFormat = 'markdown' | 'neorg' | 'org' | 'pdf';
+export type NoteFormat = 'markdown' | 'neorg' | 'org' | 'pdf' | 'json';
 
 export interface NoteGitHubLink {
   owner: string;
@@ -168,6 +168,7 @@ export function getNoteFileExtension(format?: NoteFormat): string {
     case 'neorg': return '.norg';
     case 'org': return '.org';
     case 'pdf': return '.pdf';
+    case 'json': return '.json';
     default: return '.md';
   }
 }
@@ -177,7 +178,7 @@ export function isNeorgNote(note: Note): boolean {
 }
 
 export function getSupportedFileExtensions(): string[] {
-  return ['.md', '.norg', '.org', '.pdf'];
+  return ['.md', '.norg', '.org', '.pdf', '.json'];
 }
 
 export function isSupportedFileExtension(filename: string): boolean {

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -29,9 +29,10 @@ type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'heic', 'heif', 'svg']);
 const VIDEO_EXTS = new Set(['mp4', 'mov', 'm4v', 'webm']);
 
-function classifyFile(name: string): 'pdf' | 'image' | 'video' | 'text' {
+function classifyFile(name: string): 'pdf' | 'json' | 'image' | 'video' | 'text' {
   const ext = name.toLowerCase().split('.').pop() ?? '';
   if (ext === 'pdf') return 'pdf';
+  if (ext === 'json') return 'json';
   if (IMAGE_EXTS.has(ext)) return 'image';
   if (VIDEO_EXTS.has(ext)) return 'video';
   return 'text';
@@ -256,6 +257,8 @@ export default function ExploreScreen() {
                 navigation.navigate('ImageViewer', params);
               } else if (kind === 'video') {
                 navigation.navigate('VideoViewer', params);
+              } else if (kind === 'json') {
+                navigation.navigate('FileViewer', params);
               } else {
                 navigation.navigate('FileViewer', params);
               }

--- a/src/screens/FileViewerScreen.tsx
+++ b/src/screens/FileViewerScreen.tsx
@@ -17,11 +17,12 @@ import { useTheme } from '../contexts/ThemeContext';
 import { GitHubService } from '../services/GitHubService';
 import { NeorgContentParser } from '../services/NeorgContentParser';
 import NeorgRenderer from '../components/NeorgRenderer';
+import { JsonRenderer } from '../components/JsonRenderer';
 import { HapticService } from '../utils/haptics';
 import { getMarkdownStyles, stripTopMetadata } from '../utils/preview';
 import { useRenderStyle } from '../stores/renderStyleStore';
 
-type Mode = 'markdown' | 'neorg' | 'org' | 'code' | 'plain';
+type Mode = 'markdown' | 'neorg' | 'org' | 'json' | 'code' | 'plain';
 
 const MARKDOWN_EXTS = ['md', 'markdown'];
 const NEORG_EXTS = ['norg'];
@@ -42,6 +43,7 @@ function detectMode(filename: string): Mode {
   if (MARKDOWN_EXTS.includes(ext)) return 'markdown';
   if (NEORG_EXTS.includes(ext)) return 'neorg';
   if (ORG_EXTS.includes(ext)) return 'org';
+  if (ext === 'json') return 'json';
   if (CODE_EXTS.has(ext)) return 'code';
   return 'plain';
 }
@@ -151,6 +153,8 @@ export default function FileViewerScreen() {
         >
           {mode === 'markdown' ? (
             <MarkdownBody value={renderContent} styles={markdownStyles} />
+          ) : mode === 'json' ? (
+            <JsonRenderer content={renderContent} />
           ) : (mode === 'neorg' || mode === 'org') && parsedNeorg ? (
             <NeorgRenderer blocks={parsedNeorg} format={mode === 'org' ? 'org' : 'neorg'} />
           ) : (

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -22,7 +22,7 @@ import { QuickAccessShelf } from '../components/home/QuickAccessShelf';
 import { buildPinnedFeed, buildRecentFeed, RecentItem } from '../utils/recentItems';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
-type EditableNoteFormat = Exclude<NoteFormat, 'pdf'>;
+type EditableNoteFormat = Exclude<NoteFormat, 'pdf' | 'json'>;
 
 const FORMAT_OPTIONS: { label: string; value: EditableNoteFormat; ext: string }[] = [
   { label: 'Markdown', value: 'markdown', ext: '.md' },

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -54,7 +54,7 @@ import { useResponsive } from "../hooks/useResponsive";
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
-const FORMAT_LABELS: Record<NoteFormat, string> = {
+const FORMAT_LABELS: Record<Exclude<NoteFormat, 'json'>, string> = {
   markdown: ".md",
   neorg: ".norg",
   org: ".org",
@@ -802,7 +802,7 @@ export default function NotesListScreen() {
                   color={colors.primary}
                 />
                 <Text style={[styles.chipText, { color: colors.primary }]}>
-                  {FORMAT_LABELS[selectedFormat]}
+                  {FORMAT_LABELS[selectedFormat as Exclude<NoteFormat, 'json'>]}
                 </Text>
                 <Ionicons name="close" size={12} color={colors.primary} />
               </TouchableOpacity>

--- a/src/services/NoteFormatPreferenceService.ts
+++ b/src/services/NoteFormatPreferenceService.ts
@@ -4,7 +4,7 @@ import type { NoteFormat } from '../models/Note';
 const DEFAULT_FORMAT_KEY = '@gitnotes:default_note_format';
 const REMEMBER_FORMAT_KEY = '@gitnotes:remember_note_format';
 
-export type EditableNoteFormat = Exclude<NoteFormat, 'pdf'>;
+export type EditableNoteFormat = Exclude<NoteFormat, 'pdf' | 'json'>;
 
 export class NoteFormatPreferenceService {
   static async getDefaultFormat(): Promise<EditableNoteFormat | null> {

--- a/src/services/RepoFileSyncService.ts
+++ b/src/services/RepoFileSyncService.ts
@@ -16,6 +16,7 @@ const SUPPORTED_EXTENSIONS: Record<string, NoteFormat> = {
   '.norg': 'neorg',
   '.org': 'org',
   '.pdf': 'pdf',
+  '.json': 'json',
 };
 
 function getExtension(filename: string): string {


### PR DESCRIPTION
Recovery PR — original #453 merged into wrong base. Cherry-picks `5df6474`.