### PR TITLE
feat(ui): add reanimated-color-picker for notes + render styles (#496)

### DIFF
--- a/__tests__/color-picker.test.tsx
+++ b/__tests__/color-picker.test.tsx
@@ -17,8 +17,9 @@ jest.mock('expo-blur', () => {
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 
-import ColorPicker from '../src/components/ColorPicker';
+import ColorPicker, { snapToPresetColor } from '../src/components/ColorPicker';
 import { TestThemeProvider } from './ui/testThemeProvider';
+import { NOTE_COLORS } from '../src/theme/tokens';
 
 describe('ColorPicker', () => {
   it('fires onSelect with the chosen NoteColor and then closes', () => {
@@ -77,5 +78,31 @@ describe('ColorPicker', () => {
     ].forEach((color) => {
       expect(getByTestId(`color-picker-swatch-${color}`)).toBeTruthy();
     });
+  });
+});
+
+describe('snapToPresetColor', () => {
+  it('returns the exact preset key when given the preset hex', () => {
+    expect(snapToPresetColor(NOTE_COLORS.red)).toBe('red');
+    expect(snapToPresetColor(NOTE_COLORS.blue)).toBe('blue');
+    expect(snapToPresetColor(NOTE_COLORS.gray)).toBe('gray');
+  });
+
+  it('snaps a near-red free pick to red', () => {
+    expect(snapToPresetColor('#f06060')).toBe('red');
+  });
+
+  it('snaps a near-blue free pick to blue', () => {
+    expect(snapToPresetColor('#3366ff')).toBe('blue');
+  });
+
+  it('handles 3-char hex shorthand', () => {
+    // #fff is closest to gray's lightness profile but among presets
+    // the closest by RGB distance for #00f is blue.
+    expect(snapToPresetColor('#00f')).toBe('blue');
+  });
+
+  it('falls back to first preset for invalid input', () => {
+    expect(snapToPresetColor('not-a-color')).toBe('red');
   });
 });

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -58,6 +58,43 @@ jest.mock('@react-native-async-storage/async-storage', () => {
   };
 });
 
+// reanimated-color-picker pulls in react-native-gesture-handler, which
+// depends on a TurboModule that isn't registered in the jest runtime.
+// Stub the picker with a passthrough View — its drag interactions can't
+// be unit-tested anyway; runtime verification happens on a sim.
+jest.mock('reanimated-color-picker', () => {
+  const { View } = require('react-native');
+  const Stub = ({ children }: { children?: React.ReactNode }) =>
+    require('react').createElement(View, null, children);
+  return {
+    __esModule: true,
+    default: Stub,
+    Panel1: Stub,
+    Panel2: Stub,
+    Panel3: Stub,
+    Panel4: Stub,
+    Panel5: Stub,
+    HueSlider: Stub,
+    HueCircular: Stub,
+    SaturationSlider: Stub,
+    BrightnessSlider: Stub,
+    LuminanceSlider: Stub,
+    LuminanceCircular: Stub,
+    HSLSaturationSlider: Stub,
+    OpacitySlider: Stub,
+    RedSlider: Stub,
+    GreenSlider: Stub,
+    BlueSlider: Stub,
+    Preview: Stub,
+    PreviewText: Stub,
+    InputWidget: Stub,
+    Swatches: Stub,
+    ExtraThumb: Stub,
+    colorKit: {},
+    useColorPickerContext: () => ({}),
+  };
+});
+
 jest.mock('react-native-safe-area-context', () => {
   const { View } = require('react-native');
   const insets = { top: 0, right: 0, bottom: 0, left: 0 };

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-native-web": "^0.21.0",
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.4",
+    "reanimated-color-picker": "^4.2.0",
     "zod": "^4.4.2",
     "zustand": "^5.0.12"
   },

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Pressable } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
 
-import { Modal } from './ui';
-import { useTheme } from '../contexts/ThemeContext';
+import HexColorPickerModal from './HexColorPickerModal';
 import { NOTE_COLORS } from '../theme/tokens';
 import { NoteColor, NOTE_COLOR_VALUES } from '../models/Note';
 
@@ -16,7 +13,58 @@ export interface ColorPickerProps {
   title?: string;
 }
 
-const SWATCH_SIZE = 44;
+/**
+ * Snap an arbitrary hex color (e.g. '#aabbcc') to the nearest entry in
+ * `NOTE_COLOR_VALUES` by squared RGB distance. The note model only
+ * accepts the named preset enum, so any free-picker output is coerced
+ * to the closest preset on save.
+ */
+export function snapToPresetColor(hex: string): NoteColor {
+  const rgb = parseHex(hex);
+  if (!rgb) {
+    // Fallback: deterministic default if the input is unparseable.
+    return NOTE_COLOR_VALUES[0];
+  }
+
+  let bestColor: NoteColor = NOTE_COLOR_VALUES[0];
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (const color of NOTE_COLOR_VALUES) {
+    const presetRgb = parseHex(NOTE_COLORS[color]);
+    if (!presetRgb) continue;
+    const dr = rgb.r - presetRgb.r;
+    const dg = rgb.g - presetRgb.g;
+    const db = rgb.b - presetRgb.b;
+    const distance = dr * dr + dg * dg + db * db;
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestColor = color;
+    }
+  }
+  return bestColor;
+}
+
+function parseHex(hex: string): { r: number; g: number; b: number } | null {
+  if (!hex) return null;
+  const cleaned = hex.trim().replace(/^#/, '');
+  let normalized: string;
+  if (cleaned.length === 3) {
+    normalized = cleaned
+      .split('')
+      .map((c) => c + c)
+      .join('');
+  } else if (cleaned.length === 6 || cleaned.length === 8) {
+    normalized = cleaned.slice(0, 6);
+  } else {
+    return null;
+  }
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return null;
+  return {
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16),
+  };
+}
 
 export default function ColorPicker({
   visible,
@@ -25,122 +73,33 @@ export default function ColorPicker({
   selected,
   title = 'Color',
 }: ColorPickerProps) {
-  const { colors } = useTheme();
+  const initialHex = selected ? NOTE_COLORS[selected] : undefined;
 
-  const handlePick = (color: NoteColor | null) => {
-    onSelect(color);
-    onClose();
+  const presetHexes = NOTE_COLOR_VALUES.map((c) => NOTE_COLORS[c]);
+  const presetIds = NOTE_COLOR_VALUES.slice();
+
+  const handleSelect = (hex: string | null) => {
+    if (hex === null) {
+      onSelect(null);
+      return;
+    }
+    onSelect(snapToPresetColor(hex));
   };
 
   return (
-    <Modal
+    <HexColorPickerModal
       visible={visible}
-      onRequestClose={onClose}
-      contentStyle={{ padding: 20, minWidth: 300 }}
-    >
-      <View testID="color-picker">
-        <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
-
-        <View style={styles.swatchGrid}>
-          {NOTE_COLOR_VALUES.map((color) => {
-            const hex = NOTE_COLORS[color];
-            const isSelected = selected === color;
-            return (
-              <Pressable
-                key={color}
-                testID={`color-picker-swatch-${color}`}
-                accessibilityLabel={`color ${color}`}
-                accessibilityRole="button"
-                onPress={() => handlePick(color)}
-                style={({ pressed }) => [
-                  styles.swatch,
-                  {
-                    backgroundColor: hex,
-                    borderColor: isSelected ? colors.text : 'transparent',
-                    opacity: pressed ? 0.7 : 1,
-                  },
-                ]}
-              >
-                {isSelected ? (
-                  <Ionicons name="checkmark" size={22} color="#ffffff" />
-                ) : null}
-              </Pressable>
-            );
-          })}
-        </View>
-
-        <TouchableOpacity
-          testID="color-picker-none"
-          accessibilityRole="button"
-          onPress={() => handlePick(null)}
-          style={[
-            styles.noneRow,
-            {
-              borderColor: colors.border,
-              backgroundColor: selected == null ? colors.surfaceSecondary : 'transparent',
-            },
-          ]}
-        >
-          <Ionicons name="close-circle-outline" size={20} color={colors.textSecondary} />
-          <Text style={[styles.noneText, { color: colors.text }]}>None</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity
-          testID="color-picker-cancel"
-          accessibilityRole="button"
-          onPress={onClose}
-          style={[styles.cancelRow]}
-        >
-          <Text style={[styles.cancelText, { color: colors.primary }]}>Cancel</Text>
-        </TouchableOpacity>
-      </View>
-    </Modal>
+      initialColor={initialHex}
+      title={title}
+      presets={presetHexes}
+      presetIds={presetIds}
+      presetTestIdPrefix="color-picker-swatch"
+      allowClear
+      clearTestID="color-picker-none"
+      cancelTestID="color-picker-cancel"
+      confirmTestID="color-picker-confirm"
+      onClose={onClose}
+      onSelect={handleSelect}
+    />
   );
 }
-
-const styles = StyleSheet.create({
-  title: {
-    fontSize: 18,
-    fontWeight: '600',
-    marginBottom: 16,
-    textAlign: 'center',
-  },
-  swatchGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-    gap: 12,
-    marginBottom: 16,
-  },
-  swatch: {
-    width: SWATCH_SIZE,
-    height: SWATCH_SIZE,
-    borderRadius: SWATCH_SIZE / 2,
-    borderWidth: 3,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  noneRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 12,
-    borderWidth: StyleSheet.hairlineWidth,
-    marginBottom: 8,
-  },
-  noneText: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  cancelRow: {
-    paddingVertical: 10,
-    alignItems: 'center',
-  },
-  cancelText: {
-    fontSize: 16,
-    fontWeight: '600',
-  },
-});

--- a/src/components/HexColorPickerModal.tsx
+++ b/src/components/HexColorPickerModal.tsx
@@ -1,0 +1,264 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import ColorPicker, {
+  Panel1,
+  HueSlider,
+  Preview,
+  InputWidget,
+} from 'reanimated-color-picker';
+
+import { Modal } from './ui';
+import { useTheme } from '../contexts/ThemeContext';
+
+export interface HexColorPickerModalProps {
+  visible: boolean;
+  initialColor?: string | null;
+  presets?: readonly string[];
+  presetTestIdPrefix?: string;
+  presetIds?: readonly string[];
+  allowClear?: boolean;
+  clearTestID?: string;
+  cancelTestID?: string;
+  confirmTestID?: string;
+  title?: string;
+  onClose: () => void;
+  /** Called with the chosen hex (e.g. '#aabbcc') or null if cleared. */
+  onSelect: (hex: string | null) => void;
+}
+
+const DEFAULT_INITIAL = '#3b82f6';
+
+function normalizeHex(value?: string | null): string {
+  if (!value) return DEFAULT_INITIAL;
+  const trimmed = value.trim();
+  if (!trimmed) return DEFAULT_INITIAL;
+  if (trimmed.startsWith('#')) return trimmed;
+  return `#${trimmed}`;
+}
+
+/**
+ * Shared modal that wraps `reanimated-color-picker` with the project's
+ * existing modal styling. Composes Panel1 (HSV panel) + HueSlider +
+ * Preview + InputWidget so users can pick a color visually or type a
+ * hex code. A row of presets (if provided) is rendered above the picker
+ * for one-tap selection.
+ */
+export default function HexColorPickerModal({
+  visible,
+  initialColor,
+  presets,
+  presetTestIdPrefix,
+  presetIds,
+  allowClear = false,
+  clearTestID = 'hex-color-picker-clear',
+  cancelTestID = 'hex-color-picker-cancel',
+  confirmTestID = 'hex-color-picker-confirm',
+  title = 'Pick a color',
+  onClose,
+  onSelect,
+}: HexColorPickerModalProps) {
+  const { colors } = useTheme();
+
+  const initial = normalizeHex(initialColor);
+  const [currentHex, setCurrentHex] = useState<string>(initial);
+
+  // Re-seed the working color whenever the modal is (re-)opened with a
+  // new initial value.
+  useEffect(() => {
+    if (visible) {
+      setCurrentHex(normalizeHex(initialColor));
+    }
+  }, [visible, initialColor]);
+
+  const handleConfirm = () => {
+    onSelect(currentHex);
+    onClose();
+  };
+
+  const handleClear = () => {
+    onSelect(null);
+    onClose();
+  };
+
+  const handlePreset = (hex: string) => {
+    onSelect(hex);
+    onClose();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      onRequestClose={onClose}
+      contentStyle={{ padding: 20, minWidth: 320 }}
+    >
+      <View testID="hex-color-picker">
+        <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
+
+        {presets && presets.length > 0 ? (
+          <View style={styles.presetsRow}>
+            {presets.map((hex, idx) => {
+              const presetId = presetIds?.[idx] ?? hex;
+              const testID = presetTestIdPrefix
+                ? `${presetTestIdPrefix}-${presetId}`
+                : `hex-color-preset-${presetId}`;
+              return (
+                <Pressable
+                  key={`${presetId}-${idx}`}
+                  testID={testID}
+                  accessibilityRole="button"
+                  accessibilityLabel={`color ${presetId}`}
+                  onPress={() => handlePreset(hex)}
+                  style={({ pressed }) => [
+                    styles.presetSwatch,
+                    {
+                      backgroundColor: hex,
+                      borderColor: colors.border,
+                      opacity: pressed ? 0.7 : 1,
+                    },
+                  ]}
+                />
+              );
+            })}
+          </View>
+        ) : null}
+
+        <ColorPicker
+          value={currentHex}
+          sliderThickness={20}
+          thumbSize={22}
+          thumbShape="circle"
+          onCompleteJS={(c) => setCurrentHex(c.hex)}
+          style={styles.picker}
+        >
+          <Preview style={styles.preview} hideInitialColor={false} />
+          <Panel1 style={styles.panel} />
+          <HueSlider style={styles.slider} />
+          <InputWidget
+            iconColor={colors.text}
+            inputStyle={[styles.input, { color: colors.text, borderColor: colors.border }]}
+            inputTitleStyle={{ color: colors.textSecondary }}
+            disableAlphaChannel
+            formats={['HEX', 'RGB', 'HSL']}
+            defaultFormat="HEX"
+          />
+        </ColorPicker>
+
+        <View style={styles.actionsRow}>
+          {allowClear ? (
+            <TouchableOpacity
+              testID={clearTestID}
+              accessibilityRole="button"
+              onPress={handleClear}
+              style={[styles.clearButton, { borderColor: colors.border }]}
+            >
+              <Ionicons name="close-circle-outline" size={18} color={colors.textSecondary} />
+              <Text style={[styles.clearText, { color: colors.text }]}>None</Text>
+            </TouchableOpacity>
+          ) : null}
+
+          <TouchableOpacity
+            testID={cancelTestID}
+            accessibilityRole="button"
+            onPress={onClose}
+            style={styles.cancelButton}
+          >
+            <Text style={[styles.cancelText, { color: colors.textSecondary }]}>Cancel</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            testID={confirmTestID}
+            accessibilityRole="button"
+            onPress={handleConfirm}
+            style={[styles.confirmButton, { backgroundColor: colors.primary }]}
+          >
+            <Text style={styles.confirmText}>Done</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  presetsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 10,
+    marginBottom: 16,
+  },
+  presetSwatch: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  picker: {
+    width: '100%',
+    gap: 12,
+  },
+  preview: {
+    height: 36,
+    borderRadius: 8,
+  },
+  panel: {
+    height: 200,
+    borderRadius: 12,
+  },
+  slider: {
+    borderRadius: 999,
+  },
+  input: {
+    fontSize: 13,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 8,
+  },
+  actionsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: 8,
+    marginTop: 16,
+  },
+  clearButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginRight: 'auto',
+  },
+  clearText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  cancelButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  cancelText: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  confirmButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 10,
+  },
+  confirmText: {
+    color: '#ffffff',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/src/screens/RenderStyleEditorScreen.tsx
+++ b/src/screens/RenderStyleEditorScreen.tsx
@@ -8,6 +8,7 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   Alert,
+  Pressable,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -18,6 +19,7 @@ import type { RouteProp } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
 import { useRenderStyleStore } from '../stores/renderStyleStore';
 import NeorgRenderer from '../components/NeorgRenderer';
+import HexColorPickerModal from '../components/HexColorPickerModal';
 import { NeorgContentParser } from '../services/NeorgContentParser';
 import { getMarkdownStyles } from '../utils/preview';
 import type { FormatRenderStyle, RenderFormat } from '../types/RenderStyle';
@@ -46,11 +48,25 @@ interface ColorFieldProps {
 
 function ColorField({ label, value, onChange }: ColorFieldProps) {
   const { colors } = useTheme();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
   return (
     <View style={styles.fieldRow}>
       <Text style={[styles.fieldLabel, { color: colors.text }]}>{label}</Text>
       <View style={styles.fieldRight}>
-        {value ? <View style={[styles.swatch, { backgroundColor: value, borderColor: colors.border }]} /> : null}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`pick color for ${label}`}
+          onPress={() => setPickerOpen(true)}
+          style={({ pressed }) => [
+            styles.swatch,
+            {
+              backgroundColor: value || colors.background,
+              borderColor: colors.border,
+              opacity: pressed ? 0.7 : 1,
+            },
+          ]}
+        />
         <TextInput
           style={[styles.fieldInput, { color: colors.text, borderColor: colors.border, backgroundColor: colors.background }]}
           placeholder="#rrggbb"
@@ -61,6 +77,14 @@ function ColorField({ label, value, onChange }: ColorFieldProps) {
           onChangeText={(t) => onChange(t.trim() ? t.trim() : undefined)}
         />
       </View>
+      <HexColorPickerModal
+        visible={pickerOpen}
+        title={label}
+        initialColor={value}
+        allowClear
+        onClose={() => setPickerOpen(false)}
+        onSelect={(hex) => onChange(hex ?? undefined)}
+      />
     </View>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5731,6 +5731,11 @@ readable-stream@^4.0.0:
     process "^0.11.10"
     string_decoder "^1.3.0"
 
+reanimated-color-picker@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/reanimated-color-picker/-/reanimated-color-picker-4.2.0.tgz#1a6647238f027b820d4758ae649faf9be170f50f"
+  integrity sha512-nDG/OiQu7hcvVJw3IP0rIdhw+x0rSNxhmfnrXC2je6kqlLSs4txbSVCqDA0kTnVjbD0o2CBvw9/LjY8aq2Lelw==
+
 redent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"


### PR DESCRIPTION
Closes #496

## Summary

- New shared `HexColorPickerModal` (`src/components/HexColorPickerModal.tsx`) wraps `reanimated-color-picker` (v4.2.0). It composes `Preview` + `Panel1` + `HueSlider` + `InputWidget` inside the project's existing `Modal` so the styling matches the rest of the app. An optional preset row at the top renders one-tap swatches.
- Notes long-press color picker (`src/components/ColorPicker.tsx`) is now a thin wrapper around the shared modal. The presets row keeps the original eight-swatch UI (and the original test IDs), and a free HSV picker sits underneath.
- Render Styles editor's `ColorField` (`src/screens/RenderStyleEditorScreen.tsx`) opens the same modal when the swatch is tapped, while still allowing direct hex entry in the text input.

## Decision

Kept the `NoteColor` enum (option a). Free picker output is snapped to the nearest preset by squared RGB distance on save via a new `snapToPresetColor(hex)` helper exported from `ColorPicker.tsx`. This keeps `NoteCard.tsx`, `RepoPullService.ts` frontmatter parsing, and `isNoteColor` untouched. Render styles use the raw hex (no model change).

## Files changed

- `package.json` / `yarn.lock` — adds `reanimated-color-picker@^4.2.0`
- `src/components/HexColorPickerModal.tsx` — new shared modal
- `src/components/ColorPicker.tsx` — rewritten as a wrapper, adds `snapToPresetColor` helper
- `src/screens/RenderStyleEditorScreen.tsx` — `ColorField` swatch now opens the modal
- `jest.setup.ts` — stubs `reanimated-color-picker` (it pulls in `react-native-gesture-handler`, which needs a TurboModule the jest runtime doesn't register)
- `__tests__/color-picker.test.tsx` — adds five `snapToPresetColor` unit tests; existing rendering tests keep passing against the new presets row

## What was verified

- `npm run ts:check` passes
- `npx jest` (with the existing `.worktrees/` ignore-pattern bypassed): 51 suites, 327 tests passing — including the existing `color-picker.test.tsx` rendering assertions and the new snap helper tests.

## What was NOT verified (needs sim run by reviewer)

- Visual / runtime gesture behavior of `reanimated-color-picker` on iOS / Android. The library ships native gesture-handler usage that can't be unit-tested in jest, so the picker is stubbed out for the test suite. The swatch row, modal layout, and snap-to-preset logic are tested, but the actual HSV panel drag, hue slider drag, and hex input round-trip need eyeballs on a sim.
- Dark-mode parity for the picker is left at the library default (not in scope per the issue).

## Test plan

- [ ] Long-press a note in Notes list → picker opens with preset row + HSV panel; pick a custom color → note's accent snaps to nearest preset.
- [ ] Tap "None" → note color is cleared.
- [ ] Open Customize Render Styles → tap any color swatch → picker opens; pick a color → text input updates with raw hex.
- [ ] Manually typing a hex into the render-style text input still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)