### PR TITLE
fix(renderer): markdown/neorg pipeline B2-B7 (#423) [recovery]

### DIFF
--- a/__tests__/renderer-pipeline.test.ts
+++ b/__tests__/renderer-pipeline.test.ts
@@ -1,0 +1,107 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+jest.mock('react-native-marked', () => ({
+  Renderer: class MockRenderer {
+    private key = 0;
+
+    getKey() {
+      this.key += 1;
+      return `mock-renderer-${this.key}`;
+    }
+  },
+}));
+
+jest.mock('expo-image', () => ({
+  Image: 'Image',
+}));
+
+import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
+import { createMemoizedNeorgInlineParser, parseNeorgInlineSegments } from '../src/components/NeorgRenderer';
+import { NeorgContentParser } from '../src/services/NeorgContentParser';
+
+function renderNode(node: React.ReactNode) {
+  return render(React.createElement(React.Fragment, null, node));
+}
+
+function createMarkdownRenderer() {
+  return new NotePreviewRenderer({
+    colors: {
+      primary: '#4f46e5',
+      text: '#111827',
+      surfaceSecondary: '#f3f4f6',
+    },
+  });
+}
+
+describe('renderer pipeline regression coverage', () => {
+  it('renders markdown fenced code language labels', () => {
+    const renderer = createMarkdownRenderer();
+    const node = renderer.code('const value = 1;', 'typescript', { padding: 12 }, { fontFamily: 'monospace' });
+    const { getByText } = renderNode(node);
+
+    expect(getByText('typescript')).toBeTruthy();
+    expect(getByText('const value = 1;')).toBeTruthy();
+  });
+
+  it('styles markdown inline code with monospace text and tinted background', () => {
+    const renderer = createMarkdownRenderer();
+    const node = renderer.codespan('inline()');
+    const { getByText } = renderNode(node);
+
+    const code = getByText('inline()');
+    const style = StyleSheet.flatten(code.props.style);
+
+    expect(style.fontFamily).toBe('monospace');
+    expect(style.backgroundColor).toBe('#f3f4f6');
+    expect(style.paddingHorizontal).toBe(4);
+    expect(style.borderRadius).toBe(4);
+  });
+
+  it('parses nested neorg emphasis without treating URLs as italic', () => {
+    const segments = parseNeorgInlineSegments('*outer *inner* outer* and https://x.com/path');
+
+    expect(segments).toEqual([
+      { type: 'bold', content: 'outer *inner* outer' },
+      { type: 'text', content: ' and https://x.com/path' },
+    ]);
+  });
+
+  it('captures neorg code block languages declared with =code.language', () => {
+    const result = NeorgContentParser.parseContent('=code.python\nprint("hi")\n=');
+
+    expect(result.success).toBe(true);
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks?.[0]).toMatchObject({
+      type: 'code',
+      code: { language: 'python', content: 'print("hi")' },
+    });
+  });
+
+  it('memoizes neorg inline parsing for unchanged text', () => {
+    const parser = jest.fn((text: string) => [{ type: 'text' as const, content: text }]);
+    const memoized = createMemoizedNeorgInlineParser(parser);
+
+    expect(memoized('cached inline text')).toEqual([{ type: 'text', content: 'cached inline text' }]);
+    expect(memoized('cached inline text')).toEqual([{ type: 'text', content: 'cached inline text' }]);
+
+    expect(parser).toHaveBeenCalledTimes(1);
+  });
+
+  it('derives list indentation from 4-space siblings and tabs', () => {
+    const input = ['- root', '    - four spaces', '        - eight spaces', '\t- tab indent'].join('\n');
+    const result = NeorgContentParser.parseContent(input);
+
+    expect(result.success).toBe(true);
+    expect(result.blocks?.[0]).toMatchObject({
+      type: 'list',
+      listItems: [
+        { text: 'root', indentLevel: 0 },
+        { text: 'four spaces', indentLevel: 1 },
+        { text: 'eight spaces', indentLevel: 2 },
+        { text: 'tab indent', indentLevel: 1 },
+      ],
+    });
+  });
+});

