### PR TITLE
fix(home): bigger quick-access, fix squashed small tiles, canvas previews

### DIFF
--- a/src/components/CanvasThumbnail.tsx
+++ b/src/components/CanvasThumbnail.tsx
@@ -1,0 +1,284 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import {
+  Canvas as SkiaCanvas,
+  Path,
+  Rect,
+  Oval,
+  RoundedRect,
+  Fill,
+  Group,
+  Skia,
+  Text as SkiaText,
+  matchFont,
+} from '@shopify/react-native-skia';
+
+import { CanvasChart, CanvasScene, CanvasShape, CanvasStroke, CanvasText } from '../models/Canvas';
+
+interface CanvasThumbnailProps {
+  scene: CanvasScene | undefined;
+  width: number;
+  height: number;
+  background?: string;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isPoint(point: unknown): point is { x: number; y: number } {
+  return !!point
+    && typeof point === 'object'
+    && isFiniteNumber((point as { x?: unknown }).x)
+    && isFiniteNumber((point as { y?: unknown }).y);
+}
+
+function isStrokeElement(el: unknown): el is CanvasStroke {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'stroke'
+    && Array.isArray((el as { points?: unknown }).points)
+    && (el as { points: unknown[] }).points.every(isPoint)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isString((el as { tool?: unknown }).tool);
+}
+
+function isShapeElement(el: unknown): el is CanvasShape {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'shape'
+    && isString((el as { shape?: unknown }).shape)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isFiniteNumber((el as { x1?: unknown }).x1)
+    && isFiniteNumber((el as { y1?: unknown }).y1)
+    && isFiniteNumber((el as { x2?: unknown }).x2)
+    && isFiniteNumber((el as { y2?: unknown }).y2)
+    && ((el as { fillColor?: unknown }).fillColor === undefined || isString((el as { fillColor?: unknown }).fillColor));
+}
+
+function isTextElement(el: unknown): el is CanvasText {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'text'
+    && isString((el as { text?: unknown }).text)
+    && isString((el as { color?: unknown }).color)
+    && isFiniteNumber((el as { x?: unknown }).x)
+    && isFiniteNumber((el as { y?: unknown }).y);
+}
+
+function isChartElement(el: unknown): el is CanvasChart {
+  return !!el
+    && typeof el === 'object'
+    && (el as { type?: unknown }).type === 'chart'
+    && isString((el as { chartType?: unknown }).chartType)
+    && Array.isArray((el as { labels?: unknown }).labels)
+    && (el as { labels: unknown[] }).labels.every(isString)
+    && Array.isArray((el as { values?: unknown }).values)
+    && (el as { values: unknown[] }).values.every(isFiniteNumber)
+    && isFiniteNumber((el as { x?: unknown }).x)
+    && isFiniteNumber((el as { y?: unknown }).y)
+    && isFiniteNumber((el as { width?: unknown }).width)
+    && isFiniteNumber((el as { height?: unknown }).height);
+}
+
+function buildStrokePath(points: { x: number; y: number }[]) {
+  if (points.length === 0) return null;
+  const p = Skia.Path.Make();
+  p.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < points.length; i++) {
+    p.lineTo(points[i].x, points[i].y);
+  }
+  return p;
+}
+
+function buildArrowPath(x1: number, y1: number, x2: number, y2: number, sw: number) {
+  const p = Skia.Path.Make();
+  p.moveTo(x1, y1);
+  p.lineTo(x2, y2);
+  const ang = Math.atan2(y2 - y1, x2 - x1);
+  const hl = Math.max(12, sw * 4);
+  p.moveTo(x2, y2);
+  p.lineTo(x2 - hl * Math.cos(ang - 0.4), y2 - hl * Math.sin(ang - 0.4));
+  p.moveTo(x2, y2);
+  p.lineTo(x2 - hl * Math.cos(ang + 0.4), y2 - hl * Math.sin(ang + 0.4));
+  return p;
+}
+
+function buildDiamondPath(x1: number, y1: number, x2: number, y2: number) {
+  const cx = (x1 + x2) / 2;
+  const cy = (y1 + y2) / 2;
+  const p = Skia.Path.Make();
+  p.moveTo(cx, y1);
+  p.lineTo(x2, cy);
+  p.lineTo(cx, y2);
+  p.lineTo(x1, cy);
+  p.close();
+  return p;
+}
+
+function buildLinePath(x1: number, y1: number, x2: number, y2: number) {
+  const p = Skia.Path.Make();
+  p.moveTo(x1, y1);
+  p.lineTo(x2, y2);
+  return p;
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+export default function CanvasThumbnail({ scene, width, height, background }: CanvasThumbnailProps) {
+  const font = useMemo(
+    () => matchFont({ fontFamily: 'serif', fontSize: 20, fontWeight: 'normal' as const }),
+    [],
+  );
+
+  const elements: unknown[] = Array.isArray(scene?.elements) ? (scene as CanvasScene).elements : [];
+  const sceneWidth = isFiniteNumber(scene?.width) && (scene as CanvasScene).width > 0 ? (scene as CanvasScene).width : 800;
+  const sceneHeight = isFiniteNumber(scene?.height) && (scene as CanvasScene).height > 0 ? (scene as CanvasScene).height : 600;
+  const scale = Math.min(width / sceneWidth, height / sceneHeight);
+  const fillColor = background ?? scene?.background ?? '#FFFFFF';
+
+  const renderElement = (el: unknown, idx: number) => {
+    if (isStrokeElement(el)) {
+      const path = buildStrokePath(el.points);
+      if (!path) return null;
+      const strokeColor = el.tool === 'highlighter' ? hexToRgba(el.color, 0.3) : el.color;
+      return (
+        <Group key={el.id ?? idx}>
+          <Path path={path} color={strokeColor} style="stroke" strokeWidth={el.width} strokeCap="round" strokeJoin="round" />
+        </Group>
+      );
+    }
+    if (isShapeElement(el)) {
+      const { x1, y1, x2, y2, shape, color: sColor, fillColor: sFill, width: sw } = el;
+      const minX = Math.min(x1, x2);
+      const minY = Math.min(y1, y2);
+      const w = Math.abs(x2 - x1);
+      const h = Math.abs(y2 - y1);
+      if (shape === 'line') return <Path key={el.id ?? idx} path={buildLinePath(x1, y1, x2, y2)} style="stroke" strokeWidth={sw} color={sColor} />;
+      if (shape === 'arrow') return <Path key={el.id ?? idx} path={buildArrowPath(x1, y1, x2, y2, sw)} style="stroke" strokeWidth={sw} color={sColor} />;
+      if (shape === 'rect') return (
+        <Group key={el.id ?? idx}>
+          {sFill && <Rect x={minX} y={minY} width={w} height={h} color={sFill} />}
+          <Rect x={minX} y={minY} width={w} height={h} style="stroke" strokeWidth={sw} color={sColor} />
+        </Group>
+      );
+      if (shape === 'roundRect') return (
+        <Group key={el.id ?? idx}>
+          {sFill && <RoundedRect x={minX} y={minY} width={w} height={h} r={10} color={sFill} />}
+          <RoundedRect x={minX} y={minY} width={w} height={h} r={10} style="stroke" strokeWidth={sw} color={sColor} />
+        </Group>
+      );
+      if (shape === 'ellipse') return (
+        <Group key={el.id ?? idx}>
+          {sFill && <Oval x={minX} y={minY} width={w} height={h} color={sFill} />}
+          <Oval x={minX} y={minY} width={w} height={h} style="stroke" strokeWidth={sw} color={sColor} />
+        </Group>
+      );
+      if (shape === 'diamond') {
+        const dp = buildDiamondPath(x1, y1, x2, y2);
+        return (
+          <Group key={el.id ?? idx}>
+            {sFill && <Path path={dp} color={sFill} />}
+            <Path path={dp} style="stroke" strokeWidth={sw} color={sColor} />
+          </Group>
+        );
+      }
+    }
+    if (isTextElement(el)) {
+      return <SkiaText key={el.id ?? idx} x={el.x} y={el.y} text={el.text} font={font} color={el.color} />;
+    }
+    if (isChartElement(el)) {
+      const chartColors = ['#007AFF', '#FF3B30', '#34C759', '#FF9500', '#AF52DE'];
+      if (el.chartType === 'bar') {
+        const maxVal = Math.max(...el.values, 1);
+        const bw = Math.max(8, el.width / Math.max(1, el.values.length) - 4);
+        return (
+          <Group key={el.id ?? idx}>
+            <Rect x={el.x} y={el.y} width={el.width} height={el.height} color="#f5f5f5" />
+            {el.values.map((v, i) => (
+              <Rect
+                key={`bar-${el.id}-${v}-${el.labels[i]}`}
+                x={el.x + i * (bw + 4) + 2}
+                y={el.y + el.height - (v / maxVal) * el.height}
+                width={bw}
+                height={(v / maxVal) * el.height}
+                color={chartColors[i % chartColors.length]}
+              />
+            ))}
+          </Group>
+        );
+      }
+      if (el.chartType === 'line') {
+        const maxVal = Math.max(...el.values, 1);
+        const linePath = Skia.Path.Make();
+        el.values.forEach((v, i) => {
+          const px = el.x + (i / Math.max(1, el.values.length - 1)) * el.width;
+          const py = el.y + el.height - (v / maxVal) * el.height;
+          if (i === 0) linePath.moveTo(px, py);
+          else linePath.lineTo(px, py);
+        });
+        return (
+          <Group key={el.id ?? idx}>
+            <Rect x={el.x} y={el.y} width={el.width} height={el.height} color="#f5f5f5" />
+            <Path path={linePath} color="#007AFF" style="stroke" strokeWidth={2} />
+          </Group>
+        );
+      }
+      if (el.chartType === 'pie') {
+        const total = el.values.reduce((sum, v) => sum + v, 0) || 1;
+        let acc = 0;
+        const cx = el.x + el.width / 2;
+        const cy = el.y + el.height / 2;
+        const r = Math.min(el.width, el.height) / 2;
+        return (
+          <Group key={el.id ?? idx}>
+            {el.values.map((v, i) => {
+              const startAngle = (acc / total) * Math.PI * 2 - Math.PI / 2;
+              acc += v;
+              const endAngle = (acc / total) * Math.PI * 2 - Math.PI / 2;
+              const slicePath = Skia.Path.Make();
+              slicePath.moveTo(cx, cy);
+              slicePath.arcToOval(
+                { x: cx - r, y: cy - r, width: r * 2, height: r * 2 },
+                (startAngle * 180) / Math.PI,
+                ((endAngle - startAngle) * 180) / Math.PI,
+                false,
+              );
+              slicePath.close();
+              return <Path key={`pie-${el.id}-${v}-${el.labels[i]}`} path={slicePath} color={chartColors[i % chartColors.length]} />;
+            })}
+          </Group>
+        );
+      }
+    }
+    return null;
+  };
+
+  return (
+    <View style={[styles.wrap, { width, height }]} pointerEvents="none">
+      <SkiaCanvas style={{ width, height }}>
+        <Fill color={fillColor} />
+        <Group transform={[{ scale }]}>
+          {elements.map(renderElement)}
+        </Group>
+      </SkiaCanvas>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    overflow: 'hidden',
+  },
+});

