### PR TITLE
fix(todo): propagate repo delete failure instead of silent swallow (#489)

### DIFF
--- a/__tests__/todo-delete-sync.test.ts
+++ b/__tests__/todo-delete-sync.test.ts
@@ -80,4 +80,77 @@ describe('todo delete GitHub sync', () => {
 
     expect(useTodoStore.getState().todos).toEqual([]);
   });
+
+  test('keeps the todo locally when GitHub delete fails so pull does not re-import it', async () => {
+    const syncedTodo = {
+      id: 'todo-2',
+      text: 'Keep on failure',
+      completed: false,
+      createdAt: 1,
+      updatedAt: 1,
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'todos/keep.json',
+    };
+
+    storageTodos = [syncedTodo];
+    useTodoStore.setState({ todos: [syncedTodo], isLoading: false, error: null });
+
+    (GitHubService.deleteFile as jest.Mock).mockResolvedValueOnce(null);
+
+    const ok = await useTodoStore.getState().deleteTodo('todo-2');
+
+    expect(ok).toBe(false);
+    // Local storage MUST NOT be mutated when remote delete fails — otherwise
+    // the next pull-to-refresh would re-create the todo (issue #489).
+    expect(StorageService.deleteTodo).not.toHaveBeenCalled();
+    expect(useTodoStore.getState().todos).toEqual([syncedTodo]);
+    expect(useTodoStore.getState().error).toBeTruthy();
+  });
+
+  test('refuses to delete repo-backed todo when signed out of GitHub', async () => {
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValueOnce(false);
+
+    const syncedTodo = {
+      id: 'todo-3',
+      text: 'Need auth',
+      completed: false,
+      createdAt: 1,
+      updatedAt: 1,
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'todos/need-auth.json',
+    };
+
+    storageTodos = [syncedTodo];
+    useTodoStore.setState({ todos: [syncedTodo], isLoading: false, error: null });
+
+    const ok = await useTodoStore.getState().deleteTodo('todo-3');
+
+    expect(ok).toBe(false);
+    expect(StorageService.deleteTodo).not.toHaveBeenCalled();
+    expect(GitHubService.deleteFile).not.toHaveBeenCalled();
+    expect(useTodoStore.getState().todos).toEqual([syncedTodo]);
+    expect(useTodoStore.getState().error).toBeTruthy();
+  });
+
+  test('still deletes purely-local todos with no repo metadata', async () => {
+    const localTodo = {
+      id: 'todo-4',
+      text: 'local only',
+      completed: false,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    storageTodos = [localTodo];
+    useTodoStore.setState({ todos: [localTodo], isLoading: false, error: null });
+
+    const ok = await useTodoStore.getState().deleteTodo('todo-4');
+
+    expect(ok).toBe(true);
+    expect(StorageService.deleteTodo).toHaveBeenCalledWith('todo-4');
+    expect(GitHubService.deleteFile).not.toHaveBeenCalled();
+    expect(useTodoStore.getState().todos).toEqual([]);
+  });
 });

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -221,8 +221,14 @@ export default function TodoListScreen() {
           text: 'Delete',
           style: 'destructive',
           onPress: async () => {
-            await deleteTodo(id);
+            const ok = await deleteTodo(id);
             HapticService.light();
+            if (!ok) {
+              const message =
+                useTodoStore.getState().error ??
+                'Could not delete todo. Please try again.';
+              Alert.alert('Delete failed', message);
+            }
           },
         },
       ]

