### PR TITLE
fix(notes): drop notes for files removed from repo on pull (#494)

### DIFF
--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -301,8 +301,23 @@ export class GitService {
       const keys = await AsyncStorage.getAllKeys();
       const cacheKeys = keys.filter(k => k.startsWith(CACHE_PREFIX));
       await AsyncStorage.multiRemove(cacheKeys);
+      this.memCache.clear();
     } catch (error) {
       console.warn('[GitService] Failed to clear cache:', error);
+    }
+  }
+
+  // Targeted invalidator used after a successful repo pull so the editor
+  // folder dropdown reflects the freshly fetched tree instead of a stale
+  // (TTL-bound) snapshot.
+  static async invalidateRepoFoldersCache(repoPath: string, branch?: string): Promise<void> {
+    const branchKey = branch || 'HEAD';
+    const cacheKey = `repo_folders_${repoPath.replace(/[^a-zA-Z0-9]/g, '_')}_${branchKey.replace(/[^a-zA-Z0-9]/g, '_')}`;
+    this.memCache.delete(cacheKey);
+    try {
+      await AsyncStorage.removeItem(CACHE_PREFIX + cacheKey);
+    } catch (error) {
+      console.warn('[GitService] Failed to invalidate folders cache:', error);
     }
   }
 }

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -1,4 +1,5 @@
 import { GitHubService } from './GitHubService';
+import { GitService } from './GitService';
 import { StorageService } from './StorageService';
 import { createNote, isNoteColor, NoteColor } from '../models/Note';
 import { createCanvas, updateCanvas, CanvasScene } from '../models/Canvas';
@@ -151,6 +152,13 @@ async function pullNotesFromRepo(
       FILE_FETCH_CONCURRENCY,
     );
 
+    // Build a set of remote file paths we successfully observed. The set is
+    // the basis for reconciling local notes against the remote tree below.
+    // We populate it from `noteBlobs` (the full list of relevant remote
+    // entries) — not `fetched` — so a transient per-file fetch failure does
+    // not cause us to drop a still-existing local note.
+    const remoteFilePaths = new Set<string>(noteBlobs.map((b) => b.path));
+
     let allNotes = await StorageService.getAllNotes();
     let pulled = 0;
 
@@ -226,7 +234,45 @@ async function pullNotesFromRepo(
       }
     }
 
+    // Reconcile: drop local notes that were pulled from this same repo+branch
+    // but whose backing file no longer exists in the remote tree. Without
+    // this, deleting a file on the remote (or moving/renaming it) leaves a
+    // stale local note around forever — which surfaces in the folder filter
+    // chips on the Notes list.
+    //
+    // Safety:
+    //   * Scoped to this (repoPath, branch) — never touches notes from other
+    //     repos or branches.
+    //   * Only deletes notes that have a `filePath` (i.e. originated from the
+    //     repo). Local-only drafts have no filePath and are preserved.
+    //   * The early return when `noteBlobs.length === 0` above acts as the
+    //     empty-tree guardrail: a transient empty/errored fetch skips
+    //     reconciliation entirely rather than wiping everything.
+    const beforeCount = allNotes.length;
+    allNotes = allNotes.filter((n) => {
+      if (n.repo !== repoPath) return true;
+      if (n.branch !== branch) return true;
+      if (!n.filePath) return true;
+      return remoteFilePaths.has(n.filePath);
+    });
+    const removed = beforeCount - allNotes.length;
+    if (removed > 0) {
+      console.log(
+        `[RepoPullService] Reconciled ${removed} stale note(s) for ${repoPath}@${branch}`,
+      );
+    }
+
     await StorageService.saveAllNotes(allNotes);
+
+    // Also invalidate the folders cache so editor folder dropdowns reflect
+    // the freshly pulled tree (ignored if the cache layer fails — best
+    // effort).
+    try {
+      await GitService.invalidateRepoFoldersCache(repoPath, branch);
+    } catch {
+      // best-effort; cache will expire on its own TTL.
+    }
+
     return pulled;
   } catch {
     console.warn(`[RepoPullService] Failed to pull notes from ${owner}/${repo}`);


### PR DESCRIPTION
Closes #494

## Summary
- `pullNotesFromRepo` now reconciles local notes against the remote tree: after upserts, any local note scoped to the pulled `(repo, branch)` whose `filePath` is no longer in the remote tree is deleted. This drains the stale `folderPath` values that were polluting the Notes-list folder filter chips.
- Safety: scoped strictly to the pulled `(repo, branch)`; only notes that have a `filePath` (i.e. were originally pulled from the repo) are eligible — local-only drafts are preserved. The empty-tree guardrail is the existing early `return 0` when `noteBlobs.length === 0`, which short-circuits transient/auth/rate-limit edges before reconciliation runs. The remote-paths set is built from `noteBlobs` (not the post-fetch content list) so a per-file fetch failure doesn't accidentally drop a still-existing note.
- Also added a targeted `GitService.invalidateRepoFoldersCache(repo, branch)` and call it on a successful pull, so the editor folder dropdown reflects the freshly pulled tree instead of a stale TTL-cached one.

We considered putting the new reconciliation behind a feature flag (per the issue's suggestion) but chose to keep it always-on with the empty-tree guardrail as the safety net — it's a tighter, simpler delta.

## Test plan
- [x] `npm run ts:check`
- [x] `npm test` — all 51 suites / 322 tests pass
- [ ] Manual: link repo, pull, delete a note file on the remote, pull again — confirm chip for the now-empty folder disappears
- [ ] Manual: simulate transient API failure (offline / 0 blobs) — confirm local notes are NOT deleted
- [ ] Manual: with two linked repos, pull one — confirm the other repo's notes/folder chips are untouched