### PR TITLE
fix(notes): bust FlashList cell layout when display count changes

### DIFF
--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -967,6 +967,13 @@ export default function NotesListScreen() {
         renderItem={getRenderItem()}
         keyExtractor={keyExtractor}
         key={viewMode}
+        // Bust FlashList's cached cell layouts when the visible note count
+        // changes (filter/search/delete shrink the list). Without this, the
+        // recycler keeps stale row geometry for vacated indexes — top rows
+        // can leave phantom slots behind, and the surviving rows can render
+        // outside the viewport until the user scrolls. Same fix the Todo
+        // screen carries for #490 / #505.
+        extraData={displayNotes.length}
         {...getListLayout()}
         contentContainerStyle={{ ...getListContentStyle(), paddingBottom: tabBarHeight + 16 }}
         refreshControl={


### PR DESCRIPTION
## Summary

`NotesListScreen`'s FlashList was missing `extraData`, so its recycler held onto cached row geometry whenever the visible note count shrank — toggling a filter, typing in search, or deleting the top row left phantom slots behind, and surviving rows could end up rendered above the viewport's top edge until the user scrolled.

Pass \`extraData={displayNotes.length}\` so each shrink invalidates the cached layout. Same fix Todo screen carries from #505 — Notes never picked it up because the original Todo regression was scoped to swipe-delete and we hadn't reproduced it under filter toggles on Notes yet.

### Other FlashList instances audited

- \`TodoListScreen\` — already passes \`extraData={filteredTodos.length}\` (#505).
- \`CanvasListScreen\` — uses RN's \`FlatList\`, not \`FlashList\`. It doesn't share the recycler-stale-layout class of bug, so no change is needed.

## Tests

53 suites / 338 tests pass; \`yarn ts:check\` clean. (No new test — Todo's #505 didn't add one for the same prop, and verifying \`extraData\` behavior at the recycler level requires gesture-driven integration that the suite doesn't cover today.)

## Test plan

- [ ] Notes screen with several notes; toggle the repo/folder/format filter so the list shrinks → no phantom slot, no rows hidden above the top of the viewport.
- [ ] Type in search to shrink the list down to one match → list reflows tightly with no leading whitespace.
- [ ] Swipe-delete the top note → next note slides up into the freed slot, no gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)