### PR TITLE
fix(canvas): mark uid() as worklet so gesture handlers can call it

### DIFF
--- a/src/components/CanvasModal.tsx
+++ b/src/components/CanvasModal.tsx
@@ -73,6 +73,7 @@ const TOOLS = [
 ];
 
 function uid(): string {
+  'worklet';
   return `dm-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
 }
 

--- a/src/screens/CanvasEditorScreen.tsx
+++ b/src/screens/CanvasEditorScreen.tsx
@@ -68,6 +68,7 @@ const TOOLS = [
 ];
 
 function uid(): string {
+  'worklet';
   return `el-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
 }
 


### PR DESCRIPTION
Runtime crash from tmux logs: `[Worklets] Tried to synchronously call a non-worklet function uid on the UI thread.` triggered every time a pen/shape gesture started in CanvasEditor or CanvasModal.

Add the `'worklet';` directive to both `uid()` helpers so they compile to UI-thread workers.