### PR TITLE
fix(pull,storage): reconcile notes on empty remote tree + consume boot cache on read

### DIFF
--- a/__tests__/canvas-race.test.ts
+++ b/__tests__/canvas-race.test.ts
@@ -80,6 +80,7 @@ jest.mock('../src/services/GitHubService', () => ({
   GitHubService: {
     isAuthenticated: jest.fn(() => true),
     getTreeRecursive: jest.fn(async () => []),
+    getTreeRecursiveOrThrow: jest.fn(async () => []),
     getRepoContents: jest.fn(async (_owner: string, _repo: string, dirPath: string) => {
       if (dirPath !== 'canvases') return [];
       return [{ type: 'file', path: 'canvases/remote-canvas.json', download_url: 'https://example.com/remote-canvas.json' }];

--- a/__tests__/note-color-coding.test.tsx
+++ b/__tests__/note-color-coding.test.tsx
@@ -27,6 +27,7 @@ jest.mock('../src/services/GitHubService', () => ({
     updateFile: jest.fn(async () => ({ ok: true })),
     getSavedRepositories: jest.fn(),
     getTreeRecursive: jest.fn(),
+    getTreeRecursiveOrThrow: jest.fn(),
     getFileContent: jest.fn(),
     getRepoContents: jest.fn(async () => []),
   },
@@ -206,7 +207,7 @@ describe('color round-trip via GitHub sync', () => {
       { path: 'org/repo', branch: 'main' },
     ]);
     (StorageService.getAllNotes as jest.Mock).mockResolvedValue([]);
-    (GitHubService.getTreeRecursive as jest.Mock).mockResolvedValue([
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
       { type: 'blob', path: 'notes/color-note.md' },
     ]);
     (GitHubService.getFileContent as jest.Mock).mockResolvedValue(
@@ -231,7 +232,7 @@ describe('color round-trip via GitHub sync', () => {
       { path: 'org/repo', branch: 'main' },
     ]);
     (StorageService.getAllNotes as jest.Mock).mockResolvedValue([]);
-    (GitHubService.getTreeRecursive as jest.Mock).mockResolvedValue([
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
       { type: 'blob', path: 'notes/bad-color.md' },
     ]);
     (GitHubService.getFileContent as jest.Mock).mockResolvedValue(

--- a/__tests__/notes-pull-reconcile.test.ts
+++ b/__tests__/notes-pull-reconcile.test.ts
@@ -1,0 +1,161 @@
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getTreeRecursive: jest.fn(),
+    getTreeRecursiveOrThrow: jest.fn(),
+    getFileContent: jest.fn(),
+    getRepoContents: jest.fn(async () => []),
+    getSavedRepositories: jest.fn(),
+    updateFile: jest.fn(async () => ({ ok: true })),
+  },
+}));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(),
+    getAllNotes: jest.fn(),
+    saveAllNotes: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/GitService', () => ({
+  GitService: {
+    invalidateRepoFoldersCache: jest.fn(async () => undefined),
+  },
+}));
+
+import { pullFromSingleRepo } from '../src/services/RepoPullService';
+import { GitHubService } from '../src/services/GitHubService';
+import { StorageService } from '../src/services/StorageService';
+
+const buildNote = (overrides: Record<string, unknown>) => ({
+  id: 'n-' + Math.random().toString(36).slice(2),
+  title: 'note',
+  content: 'body',
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  ...overrides,
+});
+
+describe('RepoPullService notes reconciliation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([
+      { path: 'org/repo', branch: 'main' },
+    ]);
+  });
+
+  // The bug: pullNotesFromRepo previously short-circuited when the remote tree
+  // had zero matching note blobs, *before* reconciling local notes against the
+  // (empty) remote set. Result: every notes file deleted on the remote left
+  // its local copy lingering forever.
+  it('drops local notes when the remote tree has zero notes', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([
+      buildNote({
+        id: 'ghost',
+        title: 'Ghost',
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: 'notes/ghost.md',
+      }),
+    ]);
+
+    await pullFromSingleRepo('org/repo');
+
+    const saved = (StorageService.saveAllNotes as jest.Mock).mock.calls[0][0];
+    expect(saved.find((n: any) => n.id === 'ghost')).toBeUndefined();
+    expect(saved).toHaveLength(0);
+  });
+
+  it('drops local notes whose filePath disappeared but keeps siblings still present', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
+      { type: 'blob', path: 'notes/keep.md', sha: 'a' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue('# keep\n\nbody');
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([
+      buildNote({
+        id: 'keep',
+        title: 'keep',
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: 'notes/keep.md',
+      }),
+      buildNote({
+        id: 'gone',
+        title: 'gone',
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: 'notes/gone.md',
+      }),
+    ]);
+
+    await pullFromSingleRepo('org/repo');
+
+    const saved = (StorageService.saveAllNotes as jest.Mock).mock.calls[0][0];
+    expect(saved.map((n: any) => n.id).sort()).toEqual(['keep']);
+  });
+
+  // Pending uploads have no filePath until NoteSyncQueueService writes one
+  // back after a successful push. They must survive reconciliation regardless
+  // of the remote state, otherwise a pull racing a queued upload would erase
+  // the user's draft.
+  it('preserves local-only notes (no filePath) even when remote is empty', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([
+      buildNote({ id: 'draft', title: 'Draft', repo: 'org/repo', branch: 'main' }),
+      buildNote({ id: 'pure-local', title: 'Pure local' }),
+    ]);
+
+    await pullFromSingleRepo('org/repo');
+
+    const saved = (StorageService.saveAllNotes as jest.Mock).mock.calls[0][0];
+    expect(saved.map((n: any) => n.id).sort()).toEqual(['draft', 'pure-local']);
+  });
+
+  it('does not touch notes that belong to a different repo or branch', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([
+      buildNote({
+        id: 'other-repo',
+        repo: 'other/repo',
+        branch: 'main',
+        filePath: 'notes/x.md',
+      }),
+      buildNote({
+        id: 'other-branch',
+        repo: 'org/repo',
+        branch: 'develop',
+        filePath: 'notes/y.md',
+      }),
+    ]);
+
+    await pullFromSingleRepo('org/repo');
+
+    const saved = (StorageService.saveAllNotes as jest.Mock).mock.calls[0][0];
+    expect(saved.map((n: any) => n.id).sort()).toEqual(['other-branch', 'other-repo']);
+  });
+
+  // Transient API failure (auth/rate-limit/network) must NOT wipe local notes.
+  // The strict tree fetch throws, the outer try/catch returns 0, and saveAllNotes
+  // is never called.
+  it('skips reconciliation when the tree fetch throws (transient failure)', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockRejectedValue(
+      new Error('rate limited'),
+    );
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([
+      buildNote({
+        id: 'safe',
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: 'notes/safe.md',
+      }),
+    ]);
+
+    await pullFromSingleRepo('org/repo');
+
+    expect(StorageService.saveAllNotes).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/StorageBootstrap.test.ts
+++ b/__tests__/services/StorageBootstrap.test.ts
@@ -1,0 +1,62 @@
+jest.mock(
+  '@react-native-async-storage/async-storage',
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  bootstrapStorage,
+  clearBootCache,
+  getBootValue,
+} from '../../src/services/StorageBootstrap';
+import { StorageService } from '../../src/services/StorageService';
+
+beforeEach(async () => {
+  await AsyncStorage.clear?.();
+  clearBootCache();
+});
+
+describe('StorageBootstrap.getBootValue (consume-on-read)', () => {
+  it('returns the bootstrapped value the first time and undefined afterwards', async () => {
+    await AsyncStorage.setItem('@gitnotes:repos', '[{"id":"1","name":"r1","path":"a/r1"}]');
+    await bootstrapStorage();
+
+    const first = getBootValue('@gitnotes:repos');
+    expect(first).toBe('[{"id":"1","name":"r1","path":"a/r1"}]');
+
+    // Consume-on-read: a second hit must miss the cache so callers fall
+    // through to AsyncStorage, which is the only source that reflects writes
+    // performed after bootstrap.
+    const second = getBootValue('@gitnotes:repos');
+    expect(second).toBeUndefined();
+  });
+
+  it('returns undefined when bootstrap has not run', () => {
+    expect(getBootValue('@gitnotes:repos')).toBeUndefined();
+  });
+});
+
+describe('StorageService picks up writes after bootstrap', () => {
+  it('returns the latest repos list after addRepository, without restart', async () => {
+    // Simulate an app session that booted with one repo already saved.
+    await AsyncStorage.setItem(
+      '@gitnotes:repos',
+      JSON.stringify([{ id: '1', name: 'r1', path: 'org/r1' }]),
+    );
+    await bootstrapStorage();
+
+    // First read at startup hits the boot cache and returns r1.
+    const initial = await StorageService.getSavedRepositories();
+    expect(initial.map((r) => r.path)).toEqual(['org/r1']);
+
+    // User adds a second repo. AsyncStorage now holds both. Without
+    // consume-on-read, the next getSavedRepositories would still return the
+    // pre-bootstrap snapshot until app restart.
+    await StorageService.addRepository({ id: '2', name: 'r2', path: 'org/r2' });
+
+    const after = await StorageService.getSavedRepositories();
+    expect(after.map((r) => r.path).sort()).toEqual(['org/r1', 'org/r2']);
+  });
+});

--- a/__tests__/tag-persistence.test.ts
+++ b/__tests__/tag-persistence.test.ts
@@ -19,6 +19,7 @@ jest.mock('../src/services/GitHubService', () => ({
     updateFile: jest.fn(),
     getSavedRepositories: jest.fn(),
     getTreeRecursive: jest.fn(),
+    getTreeRecursiveOrThrow: jest.fn(),
     getFileContent: jest.fn(),
     getRepoContents: jest.fn(async () => []),
   },
@@ -73,7 +74,7 @@ describe('tag persistence', () => {
       { path: 'org/repo', branch: 'main' },
     ]);
     (StorageService.getAllNotes as jest.Mock).mockResolvedValue([]);
-    (GitHubService.getTreeRecursive as jest.Mock).mockResolvedValue([
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
       { type: 'blob', path: 'notes/my-note.md' },
     ]);
     (GitHubService.getFileContent as jest.Mock).mockResolvedValue(

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -296,21 +296,34 @@ class GitHubServiceClass {
     ref: string,
   ): Promise<{ path: string; type: 'blob' | 'tree'; sha: string; size?: number }[]> {
     try {
-      const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
-      const data = await this.request(url);
-      if (!Array.isArray(data?.tree)) return [];
-      return data.tree.map((item: any) => ({
-        path: item.path,
-        type: item.type,
-        sha: item.sha,
-        size: typeof item.size === 'number' ? item.size : undefined,
-      }));
+      return await this.getTreeRecursiveOrThrow(owner, repo, ref);
     } catch (error) {
       if (!isNotFound(error)) {
         console.warn('[GitHubService] Failed to get tree:', error);
       }
       return [];
     }
+  }
+
+  // Strict variant that lets the caller distinguish "tree fetched, repo has 0
+  // entries" (resolves to []) from "tree fetch failed" (throws). The swallowing
+  // `getTreeRecursive` returns [] for both cases, which is fine for display
+  // contexts but unsafe for reconciliation logic that uses the absence of a
+  // path as evidence the file was deleted on the remote.
+  async getTreeRecursiveOrThrow(
+    owner: string,
+    repo: string,
+    ref: string,
+  ): Promise<{ path: string; type: 'blob' | 'tree'; sha: string; size?: number }[]> {
+    const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
+    const data = await this.request(url);
+    if (!Array.isArray(data?.tree)) return [];
+    return data.tree.map((item: any) => ({
+      path: item.path,
+      type: item.type,
+      sha: item.sha,
+      size: typeof item.size === 'number' ? item.size : undefined,
+    }));
   }
 
   async getFileContent(

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -132,7 +132,12 @@ async function pullNotesFromRepo(
   branch: string,
 ): Promise<number> {
   try {
-    const tree = await GitHubService.getTreeRecursive(owner, repo, branch);
+    // Use the strict variant so an actual API failure (auth/rate-limit/network)
+    // throws and is caught below, returning early *without* running the
+    // reconciliation pass. A successful fetch that returns zero note blobs is
+    // authoritative — the user has deleted every notes file on the remote — and
+    // must run reconcile so local copies for this scope are dropped.
+    const tree = await GitHubService.getTreeRecursiveOrThrow(owner, repo, branch);
     const noteBlobs = tree.filter((item) => {
       if (item.type !== 'blob') return false;
       if (!item.path.startsWith('notes/')) return false;
@@ -140,8 +145,6 @@ async function pullNotesFromRepo(
       const ext = item.path.split('.').pop()?.toLowerCase();
       return NOTE_EXTS.includes(ext as (typeof NOTE_EXTS)[number]);
     });
-
-    if (noteBlobs.length === 0) return 0;
 
     const fetched = await fetchInBatches(
       noteBlobs,
@@ -244,10 +247,14 @@ async function pullNotesFromRepo(
     //   * Scoped to this (repoPath, branch) — never touches notes from other
     //     repos or branches.
     //   * Only deletes notes that have a `filePath` (i.e. originated from the
-    //     repo). Local-only drafts have no filePath and are preserved.
-    //   * The early return when `noteBlobs.length === 0` above acts as the
-    //     empty-tree guardrail: a transient empty/errored fetch skips
-    //     reconciliation entirely rather than wiping everything.
+    //     repo). Local-only drafts and pending uploads have no filePath until
+    //     `NoteSyncQueueService` writes one back after a successful push.
+    //   * Tree fetch uses the throwing `getTreeRecursiveOrThrow`, so we only
+    //     reach this point when the GitHub API responded successfully. An
+    //     empty `remoteFilePaths` means "the user actually deleted every note
+    //     on the remote," which is a legitimate signal to wipe local copies.
+    //     Transient failures throw and are caught below, returning 0 without
+    //     running this pass.
     const beforeCount = allNotes.length;
     allNotes = allNotes.filter((n) => {
       if (n.repo !== repoPath) return true;

--- a/src/services/StorageBootstrap.ts
+++ b/src/services/StorageBootstrap.ts
@@ -43,10 +43,24 @@ export async function bootstrapStorage(): Promise<Map<string, string | null>> {
 
 /**
  * Get a pre-loaded value from the bootstrap cache.
- * Returns undefined if bootstrap hasn't run or key wasn't requested.
+ *
+ * Consumes the entry on read: subsequent calls for the same key return
+ * `undefined`, and callers fall through to `AsyncStorage.getItem` which is
+ * authoritative. Without this, a write (e.g. adding a repo, saving canvases)
+ * would leave the boot cache holding a stale snapshot, and any later read
+ * within the same session would still see the pre-write value until app
+ * restart re-bootstrapped the cache.
+ *
+ * The point of bootCache is to amortize the cost of the very first read at
+ * app startup — once a key has been read once, the optimization has already
+ * paid off and keeping the entry around is purely a foot-gun.
  */
 export function getBootValue(key: StartupKey): string | null | undefined {
-  return bootCache?.get(key);
+  if (!bootCache) return undefined;
+  if (!bootCache.has(key)) return undefined;
+  const value = bootCache.get(key);
+  bootCache.delete(key);
+  return value;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two bugs that compound into the same user-visible symptom: stale local notes that don't exist anywhere on the remote, and added repos not appearing in the UI until app restart.

### 1. Notes reconciliation gate (`RepoPullService.pullNotesFromRepo`)

The empty-tree early return masked legitimate "user deleted all notes from remote" as if it were a transient fetch failure, so the reconciliation pass at the bottom of the function never ran. `getTreeRecursive` returns `[]` for **both** "tree fetched, 0 notes" and "tree fetch failed (auth/rate-limit/network)" — conflating the two meant ghost notes lingered forever.

Added `GitHubService.getTreeRecursiveOrThrow` — same shape, rethrows API errors instead of swallowing into `[]`. `pullNotesFromRepo` swaps to the strict variant and drops the empty-tree gate so reconcile runs on legit-empty too. The existing outer `try/catch` keeps transient failures from triggering the wipe pass.

The swallowing `getTreeRecursive` is preserved for display-side callers (`RepoFileBrowser`, `ContextPickerModal`, `useGitHubTree`, `GitService`) where empty-on-failure is the correct UX.

### 2. Boot cache staleness (`StorageBootstrap.getBootValue`)

`bootCache` is populated once per session via `AsyncStorage.multiGet(STARTUP_KEYS)` and was never invalidated. `StorageService.getSavedRepositories` (and the analogous canvases/todos/folders readers) all do `getBootValue(...) ?? AsyncStorage.getItem(...)`, so any write that landed in AsyncStorage after bootstrap was masked by the still-warm boot cache until the next app restart.

Visible symptom: adding a second repo from Settings persisted to AsyncStorage, but `repoStore.addRepository` then re-read via `getSavedRepositories`, hit the stale boot value, and dispatched the **pre-write** list back into Zustand. New repo only appeared after restart.

Changed `getBootValue` to consume the entry on read. First reader at app start gets the cheap cached path (the whole reason the cache exists); a second hit returns `undefined` so callers fall through to AsyncStorage, which is always authoritative. Side-effect: same fix covers `@gitnotes:canvases`, `@gitnotes:todos`, `@gitnotes:folders` — none confirmed-broken in the field, but identical latent staleness.

## Tests

- `__tests__/notes-pull-reconcile.test.ts`: empty-tree drops ghosts; `filePath`-less drafts and pending uploads survive; cross-repo / cross-branch notes untouched; transient fetch failure skips wipe.
- `__tests__/services/StorageBootstrap.test.ts`: `getBootValue` returns the value once then misses; `addRepository` → `getSavedRepositories` reflects the new list without restart.
- Updated existing pull-path tests (`tag-persistence`, `note-color-coding`, `canvas-race`) to mock the new `getTreeRecursiveOrThrow` alongside `getTreeRecursive`.

53 suites / 338 tests pass; `yarn ts:check` clean.

## Test plan

- [ ] Add a notes file to a configured repo from the GitHub web UI; pull-to-refresh on the Notes screen → note appears.
- [ ] Delete that file from the GitHub web UI; pull-to-refresh → local note disappears.
- [ ] Delete **every** notes file from the repo on GitHub; pull-to-refresh → all local notes for that scope disappear (this is the regression case).
- [ ] Toggle airplane mode, pull-to-refresh → local notes preserved (no reconcile when fetch throws).
- [ ] Settings → add a second repo. The new repo appears in the Notes/Todos/Canvases pickers immediately, no restart needed.
- [ ] Create a local-only note (not yet synced to a repo); pull-to-refresh → draft survives even when the targeted repo has no notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)