### PR TITLE
fix(chat): align swipe action buttons with card height (#492)

### DIFF
--- a/src/screens/ChatThreadListScreen.tsx
+++ b/src/screens/ChatThreadListScreen.tsx
@@ -160,8 +160,9 @@ export default function ChatThreadListScreen() {
       <ReanimatedSwipeable
         renderRightActions={() => renderRightActions(item)}
         friction={2}
+        containerStyle={{ marginBottom: spacing[3] }}
       >
-        <TouchableOpacity onPress={() => handleThreadPress(item.id)} activeOpacity={0.7} style={{ marginBottom: spacing[3] }}>
+        <TouchableOpacity onPress={() => handleThreadPress(item.id)} activeOpacity={0.7}>
           <Surface style={styles.threadCard}>
             <View style={styles.threadContent}>
               <View style={styles.threadHeader}>
@@ -276,7 +277,6 @@ const styles = StyleSheet.create({
   swipeActions: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 12,
     marginLeft: 12,
     height: '100%',
   },


### PR DESCRIPTION
Closes #492

## Approach
Moved `marginBottom: spacing[3]` from the inner `TouchableOpacity` onto the `ReanimatedSwipeable` wrapper via `containerStyle`. Previously the swipeable's bounds included the child's bottom margin, so the right-action buttons (sized at `height: '100%'`) resolved to a height taller than the card surface — extending above/below the card visually. By moving the spacing onto the swipeable wrapper itself, the swipeable bounds now match the card bounds, and the action buttons inherit the card's actual height.

Also dropped the now-redundant `marginBottom: 12` on the `swipeActions` style, which was contributing to the same height mismatch on the action side.

## Test plan
- [ ] Open AI chat thread list with at least one thread
- [ ] Swipe a thread left to reveal rename/delete actions
- [ ] Verify rename/delete buttons match the card height exactly (no overhang above or below)
- [ ] Verify spacing between threads is unchanged