### PR TITLE
feat(theme): rename Neumorphic UI to Updated UI; nest Glossy as sub-option

### DIFF
--- a/__tests__/glossy-ui.test.tsx
+++ b/__tests__/glossy-ui.test.tsx
@@ -105,39 +105,44 @@ const TestConsumer = () => {
 };
 
 describe('Glossy UI mode', () => {
-  it('is OFF by default and turning it ON disables Neumorphic', async () => {
-    const { getByTestId, getByText } = renderWithProviders(
+  it('coexists with Updated UI and is gated off when style is flat', async () => {
+    const { getByTestId, queryByTestId } = renderWithProviders(
       <>
         <TestConsumer />
         <SettingsScreen />
       </>
     );
 
-    // Initial state: default is flat or neumorphic (neumorphic typically), glossy false
+    // Default: style=neumorphic, glossy=false
     await waitFor(() => {
       expect(getByTestId('glossy-val').props.children).toBe('false');
+      expect(getByTestId('style-val').props.children).toBe('neumorphic');
     });
 
-    // Toggle Glossy ON
-    const glossyToggle = getByTestId('glossy-toggle');
-    fireEvent(glossyToggle, 'valueChange', true);
-
+    // Toggle Glossy ON — style stays neumorphic, glossy is effective
+    fireEvent(getByTestId('glossy-toggle'), 'valueChange', true);
     await waitFor(() => {
       expect(getByTestId('glossy-val').props.children).toBe('true');
-      expect(getByTestId('style-val').props.children).toBe('flat'); // Neumorphic disabled
+      expect(getByTestId('style-val').props.children).toBe('neumorphic');
     });
-    
-    // Toggle Neumorphic ON
-    const neuToggle = getByTestId('neu-toggle');
-    fireEvent(neuToggle, 'valueChange', true);
-    
+
+    // Switch to Flat — glossy toggle disappears; effective glossy becomes false
+    fireEvent(getByTestId('neu-toggle'), 'valueChange', false);
+    await waitFor(() => {
+      expect(getByTestId('style-val').props.children).toBe('flat');
+      expect(getByTestId('glossy-val').props.children).toBe('false');
+      expect(queryByTestId('glossy-toggle')).toBeNull();
+    });
+
+    // Switch back to Updated UI — glossy preference returns to effective true
+    fireEvent(getByTestId('neu-toggle'), 'valueChange', true);
     await waitFor(() => {
       expect(getByTestId('style-val').props.children).toBe('neumorphic');
-      expect(getByTestId('glossy-val').props.children).toBe('false'); // Glossy disabled
+      expect(getByTestId('glossy-val').props.children).toBe('true');
     });
   });
 
-  it('renders BlurView when glossy is ON', async () => {
+  it('renders BlurView when glossy is ON and style is neumorphic', async () => {
     const { getByTestId, queryByTestId, getAllByTestId } = render(
       <ThemeProvider>
         <TestSurface />
@@ -146,10 +151,9 @@ describe('Glossy UI mode', () => {
 
     // Initial glossy false
     expect(queryByTestId('blur-view')).toBeNull();
-    
-    // Check after toggling
+
     fireEvent.press(getByTestId('toggle-btn'));
-    
+
     await waitFor(() => {
       expect(getAllByTestId('blur-view').length).toBeGreaterThan(0);
     });

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -24,7 +24,10 @@ interface ThemeContextType {
   theme: ThemeMode;
   isDark: boolean;
   style: ThemeStyle;
+  /** Effective glossy: true only when the user enabled it AND style === 'neumorphic' (Updated UI). */
   glossy: boolean;
+  /** Raw user preference for glossy, regardless of current style. Use in Settings UI. */
+  glossyEnabled: boolean;
   setTheme: (theme: ThemeMode) => void;
   setStyle: (style: ThemeStyle) => void;
   setGlossy: (glossy: boolean) => void;
@@ -117,10 +120,6 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     try {
       setStyleState(newStyle);
       await AsyncStorage.setItem(STYLE_STORAGE_KEY, newStyle);
-      if (newStyle === 'neumorphic') {
-        setGlossyState(false);
-        await AsyncStorage.setItem(GLOSSY_STORAGE_KEY, 'false');
-      }
     } catch (error) {
       console.error('Error saving style:', error);
     }
@@ -130,14 +129,12 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     try {
       setGlossyState(newGlossy);
       await AsyncStorage.setItem(GLOSSY_STORAGE_KEY, newGlossy ? 'true' : 'false');
-      if (newGlossy) {
-        setStyleState('flat');
-        await AsyncStorage.setItem(STYLE_STORAGE_KEY, 'flat');
-      }
     } catch (error) {
       console.error('Error saving glossy:', error);
     }
   }, []);
+
+  const effectiveGlossy = glossy && style === 'neumorphic';
 
   const colors = useMemo(() => resolveColors(style, isDark), [style, isDark]);
 
@@ -147,8 +144,19 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   );
 
   const value: ThemeContextType = useMemo(
-    () => ({ theme, isDark, style, glossy, setTheme, setStyle, setGlossy, colors, tokens }),
-    [theme, isDark, style, glossy, setTheme, setStyle, setGlossy, colors, tokens],
+    () => ({
+      theme,
+      isDark,
+      style,
+      glossy: effectiveGlossy,
+      glossyEnabled: glossy,
+      setTheme,
+      setStyle,
+      setGlossy,
+      colors,
+      tokens,
+    }),
+    [theme, isDark, style, glossy, effectiveGlossy, setTheme, setStyle, setGlossy, colors, tokens],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -44,7 +44,7 @@ import { useAIStore } from '../stores/aiStore';
 import type { AIProviderConfig } from '../models/AIProvider';
 
 export default function SettingsScreen() {
-  const { theme, colors, setTheme, style: uiStyle, setStyle, glossy, setGlossy } = useTheme();
+  const { theme, colors, setTheme, style: uiStyle, setStyle, glossyEnabled, setGlossy } = useTheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { isTablet, maxContentWidth } = useResponsive();
   const { clearAllNotes, refreshNotes } = useNotes();
@@ -332,7 +332,7 @@ export default function SettingsScreen() {
       <ScreenHeader title="Settings" />
       <ScrollView style={styles.scrollContent} keyboardShouldPersistTaps="handled" contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 16, gap: 20 }}>
 
-        <Group title="Appearance" footer={uiStyle === 'neumorphic' ? 'Soft-UI shadows. Toggle off for the classic flat look.' : 'Classic flat look. Toggle on for neumorphic styling.'}>
+        <Group title="Appearance" footer={uiStyle === 'neumorphic' ? 'Soft-UI shadows. Toggle off for the classic flat look. Glossy adds blurred translucency on top.' : 'Classic flat look. Switch to Updated UI to enable Glossy.'}>
           <GroupRow
             trailing={
               <Toggle
@@ -342,8 +342,21 @@ export default function SettingsScreen() {
               />
             }
           >
-            <Text style={[styles.settingLabel, { color: colors.text }]}>Neumorphic UI</Text>
+            <Text style={[styles.settingLabel, { color: colors.text }]}>Updated UI</Text>
           </GroupRow>
+          {uiStyle === 'neumorphic' && (
+            <GroupRow
+              trailing={
+                <Toggle
+                  testID="glossy-toggle"
+                  value={glossyEnabled}
+                  onValueChange={setGlossy}
+                />
+              }
+            >
+              <Text style={[styles.settingLabel, { color: colors.text, paddingLeft: 16 }]}>Glossy</Text>
+            </GroupRow>
+          )}
           <GroupRow
             trailing={
               <Toggle
@@ -353,17 +366,6 @@ export default function SettingsScreen() {
             }
           >
             <Text style={[styles.settingLabel, { color: colors.text }]}>Dark Mode</Text>
-          </GroupRow>
-          <GroupRow
-            trailing={
-              <Toggle
-                testID="glossy-toggle"
-                value={glossy}
-                onValueChange={setGlossy}
-              />
-            }
-          >
-            <Text style={[styles.settingLabel, { color: colors.text }]}>Glossy UI</Text>
           </GroupRow>
           <GroupRow
             onPress={() => setTheme('system')}


### PR DESCRIPTION
Glossy was incompatible with Neumorphic in the merged design (mutually exclusive).
This restructures so Glossy layers on top of the renamed 'Updated UI' style.

- ThemeContext: remove mutual-exclusion side-effects, expose effective `glossy` (gated by style) + raw `glossyEnabled`
- SettingsScreen: 'Neumorphic UI' → 'Updated UI', Glossy row only visible under it
- Internal enum keeps `'neumorphic'` (no AsyncStorage migration)
- Tests rewritten for new coexistence semantics