### PR TITLE
fix(notes): add link classifier for anchor/note/web routing (#417) [recovery]

### DIFF
--- a/.sisyphus/notepads/ai-chat/decisions.md
+++ b/.sisyphus/notepads/ai-chat/decisions.md
@@ -15,3 +15,7 @@
 - Confirm mode stays inline in the conversation via a pending confirmation card driven by `executeToolCall(..., 'confirm')`, while Apply re-runs the same tool in auto mode so the screen never mutates note/todo stores directly.
 - Keep AI chat entry out of tab navigation; register `ChatThreadList`/`ChatScreen` only in the root stack and mount `FloatingAIButton` plus `ChatRepoPickerModal` as navigator-level overlays.
 - Use the chat repo from `aiStore` as the source of truth for AI context browsing, with `GitHubService.getTreeRecursive()` providing the file/folder lists shown in the modal.
+
+## 2026-05-03
+- Added `classifyHref` as a pure utility so link routing rules are unit-testable outside the renderer.
+- Kept external `http(s)`, `mailto:`, and `tel:` links on the native platform via `Linking.openURL` instead of adding in-app web handling.

--- a/.sisyphus/notepads/ai-chat/learnings.md
+++ b/.sisyphus/notepads/ai-chat/learnings.md
@@ -28,3 +28,7 @@
 - Context pickers can reuse the authenticated GitHub tree API directly for file/folder selection instead of relying on placeholder copy or store-only repo metadata.
 
 - Plan-compliance review needs to verify behavior, not just file existence: route overlays rendered outside `NavigationContainer`, placeholder context tabs, and local-only rename flows can still pass typecheck/tests while missing the requested user flow.
+
+## 2026-05-03
+- Markdown preview links need target classification before routing; raw `Linking.openURL` breaks internal note navigation and fragment scrolling behavior.
+- Relative note links should resolve against the current note file path, while stored note lookups should normalize away leading slashes because folder selections use `/path` but synced note `filePath` values do not.

--- a/__tests__/link-routing.test.ts
+++ b/__tests__/link-routing.test.ts
@@ -1,0 +1,106 @@
+import React from 'react';
+import { Alert, Linking, ScrollView, Text } from 'react-native';
+
+jest.mock('react-native-marked', () => ({
+  Renderer: class {
+    private key = 0;
+    getKey() {
+      this.key += 1;
+      return `key-${this.key}`;
+    }
+  },
+}));
+
+jest.mock('expo-image', () => ({ Image: () => null }));
+
+import { classifyHref } from '../src/utils/linkClassifier';
+import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
+
+describe('classifyHref', () => {
+  it('classifies anchor links using heading slug rules', () => {
+    expect(classifyHref('#Anchor Slug')).toEqual({ kind: 'anchor', target: 'anchor-slug' });
+  });
+
+  it('resolves sibling note links', () => {
+    expect(classifyHref('foo.md', 'notes/current.md')).toEqual({ kind: 'note', target: 'notes/foo.md' });
+    expect(classifyHref('./notes/foo.md', 'docs/current.md')).toEqual({ kind: 'note', target: 'docs/notes/foo.md' });
+  });
+
+  it('resolves parent-relative note links', () => {
+    expect(classifyHref('../shared/foo.md', 'notes/daily/today.md')).toEqual({ kind: 'note', target: 'notes/shared/foo.md' });
+  });
+
+  it('classifies web links', () => {
+    expect(classifyHref('https://example.com')).toEqual({ kind: 'web', target: 'https://example.com' });
+    expect(classifyHref('http://example.com')).toEqual({ kind: 'web', target: 'http://example.com' });
+  });
+
+  it('classifies mailto and tel links', () => {
+    expect(classifyHref('mailto:hello@example.com')).toEqual({ kind: 'mailto', target: 'hello@example.com' });
+    expect(classifyHref('tel:+15551234567')).toEqual({ kind: 'mailto', target: '+15551234567' });
+  });
+});
+
+describe('NotePreviewRenderer link routing', () => {
+  const openUrlSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
+  const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    openUrlSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  function createRenderer(overrides: Partial<ConstructorParameters<typeof NotePreviewRenderer>[0]> = {}) {
+    return new NotePreviewRenderer({
+      colors: { primary: '#2563eb', text: '#111', surfaceSecondary: '#eee' },
+      previewContent: '# Intro\nBody\n## Deep Link\nMore body',
+      previewScrollRef: { current: { scrollTo: jest.fn() } as unknown as ScrollView },
+      currentNotePath: 'notes/current.md',
+      onOpenNote: jest.fn(() => true),
+      ...overrides,
+    });
+  }
+
+  function pressLink(renderer: NotePreviewRenderer, href: string) {
+    const element = renderer.link(['label'], href) as React.ReactElement<React.ComponentProps<typeof Text>>;
+    (element.props as { onPress?: (event: unknown) => void }).onPress?.(undefined);
+  }
+
+  it('opens external web links with Linking', () => {
+    const renderer = createRenderer();
+    pressLink(renderer, 'https://example.com');
+
+    expect(openUrlSpy).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('routes note links through the note opener', () => {
+    const onOpenNote = jest.fn(() => true);
+    const renderer = createRenderer({ onOpenNote });
+    pressLink(renderer, './child.md');
+
+    expect(onOpenNote).toHaveBeenCalledWith('notes/child.md');
+    expect(openUrlSpy).not.toHaveBeenCalled();
+  });
+
+  it('alerts when linked note cannot be found', () => {
+    const renderer = createRenderer({ onOpenNote: jest.fn(() => false) });
+    pressLink(renderer, './missing.md');
+
+    expect(alertSpy).toHaveBeenCalledWith('Link target not found');
+  });
+
+  it('scrolls preview for anchor links', () => {
+    const scrollTo = jest.fn();
+    const renderer = createRenderer({
+      previewScrollRef: { current: { scrollTo } as unknown as ScrollView },
+      approxLinePx: 30,
+    });
+    pressLink(renderer, '#Deep Link');
+
+    expect(scrollTo).toHaveBeenCalledWith({ y: 60, animated: true });
+  });
+});

--- a/__tests__/offline-gray-uncached.test.tsx
+++ b/__tests__/offline-gray-uncached.test.tsx
@@ -1,0 +1,160 @@
+var mockNavigate = jest.fn();
+
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: false, isInternetReachable: false }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+jest.mock('@shopify/flash-list', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const FlashList = React.forwardRef(({ data = [], renderItem }: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({ scrollToIndex: jest.fn() }));
+    return <View>{data.map((item: any, index: number) => renderItem({ item, index }))}</View>;
+  });
+  return { FlashList };
+});
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return React.forwardRef(({ children }: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({ close: jest.fn() }));
+    return <View>{children}</View>;
+  });
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const { createElement } = require('react');
+  const { Text } = require('react-native');
+  return { Ionicons: ({ name }: any) => createElement(Text, null, name) };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('../src/contexts/NoteContext', () => ({
+  useNotes: jest.fn(),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null } }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({ repositories: [] }),
+}));
+
+jest.mock('../src/contexts/ViewModeContext', () => ({
+  useViewMode: () => ({ viewMode: 'list', setViewMode: jest.fn() }),
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+jest.mock('../src/components/SearchBar', () => () => null);
+jest.mock('../src/components/GitHubActivityIndicator', () => ({ GitHubActivityIndicator: () => null }));
+jest.mock('../src/components/ui/OfflineBanner', () => ({ OfflineBanner: () => null }));
+jest.mock('../src/components/ui', () => ({ ScreenHeader: () => null }));
+jest.mock('../src/hooks/useResponsive', () => ({ useResponsive: () => ({ isTablet: false, maxContentWidth: 720 }) }));
+jest.mock('../src/hooks/useNetworkStatus', () => ({ useNetworkStatus: () => ({ isConnected: false, isInternetReachable: false }) }));
+jest.mock('../src/services/GitHubService', () => ({ GitHubService: { setToken: jest.fn() } }));
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    pendingCount: jest.fn(() => Promise.resolve(0)),
+    subscribe: jest.fn(() => jest.fn()),
+    drain: jest.fn(() => Promise.resolve({ succeeded: 0 })),
+  },
+}));
+jest.mock('../src/services/RepoPullService', () => ({ pullAllFromRepos: jest.fn() }));
+jest.mock('../src/services/ShareService', () => ({ ShareService: { isAvailable: jest.fn(() => false) } }));
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: { light: jest.fn(), medium: jest.fn(), selection: jest.fn(), success: jest.fn(), warning: jest.fn() },
+}));
+jest.mock('../src/stores/githubActivityStore', () => ({
+  githubActivity: { begin: jest.fn(), end: jest.fn() },
+}));
+
+import { Alert, StyleSheet } from 'react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import NoteCard from '../src/components/NoteCard';
+import NotesListScreen from '../src/screens/NotesListScreen';
+import { useNotes } from '../src/contexts/NoteContext';
+import { Note } from '../src/models/Note';
+import { NEUMORPHIC_LIGHT } from '../src/theme/tokens';
+import { TestThemeProvider } from './ui/testThemeProvider';
+
+const mockedUseNotes = useNotes as jest.MockedFunction<typeof useNotes>;
+
+const buildNote = (overrides: Partial<Note> = {}): Note => ({
+  id: 'note-1',
+  title: 'Offline note',
+  content: '',
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  ...overrides,
+});
+
+describe('offline gray uncached behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('grays out uncached notes offline and keeps online notes normal', () => {
+    const offlineRender = render(
+      <TestThemeProvider mode="light">
+        <NoteCard note={buildNote()} onPress={jest.fn()} isOffline isCached={false} />
+      </TestThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(offlineRender.getByTestId('note-card-note-1').props.style).opacity).toBe(0.5);
+    expect(StyleSheet.flatten(offlineRender.getByTestId('note-card-title-note-1').props.style).color).toBe(NEUMORPHIC_LIGHT.textSecondary);
+
+    offlineRender.unmount();
+
+    const onlineRender = render(
+      <TestThemeProvider mode="light">
+        <NoteCard note={buildNote()} onPress={jest.fn()} isOffline={false} isCached={false} />
+      </TestThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(onlineRender.getByTestId('note-card-note-1').props.style).opacity).toBe(1);
+    expect(StyleSheet.flatten(onlineRender.getByTestId('note-card-title-note-1').props.style).color).toBe(NEUMORPHIC_LIGHT.text);
+  });
+
+  it('blocks navigation for offline uncached notes', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined as never);
+    mockNavigate.mockClear();
+
+    mockedUseNotes.mockReturnValue({
+      notes: [buildNote()],
+      filteredNotes: [buildNote()],
+      isLoading: false,
+      searchQuery: '',
+      setSearchQuery: jest.fn(),
+      deleteNote: jest.fn(),
+      refreshNotes: jest.fn(),
+      togglePin: jest.fn(),
+      error: null,
+      createNote: jest.fn(),
+    } as any);
+
+    const { getByTestId, unmount } = render(
+      <TestThemeProvider mode="light">
+        <NotesListScreen />
+      </TestThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(getByTestId('note-card-note-1').props.style).opacity).toBe(0.5);
+
+    fireEvent.press(getByTestId('note-card-note-1'));
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledWith('Not available offline'));
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+    unmount();
+  });
+});

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -47,13 +47,26 @@ interface NoteCardProps {
   compact?: boolean;
   highlighted?: boolean;
   variant?: 'default' | 'card';
+  isOffline?: boolean;
+  isCached?: boolean;
 }
 
