### PR TITLE
feat(theme): floating BlurView ScreenHeader (matches TabBar)

### DIFF
--- a/__tests__/save-loading-indicator.test.ts
+++ b/__tests__/save-loading-indicator.test.ts
@@ -159,6 +159,8 @@ jest.mock('../src/components/ui', () => {
     IconButton: ({ children, onPress }: any) => require('react').createElement(Pressable, { onPress }, children),
     Modal: ({ visible, children }: any) => (visible ? require('react').createElement(View, null, children) : null),
     ScreenHeader: ({ title }: any) => require('react').createElement(Text, null, title),
+    useScreenHeaderHeight: () => 60,
+    SCREEN_HEADER_BASE_HEIGHT: 60,
   };
 });
 jest.mock('../src/components/ui/OfflineBanner', () => ({ OfflineBanner: () => null }));

--- a/__tests__/template-manager-screen.test.tsx
+++ b/__tests__/template-manager-screen.test.tsx
@@ -50,6 +50,8 @@ jest.mock('../src/components/ui', () => {
   const React = require('react');
   const { Text, View, TouchableOpacity } = require('react-native');
   return {
+    useScreenHeaderHeight: () => 60,
+    SCREEN_HEADER_BASE_HEIGHT: 60,
     ScreenHeader: ({ title, subtitle, actions }: any) => (
       <View>
         <Text>{title}</Text>

--- a/src/components/ui/ScreenHeader.tsx
+++ b/src/components/ui/ScreenHeader.tsx
@@ -1,8 +1,23 @@
 import React, { ReactNode } from 'react';
-import { Text, View, StyleProp, ViewStyle } from 'react-native';
+import { Platform, Text, View, StyleProp, ViewStyle } from 'react-native';
+import { BlurView } from 'expo-blur';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { useTokens } from '../../contexts/ThemeContext';
+import { useTheme, useTokens } from '../../contexts/ThemeContext';
 import { IconButton } from './IconButton';
+
+export const SCREEN_HEADER_BASE_HEIGHT = 60;
+
+/**
+ * Total reserved space for the floating ScreenHeader, including the
+ * top safe-area inset. Use as `paddingTop` on the screen's first
+ * scroll/list container so content can scroll behind the bar without
+ * being permanently hidden under it.
+ */
+export function useScreenHeaderHeight(): number {
+  const insets = useSafeAreaInsets();
+  return insets.top + SCREEN_HEADER_BASE_HEIGHT;
+}
 
 export interface ScreenHeaderProps {
   title: string;
@@ -15,80 +30,96 @@ export interface ScreenHeaderProps {
 
 export function ScreenHeader(props: ScreenHeaderProps) {
   const { title, subtitle, badge, onBack, actions, style } = props;
+  const { isDark } = useTheme();
   const { colors, spacing, type } = useTokens();
+  const insets = useSafeAreaInsets();
 
   return (
-    <View
-      style={[
-        {
-          flexDirection: 'row',
-          alignItems: 'center',
-          paddingHorizontal: spacing[4],
-          paddingTop: spacing[3],
-          paddingBottom: spacing[3],
-          gap: spacing[3],
-        },
-        style,
-      ]}
+    <BlurView
+      pointerEvents="box-none"
+      intensity={Platform.OS === 'ios' ? 60 : 30}
+      tint={isDark ? 'dark' : 'light'}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        paddingTop: insets.top,
+        zIndex: 10,
+      }}
     >
-      {onBack && (
-        <IconButton size="sm" onPress={onBack} accessibilityLabel="Back">
-          <Ionicons name="arrow-back" size={18} color={colors.accent} />
-        </IconButton>
-      )}
-      <View style={{ flex: 1 }}>
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[2] }}>
-          <Text
-            style={{
-              color: colors.text,
-              fontSize: type['2xl'],
-              fontWeight: '700',
-              flexShrink: 1,
-            }}
-            numberOfLines={1}
-          >
-            {title}
-          </Text>
-          {badge && (
-            <View
+      <View
+        style={[
+          {
+            flexDirection: 'row',
+            alignItems: 'center',
+            paddingHorizontal: spacing[4],
+            paddingTop: spacing[3],
+            paddingBottom: spacing[3],
+            gap: spacing[3],
+          },
+          style,
+        ]}
+      >
+        {onBack && (
+          <IconButton size="sm" onPress={onBack} accessibilityLabel="Back">
+            <Ionicons name="arrow-back" size={18} color={colors.accent} />
+          </IconButton>
+        )}
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[2] }}>
+            <Text
               style={{
-                backgroundColor: '#3B82F6',
-                paddingHorizontal: spacing[2],
-                paddingVertical: 2,
-                borderRadius: 6,
+                color: colors.text,
+                fontSize: type['2xl'],
+                fontWeight: '700',
+                flexShrink: 1,
               }}
+              numberOfLines={1}
             >
-              <Text
+              {title}
+            </Text>
+            {badge && (
+              <View
                 style={{
-                  color: '#ffffff',
-                  fontSize: 10,
-                  fontWeight: '800',
-                  letterSpacing: 0.5,
+                  backgroundColor: '#3B82F6',
+                  paddingHorizontal: spacing[2],
+                  paddingVertical: 2,
+                  borderRadius: 6,
                 }}
               >
-                {badge}
-              </Text>
-            </View>
+                <Text
+                  style={{
+                    color: '#ffffff',
+                    fontSize: 10,
+                    fontWeight: '800',
+                    letterSpacing: 0.5,
+                  }}
+                >
+                  {badge}
+                </Text>
+              </View>
+            )}
+          </View>
+          {subtitle && (
+            <Text
+              style={{
+                color: colors.textSecondary,
+                fontSize: type.sm,
+                marginTop: 2,
+              }}
+              numberOfLines={1}
+            >
+              {subtitle}
+            </Text>
           )}
         </View>
-        {subtitle && (
-          <Text
-            style={{
-              color: colors.textSecondary,
-              fontSize: type.sm,
-              marginTop: 2,
-            }}
-            numberOfLines={1}
-          >
-            {subtitle}
-          </Text>
+        {actions && (
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[2] }}>
+            {actions}
+          </View>
         )}
       </View>
-      {actions && (
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[2] }}>
-          {actions}
-        </View>
-      )}
-    </View>
+    </BlurView>
   );
 }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -17,5 +17,5 @@ export type { ToggleProps } from './Toggle';
 export { Modal } from './Modal';
 export type { ModalProps } from './Modal';
 export { TabBar } from './TabBar';
