### PR TITLE
fix(notes): persist tags to frontmatter on save (#418) [recovery]

### DIFF
--- a/.sisyphus/notepads/wave3-ux/decisions.md
+++ b/.sisyphus/notepads/wave3-ux/decisions.md
@@ -1,2 +1,3 @@
 - Kept the canvas pan/fit logic inside `CanvasEditorScreen` as exported pure helpers so the screen and unit test stay in sync without changing the canvas data model.
 - Used the same fit-to-content translation for initial auto-fit and the reset button so both flows center existing content consistently.
+- Introduced `src/utils/noteTagSupport.ts` for tag-format capability checks so `NoteEditorScreen` and `RepoPullService` no longer depend on `NoteGitHubSyncService` for a pure predicate.

--- a/.sisyphus/notepads/wave3-ux/learnings.md
+++ b/.sisyphus/notepads/wave3-ux/learnings.md
@@ -3,3 +3,5 @@
 - RNTL `UNSAFE_getAllByType(Text)` is enough to verify selectable props on rendered preview text without adding UI-specific assertions.
 - Canvas viewport clamping is easiest when the content bbox and fit-to-center translation are pure helpers shared by the gesture worklets and reset/open flows.
 - The pan clamp needs to be scale-aware; clamping against screen-space bbox edges keeps at least the requested margin visible after pinch zoom.
+- Tags need a shared format-support helper; importing it from the sync service caused unrelated Jest mocks to break, so a tiny utility module kept the editor, pull flow, and tests aligned.
+- Markdown/org/neorg tag persistence works best when sync and pull use matching serializers/parsers; write the metadata once at save time and read it back during repo refresh.

--- a/__tests__/tag-persistence.test.ts
+++ b/__tests__/tag-persistence.test.ts
@@ -1,0 +1,104 @@
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: {
+    fetch: jest.fn(async () => ({ isConnected: true, isInternetReachable: true })),
+    addEventListener: jest.fn(() => jest.fn()),
+  },
+}));
+
+jest.mock('expo-file-system/legacy', () => ({
+  __esModule: true,
+  default: {},
+  readAsStringAsync: jest.fn(),
+  EncodingType: { Base64: 'base64' },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    updateFile: jest.fn(),
+    getSavedRepositories: jest.fn(),
+    getTreeRecursive: jest.fn(),
+    getFileContent: jest.fn(),
+    getRepoContents: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(),
+    getAllNotes: jest.fn(),
+    createNote: jest.fn(),
+    saveAllNotes: jest.fn(),
+  },
+}));
+
+import { canPersistNoteTags } from '../src/utils/noteTagSupport';
+import { syncNoteToGitHub } from '../src/services/NoteGitHubSyncService';
+import { pullFromSingleRepo } from '../src/services/RepoPullService';
+import { GitHubService } from '../src/services/GitHubService';
+import { StorageService } from '../src/services/StorageService';
+
+describe('tag persistence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
+  });
+
+  test('syncs markdown tags into frontmatter before upload', async () => {
+    (GitHubService.updateFile as jest.Mock).mockResolvedValue({ ok: true });
+
+    await syncNoteToGitHub({
+      repo: 'org/repo',
+      branch: 'main',
+      title: 'My Note',
+      content: 'hello world',
+      format: 'markdown',
+      tags: ['alpha', 'beta'],
+    });
+
+    expect(GitHubService.updateFile).toHaveBeenCalledWith(
+      'org',
+      'repo',
+      'notes/my-note.md',
+      expect.stringContaining('tags: [alpha, beta]'),
+      'Create note: My Note',
+      'main'
+    );
+  });
+
+  test('restores tags from repo content on refresh', async () => {
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([
+      { path: 'org/repo', branch: 'main' },
+    ]);
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([]);
+    (GitHubService.getTreeRecursive as jest.Mock).mockResolvedValue([
+      { type: 'blob', path: 'notes/my-note.md' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue(
+      '---\ntags: [alpha, beta]\n---\n\nhello world'
+    );
+
+    await pullFromSingleRepo('org/repo');
+
+    expect(StorageService.saveAllNotes).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: 'my note',
+          tags: ['alpha', 'beta'],
+          filePath: 'notes/my-note.md',
+          repo: 'org/repo',
+        }),
+      ])
+    );
+  });
+
+  test('hides tag input for unsupported formats', () => {
+    expect(canPersistNoteTags('markdown')).toBe(true);
+    expect(canPersistNoteTags('org')).toBe(true);
+    expect(canPersistNoteTags('neorg')).toBe(true);
+    expect(canPersistNoteTags('json')).toBe(false);
+    expect(canPersistNoteTags('pdf')).toBe(false);
+    expect(canPersistNoteTags('txt')).toBe(false);
+  });
+});

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -55,6 +55,7 @@ import { useRenderStyle } from '../stores/renderStyleStore';
 import { Button, IconButton, Modal } from '../components/ui';
 import { GitHubActivityIndicator } from '../components/GitHubActivityIndicator';
 import { NotePreviewRenderer } from '../utils/markdownRenderer';