-function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted = false, variant = 'default' }: NoteCardProps) {
+function NoteCardImpl({
+  note,
+  onPress,
+  onLongPress,
+  compact = false,
+  highlighted = false,
+  variant = 'default',
+  isOffline = false,
+  isCached = true,
+}: NoteCardProps) {
   const { colors, isDark, glossy } = useTheme();
   const { isTablet } = useResponsive();
   const isCard = variant === 'card';
   const showCompact = isCard ? false : compact;
+  const isOfflineUncached = isOffline && !isCached;
+  const titleColor = isOfflineUncached ? colors.textSecondary : colors.text;
   
   const checklistProgress = useMemo(() => {
     if (!hasChecklists(note.content)) return null;
@@ -68,12 +81,14 @@ function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted
           backgroundColor: glossy ? colors.glassCard : colors.card,
           shadowColor: colors.shadow,
           shadowOpacity: isDark ? 0 : 0.1,
+          opacity: isOfflineUncached ? 0.5 : 1,
         },
         showCompact && styles.cardCompact,
         isCard && styles.cardVariant,
         isTablet && styles.cardTablet,
         highlighted && { borderWidth: 2, borderColor: colors.primary },
       ]}
+      testID={`note-card-${note.id}`}
       onPress={() => onPress(note)}
       onLongPress={() => onLongPress?.(note)}
       activeOpacity={0.7}
@@ -84,11 +99,19 @@ function NoteCardImpl({ note, onPress, onLongPress, compact = false, highlighted
         </View>
       )}
       <View style={styles.header}>
-        <Text style={[styles.title, { color: colors.text }, showCompact && styles.titleCompact]} numberOfLines={showCompact ? 1 : 2}>
+        <Text
+          testID={`note-card-title-${note.id}`}
+          style={[styles.title, { color: titleColor }, showCompact && styles.titleCompact]}
+          numberOfLines={showCompact ? 1 : 2}
+        >
           {note.title || 'Untitled Note'}
         </Text>
         {!showCompact && (
-          <Text style={[styles.content, { color: colors.textSecondary }]} numberOfLines={isCard ? 3 : 2}>
+          <Text
+            testID={`note-card-content-${note.id}`}
+            style={[styles.content, { color: colors.textSecondary }]}
+            numberOfLines={isCard ? 3 : 2}
+          >
             {stripPreview(note.content, note.format) || 'No content'}
           </Text>
         )}

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -65,6 +65,10 @@ interface TocEntry {
 
 const APPROX_LINE_PX = 22;
 
+function normalizeNotePathForLookup(path: string): string {
+  return path.replace(/^\/+/, '').replace(/\/+/g, '/');
+}
+
 function extractTocFromMarkdown(content: string): TocEntry[] {
   const out: TocEntry[] = [];
   const lines = content.split('\n');
@@ -122,7 +126,7 @@ export default function NoteEditorScreen() {
   const { sideBySide } = useResponsive();
   const { noteId, format: initialFormat, initialTitle, initialContent, repo: initialRepo, branch: initialBranch, folderPath: initialFolderPath } = route.params || {};
 
-  const { getNoteById, createNote, updateNote } = useNotes();
+  const { notes, getNoteById, createNote, updateNote } = useNotes();
   const { canvases } = useCanvases();
 
   const [title, setTitle] = useState(initialTitle ?? '');
@@ -632,6 +636,23 @@ export default function NoteEditorScreen() {
 
   const previewScrollRef = useRef<ScrollView>(null);
 
+  const currentNotePath = useMemo(() => {
+    if (noteId) {
+      return notes.find((note) => note.id === noteId)?.filePath;
+    }
+    return folderPath && title.trim()
+      ? normalizeNotePathForLookup(`${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}`)
+      : undefined;
+  }, [folderPath, noteFormat, noteId, notes, title]);
+
+  const handleOpenLinkedNote = useCallback((targetPath: string) => {
+    const normalizedTargetPath = normalizeNotePathForLookup(targetPath);
+    const targetNote = notes.find((note) => note.filePath && normalizeNotePathForLookup(note.filePath) === normalizedTargetPath);
+    if (!targetNote?.id) return false;
+    navigation.navigate('NoteEditor', { noteId: targetNote.id });
+    return true;
+  }, [navigation, notes]);
+
   const notePreviewRenderer = useMemo(
     () =>
       new NotePreviewRenderer({
@@ -641,8 +662,10 @@ export default function NoteEditorScreen() {
         previewScrollRef,
         CanvasPreview,
         approxLinePx: APPROX_LINE_PX,
+        currentNotePath,
+        onOpenNote: handleOpenLinkedNote,
       }),
-    [colors, navigation, previewContent],
+    [colors, currentNotePath, handleOpenLinkedNote, navigation, previewContent],
   );
 
   const speakableContent = useMemo(() => {

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -50,6 +50,7 @@ import {
 } from "../utils/viewModes";
 import { ShareService } from "../services/ShareService";
 import { useResponsive } from "../hooks/useResponsive";
+import { useNetworkStatus } from "../hooks/useNetworkStatus";
 import { GitHubActivityIndicator } from "../components/GitHubActivityIndicator";
 import { githubActivity } from "../stores/githubActivityStore";
 
@@ -80,6 +81,7 @@ export default function NotesListScreen() {
   } = useNotes();
   const { viewMode, setViewMode } = useViewMode();
   const { isTablet, maxContentWidth } = useResponsive();
+  const { isConnected } = useNetworkStatus();
   const { repositories } = useRepos();
   const listRef = useRef<FlashListRef<Note>>(null);
   const swipeableRefs = useRef<
@@ -290,6 +292,11 @@ export default function NotesListScreen() {
 
   const handleNotePress = useCallback(
     (note: Note) => {
+      if (isConnected === false && !note.content?.trim()) {
+        Alert.alert("Not available offline");
+        return;
+      }
+
       if (note.format === "pdf" && note.repo && note.filePath) {
         const info = parseRepoPath(note.repo);
         if (info) {
@@ -305,7 +312,7 @@ export default function NotesListScreen() {
       }
       navigation.navigate("NoteEditor", { noteId: note.id });
     },
-    [navigation],
+    [isConnected, navigation],
   );
 
   const [longPressedNote, setLongPressedNote] = useState<Note | null>(null);
@@ -455,6 +462,8 @@ export default function NotesListScreen() {
           onPress={handleNotePress}
           onLongPress={handleNoteLongPress}
           highlighted={hasActiveSearch && index === currentSearchMatchIndex}
+          isOffline={isConnected === false}
+          isCached={!!note.content?.trim()}
         />
       </ReanimatedSwipeable>
     ),

--- a/src/utils/linkClassifier.ts
+++ b/src/utils/linkClassifier.ts
@@ -1,0 +1,71 @@
+export type LinkKind = 'anchor' | 'note' | 'web' | 'mailto';
+
+export interface ClassifiedHref {
+  kind: LinkKind;
+  target: string;
+}
+
+function slugifyFragment(fragment: string): string {
+  return decodeURIComponent(fragment)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function normalizePath(path: string): string {
+  const isAbsolute = path.startsWith('/');
+  const parts = path.split('/');
+  const normalized: string[] = [];
+
+  for (const part of parts) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      if (normalized.length > 0) normalized.pop();
+      continue;
+    }
+    normalized.push(part);
+  }
+
+  const joined = normalized.join('/');
+  return isAbsolute ? `/${joined}` : joined;
+}
+
+function dirname(path: string): string {
+  const normalized = normalizePath(path);
+  const lastSlash = normalized.lastIndexOf('/');
+  if (lastSlash < 0) return '';
+  return normalized.slice(0, lastSlash);
+}
+
+function resolveNotePath(href: string, currentNotePath?: string): string {
+  if (href.startsWith('/')) {
+    return normalizePath(href).replace(/^\//, '');
+  }
+
+  const baseDir = currentNotePath ? dirname(currentNotePath) : '';
+  return normalizePath(baseDir ? `${baseDir}/${href}` : href);
+}
+
+export function classifyHref(href: string, currentNotePath?: string): ClassifiedHref | null {
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('#')) {
+    return { kind: 'anchor', target: slugifyFragment(trimmed.slice(1)) };
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return { kind: 'web', target: trimmed };
+  }
+
+  if (/^(mailto|tel):/i.test(trimmed)) {
+    return { kind: 'mailto', target: trimmed.replace(/^(mailto|tel):/i, '') };
+  }
+
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && /\.(md|norg|org|pdf|json)$/i.test(trimmed)) {
+    return { kind: 'note', target: resolveNotePath(trimmed, currentNotePath) };
+  }
+
+  return null;
+}

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -1,10 +1,11 @@
 import React, { type ReactNode } from 'react';
-import { Text, type TextStyle, type ViewStyle, type ImageStyle, type ScrollView, Linking } from 'react-native';
+import { Alert, Text, type TextStyle, type ViewStyle, type ImageStyle, type ScrollView, Linking } from 'react-native';
 import { Renderer, type RendererInterface } from 'react-native-marked';
 import { Image } from 'expo-image';
 
 import { isCanvasLink, canvasIdFromLink } from '../models/Canvas';
 import { ErrorBoundary } from '../components/ui/ErrorBoundary';
+import { classifyHref } from './linkClassifier';
 
 interface CustomRendererDeps {
   colors: {
@@ -19,6 +20,8 @@ interface CustomRendererDeps {
   previewScrollRef?: React.RefObject<ScrollView | null>;
   CanvasPreview?: React.ComponentType<{ canvasId: string }>;
   approxLinePx?: number;
+  currentNotePath?: string;
+  onOpenNote?: (path: string) => boolean;
 }
 
 export class NotePreviewRenderer extends Renderer implements RendererInterface {
@@ -92,15 +95,20 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
 
     const onPress = () => {
       if (!href) return;
-      if (href.startsWith('note:')) {
-        const id = href.slice('note:'.length);
-        if (id && this.deps.navigation) {
-          this.deps.navigation.navigate('NoteEditor', { noteId: id });
+      const classified = classifyHref(href, this.deps.currentNotePath);
+      if (!classified) {
+        Linking.openURL(href).catch(() => {});
+        return;
+      }
+      if (classified.kind === 'note') {
+        const opened = this.deps.onOpenNote?.(classified.target) ?? false;
+        if (!opened) {
+          Alert.alert('Link target not found');
         }
         return;
       }
-      if (href.startsWith('#')) {
-        const slug = href.slice(1).toLowerCase();
+      if (classified.kind === 'anchor') {
+        const slug = classified.target;
         const content = this.deps.previewContent ?? '';
         const target = content
           .split('\n')
@@ -118,6 +126,10 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
           const px = this.deps.approxLinePx ?? 22;
           this.deps.previewScrollRef.current.scrollTo({ y: target * px, animated: true });
         }
+        return;
+      }
+      if (classified.kind === 'web' || classified.kind === 'mailto') {
+        Linking.openURL(href).catch(() => {});
         return;
       }
       Linking.openURL(href).catch(() => {});


### PR DESCRIPTION
Recovery PR — cherry-picks `96962c9` with NoteCard signature merged (combine glossy + isOffline/isCached props).