-export { ScreenHeader } from './ScreenHeader';
+export { ScreenHeader, useScreenHeaderHeight, SCREEN_HEADER_BASE_HEIGHT } from './ScreenHeader';
 export type { ScreenHeaderProps } from './ScreenHeader';

--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -20,7 +20,7 @@ import { useRepos } from '../contexts/RepoContext';
 import { RootStackParamList } from '../navigation/types';
 import { Canvas } from '../models/Canvas';
 import SearchBar from '../components/SearchBar';
-import { ScreenHeader, IconButton } from '../components/ui';
+import { ScreenHeader, IconButton, useScreenHeaderHeight } from '../components/ui';
 import { EntityFilterModal } from '../components/EntityFilterModal';
 import { ActiveFilterStrip } from '../components/ActiveFilterStrip';
 import { useEntityFilter } from '../hooks/useEntityFilter';
@@ -38,6 +38,7 @@ const CANVAS_PRESETS = [
 export default function CanvasListScreen() {
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTheme();
+  const headerHeight = useScreenHeaderHeight();
   const { canvases, filteredCanvases, searchQuery, setSearchQuery, deleteCanvas, refreshCanvases } = useCanvases();
   const { repositories } = useRepos();
   const filter = useEntityFilter<Canvas>(canvases);
@@ -158,32 +159,8 @@ export default function CanvasListScreen() {
   );
 
   return (
-    <SafeAreaView edges={['top', 'bottom']} style={[styles.container, { backgroundColor: colors.background }]}>
-      <ScreenHeader
-        title="Canvases"
-        badge="BETA"
-        actions={
-          <>
-            <IconButton
-              size="sm"
-              active={filter.activeCount > 0}
-              onPress={() => setShowFilterModal(true)}
-              accessibilityLabel="Filters"
-            >
-              <Ionicons
-                name="funnel-outline"
-                size={18}
-                color={filter.activeCount > 0 ? colors.accent : colors.textSecondary}
-              />
-            </IconButton>
-            <IconButton size="sm" onPress={handleCreate} accessibilityLabel="New canvas">
-              <Ionicons name="add" size={20} color={colors.accent} />
-            </IconButton>
-          </>
-        }
-      />
-
-      <View style={styles.searchBarContainer}>
+    <SafeAreaView edges={['bottom']} style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.searchBarContainer, { paddingTop: headerHeight }]}>
         <SearchBar
           value={searchQuery}
           onChangeText={setSearchQuery}
@@ -296,6 +273,29 @@ export default function CanvasListScreen() {
           </View>
         </TouchableOpacity>
       </Modal>
+      <ScreenHeader
+        title="Canvases"
+        badge="BETA"
+        actions={
+          <>
+            <IconButton
+              size="sm"
+              active={filter.activeCount > 0}
+              onPress={() => setShowFilterModal(true)}
+              accessibilityLabel="Filters"
+            >
+              <Ionicons
+                name="funnel-outline"
+                size={18}
+                color={filter.activeCount > 0 ? colors.accent : colors.textSecondary}
+              />
+            </IconButton>
+            <IconButton size="sm" onPress={handleCreate} accessibilityLabel="New canvas">
+              <Ionicons name="add" size={20} color={colors.accent} />
+            </IconButton>
+          </>
+        }
+      />
     </SafeAreaView>
   );
 }

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -15,7 +15,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { ChatMessageBubble } from '../components/ai/ChatMessageBubble';
 import { ChatInputBar } from '../components/ai/ChatInputBar';
 import ContextPickerModal from '../components/ai/ContextPickerModal';