+import { canPersistNoteTags } from '../utils/noteTagSupport';
 import { githubActivity } from '../stores/githubActivityStore';
 
 interface TocEntry {
@@ -353,6 +354,7 @@ export default function NoteEditorScreen() {
           content: content.trim(),
           format: noteFormat,
           accountId,
+          tags,
         };
 
         const syncResult = await syncNoteToGitHub(syncParams);
@@ -977,7 +979,7 @@ export default function NoteEditorScreen() {
         </View>
       </View>
 
-      <TagInput tags={tags} onTagsChange={handleTagsChange} />
+      {canPersistNoteTags(noteFormat) ? <TagInput tags={tags} onTagsChange={handleTagsChange} /> : null}
 
       {canvasJsonRefs.length > 0 && (
         <View style={styles.canvasChipsRow}>

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -17,6 +17,91 @@ export interface NoteGitHubSyncResult {
   error?: string;
 }
 
+export function canPersistNoteTags(format?: string): boolean {
+  return format === 'markdown' || format === 'neorg' || format === 'org';
+}
+
+function joinTags(tags: string[]): string {
+  return tags.map((tag) => tag.trim()).filter(Boolean).join(', ');
+}
+
+function splitLines(value: string): string[] {
+  return value.length === 0 ? [] : value.split('\n');
+}
+
+function upsertMarkdownTags(content: string, tags: string[]): string {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) {
+    return tags.length > 0 ? `---\ntags: [${joinTags(tags)}]\n---\n\n${content}` : content;
+  }
+
+  const body = content.slice(match[0].length);
+  const lines = splitLines(match[1]).filter((line) => !/^tags\s*:/i.test(line.trim()));
+  if (tags.length > 0) {
+    lines.push(`tags: [${joinTags(tags)}]`);
+  }
+
+  if (lines.length === 0) {
+    return body.replace(/^\n+/, '');
+  }
+
+  return `---\n${lines.join('\n')}\n---\n\n${body.replace(/^\n+/, '')}`;
+}
+
+function upsertOrgTags(content: string, tags: string[]): string {
+  const lines = splitLines(content);
+  const index = lines.findIndex((line) => /^#\+FILETAGS:/i.test(line.trim()));
+
+  if (index === -1) {
+    if (tags.length === 0) return content;
+    return `#+FILETAGS: :${tags.map((tag) => tag.trim()).filter(Boolean).join(':')}:\n\n${content}`;
+  }
+
+  if (tags.length === 0) {
+    lines.splice(index, 1);
+    return lines.join('\n').replace(/^\n+/, '');
+  }
+
+  lines[index] = `#+FILETAGS: :${tags.map((tag) => tag.trim()).filter(Boolean).join(':')}:`;
+  return lines.join('\n');
+}
+
+function upsertNeorgTags(content: string, tags: string[]): string {
+  const lines = splitLines(content);
+  const startIndex = lines.findIndex((line) => line.trim() === '@document.meta');
+
+  if (startIndex === -1) {
+    if (tags.length === 0) return content;
+    return `@document.meta\ncategories: [${joinTags(tags)}]\n@end\n\n${content}`;
+  }
+
+  const endIndex = lines.findIndex((line, idx) => idx > startIndex && line.trim() === '@end');
+  if (endIndex === -1) return content;
+
+  const metaLines = lines.slice(startIndex + 1, endIndex).filter((line) => !/^categories\s*:/i.test(line.trim()));
+  if (tags.length > 0) {
+    metaLines.push(`categories: [${joinTags(tags)}]`);
+  }
+
+  if (metaLines.length === 0) {
+    return content;
+  }
+
+  return [
+    ...lines.slice(0, startIndex + 1),
+    ...metaLines,
+    ...lines.slice(endIndex),
+  ].join('\n');
+}
+
+export function applyNoteTagsToContent(content: string, format?: NoteFormat, tags: string[] = []): string {
+  if (!canPersistNoteTags(format)) return content;
+  if (format === 'markdown') return upsertMarkdownTags(content, tags);
+  if (format === 'org') return upsertOrgTags(content, tags);
+  if (format === 'neorg') return upsertNeorgTags(content, tags);
+  return content;
+}
+
 function getExtension(format?: NoteFormat): string {
   switch (format) {
     case 'neorg': return '.norg';
@@ -166,8 +251,9 @@ export async function syncNoteToGitHub(params: {
   content: string;
   format?: NoteFormat;
   accountId?: string;
+  tags?: string[];
 }): Promise<NoteGitHubSyncResult> {
-  const { repo: repoPath, branch, filePath, title, content, format, accountId } = params;
+  const { repo: repoPath, branch, filePath, title, content, format, accountId, tags = [] } = params;
   const tokenOverride = await resolveToken(accountId);
 
   if (!tokenOverride && !GitHubService.isAuthenticated()) {
@@ -191,9 +277,9 @@ export async function syncNoteToGitHub(params: {
 
   const noteSlug = slugify(title);
 
-  let finalContent = content;
+  let finalContent = applyNoteTagsToContent(content, format, tags);
   try {
-    finalContent = await uploadLocalImages(content, repoInfo.owner, repoInfo.repo, targetBranch, noteSlug);
+    finalContent = await uploadLocalImages(finalContent, repoInfo.owner, repoInfo.repo, targetBranch, noteSlug);
   } catch (error) {
     console.warn('[NoteGitHubSync] Image upload failed, syncing note without images:', error);
   }

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -13,6 +13,7 @@ export interface NoteUpsertParams {
   title: string;
   content: string;
   format?: NoteFormat;
+  tags?: string[];
 }
 
 export interface QueuedMutation {

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -4,6 +4,7 @@ import { createNote } from '../models/Note';
 import { createCanvas, updateCanvas, CanvasScene } from '../models/Canvas';
 import { createTodoItem, applyTodoUpdate, reorderTodos } from '../models/Todo';
 import { parseRepoPath } from '../utils/gitPathParser';
+import { canPersistNoteTags } from '../utils/noteTagSupport';
 
 async function fetchDirectoryFiles(
   owner: string,
@@ -50,6 +51,40 @@ async function fetchInBatches<T, R>(
     out.push(...batchOut);
   }
   return out;
+}
+
+function extractTagsFromMarkdown(content: string): string[] {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return [];
+
+  const tagsLine = match[1].split('\n').find((line) => /^tags\s*:/i.test(line.trim()));
+  if (!tagsLine) return [];
+
+  const raw = tagsLine.replace(/^tags\s*:\s*/i, '').trim();
+  const inner = raw.replace(/^\[/, '').replace(/\]$/, '').trim();
+  if (!inner) return [];
+
+  return inner.split(',').map((tag) => tag.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
+}
+
+function extractTagsFromOrg(content: string): string[] {
+  const match = content.match(/^#\+FILETAGS:\s*:(.+?):\s*$/im);
+  if (!match) return [];
+  return match[1].split(':').map((tag) => tag.trim()).filter(Boolean);
+}
+
+function extractTagsFromNeorg(content: string): string[] {
+  const match = content.match(/^categories:\s*\[(.+?)\]\s*$/im);
+  if (!match) return [];
+  return match[1].split(',').map((tag) => tag.trim()).filter(Boolean);
+}
+
+function extractTagsFromContent(content: string, format: 'markdown' | 'neorg' | 'org' | 'pdf' | 'json'): string[] {
+  if (!canPersistNoteTags(format)) return [];
+  if (format === 'markdown') return extractTagsFromMarkdown(content);
+  if (format === 'org') return extractTagsFromOrg(content);
+  if (format === 'neorg') return extractTagsFromNeorg(content);
+  return [];
 }
 
 async function pullNotesFromRepo(
@@ -105,6 +140,8 @@ async function pullNotesFromRepo(
     for (const item of fetched) {
       if (!item) continue;
       const ext = item.path.split('.').pop()?.toLowerCase() ?? 'md';
+      const format = noteFormatFromExt(ext);
+      const tags = extractTagsFromContent(item.content, format);
       const titleFromPath = item.path
         .replace(/^notes\//, '')
         .replace(/\.[^.]+$/, '')
@@ -125,6 +162,7 @@ async function pullNotesFromRepo(
           allNotes[existingIdx] = {
             ...existing,
             content: item.content,
+            tags,
             updatedAt: Date.now(),
           };
           pulled++;
@@ -137,7 +175,8 @@ async function pullNotesFromRepo(
             repo: repoPath,
             branch,
             filePath: item.path,
-            format: noteFormatFromExt(ext),
+            format,
+            tags,
           }),
         );
         pulled++;

--- a/src/utils/noteTagSupport.ts
+++ b/src/utils/noteTagSupport.ts
@@ -1,0 +1,3 @@
+export function canPersistNoteTags(format?: string): boolean {
+  return format === 'markdown' || format === 'neorg' || format === 'org';
+}


### PR DESCRIPTION
Recovery PR — cherry-picks `27ec665`. Conflicts resolved by combining accountId (multi-account) + tags fields in syncNoteToGitHub params.