### PR TITLE
fix(ui): drop RepoFileTree's own surface background

### DIFF
--- a/__tests__/file-tree-bg.test.tsx
+++ b/__tests__/file-tree-bg.test.tsx
@@ -58,7 +58,11 @@ const isBlackBg = (value: unknown) =>
   value === '#000' || value === '#000000' || value === 'black';
 
 describe('file tree backgrounds', () => {
-  it('uses theme colors instead of black backgrounds', async () => {
+  // The tree used to paint `colors.surface` as its own background, which
+  // produced a visible step against the screen's background on Explore.
+  // The tree is now expected to inherit the parent screen background — no
+  // explicit `backgroundColor` of its own, no opaque black either.
+  it('does not paint its own background, letting the parent show through', async () => {
     const screen = render(<RepoFileTree owner="acme" repo="notes" />);
 
     await waitFor(() => expect(screen.queryAllByText('notes.md').length).toBeGreaterThan(0));
@@ -66,7 +70,7 @@ describe('file tree backgrounds', () => {
     const root = screen.getByTestId('repo-file-tree-root');
     const styles = StyleSheet.flatten(root.props.style);
 
+    expect(styles?.backgroundColor).toBeUndefined();
     expect(isBlackBg(styles?.backgroundColor)).toBe(false);
-    expect(styles?.backgroundColor).toBe('#222222');
   });
 });

--- a/src/components/RepoFileTree.tsx
+++ b/src/components/RepoFileTree.tsx
@@ -687,7 +687,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (loading) {
     return (
-      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
+      <View style={[treeStyles.center]}>
         <ActivityIndicator size="large" color={colors.primary} />
         <Text style={[treeStyles.loadingText, { color: colors.textSecondary }]}>
           Loading file tree…
@@ -698,7 +698,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (error) {
     return (
-      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
+      <View style={[treeStyles.center]}>
         <Ionicons name="alert-circle-outline" size={40} color={colors.textSecondary} />
         <Text style={[treeStyles.emptyText, { color: colors.text }]}>Failed to load</Text>
         <Button variant="secondary" label="Retry" onPress={loadRoot} style={{ marginTop: 8 }} />
@@ -708,7 +708,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
 
   if (rootItems.length === 0) {
     return (
-      <View style={[treeStyles.center, { backgroundColor: colors.surface }]}>
+      <View style={[treeStyles.center]}>
         <Ionicons name="folder-open-outline" size={40} color={colors.textSecondary} />
         <Text style={[treeStyles.emptyText, { color: colors.text }]}>Empty Repository</Text>
         <Text style={[treeStyles.emptySub, { color: colors.textSecondary }]}>
@@ -719,7 +719,7 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
   }
 
   return (
-    <View testID="repo-file-tree-root" style={{ flex: 1, backgroundColor: colors.surface }}>
+    <View testID="repo-file-tree-root" style={{ flex: 1 }}>
       {rootItems.map((item) => (
         <TreeItem
           key={item.path}


### PR DESCRIPTION
## Summary

`RepoFileTree` painted `colors.surface` on its root + on its loading/error/empty states. On Explore, the tree sits inside a screen that already has its own background, so the surface fill produced a visible step between the screen background and the tree list — most obvious in dark mode where the screen is near-black and surface is a slightly-lighter dark.

Dropping the explicit `backgroundColor` from those four call sites lets the tree inherit the parent screen background and render flush with it. Selected-row highlights still come from `colors.primary + '15'` on `TreeItem`, so removing the underlying surface doesn't disturb selection visuals.

## Tests

Updated `__tests__/file-tree-bg.test.tsx`. Prior contract was "must be theme.surface, not opaque black" (added when we last fixed a black-bg regression). New contract: "no explicit `backgroundColor` at all" — which is what the UI fix encodes.

51 suites / 330 tests pass; `yarn ts:check` clean.

## Test plan

- [ ] Open Explore → pick a repo → confirm the tree list sits flush with the page background (no visible color step at the top of the list or around the loading/error/empty states).
- [ ] Light mode and dark mode both look right.
- [ ] Selected row highlight still visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)