### PR TITLE
fix(ci): align jest config and test mocks with new floating UI hooks

### DIFF
--- a/__mocks__/expo-secure-store.ts
+++ b/__mocks__/expo-secure-store.ts
@@ -1,0 +1,14 @@
+// In-memory mock for expo-secure-store; tests should not hit Keychain.
+const store: Record<string, string> = {};
+
+export async function getItemAsync(key: string): Promise<string | null> {
+  return key in store ? store[key] : null;
+}
+
+export async function setItemAsync(key: string, value: string): Promise<void> {
+  store[key] = value;
+}
+
+export async function deleteItemAsync(key: string): Promise<void> {
+  delete store[key];
+}

--- a/__tests__/filter-modal-overflow.test.tsx
+++ b/__tests__/filter-modal-overflow.test.tsx
@@ -141,6 +141,11 @@ jest.mock('../src/components/ui', () => ({
     const { Text } = require('react-native');
     return <Text>{title}</Text>;
   },
+  useScreenHeaderHeight: () => 60,
+  SCREEN_HEADER_BASE_HEIGHT: 60,
+  SCREEN_HEADER_SUBTITLE_HEIGHT: 88,
+  useTabBarHeight: () => 84,
+  TAB_BAR_BASE_HEIGHT: 84,
 }));
 
 jest.mock('../src/components/NoteCard', () => ({

--- a/__tests__/note-color-coding.test.tsx
+++ b/__tests__/note-color-coding.test.tsx
@@ -197,6 +197,7 @@ describe('color round-trip via GitHub sync', () => {
       expect.stringMatching(/color: purple/),
       'Create note: Color Note',
       'main',
+      undefined,
     );
   });
 

--- a/__tests__/offline-banner-todos-explore.test.tsx
+++ b/__tests__/offline-banner-todos-explore.test.tsx
@@ -76,6 +76,11 @@ jest.mock('../src/components/ui', () => {
     IconButton: ({ children, onPress }: any) => (
       <TouchableOpacity onPress={onPress}>{children}</TouchableOpacity>
     ),
+    useScreenHeaderHeight: () => 60,
+    SCREEN_HEADER_BASE_HEIGHT: 60,
+    SCREEN_HEADER_SUBTITLE_HEIGHT: 88,
+    useTabBarHeight: () => 84,
+    TAB_BAR_BASE_HEIGHT: 84,
   };
 });
 
@@ -92,6 +97,10 @@ jest.mock('../src/contexts/TodoContext', () => ({
 
 jest.mock('../src/stores/todoStore', () => ({
   useTodoStore: (selector: any) => selector({ deleteTodo: jest.fn() }),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null, user: null, isAuthenticated: false } }),
 }));
 
 jest.mock('../src/contexts/RepoContext', () => ({

--- a/__tests__/offline-gray-uncached.test.tsx
+++ b/__tests__/offline-gray-uncached.test.tsx
@@ -56,7 +56,14 @@ jest.mock('../src/components/ColorPicker', () => ({ __esModule: true, default: (
 jest.mock('../src/components/SearchBar', () => () => null);
 jest.mock('../src/components/GitHubActivityIndicator', () => ({ GitHubActivityIndicator: () => null }));
 jest.mock('../src/components/ui/OfflineBanner', () => ({ OfflineBanner: () => null }));
-jest.mock('../src/components/ui', () => ({ ScreenHeader: () => null }));
+jest.mock('../src/components/ui', () => ({
+  ScreenHeader: () => null,
+  useScreenHeaderHeight: () => 60,
+  SCREEN_HEADER_BASE_HEIGHT: 60,
+  SCREEN_HEADER_SUBTITLE_HEIGHT: 88,
+  useTabBarHeight: () => 84,
+  TAB_BAR_BASE_HEIGHT: 84,
+}));
 jest.mock('../src/hooks/useResponsive', () => ({ useResponsive: () => ({ isTablet: false, maxContentWidth: 720 }) }));
 jest.mock('../src/hooks/useNetworkStatus', () => ({ useNetworkStatus: () => ({ isConnected: false, isInternetReachable: false }) }));
 jest.mock('../src/services/GitHubService', () => ({ GitHubService: { setToken: jest.fn() } }));

--- a/__tests__/swipe-delete.test.tsx
+++ b/__tests__/swipe-delete.test.tsx
@@ -136,6 +136,11 @@ jest.mock('../src/components/ui', () => ({
     const { Text } = require('react-native');
     return <Text>{title}</Text>;
   },
+  useScreenHeaderHeight: () => 60,
+  SCREEN_HEADER_BASE_HEIGHT: 60,
+  SCREEN_HEADER_SUBTITLE_HEIGHT: 88,
+  useTabBarHeight: () => 84,
+  TAB_BAR_BASE_HEIGHT: 84,
 }));
 
 jest.mock('../src/components/NoteCard', () => ({

--- a/__tests__/tag-persistence.test.ts
+++ b/__tests__/tag-persistence.test.ts
@@ -63,7 +63,8 @@ describe('tag persistence', () => {
       'notes/my-note.md',
       expect.stringContaining('tags: [alpha, beta]'),
       'Create note: My Note',
-      'main'
+      'main',
+      undefined
     );
   });
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,14 +14,20 @@ module.exports = {
   moduleNameMapper: {
     '^expo-blur$': '<rootDir>/__mocks__/expo-blur.ts',
     '^expo-file-system/legacy$': '<rootDir>/__mocks__/expo-file-system-legacy.ts',
+    '^expo-secure-store$': '<rootDir>/__mocks__/expo-secure-store.ts',
   },
   setupFiles: ['<rootDir>/jest.setup.ts'],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/.worktrees/',
+  ],
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation|expo|@expo|react-native-reanimated|@shopify)/)',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|expo|expo-[^/]+|@expo|react-native-reanimated|@shopify)/)',
   ],
   collectCoverage: true,
   coveragePathIgnorePatterns: [
     '/node_modules/',
     '/__tests__/',
+    '/.worktrees/',
   ],
 };


### PR DESCRIPTION
## Summary
- Fixes failing CI from recent floating-header/navbar refactor.
- `jest.config.js`: extend `transformIgnorePatterns` to cover `expo-*` packages, ignore `.worktrees/`, and map `expo-secure-store` to an in-memory mock.
- Update 4 screen-test `../src/components/ui` mocks to expose `useScreenHeaderHeight`, `useTabBarHeight`, and the new height constants.
- Add `AuthContext` mock to `offline-banner-todos-explore` for `TodoListScreen`'s new `useAuth` call.
- Add 7th `undefined` arg to `GitHubService.updateFile` expectations in tag/color tests (matches new `opts` param).

## Test plan
- [x] `npx jest` — 51 suites, 322 tests, all passing locally
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)