--- a/src/components/home/BentoTile.tsx
+++ b/src/components/home/BentoTile.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../../contexts/ThemeContext';
 import type { RecentItem, BentoSize } from '../../utils/recentItems';
+import CanvasThumbnail from '../CanvasThumbnail';
 
 interface Props {
   item: RecentItem;
@@ -50,10 +51,20 @@ function subtitleFor(item: RecentItem): string {
   return relativeTime(item.updatedAt);
 }
 
+const HEIGHT_FOR: Record<BentoSize, number> = { large: 184, medium: 132, small: 112 };
+const PADDING_FOR: Record<BentoSize, number> = { large: 18, medium: 14, small: 12 };
+const TITLE_SIZE: Record<BentoSize, number> = { large: 18, medium: 15, small: 13 };
+const SUB_SIZE: Record<BentoSize, number> = { large: 13, medium: 12, small: 11 };
+const ICON_SIZE: Record<BentoSize, number> = { large: 28, medium: 22, small: 18 };
+const RADIUS_FOR: Record<BentoSize, number> = { large: 20, medium: 16, small: 14 };
+const THUMB_HEIGHT: Record<BentoSize, number> = { large: 110, medium: 70, small: 56 };
+const TILE_WIDTH_HINT: Record<BentoSize, number> = { large: 320, medium: 160, small: 160 };
+
 export function BentoTile({ item, size, onPress }: Props) {
   const { colors } = useTheme();
   const isLarge = size === 'large';
   const isMedium = size === 'medium';
+  const isCanvas = item.kind === 'canvas';
 
   const accentByKind: Record<RecentItem['kind'], string> = {
     note: colors.primary,
@@ -62,12 +73,52 @@ export function BentoTile({ item, size, onPress }: Props) {
   };
   const accent = accentByKind[item.kind];
 
-  const heightFor: Record<BentoSize, number> = { large: 168, medium: 124, small: 84 };
-  const padding: Record<BentoSize, number> = { large: 18, medium: 14, small: 12 };
-  const titleSize: Record<BentoSize, number> = { large: 18, medium: 15, small: 13 };
-  const subSize: Record<BentoSize, number> = { large: 13, medium: 12, small: 11 };
-  const iconSize: Record<BentoSize, number> = { large: 28, medium: 22, small: 18 };
-  const radius: Record<BentoSize, number> = { large: 20, medium: 16, small: 14 };
+  const tileHeight = HEIGHT_FOR[size];
+  const tilePad = PADDING_FOR[size];
+  const tileRadius = RADIUS_FOR[size];
+
+  if (isCanvas) {
+    const thumbHeight = THUMB_HEIGHT[size];
+    const scene = item.data.scene;
+    return (
+      <Pressable
+        onPress={onPress}
+        style={({ pressed }) => [
+          styles.tile,
+          {
+            backgroundColor: colors.surface,
+            borderColor: colors.border,
+            height: tileHeight,
+            borderRadius: tileRadius,
+            opacity: pressed ? 0.92 : 1,
+            transform: [{ scale: pressed ? 0.985 : 1 }],
+          },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={`canvas ${titleFor(item)}`}
+      >
+        <View style={[styles.thumbWrap, { height: thumbHeight, backgroundColor: '#FFFFFF' }]}>
+          <CanvasThumbnail scene={scene} width={TILE_WIDTH_HINT[size]} height={thumbHeight} />
+          <View style={[styles.canvasBadge, { backgroundColor: colors.background }]}>
+            <Ionicons name="easel" size={12} color={accent} />
+          </View>
+          {item.pinned ? (
+            <View style={[styles.pin, { backgroundColor: colors.background }]}>
+              <Ionicons name="pin" size={11} color={accent} />
+            </View>
+          ) : null}
+        </View>
+        <View style={[styles.canvasFooter, { padding: tilePad }]}>
+          <Text style={[styles.title, { color: colors.text, fontSize: TITLE_SIZE[size] }]} numberOfLines={isLarge ? 2 : 1}>
+            {titleFor(item)}
+          </Text>
+          <Text style={[styles.subtitle, { color: colors.textSecondary, fontSize: SUB_SIZE[size] }]} numberOfLines={1}>
+            {subtitleFor(item)}
+          </Text>
+        </View>
+      </Pressable>
+    );
+  }
 
   return (
     <Pressable
@@ -77,9 +128,9 @@ export function BentoTile({ item, size, onPress }: Props) {
         {
           backgroundColor: colors.surface,
           borderColor: colors.border,
-          height: heightFor[size],
-          padding: padding[size],
-          borderRadius: radius[size],
+          height: tileHeight,
+          padding: tilePad,
+          borderRadius: tileRadius,
           opacity: pressed ? 0.92 : 1,
           transform: [{ scale: pressed ? 0.985 : 1 }],
         },
@@ -88,7 +139,7 @@ export function BentoTile({ item, size, onPress }: Props) {
       accessibilityLabel={`${item.kind} ${titleFor(item)}`}
     >
       <View style={[styles.badge, { backgroundColor: accent + '1F' }]}>
-        <Ionicons name={iconFor(item.kind)} size={iconSize[size]} color={accent} />
+        <Ionicons name={iconFor(item.kind)} size={ICON_SIZE[size]} color={accent} />
       </View>
       {item.pinned ? (
         <View style={[styles.pin, { backgroundColor: colors.background }]}>
@@ -96,10 +147,10 @@ export function BentoTile({ item, size, onPress }: Props) {
         </View>
       ) : null}
       <View style={styles.spacer} />
-      <Text style={[styles.title, { color: colors.text, fontSize: titleSize[size] }]} numberOfLines={isLarge ? 3 : isMedium ? 2 : 1}>
+      <Text style={[styles.title, { color: colors.text, fontSize: TITLE_SIZE[size] }]} numberOfLines={isLarge ? 3 : isMedium ? 2 : 2}>
         {titleFor(item)}
       </Text>
-      <Text style={[styles.subtitle, { color: colors.textSecondary, fontSize: subSize[size] }]} numberOfLines={1}>
+      <Text style={[styles.subtitle, { color: colors.textSecondary, fontSize: SUB_SIZE[size] }]} numberOfLines={1}>
         {subtitleFor(item)}
       </Text>
     </Pressable>
@@ -127,6 +178,7 @@ const styles = StyleSheet.create({
     borderRadius: 11,
     alignItems: 'center',
     justifyContent: 'center',
+    zIndex: 2,
   },
   spacer: { flex: 1 },
   title: {
@@ -136,6 +188,27 @@ const styles = StyleSheet.create({
   subtitle: {
     fontWeight: '500',
     marginTop: 2,
+  },
+  thumbWrap: {
+    width: '100%',
+    overflow: 'hidden',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+  },
+  canvasBadge: {
+    position: 'absolute',
+    top: 8,
+    left: 8,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  canvasFooter: {
+    flex: 1,
+    justifyContent: 'flex-end',
   },
 });
 

--- a/src/components/home/QuickAccessShelf.tsx
+++ b/src/components/home/QuickAccessShelf.tsx
@@ -3,11 +3,16 @@ import { View, Text, StyleSheet, ScrollView, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../../contexts/ThemeContext';
 import type { RecentItem } from '../../utils/recentItems';
+import CanvasThumbnail from '../CanvasThumbnail';
 
 interface Props {
   items: RecentItem[];
   onOpen: (item: RecentItem) => void;
 }
+
+const CARD_WIDTH = 176;
+const CARD_HEIGHT = 116;
+const THUMB_HEIGHT = 64;
 
 function iconFor(kind: RecentItem['kind']): keyof typeof Ionicons.glyphMap {
   if (kind === 'canvas') return 'easel';
@@ -42,6 +47,7 @@ export function QuickAccessShelf({ items, onOpen }: Props) {
       >
         {items.map((item) => {
           const accent = item.kind === 'note' ? colors.primary : colors.accent;
+          const isCanvas = item.kind === 'canvas';
           return (
             <Pressable
               key={`${item.kind}-${item.data.id}`}
@@ -58,15 +64,26 @@ export function QuickAccessShelf({ items, onOpen }: Props) {
               accessibilityRole="button"
               accessibilityLabel={`Pinned ${item.kind} ${titleFor(item)}`}
             >
-              <View style={[styles.badge, { backgroundColor: accent + '1F' }]}>
-                <Ionicons name={iconFor(item.kind)} size={16} color={accent} />
+              {isCanvas ? (
+                <View style={[styles.thumbWrap, { height: THUMB_HEIGHT }]}>
+                  <CanvasThumbnail scene={item.data.scene} width={CARD_WIDTH} height={THUMB_HEIGHT} />
+                  <View style={[styles.canvasBadge, { backgroundColor: colors.background }]}>
+                    <Ionicons name="easel" size={11} color={accent} />
+                  </View>
+                </View>
+              ) : (
+                <View style={[styles.badge, { backgroundColor: accent + '1F' }]}>
+                  <Ionicons name={iconFor(item.kind)} size={18} color={accent} />
+                </View>
+              )}
+              <View style={styles.titleWrap}>
+                <Text
+                  style={[styles.title, { color: colors.text }]}
+                  numberOfLines={2}
+                >
+                  {titleFor(item)}
+                </Text>
               </View>
-              <Text
-                style={[styles.title, { color: colors.text }]}
-                numberOfLines={2}
-              >
-                {titleFor(item)}
-              </Text>
             </Pressable>
           );
         })}
@@ -94,27 +111,48 @@ const styles = StyleSheet.create({
     letterSpacing: 0.6,
   },
   row: {
-    gap: 10,
+    gap: 12,
     paddingRight: 12,
   },
   card: {
-    width: 148,
-    minHeight: 88,
-    borderRadius: 14,
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    borderRadius: 16,
     borderWidth: StyleSheet.hairlineWidth,
-    padding: 12,
-    gap: 8,
+    overflow: 'hidden',
     justifyContent: 'space-between',
   },
   badge: {
-    width: 28,
-    height: 28,
-    borderRadius: 9,
+    width: 32,
+    height: 32,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 12,
+  },
+  thumbWrap: {
+    width: '100%',
+    overflow: 'hidden',
+    backgroundColor: '#FFFFFF',
+    position: 'relative',
+  },
+  canvasBadge: {
+    position: 'absolute',
+    top: 6,
+    left: 6,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
     alignItems: 'center',
     justifyContent: 'center',
   },
+  titleWrap: {
+    paddingHorizontal: 12,
+    paddingBottom: 12,
+    paddingTop: 4,
+  },
   title: {
-    fontSize: 13,
+    fontSize: 14,
     fontWeight: '600',
     letterSpacing: -0.1,
   },


### PR DESCRIPTION
## Summary
Three home-screen UI fixes:

1. **Quick Access cards bigger.** 148x88 -> 176x116, larger title block. Cards now read as proper tiles instead of chips.
2. **Recent: fix squashed small tiles.** Rows 4+ used height 84 with numberOfLines={1} titles, so anything below the first 3 looked clipped. Bumped to 112 and allowed 2-line titles to match the upper rows' visual weight.
3. **Canvas thumbnails.** Both Quick Access and Recent now render an actual mini-render of the canvas scene (Skia) instead of a generic easel badge.

## How
- New `src/components/CanvasThumbnail.tsx` -- pure scene renderer (stroke / shape / text / chart). Same element validators + render logic as `CanvasPreview` but stripped of nav, touch, and footer.
- `BentoTile`: branches on canvas kind to render thumbnail-on-top + title strip; size constants bumped (small: 84 -> 112).
- `QuickAccessShelf`: same canvas branch + bumped card dims.

`CanvasPreview` left untouched (used inline in note bodies). Type-guard duplication is a known dedupe target -- easy follow-up.

## Test plan
- [x] tsc --noEmit clean
- [x] jest 51 suites / 322 tests pass
- [ ] Manual smoke on device: pin a canvas, confirm thumbnail; create canvases until row 4+ in Recent. Cannot run simulator from shell.

Generated with Claude Code