--- a/src/components/NeorgRenderer.tsx
+++ b/src/components/NeorgRenderer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { NeorgContentBlock, NeorgHeading, NeorgListItem, NeorgChecklistItem, NeorgDefinitionItem } from '../models/NeorgContent';
 import { useTheme } from '../contexts/ThemeContext';
@@ -22,6 +22,168 @@ type InlineSegment =
   | { type: 'subscript'; content: string }
   | { type: 'link'; label: string; target: string }
   | { type: 'tag'; name: string };
+
+type InlinePattern = {
+  regex: RegExp;
+  handler: (match: RegExpMatchArray) => InlineSegment | null;
+  validate?: (source: string, match: RegExpMatchArray) => boolean;
+};
+
+const URL_SHAPED_REGEX = /https?:\/\/[^\s<>()]+/g;
+const WORD_CHAR_REGEX = /[A-Za-z0-9]/;
+
+const inlinePatterns: InlinePattern[] = [
+  {
+    regex: /\{([a-z0-9_.:]+)\}(?:\[([^\]]+)\])?/g,
+    handler: (m) => {
+      const target = m[1];
+      if (/^[a-z0-9_.:-]+$/.test(target)) {
+        if (m[2]) return { type: 'link', label: m[2], target };
+        return { type: 'tag', name: target };
+      }
+      return null;
+    },
+  },
+  {
+    regex: /\[\[([^\]]+)\]\[([^\]]+)\]\]/g,
+    handler: (m) => ({ type: 'link', label: m[2], target: m[1] }),
+  },
+  {
+    regex: /\[\[([^\]]+)\]\]/g,
+    handler: (m) => ({ type: 'link', label: m[1], target: m[1] }),
+  },
+  {
+    regex: /\[([^\]]+)\]\(([^)]+)\)/g,
+    handler: (m) => ({ type: 'link', label: m[1], target: m[2] }),
+  },
+  {
+    regex: /`([^`]+)`/g,
+    handler: (m) => ({ type: 'code', content: m[1] }),
+  },
+  {
+    regex: /\*(\S[^*]*?)\*/g,
+    handler: (m) => ({ type: 'bold', content: m[1] }),
+  },
+  {
+    regex: /\/(\S[^/]*?)\//g,
+    handler: (m) => ({ type: 'italic', content: m[1] }),
+    validate: (source, match) => {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      const prev = start > 0 ? source[start - 1] : '';
+      const next = end < source.length ? source[end] : '';
+      return (!prev || !WORD_CHAR_REGEX.test(prev)) && (!next || !WORD_CHAR_REGEX.test(next));
+    },
+  },
+  {
+    regex: /_([^_]+)_/g,
+    handler: (m) => ({ type: 'underline', content: m[1] }),
+  },
+  {
+    regex: /-([^-\s][^-]*)-/g,
+    handler: (m) => ({ type: 'strikethrough', content: m[1] }),
+  },
+  {
+    regex: /\^([^^]+)\^/g,
+    handler: (m) => ({ type: 'superscript', content: m[1] }),
+  },
+  {
+    regex: /,([^,]+),/g,
+    handler: (m) => ({ type: 'subscript', content: m[1] }),
+  },
+];
+
+function findOuterDelimitedMatch(text: string, delimiter: '*' | '/'): { length: number; segment: InlineSegment } | null {
+  if (!text.startsWith(delimiter)) return null;
+
+  const closingIndex = text.lastIndexOf(delimiter);
+  if (closingIndex <= 0) return null;
+
+  const content = text.slice(1, closingIndex);
+  if (!content || !content.includes(delimiter)) return null;
+  if (!/^\S/.test(content)) return null;
+
+  return {
+    length: closingIndex + 1,
+    segment: delimiter === '*'
+      ? { type: 'bold', content }
+      : { type: 'italic', content },
+  };
+}
+
+export function parseNeorgInlineSegments(text: string): InlineSegment[] {
+  const segments: InlineSegment[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    let earliestMatch: { index: number; length: number; segment: InlineSegment } | null = null;
+
+    const urlMatch = remaining.match(URL_SHAPED_REGEX);
+    if (urlMatch?.index !== undefined) {
+      earliestMatch = {
+        index: urlMatch.index,
+        length: urlMatch[0].length,
+        segment: { type: 'text', content: urlMatch[0] },
+      };
+    }
+
+    const nestedBold = findOuterDelimitedMatch(remaining, '*');
+    if (nestedBold) {
+      earliestMatch = {
+        index: 0,
+        length: nestedBold.length,
+        segment: nestedBold.segment,
+      };
+    }
+
+    const nestedItalic = findOuterDelimitedMatch(remaining, '/');
+    if (nestedItalic && (!earliestMatch || earliestMatch.index > 0 || nestedItalic.length > earliestMatch.length)) {
+      earliestMatch = {
+        index: 0,
+        length: nestedItalic.length,
+        segment: nestedItalic.segment,
+      };
+    }
+
+    for (const { regex, handler, validate } of inlinePatterns) {
+      regex.lastIndex = 0;
+      const match = regex.exec(remaining);
+      if (match && match.index >= 0 && (!validate || validate(remaining, match))) {
+        const seg = handler(match);
+        if (seg && (!earliestMatch || match.index < earliestMatch.index)) {
+          earliestMatch = { index: match.index, length: match[0].length, segment: seg };
+        }
+      }
+    }
+
+    if (earliestMatch) {
+      if (earliestMatch.index > 0) {
+        segments.push({ type: 'text', content: remaining.slice(0, earliestMatch.index) });
+      }
+      segments.push(earliestMatch.segment);
+      remaining = remaining.slice(earliestMatch.index + earliestMatch.length);
+    } else {
+      segments.push({ type: 'text', content: remaining });
+      break;
+    }
+  }
+
+  return segments;
+}
+
+export function createMemoizedNeorgInlineParser(
+  parser: (text: string) => InlineSegment[] = parseNeorgInlineSegments,
+): (text: string) => InlineSegment[] {
+  const cache = new Map<string, InlineSegment[]>();
+
+  return (text: string): InlineSegment[] => {
+    const cached = cache.get(text);
+    if (cached) return cached;
+    const parsed = parser(text);
+    cache.set(text, parsed);
+    return parsed;
+  };
+}
 
 export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendererProps) {
   const { colors } = useTheme();
@@ -49,93 +211,7 @@ export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendere
   const quoteText = overrides.blockquote?.text ?? colors.text;
   const dividerColor = overrides.divider?.color ?? colors.border;
 
-  const parseInline = (text: string): InlineSegment[] => {
-    const segments: InlineSegment[] = [];
-    const patterns: { regex: RegExp; handler: (m: RegExpMatchArray) => InlineSegment | null }[] = [
-      {
-        regex: /\{([a-z0-9_.:]+)\}(?:\[([^\]]+)\])?/g,
-        handler: (m) => {
-          const target = m[1];
-          if (/^[a-z0-9_.:-]+$/.test(target)) {
-            if (m[2]) return { type: 'link', label: m[2], target };
-            return { type: 'tag', name: target };
-          }
-          return null;
-        },
-      },
-      {
-        regex: /\[\[([^\]]+)\]\[([^\]]+)\]\]/g,
-        handler: (m) => ({ type: 'link', label: m[2], target: m[1] }),
-      },
-      {
-        regex: /\[\[([^\]]+)\]\]/g,
-        handler: (m) => ({ type: 'link', label: m[1], target: m[1] }),
-      },
-      {
-        regex: /\[([^\]]+)\]\(([^)]+)\)/g,
-        handler: (m) => ({ type: 'link', label: m[1], target: m[2] }),
-      },
-      {
-        regex: /`([^`]+)`/g,
-        handler: (m) => ({ type: 'code', content: m[1] }),
-      },
-      {
-        regex: /\*([^*]+)\*/g,
-        handler: (m) => ({ type: 'bold', content: m[1] }),
-      },
-      {
-        regex: /\/([^/]+)\//g,
-        handler: (m) => ({ type: 'italic', content: m[1] }),
-      },
-      {
-        regex: /_([^_]+)_/g,
-        handler: (m) => ({ type: 'underline', content: m[1] }),
-      },
-      {
-        regex: /-([^-\s][^-]*)-/g,
-        handler: (m) => ({ type: 'strikethrough', content: m[1] }),
-      },
-      {
-        regex: /\^([^^]+)\^/g,
-        handler: (m) => ({ type: 'superscript', content: m[1] }),
-      },
-      {
-        regex: /,([^,]+),/g,
-        handler: (m) => ({ type: 'subscript', content: m[1] }),
-      },
-    ];
-
-    let remaining = text;
-    while (remaining.length > 0) {
-      let earliestMatch: { index: number; length: number; segment: InlineSegment } | null = null;
-
-      for (const { regex, handler } of patterns) {
-        regex.lastIndex = 0;
-        const match = regex.exec(remaining);
-        if (match && match.index >= 0) {
-          if (!earliestMatch || match.index < earliestMatch.index) {
-            const seg = handler(match);
-            if (seg) {
-              earliestMatch = { index: match.index, length: match[0].length, segment: seg };
-            }
-          }
-        }
-      }
-
-      if (earliestMatch) {
-        if (earliestMatch.index > 0) {
-          segments.push({ type: 'text', content: remaining.slice(0, earliestMatch.index) });
-        }
-        segments.push(earliestMatch.segment);
-        remaining = remaining.slice(earliestMatch.index + earliestMatch.length);
-      } else {
-        segments.push({ type: 'text', content: remaining });
-        break;
-      }
-    }
-
-    return segments;
-  };
+  const parseInline = useMemo(() => createMemoizedNeorgInlineParser(), []);
 
   const segKey = (seg: InlineSegment, i: number): string =>
     `${i}-${seg.type}-${'content' in seg ? seg.content : 'name' in seg ? seg.name : seg.type}`;