--- a/src/stores/todoStore.ts
+++ b/src/stores/todoStore.ts
@@ -70,29 +70,44 @@ export const useTodoStore = create<TodoState & TodoActions>()((set, get) => ({
     try {
       set({ error: null });
       const todoToDelete = get().todos.find((t) => t.id === id);
+      const isRepoBacked = !!(todoToDelete?.repo && todoToDelete.filePath);
+
+      // If the todo originated from a repo, the remote file MUST be deleted
+      // first. Otherwise the next pull-to-refresh will re-import it (issue #489).
+      if (isRepoBacked) {
+        if (!GitHubService.isAuthenticated()) {
+          set({ error: 'Cannot delete repo-backed todo while signed out of GitHub' });
+          return false;
+        }
+        const repoInfo = parseRepoPath(todoToDelete!.repo!);
+        if (!repoInfo) {
+          set({ error: 'Cannot delete todo: invalid repository path' });
+          return false;
+        }
+        const branch = todoToDelete!.branch || 'main';
+        const filePath = todoToDelete!.filePath!;
+        const sha = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, filePath, branch);
+        if (!sha) {
+          set({ error: 'Cannot delete todo: failed to look up remote file' });
+          return false;
+        }
+        const result = await GitHubService.deleteFile(
+          repoInfo.owner,
+          repoInfo.repo,
+          filePath,
+          `Delete todo: ${todoToDelete!.text}`,
+          sha,
+          branch,
+        );
+        if (!result) {
+          set({ error: 'Cannot delete todo: GitHub delete failed' });
+          return false;
+        }
+      }
+
       const success = await StorageService.deleteTodo(id);
       if (success) {
         set((state) => ({ todos: state.todos.filter((t) => t.id !== id) }));
-        if (todoToDelete?.repo && todoToDelete.filePath && GitHubService.isAuthenticated()) {
-          const repoInfo = parseRepoPath(todoToDelete.repo);
-          if (repoInfo) {
-            const branch = todoToDelete.branch || 'main';
-            const sha = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, todoToDelete.filePath, branch);
-            if (sha) {
-              const result = await GitHubService.deleteFile(
-                repoInfo.owner,
-                repoInfo.repo,
-                todoToDelete.filePath,
-                `Delete todo: ${todoToDelete.text}`,
-                sha,
-                branch,
-              );
-              if (!result) {
-                console.warn('[TodoStore] GitHub delete failed for todo:', id);
-              }
-            }
-          }
-        }
       }
       return success;
     } catch (err) {


### PR DESCRIPTION
Closes #489

## Root cause
`todoStore.deleteTodo` deleted the todo from local storage first and only afterwards *tried* to delete the remote file in the repo. Any failure of `getFileSha` / `deleteFile` was swallowed with a `console.warn`, and missing GitHub auth caused the remote delete branch to be skipped entirely. Because `RepoPullService.pullTodosFromRepo` re-creates a `Todo` from any `todos/*.json` it finds on the next pull, those silently-skipped remote deletes resurrected the todo on the next pull-to-refresh.

(The pulled todos themselves DO carry `repo`/`branch`/`filePath` correctly via `createTodoItem` — that part of the diagnosis was clean. The bug is purely in the delete path.)

## Fix
Restructure `deleteTodo` so the remote delete is the gating step for repo-backed todos:
- If the todo has `repo` + `filePath` and the user is NOT GitHub-authenticated, refuse the delete (set `error`, return `false`). Don't strand the user with a "deleted" todo that pull will re-import.
- If `parseRepoPath` / `getFileSha` / `deleteFile` returns null/falsy, set a specific `error` and return `false` BEFORE touching local state.
- Only on remote delete success do we call `StorageService.deleteTodo` and update the in-memory list.
- Purely-local todos (no `repo`/`filePath`) keep the original local-only behavior.

`TodoListScreen.handleDeleteTodo` now reads `useTodoStore.getState().error` after a `false` return and shows an `Alert` so users actually see why their swipe-delete didn't take.

## Tests
Extended `__tests__/todo-delete-sync.test.ts` with three new cases:
- Remote delete failure -> local todo is preserved, `StorageService.deleteTodo` is never called, `error` is set.
- Signed-out + repo-backed todo -> refused, no calls made, `error` is set.
- Purely-local todo -> deleted as before, `GitHubService.deleteFile` is not called.

Existing case (happy path remote delete + refresh) still passes.

## Verification
- `npm run ts:check` -> clean.
- `npx jest --no-coverage` -> 325/325 tests pass across 51 suites (had to override `testPathIgnorePatterns` because the worktree path itself contains `.worktrees`, which is in the default ignore list — non-issue in CI).
- The actual GitHub API DELETE call is not exercised end-to-end here; the unit tests mock `GitHubService` per the existing pattern. A live integration check (delete a synced todo against a real repo, then pull-to-refresh) is the only way to fully verify the round-trip and was not run as part of this change.

## Test plan
- [ ] Sign in to GitHub, sync a todo to a repo so `todos/<slug>.json` exists.
- [ ] Swipe-delete the todo. Confirm it disappears locally AND the file is gone from the repo on github.com.
- [ ] Pull-to-refresh on the todos screen. Confirm the todo does NOT come back.
- [ ] Sign out of GitHub. Try to swipe-delete a previously-synced todo. Confirm an alert appears explaining why and the todo stays in the list.
- [ ] Create a purely-local todo (no repo selected). Swipe-delete. Confirm normal local-only delete still works.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)