### PR TITLE
fix(todo): add gap between swipe delete button and card (#491)

### DIFF
--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -828,6 +828,7 @@ const styles = StyleSheet.create({
     width: 80,
     borderRadius: 12,
     marginBottom: 8,
+    marginLeft: 8,
   },
   emptyContainer: {
     flex: 1,


### PR DESCRIPTION
## Summary
Adds an 8px left margin to the todo swipe delete action so the red button no longer sits flush against the card's right edge.

Closes #491