### PR TITLE
docs(readme): drop Features section, document iOS icon regen step

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,82 +14,6 @@ A mobile notes, todos, and canvas app that uses GitHub repositories as durable, 
 
 GitNotēs treats your notes as plain files in a Git repository: every note, todo, and canvas is a real Markdown / Neorg / Org / JSON file you can read, edit, and share outside the app. Notes are kept in sync with GitHub, edits are queued and retried when offline, and everything renders locally with native gestures, haptics, and a neumorphic UI.
 
-## Features
-
-### Content types
-
-- Markdown notes with live preview, code-fence rendering, and editor toolbar (undo/redo, headings, lists, code).
-- Neorg notes with a custom parser (block, inline, link, table parsers) and dedicated rendering.
-- Org-mode notes.
-- Todos with checkboxes, due dates, and per-repo sync.
-- Canvas drawings with pinch-zoom, two-finger pan, and JSON-backed scenes.
-- Templates for quickly creating structured notes.
-- **GitNotes AI** chat with notes / todos as tools, contexts attached from your repo, threads versioned in GitHub. Provider quirks and known issues documented in [`docs/LLM-issues-fixes.md`](docs/LLM-issues-fixes.md).
-
-### GitNotes AI
-
-- Multi-provider: Apple Foundation Models (on-device, iOS), Llama via `@react-native-ai/llama` (SmolLM3-3B), and any OpenAI-compatible endpoint (OpenAI, Z.AI Coding Plan, local Ollama, etc.).
-- Tool calling: `create_note`, `edit_note`, `search_notes`, `create_todo`, etc., with optional confirm-before-apply mode.
-- Context picker: attach files / folders / whole repos / local notes / local todos to a message; contexts persist across turns in a thread.
-- Token-budget warnings tuned per model (4K hard limit on Apple, 64K on SmolLM3).
-- Streaming with Stop button, edit-and-resend, regenerate, auto-titled threads.
-- Per-provider quirks isolated in [`src/services/ai/providerQuirks.ts`](src/services/ai/providerQuirks.ts) so divergences (e.g. Z.AI's `tool_stream`) don't leak into the chat code.
-- Threads stored as JSON files under `chat/` in your selected repo, retried on 409 conflicts.
-
-### GitHub sync
-
-- Pull notes, todos, and canvases from any linked repository, with safe merge that won't clobber unsynced local edits.
-- Push edits with conflict-aware uploads (retries on 409, skips on 422 already-exists).
-- Offline sync queue: failed mutations persist to disk and drain on reconnect.
-- True deletes: removing a note also deletes the remote file so the next pull won't resurrect it.
-- Image upload: local images embedded in notes are uploaded to `notes/images/<slug>/` on first sync and rewritten to raw URLs.
-- Lists private repos and collaborator repos with paginated fetch.
-- Personal Access Token auth, token stored in secure storage.
-
-### File browser and tree
-
-- Repository file tree with expandable folders and lazy-loaded children.
-- Rename, move, and delete files or whole directories with recursive operations.
-- File viewer for Markdown, images (zoomable), PDFs, and videos.
-- Long-press context menu for file operations and details.
-
-### Organization and search
-
-- Folder filter chips, scoped to the active repository.
-- Multi-field search across title, content, and tags.
-- Pinned notes float to the top.
-- Per-screen search bar with match navigation.
-
-### UI and design system
-
-- Neumorphic primitives in `src/components/ui/`: `Surface`, `Group`/`GroupRow`, `Button`, `IconButton`, `Card`, `Chip`, `Input`, `Modal`, `Toggle`, `ScreenHeader`, `TabBar`.
-- Token-based theming via `useTokens` and `useTheme`: colors, spacing, type scale, elevation.
-- Three theme modes: automatic, light, dark, with full coverage across modals, pickers, markdown renderers, and the file tree.
-- Floating tab bar pill with haptic selection.
-- Cross-platform soft shadows (iOS + Android).
-
-### State and data
-
-- Zustand stores for notes, todos, canvases, folders, and repos, keeping screens lean and selectors cheap.
-- TanStack Query for GitHub API calls, with caching and background refetch.
-- AsyncStorage with per-note keys (no whole-blob writes), plus an automatic migration from the legacy single-blob format.
-- Position memory: scroll position and last-opened state restored across sessions.
-
-### Reliability
-
-- Strict TypeScript across the app.
-- Comprehensive error states and loading indicators on async ops.
-- Defensive parsing for Neorg and Org documents.
-- Atomic per-note storage: a corrupt entry can't take down the whole index.
-
-### Platform
-
-- Onboarding flow with GitHub authentication.
-- Share intent support for incoming text and images.
-- Local notifications.
-- Haptic feedback on key interactions.
-- iOS and Android, single codebase.
-
 ## Getting started
 
 ### Prerequisites
@@ -171,6 +95,26 @@ The repository ships with an `eas.json` containing three build profiles:
 - `development` — for testing during development.
 - `preview` — for internal distribution.
 - `production` — for App Store and Play Store submission.
+
+### iOS app icon — regenerate before each release
+
+`ios/` is gitignored and regenerated by `expo prebuild`. The asset catalog (`ios/GitNots/Images.xcassets/AppIcon.appiconset/App-Icon-1024x1024@1x.png`) is a stale copy from whenever prebuild last ran locally — if `assets/icon.png` has been updated since then, the next build will ship the old icon.
+
+Before any iOS production build, regenerate the native dir from the current source icon:
+
+```bash
+rm -rf ios/
+npx expo prebuild -p ios
+```
+
+Then verify the asset-catalog file is `1024×1024`, no alpha (Apple rejects alpha):
+
+```bash
+sips -g pixelWidth -g pixelHeight -g hasAlpha \
+  ios/GitNots/Images.xcassets/AppIcon.appiconset/App-Icon-1024x1024@1x.png
+```
+
+Bump `expo.version` and `ios.buildNumber` in `app.json` so App Store Connect accepts the upload, then build + submit. After upload, ASC takes 10-30 min to render the icon — confirm the **Marketing Icon** in the Build detail view (not just App Information) before promoting.
 
 ### Build
 


### PR DESCRIPTION
Closes #502

## Summary

- Removed the long `## Features` section from `README.md` (per request — file no longer enumerates content types, AI, sync, file browser, organization, UI, state, reliability, platform).
- Added a new `### iOS app icon — regenerate before each release` subsection under `## Deployment`, capturing the operational fix for #502: `ios/` is gitignored, so the asset-catalog 1024×1024 file goes stale whenever `assets/icon.png` is updated without a fresh prebuild. New section documents the `rm -rf ios/ && npx expo prebuild -p ios` flow, the `sips` size/alpha check, the `app.json` version bump, and ASC's render-delay caveat.

## Note on #502 closure

Repo-side fix is documentation only — the actual icon refresh is an operational step run before each iOS build. Closing #502 with this PR since the README now captures the procedure; if the icon still ships stale on the next submit, that's a release-flow issue, not a repo issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)