### PR TITLE
fix(explore): remove raised Surface wrapping repo file tree (#493)

### DIFF
--- a/__tests__/file-tree-bg.test.tsx
+++ b/__tests__/file-tree-bg.test.tsx
@@ -1,8 +1,6 @@
 import { StyleSheet } from 'react-native';
 import { render, waitFor } from '@testing-library/react-native';
 
-import { Group } from '../src/components/ui';
-
 jest.mock('../src/contexts/ThemeContext', () => ({
   useTheme: () => ({
     colors: {
@@ -65,8 +63,8 @@ describe('file tree backgrounds', () => {
 
     await waitFor(() => expect(screen.queryAllByText('notes.md').length).toBeGreaterThan(0));
 
-    const group = screen.UNSAFE_getByType(Group);
-    const styles = StyleSheet.flatten(group.props.style);
+    const root = screen.getByTestId('repo-file-tree-root');
+    const styles = StyleSheet.flatten(root.props.style);
 
     expect(isBlackBg(styles?.backgroundColor)).toBe(false);
     expect(styles?.backgroundColor).toBe('#222222');

--- a/src/components/RepoFileTree.tsx
+++ b/src/components/RepoFileTree.tsx
@@ -719,7 +719,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.surface }}>
+    <View testID="repo-file-tree-root" style={{ flex: 1, backgroundColor: colors.surface }}>
       {rootItems.map((item) => (
         <TreeItem
           key={item.path}

--- a/src/components/RepoFileTree.tsx
+++ b/src/components/RepoFileTree.tsx
@@ -16,7 +16,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { GitHubService, GitHubContent } from '../services/GitHubService';
 import { HapticService } from '../utils/haptics';
 import ContextMenu from './ContextMenu';
-import { Group, GroupRow, Modal, Input, Button } from './ui';
+import { GroupRow, Modal, Input, Button } from './ui';
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
@@ -719,7 +719,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
   }
 
   return (
-    <Group style={{ flex: 1, backgroundColor: colors.surface }}>
+    <View style={{ flex: 1, backgroundColor: colors.surface }}>
       {rootItems.map((item) => (
         <TreeItem
           key={item.path}
@@ -732,7 +732,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
           onRefresh={loadRoot}
         />
       ))}
-    </Group>
+    </View>
   );
 }
 


### PR DESCRIPTION
Closes #493

Replaces the `Group` Surface wrapper around the repo file tree's success branch with a plain `View`, so the tree sits flush on the screen background and matches the loading/empty/error branches.