### PR TITLE
fix(theme): bump header height + add useTabBarHeight for floating-bar padding

### DIFF
--- a/__tests__/save-loading-indicator.test.ts
+++ b/__tests__/save-loading-indicator.test.ts
@@ -161,6 +161,8 @@ jest.mock('../src/components/ui', () => {
     ScreenHeader: ({ title }: any) => require('react').createElement(Text, null, title),
     useScreenHeaderHeight: () => 60,
     SCREEN_HEADER_BASE_HEIGHT: 60,
+    useTabBarHeight: () => 84,
+    TAB_BAR_BASE_HEIGHT: 84,
   };
 });
 jest.mock('../src/components/ui/OfflineBanner', () => ({ OfflineBanner: () => null }));

--- a/src/components/ui/ScreenHeader.tsx
+++ b/src/components/ui/ScreenHeader.tsx
@@ -6,7 +6,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTheme, useTokens } from '../../contexts/ThemeContext';
 import { IconButton } from './IconButton';
 
-export const SCREEN_HEADER_BASE_HEIGHT = 60;
+export const SCREEN_HEADER_BASE_HEIGHT = 88;
 
 /**
  * Total reserved space for the floating ScreenHeader, including the

--- a/src/components/ui/TabBar.tsx
+++ b/src/components/ui/TabBar.tsx
@@ -9,6 +9,20 @@ import { useTheme, useTokens } from '../../contexts/ThemeContext';
 
 type IoniconName = keyof typeof Ionicons.glyphMap;
 
+export const TAB_BAR_BASE_HEIGHT = 84;
+
+/**
+ * Total reserved space for the floating TabBar, including the bottom
+ * safe-area inset. Use as `paddingBottom` on a tab screen's first
+ * scroll/list container so the last items aren't permanently hidden
+ * under the floating bar. Returns 0 when the custom TabBar is not
+ * rendered (e.g. tablet rail or system tab bar in flat style).
+ */
+export function useTabBarHeight(): number {
+  const insets = useSafeAreaInsets();
+  return insets.bottom + TAB_BAR_BASE_HEIGHT;
+}
+
 const TAB_ICONS: Record<string, { focused: IoniconName; outline: IoniconName; label: string }> = {
   HomeTab: { focused: 'home', outline: 'home-outline', label: 'Home' },
   NotesTab: { focused: 'document-text', outline: 'document-text-outline', label: 'Notes' },

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -16,6 +16,6 @@ export { Toggle } from './Toggle';
 export type { ToggleProps } from './Toggle';
 export { Modal } from './Modal';
 export type { ModalProps } from './Modal';
-export { TabBar } from './TabBar';
+export { TabBar, useTabBarHeight, TAB_BAR_BASE_HEIGHT } from './TabBar';
 export { ScreenHeader, useScreenHeaderHeight, SCREEN_HEADER_BASE_HEIGHT } from './ScreenHeader';
 export type { ScreenHeaderProps } from './ScreenHeader';

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -20,7 +20,7 @@ import { HapticService } from '../utils/haptics';
 import { parseRepoPath } from '../utils/gitPathParser';
 import RepoFileTree, { TreeNode } from '../components/RepoFileTree';
 import { RootStackParamList } from '../navigation/types';
-import { ScreenHeader, useScreenHeaderHeight } from '../components/ui';
+import { ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import SearchBar from '../components/SearchBar';
 
@@ -44,6 +44,7 @@ export default function ExploreScreen() {
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTheme();
   const headerHeight = useScreenHeaderHeight();
+  const tabBarHeight = useTabBarHeight();
   const { repositories: repos, refreshRepos } = useRepos();
   const [view, setView] = useState<ExploreView>('repoList');
   const [selectedRepo, setSelectedRepo] = useState<GitRepository | null>(null);
@@ -159,6 +160,7 @@ export default function ExploreScreen() {
             data={filteredRepos}
             keyExtractor={(item) => item.id.toString()}
             renderItem={renderRepoItem}
+            contentContainerStyle={{ paddingBottom: tabBarHeight + 16 }}
             refreshControl={
               <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.primary} />
             }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -16,7 +16,7 @@ import TemplateSelector from '../components/TemplateSelector';
 import { NoteTemplate } from '../services/TemplateService';
 import { NoteFormatPreferenceService } from '../services/NoteFormatPreferenceService';
 import { useResponsive } from '../hooks/useResponsive';
-import { Button, Card, Modal, ScreenHeader, useScreenHeaderHeight } from '../components/ui';
+import { Button, Card, Modal, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
 import { BentoRecent } from '../components/home/BentoRecent';
 import { QuickAccessShelf } from '../components/home/QuickAccessShelf';
 import { buildPinnedFeed, buildRecentFeed, RecentItem } from '../utils/recentItems';
@@ -37,6 +37,7 @@ export default function HomeScreen() {
   const { canvases } = useCanvases();
   const { isTablet, maxContentWidth } = useResponsive();
   const headerHeight = useScreenHeaderHeight();
+  const tabBarHeight = useTabBarHeight();
   const [showFormatPicker, setShowFormatPicker] = useState(false);
   const [showTemplateSelector, setShowTemplateSelector] = useState(false);
   const [defaultFormat, setDefaultFormat] = useState<EditableNoteFormat | null>(null);
@@ -125,7 +126,7 @@ export default function HomeScreen() {
 
   return (
     <SafeAreaView edges={[]} style={[styles.safeArea, { backgroundColor: colors.background }]}>
-      <ScrollView style={styles.container} contentContainerStyle={[styles.content, { paddingTop: headerHeight }, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]} showsVerticalScrollIndicator={false}>
+      <ScrollView style={styles.container} contentContainerStyle={[styles.content, { paddingTop: headerHeight, paddingBottom: tabBarHeight + 20 }, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]} showsVerticalScrollIndicator={false}>
       <View style={styles.bentoGrid}>
         <Pressable
           onPress={handleCreateNote}

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -42,7 +42,7 @@ import ColorPicker from "../components/ColorPicker";
 import NoteCard from "../components/NoteCard";
 import SearchBar from "../components/SearchBar";
 import { OfflineBanner } from "../components/ui/OfflineBanner";
-import { ScreenHeader, useScreenHeaderHeight } from "../components/ui";
+import { ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from "../components/ui";
 import { parseRepoPath } from "../utils/gitPathParser";
 import { HapticService } from "../utils/haptics";
 import {
@@ -70,6 +70,7 @@ export default function NotesListScreen() {
   const { colors } = useTheme();
   const { authState } = useAuth();
   const headerHeight = useScreenHeaderHeight();
+  const tabBarHeight = useTabBarHeight();
   const {
     notes,
     filteredNotes,
@@ -967,7 +968,7 @@ export default function NotesListScreen() {
         keyExtractor={keyExtractor}
         key={viewMode}
         {...getListLayout()}
-        contentContainerStyle={getListContentStyle()}
+        contentContainerStyle={{ ...getListContentStyle(), paddingBottom: tabBarHeight + 16 }}
         refreshControl={
           <RefreshControl
             refreshing={isPullRefreshing}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -39,7 +39,7 @@ import type { RootStackParamList } from '../navigation/types';
 import { ModelSelector } from '../components/ai/ModelSelector';
 import { ProviderConfigModal } from '../components/ai/ProviderConfigModal';
 import { ChatRepoPickerModal } from '../components/ai/ChatRepoPickerModal';
-import { Group, GroupRow, Toggle, ScreenHeader, useScreenHeaderHeight } from '../components/ui';
+import { Group, GroupRow, Toggle, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
 import { useAIStore } from '../stores/aiStore';
 import type { AIProviderConfig } from '../models/AIProvider';
 
@@ -48,6 +48,7 @@ export default function SettingsScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { isTablet, maxContentWidth } = useResponsive();
   const headerHeight = useScreenHeaderHeight();
+  const tabBarHeight = useTabBarHeight();
   const { clearAllNotes, refreshNotes } = useNotes();
   const { refreshCanvases } = useCanvases();
   const { refreshTodos } = useTodos();
@@ -334,7 +335,7 @@ export default function SettingsScreen() {
 
   return (
     <SafeAreaView edges={[]} style={[styles.container, { backgroundColor: colors.background }, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]}>
-      <ScrollView style={styles.scrollContent} keyboardShouldPersistTaps="handled" contentContainerStyle={{ paddingHorizontal: 16, paddingTop: headerHeight + 16, gap: 20 }}>
+      <ScrollView style={styles.scrollContent} keyboardShouldPersistTaps="handled" contentContainerStyle={{ paddingHorizontal: 16, paddingTop: headerHeight + 16, paddingBottom: tabBarHeight + 16, gap: 20 }}>
 
         <Group title="Appearance" footer={uiStyle === 'neumorphic' ? 'Soft-UI shadows. Toggle off for the classic flat look.' : 'Classic flat look. Toggle on for the Updated UI shadows.'}>
           <GroupRow

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -27,7 +27,7 @@ import { useResponsive } from '../hooks/useResponsive';
 import GitContextPicker from '../components/GitContextPicker';
 import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
 import { pullAllFromRepos } from '../services/RepoPullService';
-import { IconButton, ScreenHeader, useScreenHeaderHeight } from '../components/ui';
+import { IconButton, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import SearchBar from '../components/SearchBar';
 import { EntityFilterModal } from '../components/EntityFilterModal';
@@ -52,6 +52,7 @@ export default function TodoListScreen() {
   const { colors, isDark } = useTheme();
   const { isTablet, maxContentWidth } = useResponsive();
   const headerHeight = useScreenHeaderHeight();
+  const tabBarHeight = useTabBarHeight();
   const { todos, createTodo, updateTodo, toggleTodo, refreshTodos } = useTodos();
   const deleteTodo = useTodoStore((state) => state.deleteTodo);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -436,7 +437,7 @@ export default function TodoListScreen() {
         data={filteredTodos}
         renderItem={renderTodoItem}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={{ ...styles.listContent, paddingBottom: tabBarHeight + 16 }}
         ListEmptyComponent={renderEmptyState}
         showsVerticalScrollIndicator={false}
         refreshControl={


### PR DESCRIPTION
Two follow-ups to PR #482:

- Header was 60px base; subtitle screens (Home) overflowed. Bumped to 88.
- Tab screens had no bottom padding — last items were hidden under the floating navbar. Added `useTabBarHeight()` hook + `TAB_BAR_BASE_HEIGHT` constant exported from TabBar, applied to all 5 tab screens (Home, Notes, Todos, Explore, Settings).