-import { Button, ScreenHeader, Surface } from '../components/ui';
+import { Button, ScreenHeader, Surface, useScreenHeaderHeight } from '../components/ui';
 import { useTokens } from '../contexts/ThemeContext';
 import type { AIContextItem, AIProviderConfig } from '../models/AIProvider';
 import type { ChatMessage } from '../models/Chat';
@@ -154,6 +154,7 @@ export default function ChatScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<ChatScreenRouteProp>();
   const { colors, spacing, type } = useTokens();
+  const headerHeight = useScreenHeaderHeight();
   const { threadId } = route.params;
 
   const flatListRef = useRef<FlatList<ChatMessage>>(null);
@@ -692,18 +693,13 @@ export default function ChatScreen() {
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 8 : 0}
       >
-        <ScreenHeader
-          title={thread?.title ?? 'GitNotes AI'}
-          subtitle={thread ? `${messages.length} messages` : 'Loading conversation'}
-          onBack={() => navigation.goBack()}
-        />
-
         <View style={styles.content}>
           <FlatList
             ref={flatListRef}
             data={messages}
             keyExtractor={(item) => item.id}
             contentContainerStyle={{
+              paddingTop: headerHeight,
               paddingHorizontal: spacing[4],
               paddingBottom: spacing[4],
               gap: spacing[1],
@@ -755,6 +751,11 @@ export default function ChatScreen() {
           setAttachedContexts(items);
           setIsContextPickerVisible(false);
         }}
+      />
+      <ScreenHeader
+        title={thread?.title ?? 'GitNotes AI'}
+        subtitle={thread ? `${messages.length} messages` : 'Loading conversation'}
+        onBack={() => navigation.goBack()}
       />
     </SafeAreaView>
   );

--- a/src/screens/ChatThreadListScreen.tsx
+++ b/src/screens/ChatThreadListScreen.tsx
@@ -14,13 +14,14 @@ import { githubActivity } from '../stores/githubActivityStore';
 import { useTokens } from '../contexts/ThemeContext';
 import { RootStackParamList } from '../navigation/types';
 import { ChatThreadSummary } from '../models/Chat';
