### PR TITLE
fix(theme): make useScreenHeaderHeight subtitle-aware

### DIFF
--- a/src/components/ui/ScreenHeader.tsx
+++ b/src/components/ui/ScreenHeader.tsx
@@ -6,17 +6,23 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTheme, useTokens } from '../../contexts/ThemeContext';
 import { IconButton } from './IconButton';
 
-export const SCREEN_HEADER_BASE_HEIGHT = 88;
+export const SCREEN_HEADER_BASE_HEIGHT = 60;
+export const SCREEN_HEADER_SUBTITLE_HEIGHT = 88;
 
 /**
  * Total reserved space for the floating ScreenHeader, including the
  * top safe-area inset. Use as `paddingTop` on the screen's first
  * scroll/list container so content can scroll behind the bar without
  * being permanently hidden under it.
+ *
+ * Pass `{ subtitle: true }` when the screen's ScreenHeader has a
+ * subtitle; the extra height keeps two-line headers from clipping
+ * content.
  */
-export function useScreenHeaderHeight(): number {
+export function useScreenHeaderHeight(opts?: { subtitle?: boolean }): number {
   const insets = useSafeAreaInsets();
-  return insets.top + SCREEN_HEADER_BASE_HEIGHT;
+  const base = opts?.subtitle ? SCREEN_HEADER_SUBTITLE_HEIGHT : SCREEN_HEADER_BASE_HEIGHT;
+  return insets.top + base;
 }
 
 export interface ScreenHeaderProps {

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -17,5 +17,5 @@ export type { ToggleProps } from './Toggle';
 export { Modal } from './Modal';
 export type { ModalProps } from './Modal';
 export { TabBar, useTabBarHeight, TAB_BAR_BASE_HEIGHT } from './TabBar';
-export { ScreenHeader, useScreenHeaderHeight, SCREEN_HEADER_BASE_HEIGHT } from './ScreenHeader';
+export { ScreenHeader, useScreenHeaderHeight, SCREEN_HEADER_BASE_HEIGHT, SCREEN_HEADER_SUBTITLE_HEIGHT } from './ScreenHeader';
 export type { ScreenHeaderProps } from './ScreenHeader';

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -154,7 +154,7 @@ export default function ChatScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<ChatScreenRouteProp>();
   const { colors, spacing, type } = useTokens();
-  const headerHeight = useScreenHeaderHeight();
+  const headerHeight = useScreenHeaderHeight({ subtitle: true });
   const { threadId } = route.params;
 
   const flatListRef = useRef<FlatList<ChatMessage>>(null);

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -36,7 +36,7 @@ export default function HomeScreen() {
   const { notes } = useNotes();
   const { canvases } = useCanvases();
   const { isTablet, maxContentWidth } = useResponsive();
-  const headerHeight = useScreenHeaderHeight();
+  const headerHeight = useScreenHeaderHeight({ subtitle: true });
   const tabBarHeight = useTabBarHeight();
   const [showFormatPicker, setShowFormatPicker] = useState(false);
   const [showTemplateSelector, setShowTemplateSelector] = useState(false);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -335,7 +335,7 @@ export default function SettingsScreen() {
 
   return (
     <SafeAreaView edges={[]} style={[styles.container, { backgroundColor: colors.background }, isTablet && { maxWidth: maxContentWidth, alignSelf: 'center', width: '100%' }]}>
-      <ScrollView style={styles.scrollContent} keyboardShouldPersistTaps="handled" contentContainerStyle={{ paddingHorizontal: 16, paddingTop: headerHeight + 16, paddingBottom: tabBarHeight + 16, gap: 20 }}>
+      <ScrollView style={styles.scrollContent} keyboardShouldPersistTaps="handled" contentContainerStyle={{ paddingHorizontal: 16, paddingTop: headerHeight, paddingBottom: tabBarHeight + 16, gap: 20 }}>
 
         <Group title="Appearance" footer={uiStyle === 'neumorphic' ? 'Soft-UI shadows. Toggle off for the classic flat look.' : 'Classic flat look. Toggle on for the Updated UI shadows.'}>
           <GroupRow

--- a/src/screens/TemplateManagerScreen.tsx
+++ b/src/screens/TemplateManagerScreen.tsx
@@ -23,7 +23,7 @@ import { HapticService } from '../utils/haptics';
 export default function TemplateManagerScreen() {
   const navigation = useNavigation();
   const { colors } = useTheme();
-  const headerHeight = useScreenHeaderHeight();
+  const headerHeight = useScreenHeaderHeight({ subtitle: true });
 
   const customTemplates = useTemplateStore((s) => s.customTemplates);
   const pinnedIds = useTemplateStore((s) => s.pinnedIds);


### PR DESCRIPTION
Settings (no subtitle) was over-padded. Split header sizing into base (60) and subtitle (88) variants. Subtitle screens (Home, Chat, Templates) opt in via `useScreenHeaderHeight({ subtitle: true })`.