@@ -150,13 +226,13 @@ export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendere
           const k = segKey(seg, i);
           switch (seg.type) {
             case 'bold':
-              return <Text key={k} selectable style={styles.bold}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.bold}>{renderInline(seg.content)}</Text>;
             case 'italic':
-              return <Text key={k} selectable style={styles.italic}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.italic}>{renderInline(seg.content)}</Text>;
             case 'underline':
-              return <Text key={k} selectable style={styles.underline}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.underline}>{renderInline(seg.content)}</Text>;
             case 'strikethrough':
-              return <Text key={k} selectable style={styles.strikethrough}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.strikethrough}>{renderInline(seg.content)}</Text>;
             case 'code':
               return (
                 <Text
@@ -172,9 +248,9 @@ export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendere
                 </Text>
               );
             case 'superscript':
-              return <Text key={k} selectable style={styles.superscript}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.superscript}>{renderInline(seg.content)}</Text>;
             case 'subscript':
-              return <Text key={k} selectable style={styles.subscript}>{seg.content}</Text>;
+              return <Text key={k} selectable style={styles.subscript}>{renderInline(seg.content)}</Text>;
             case 'link':
               return (
                 <Text key={k} selectable style={[styles.link, { color: linkColor }]}>
@@ -211,19 +287,15 @@ export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendere
 
   const renderHeading = (heading: NeorgHeading, blockIndex: number) => {
     const fontSize = 32 - (heading.level - 1) * 4;
-    const weight = headingWeightFor(heading.level);
+    const fontWeight = headingWeightFor(heading.level);
     return (
       <Text
         key={`heading-${blockIndex}`}
         selectable
         style={[
           styles.heading,
-          {
-            fontSize,
-            color: headingColorFor(heading.level),
-            marginTop: heading.level === 1 ? 16 : 12,
-            ...(weight ? { fontWeight: weight } : {}),
-          },
+          { fontSize, color: headingColorFor(heading.level), marginTop: heading.level === 1 ? 16 : 12 },
+          fontWeight ? { fontWeight } : null,
         ]}
       >
         {renderInline(heading.text)}

--- a/src/services/NeorgContentParser.ts
+++ b/src/services/NeorgContentParser.ts
@@ -14,6 +14,9 @@ export class NeorgContentParser {
       let currentChecklist: NeorgChecklistItem[] | null = null;
       let currentTableRows: NeorgTableRow[] | null = null;
       let currentDefinitions: NeorgDefinitionItem[] | null = null;
+      let listIndentWidth: number | null = null;
+      let checklistIndentWidth: number | null = null;
+      let definitionIndentWidth: number | null = null;
       let tableHasHeader: boolean[] = [];
       let inOrgDrawer = false;
       let inOrgBlock = false;
@@ -25,6 +28,7 @@ export class NeorgContentParser {
           blocks.push({ type: 'list', listItems: currentList });
           currentList = null;
         }
+        listIndentWidth = null;
       };
 
       const flushChecklist = () => {
@@ -32,6 +36,7 @@ export class NeorgContentParser {
           blocks.push({ type: 'checklist', checklistItems: currentChecklist });
           currentChecklist = null;
         }
+        checklistIndentWidth = null;
       };
 
       const flushTable = () => {
@@ -47,6 +52,7 @@ export class NeorgContentParser {
           blocks.push({ type: 'definition', definitionItems: currentDefinitions });
           currentDefinitions = null;
         }
+        definitionIndentWidth = null;
       };
 
       let pendingParagraphLines: string[] = [];
@@ -127,13 +133,11 @@ export class NeorgContentParser {
           continue;
         }
 
-        const norgBlockMatch = trimmed.match(/^=(code|raw|embed(?:\.\w+)?)\s*$/);
+        const norgBlockMatch = trimmed.match(/^=(code|raw|embed)(?:\.(\w+))?\s*$/);
         if (norgBlockMatch && !currentCodeBlock) {
           flushAll();
           currentCodeBlock = {
-            language: norgBlockMatch[1].startsWith('code') && norgBlockMatch[1].includes('.')
-              ? norgBlockMatch[1].split('.')[1]
-              : undefined,
+            language: norgBlockMatch[1] === 'code' ? norgBlockMatch[2] : undefined,
             lines: [],
           };
           continue;
@@ -206,12 +210,14 @@ export class NeorgContentParser {
           continue;
         }
 
-        const checklistItem = this.parseChecklistItem(line);
+        const nextChecklistIndentWidth = this.resolveIndentWidth(checklistIndentWidth, line);
+        const checklistItem = this.parseChecklistItem(line, nextChecklistIndentWidth ?? undefined);
         if (checklistItem) {
           flushParagraph();
           flushList();
           flushDefinitions();
           if (!currentChecklist) currentChecklist = [];
+          checklistIndentWidth = nextChecklistIndentWidth;
           currentChecklist.push(checklistItem);
           continue;
         }
@@ -223,22 +229,26 @@ export class NeorgContentParser {
           continue;
         }
 
-        const listItem = this.parseListItem(line);
+        const nextListIndentWidth = this.resolveIndentWidth(listIndentWidth, line);
+        const listItem = this.parseListItem(line, nextListIndentWidth ?? undefined);
         if (listItem) {
           flushParagraph();
           flushChecklist();
           flushDefinitions();
           if (!currentList) currentList = [];
+          listIndentWidth = nextListIndentWidth;
           currentList.push(listItem);
           continue;
         }
 
-        const definitionItem = this.parseDefinitionItem(line);
+        const nextDefinitionIndentWidth = this.resolveIndentWidth(definitionIndentWidth, line);
+        const definitionItem = this.parseDefinitionItem(line, nextDefinitionIndentWidth ?? undefined);
         if (definitionItem) {
           flushParagraph();
           flushList();
           flushChecklist();
           if (!currentDefinitions) currentDefinitions = [];
+          definitionIndentWidth = nextDefinitionIndentWidth;
           currentDefinitions.push(definitionItem);
           continue;
         }
@@ -290,12 +300,43 @@ export class NeorgContentParser {
     return null;
   }
 
-  static parseListItem(line: string): NeorgListItem | null {
+  private static getIndentLevel(spaces: string, indentWidth = 2): number {
+    let level = 0;
+    let consecutiveSpaces = 0;
+
+    for (const char of spaces) {
+      if (char === '\t') {
+        level += 1;
+        consecutiveSpaces = 0;
+      } else {
+        consecutiveSpaces += 1;
+        if (consecutiveSpaces >= indentWidth) {
+          level += 1;
+          consecutiveSpaces = 0;
+        }
+      }
+    }
+
+    if (consecutiveSpaces > 0) {
+      level += 1;
+    }
+
+    return level;
+  }
+
+  private static resolveIndentWidth(currentIndentWidth: number | null, line: string): number | null {
+    if (currentIndentWidth) return currentIndentWidth;
+    const spaces = line.match(/^(\s*)/)?.[1] ?? '';
+    if (!spaces || spaces.includes('\t')) return currentIndentWidth;
+    return spaces.length > 0 ? spaces.length : currentIndentWidth;
+  }
+
+  static parseListItem(line: string, indentWidth = 2): NeorgListItem | null {
     const indentMatch = line.match(/^(\s*)(.*)$/);
     if (!indentMatch) return null;
 
     const spaces = indentMatch[1];
-    const indentLevel = Math.floor(spaces.length / 2);
+    const indentLevel = this.getIndentLevel(spaces, indentWidth);
     const content = indentMatch[2];
 
     // Unordered: - item
@@ -335,12 +376,12 @@ export class NeorgContentParser {
     return null;
   }
 
-  static parseChecklistItem(line: string): NeorgChecklistItem | null {
+  static parseChecklistItem(line: string, indentWidth = 2): NeorgChecklistItem | null {
     const indentMatch = line.match(/^(\s*)(.*)$/);
     if (!indentMatch) return null;
 
     const spaces = indentMatch[1];
-    const indentLevel = Math.floor(spaces.length / 2);
+    const indentLevel = this.getIndentLevel(spaces, indentWidth);
     const content = indentMatch[2];
 
     // - [ ] or - [x] (markdown and norg task syntax)
@@ -357,12 +398,12 @@ export class NeorgContentParser {
     return null;
   }
 
-  static parseDefinitionItem(line: string): NeorgDefinitionItem | null {
+  static parseDefinitionItem(line: string, indentWidth = 2): NeorgDefinitionItem | null {
     const indentMatch = line.match(/^(\s*)(.*)$/);
     if (!indentMatch) return null;
 
     const spaces = indentMatch[1];
-    const indentLevel = Math.floor(spaces.length / 2);
+    const indentLevel = this.getIndentLevel(spaces, indentWidth);
     const content = indentMatch[2];
 
     // Neorg definition: $ Term

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -1,5 +1,5 @@
 import React, { type ReactNode } from 'react';
-import { Alert, Text, type TextStyle, type ViewStyle, type ImageStyle, type ScrollView, Linking } from 'react-native';
+import { Alert, Text, View, type TextStyle, type ViewStyle, type ImageStyle, type ScrollView, Linking } from 'react-native';
 import { Renderer, type RendererInterface } from 'react-native-marked';
 import { Image } from 'expo-image';
 
@@ -157,17 +157,48 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
 
   codespan(text: string, styles?: TextStyle): ReactNode {
     return (
-      <Text key={this.getKey()} selectable style={styles}>
+      <Text
+        key={this.getKey()}
+        selectable
+        style={[
+          {
+            backgroundColor: this.deps.colors.surfaceSecondary ?? '#f0f0f0',
+            paddingHorizontal: 4,
+            borderRadius: 4,
+            fontFamily: 'monospace',
+            fontSize: 14,
+            color: this.deps.colors.text,
+          },
+          styles,
+        ]}
+      >
         {text}
       </Text>
     );
   }
 
-  code(text: string, _language?: string, containerStyle?: ViewStyle, textStyle?: TextStyle): ReactNode {
+  code(text: string, language?: string, containerStyle?: ViewStyle, textStyle?: TextStyle): ReactNode {
     return (
-      <Text key={this.getKey()} selectable style={[containerStyle, textStyle]}>
-        {text}
-      </Text>
+      <View key={this.getKey()} style={containerStyle}>
+        {language ? (
+          <Text
+            selectable
+            style={{
+              fontSize: 12,
+              fontWeight: '600',
+              textTransform: 'uppercase',
+              marginBottom: 4,
+              color: this.deps.colors.text,
+              opacity: 0.7,
+            }}
+          >
+            {language}
+          </Text>
+        ) : null}
+        <Text selectable style={textStyle}>
+          {text}
+        </Text>
+      </View>
     );
   }
 }


### PR DESCRIPTION
Recovery PR — cherry-picks `04fe5ae` with NeorgRenderer surgical merge:

- Took theirs for the pipeline refactor (module-scope inlinePatterns, URL detection, nested bold/italic outer-delimiter handling, italic word-boundary validation)
- Re-added render-style overrides on top so #439 functionality is preserved
- NeorgContentParser changes (indent-width tracking, =code regex tightening) auto-merged

30 pipeline tests pass.