-import { ScreenHeader, Surface, Button } from '../components/ui';
+import { ScreenHeader, Surface, Button, useScreenHeaderHeight } from '../components/ui';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 export default function ChatThreadListScreen() {
   const navigation = useNavigation<NavigationProp>();
   const { colors, type, spacing } = useTokens();
+  const headerHeight = useScreenHeaderHeight();
 
   const {
     threads,
@@ -208,14 +209,8 @@ export default function ChatThreadListScreen() {
   };
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={['top']}>
-      <ScreenHeader
-        title="GitNotes AI"
-        badge="BETA"
-        onBack={() => navigation.goBack()}
-      />
-
-      <View style={[styles.headerControls, { paddingHorizontal: spacing[4], paddingVertical: spacing[3] }]}>
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={[]}>
+      <View style={[styles.headerControls, { paddingTop: headerHeight, paddingHorizontal: spacing[4], paddingVertical: spacing[3] }]}>
         <Button
           label="New Chat"
           onPress={handleNewChat}
@@ -233,6 +228,11 @@ export default function ChatThreadListScreen() {
         ListEmptyComponent={renderEmptyState}
         refreshing={isPullRefreshing}
         onRefresh={handleRefresh}
+      />
+      <ScreenHeader
+        title="GitNotes AI"
+        badge="BETA"
+        onBack={() => navigation.goBack()}
       />
     </SafeAreaView>
   );

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -20,7 +20,7 @@ import { HapticService } from '../utils/haptics';
 import { parseRepoPath } from '../utils/gitPathParser';
 import RepoFileTree, { TreeNode } from '../components/RepoFileTree';
 import { RootStackParamList } from '../navigation/types';
-import { ScreenHeader } from '../components/ui';
+import { ScreenHeader, useScreenHeaderHeight } from '../components/ui';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import SearchBar from '../components/SearchBar';
 
@@ -43,6 +43,7 @@ type ExploreView = 'repoList' | 'repoDetail' | 'fileTree';
 export default function ExploreScreen() {
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTheme();
+  const headerHeight = useScreenHeaderHeight();
   const { repositories: repos, refreshRepos } = useRepos();
   const [view, setView] = useState<ExploreView>('repoList');
   const [selectedRepo, setSelectedRepo] = useState<GitRepository | null>(null);
@@ -127,9 +128,10 @@ export default function ExploreScreen() {
 
   if (view === 'repoList') {
     return (
-      <SafeAreaView style={[s.container, { backgroundColor: colors.background }]} edges={['top', 'bottom']}>
-        <ScreenHeader title="Explore" />
-        <OfflineBanner />
+      <SafeAreaView style={[s.container, { backgroundColor: colors.background }]} edges={['bottom']}>
+        <View style={{ paddingTop: headerHeight }}>
+          <OfflineBanner />
+        </View>
         <View style={{ paddingHorizontal: 16, paddingBottom: 12 }}>
           <SearchBar
             value={repoSearch}
@@ -162,6 +164,7 @@ export default function ExploreScreen() {
             }
           />
         )}
+        <ScreenHeader title="Explore" />
       </SafeAreaView>
     );
   }
@@ -170,9 +173,10 @@ export default function ExploreScreen() {
     const parsed = parseRepoPath(selectedRepo.path);
 
     return (
-      <SafeAreaView style={[s.container, { backgroundColor: colors.background }]} edges={['top', 'bottom']}>
-        <ScreenHeader title={selectedRepo.name} onBack={handleBack} />
-        <OfflineBanner />
+      <SafeAreaView style={[s.container, { backgroundColor: colors.background }]} edges={['bottom']}>
+        <View style={{ paddingTop: headerHeight }}>
+          <OfflineBanner />
+        </View>
 
         <View style={[s.detailCard, { backgroundColor: colors.surface, borderColor: colors.border + '30' }]}>
           <View style={s.detailTop}>
@@ -209,6 +213,7 @@ export default function ExploreScreen() {
             <Text style={s.fileTreeButtonText}>Browse Files</Text>
           </TouchableOpacity>
         </View>
+        <ScreenHeader title={selectedRepo.name} onBack={handleBack} />
       </SafeAreaView>
     );
   }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -16,7 +16,7 @@ import TemplateSelector from '../components/TemplateSelector';
 import { NoteTemplate } from '../services/TemplateService';
 import { NoteFormatPreferenceService } from '../services/NoteFormatPreferenceService';
 import { useResponsive } from '../hooks/useResponsive';
-import { Button, Card, Modal, ScreenHeader } from '../components/ui';
+import { Button, Card, Modal, ScreenHeader, useScreenHeaderHeight } from '../components/ui';
 import { BentoRecent } from '../components/home/BentoRecent';
 import { QuickAccessShelf } from '../components/home/QuickAccessShelf';
 import { buildPinnedFeed, buildRecentFeed, RecentItem } from '../utils/recentItems';
@@ -36,6 +36,7 @@ export default function HomeScreen() {
   const { notes } = useNotes();
   const { canvases } = useCanvases();
   const { isTablet, maxContentWidth } = useResponsive();
+  const headerHeight = useScreenHeaderHeight();
   const [showFormatPicker, setShowFormatPicker] = useState(false);
   const [showTemplateSelector, setShowTemplateSelector] = useState(false);
   const [defaultFormat, setDefaultFormat] = useState<EditableNoteFormat | null>(null);
@@ -123,9 +124,8 @@ export default function HomeScreen() {
   );
 
   return (
-    <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: colors.background }]}>
-      <ScreenHeader title="GitNotēs" subtitle="Your development notes, organized." />
-      <ScrollView style={styles.container} contentContainerStyle={[styles.content, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]} showsVerticalScrollIndicator={false}>
+    <SafeAreaView edges={[]} style={[styles.safeArea, { backgroundColor: colors.background }]}>
+      <ScrollView style={styles.container} contentContainerStyle={[styles.content, { paddingTop: headerHeight }, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]} showsVerticalScrollIndicator={false}>
       <View style={styles.bentoGrid}>
         <Pressable
           onPress={handleCreateNote}
@@ -231,6 +231,7 @@ export default function HomeScreen() {
         onSelect={handleTemplateSelect}
       />
       </ScrollView>
+      <ScreenHeader title="GitNotēs" subtitle="Your development notes, organized." />
     </SafeAreaView>
   );
 }

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -42,7 +42,7 @@ import ColorPicker from "../components/ColorPicker";
 import NoteCard from "../components/NoteCard";
 import SearchBar from "../components/SearchBar";
 import { OfflineBanner } from "../components/ui/OfflineBanner";
-import { ScreenHeader } from "../components/ui";
+import { ScreenHeader, useScreenHeaderHeight } from "../components/ui";
 import { parseRepoPath } from "../utils/gitPathParser";
 import { HapticService } from "../utils/haptics";
 import {
@@ -69,6 +69,7 @@ export default function NotesListScreen() {
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTheme();
   const { authState } = useAuth();
+  const headerHeight = useScreenHeaderHeight();
   const {
     notes,
     filteredNotes,
@@ -575,7 +576,7 @@ export default function NotesListScreen() {
 
   return (
     <SafeAreaView
-      edges={['top']}
+      edges={[]}
       style={[
         styles.container,
         { backgroundColor: colors.background },
@@ -587,8 +588,9 @@ export default function NotesListScreen() {
       ]}
     >
       {isDeleting ? <GitHubActivityIndicator /> : null}
-      <ScreenHeader title="Notes" />
-      <OfflineBanner />
+      <View style={{ paddingTop: headerHeight }}>
+        <OfflineBanner />
+      </View>
 
       <View style={styles.topBar}>
         <SearchBar
@@ -1523,6 +1525,7 @@ export default function NotesListScreen() {
         selected={colorPickerNote?.color ?? null}
         onSelect={handleColorSelect}
       />
+      <ScreenHeader title="Notes" />
     </SafeAreaView>
   );
 }

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -39,7 +39,7 @@ import type { RootStackParamList } from '../navigation/types';
 import { ModelSelector } from '../components/ai/ModelSelector';
 import { ProviderConfigModal } from '../components/ai/ProviderConfigModal';
 import { ChatRepoPickerModal } from '../components/ai/ChatRepoPickerModal';
-import { Group, GroupRow, Toggle, ScreenHeader } from '../components/ui';
+import { Group, GroupRow, Toggle, ScreenHeader, useScreenHeaderHeight } from '../components/ui';
 import { useAIStore } from '../stores/aiStore';
 import type { AIProviderConfig } from '../models/AIProvider';
 
@@ -47,6 +47,7 @@ export default function SettingsScreen() {
   const { theme, colors, setTheme, style: uiStyle, setStyle } = useTheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { isTablet, maxContentWidth } = useResponsive();
+  const headerHeight = useScreenHeaderHeight();
   const { clearAllNotes, refreshNotes } = useNotes();
   const { refreshCanvases } = useCanvases();
   const { refreshTodos } = useTodos();
@@ -332,9 +333,8 @@ export default function SettingsScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: colors.background }, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]}>
-      <ScreenHeader title="Settings" />
-      <ScrollView style={styles.scrollContent} keyboardShouldPersistTaps="handled" contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 16, gap: 20 }}>
+    <SafeAreaView edges={[]} style={[styles.container, { backgroundColor: colors.background }, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]}>
+      <ScrollView style={styles.scrollContent} keyboardShouldPersistTaps="handled" contentContainerStyle={{ paddingHorizontal: 16, paddingTop: headerHeight + 16, gap: 20 }}>
 
         <Group title="Appearance" footer={uiStyle === 'neumorphic' ? 'Soft-UI shadows. Toggle off for the classic flat look.' : 'Classic flat look. Toggle on for the Updated UI shadows.'}>
           <GroupRow
@@ -852,6 +852,7 @@ export default function SettingsScreen() {
         onClose={() => setShowChatRepoPicker(false)}
         onSelected={() => setShowChatRepoPicker(false)}
       />
+      <ScreenHeader title="Settings" />
     </SafeAreaView>
   );
 }

--- a/src/screens/TemplateManagerScreen.tsx
+++ b/src/screens/TemplateManagerScreen.tsx
@@ -15,7 +15,7 @@ import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 
 import { useTheme } from '../contexts/ThemeContext';
-import { ScreenHeader, IconButton, Modal } from '../components/ui';
+import { ScreenHeader, IconButton, Modal, useScreenHeaderHeight } from '../components/ui';
 import { useTemplateStore } from '../stores/templateStore';
 import { NoteTemplate } from '../services/TemplateService';
 import { HapticService } from '../utils/haptics';
@@ -23,6 +23,7 @@ import { HapticService } from '../utils/haptics';
 export default function TemplateManagerScreen() {
   const navigation = useNavigation();
   const { colors } = useTheme();
+  const headerHeight = useScreenHeaderHeight();
 
   const customTemplates = useTemplateStore((s) => s.customTemplates);
   const pinnedIds = useTemplateStore((s) => s.pinnedIds);
@@ -190,21 +191,10 @@ export default function TemplateManagerScreen() {
   const customCount = customTemplates.length;
 
   return (
-    <SafeAreaView edges={['top', 'bottom']} style={[styles.container, { backgroundColor: colors.background }]}>
-      <ScreenHeader
-        title="Templates"
-        subtitle={`${allTemplates.length} total · ${customCount} custom`}
-        onBack={handleBack}
-        actions={
-          <IconButton size="sm" onPress={handleOpenCreate} accessibilityLabel="New template">
-            <Ionicons name="add" size={20} color={colors.accent} />
-          </IconButton>
-        }
-      />
-
+    <SafeAreaView edges={['bottom']} style={[styles.container, { backgroundColor: colors.background }]}>
       <ScrollView
         style={styles.scroll}
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[styles.scrollContent, { paddingTop: headerHeight }]}
         keyboardShouldPersistTaps="handled"
       >
         <TouchableOpacity
@@ -289,6 +279,16 @@ export default function TemplateManagerScreen() {
           </View>
         </KeyboardAvoidingView>
       </Modal>
+      <ScreenHeader
+        title="Templates"
+        subtitle={`${allTemplates.length} total · ${customCount} custom`}
+        onBack={handleBack}
+        actions={
+          <IconButton size="sm" onPress={handleOpenCreate} accessibilityLabel="New template">
+            <Ionicons name="add" size={20} color={colors.accent} />
+          </IconButton>
+        }
+      />
     </SafeAreaView>
   );
 }

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -27,7 +27,7 @@ import { useResponsive } from '../hooks/useResponsive';
 import GitContextPicker from '../components/GitContextPicker';
 import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
 import { pullAllFromRepos } from '../services/RepoPullService';
-import { IconButton, ScreenHeader } from '../components/ui';
+import { IconButton, ScreenHeader, useScreenHeaderHeight } from '../components/ui';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import SearchBar from '../components/SearchBar';
 import { EntityFilterModal } from '../components/EntityFilterModal';
@@ -51,6 +51,7 @@ function findReminderLabel(minutes: number): string {
 export default function TodoListScreen() {
   const { colors, isDark } = useTheme();
   const { isTablet, maxContentWidth } = useResponsive();
+  const headerHeight = useScreenHeaderHeight();
   const { todos, createTodo, updateTodo, toggleTodo, refreshTodos } = useTodos();
   const deleteTodo = useTodoStore((state) => state.deleteTodo);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -408,42 +409,10 @@ export default function TodoListScreen() {
   );
 
   return (
-    <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: colors.background }, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]}>
-      <ScreenHeader
-        title="Todos"
-        actions={
-          <>
-            <IconButton
-              size="sm"
-              active={filterCompleted}
-              onPress={() => setFilterCompleted(!filterCompleted)}
-              accessibilityLabel="Toggle completed filter"
-            >
-              <Ionicons
-                name={filterCompleted ? 'eye-off' : 'eye'}
-                size={18}
-                color={filterCompleted ? colors.accent : colors.textSecondary}
-              />
-            </IconButton>
-            <IconButton
-              size="sm"
-              active={filter.activeCount > 0}
-              onPress={() => setShowFilterModal(true)}
-              accessibilityLabel="Filters"
-            >
-              <Ionicons
-                name="funnel-outline"
-                size={18}
-                color={filter.activeCount > 0 ? colors.accent : colors.textSecondary}
-              />
-            </IconButton>
-            <IconButton size="sm" onPress={() => setShowAddModal(true)} accessibilityLabel="Add todo">
-              <Ionicons name="add" size={20} color={colors.accent} />
-            </IconButton>
-          </>
-        }
-      />
-      <OfflineBanner />
+    <SafeAreaView edges={[]} style={[styles.container, { backgroundColor: colors.background }, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]}>
+      <View style={{ paddingTop: headerHeight }}>
+        <OfflineBanner />
+      </View>
 
       <View style={{ paddingHorizontal: 16, paddingBottom: 12 }}>
         <SearchBar
@@ -688,6 +657,40 @@ export default function TodoListScreen() {
           </View>
         </View>
       </Modal>
+      <ScreenHeader
+        title="Todos"
+        actions={
+          <>
+            <IconButton
+              size="sm"
+              active={filterCompleted}
+              onPress={() => setFilterCompleted(!filterCompleted)}
+              accessibilityLabel="Toggle completed filter"
+            >
+              <Ionicons
+                name={filterCompleted ? 'eye-off' : 'eye'}
+                size={18}
+                color={filterCompleted ? colors.accent : colors.textSecondary}
+              />
+            </IconButton>
+            <IconButton
+              size="sm"
+              active={filter.activeCount > 0}
+              onPress={() => setShowFilterModal(true)}
+              accessibilityLabel="Filters"
+            >
+              <Ionicons
+                name="funnel-outline"
+                size={18}
+                color={filter.activeCount > 0 ? colors.accent : colors.textSecondary}
+              />
+            </IconButton>
+            <IconButton size="sm" onPress={() => setShowAddModal(true)} accessibilityLabel="Add todo">
+              <Ionicons name="add" size={20} color={colors.accent} />
+            </IconButton>
+          </>
+        }
+      />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
Top header bars now use the same translucent floating treatment as the bottom navbar. Content scrolls behind them.

- ScreenHeader: BlurView + absolute + safe-area-top
- Export `useScreenHeaderHeight()` and `SCREEN_HEADER_BASE_HEIGHT`
- 8 screens updated to drop top safe-area edge and add header padding to scroll containers
- Two test mocks updated for the new hook