### PR TITLE
chore(release): bump version to 1.0.4

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "GitNotēs",
     "slug": "gitnotes",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnotes",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "expo/AppEntry.js",
   "engines": {
     "node": ">=20.18"


### PR DESCRIPTION
Bumps app.json + package.json from 1.0.3 to 1.0.4. Ships today's recovery PRs + theme/canvas fixes.