### PR TITLE
feat(templates): persist custom templates to repo /templates folder (#508)

### DIFF
--- a/__tests__/custom-templates.test.ts
+++ b/__tests__/custom-templates.test.ts
@@ -6,6 +6,14 @@ jest.mock('@react-native-community/netinfo', () => ({
   },
 }));
 
+jest.mock('../src/services/TemplateRepoPreferenceService', () => ({
+  TemplateRepoPreferenceService: { get: jest.fn(async () => null) },
+}));
+jest.mock('../src/services/TemplateGitHubSyncService', () => ({
+  syncTemplateToGitHub: jest.fn(async () => ({ success: true })),
+  deleteTemplateFromGitHub: jest.fn(async () => ({ success: true })),
+}));
+
 jest.mock('../src/services/StorageService', () => ({
   StorageService: {
     loadCustomTemplates: jest.fn(async () => []),

--- a/__tests__/template-github-sync.test.ts
+++ b/__tests__/template-github-sync.test.ts
@@ -1,0 +1,82 @@
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    updateFile: jest.fn(async () => ({ content: { sha: 'abc' }, commit: { sha: 'xyz' } })),
+    deleteFile: jest.fn(async () => ({ commit: { sha: 'del' } })),
+    getFileSha: jest.fn(async () => 'abc'),
+  },
+}));
+
+import { GitHubService } from '../src/services/GitHubService';
+import {
+  syncTemplateToGitHub,
+  deleteTemplateFromGitHub,
+} from '../src/services/TemplateGitHubSyncService';
+
+const baseTemplate = {
+  id: 'custom-abc',
+  name: 'Sprint Retro',
+  icon: 'clipboard-outline' as const,
+  description: '',
+  content: '## body\n',
+  tags: [],
+  isCustom: true,
+};
+
+describe('TemplateGitHubSyncService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('syncTemplateToGitHub builds the path from the slug when no filePath is set', async () => {
+    const result = await syncTemplateToGitHub({
+      repoPath: 'me/repo',
+      branch: 'main',
+      template: baseTemplate,
+    });
+    expect(result.success).toBe(true);
+    expect(result.filePath).toBe('templates/sprint-retro.md');
+    expect(GitHubService.updateFile).toHaveBeenCalledWith(
+      'me', 'repo', 'templates/sprint-retro.md',
+      expect.stringContaining('name: Sprint Retro'),
+      expect.stringContaining('Add template'),
+      'main',
+      undefined,
+    );
+  });
+
+  test('syncTemplateToGitHub reuses filePath on update', async () => {
+    await syncTemplateToGitHub({
+      repoPath: 'me/repo',
+      branch: 'main',
+      template: { ...baseTemplate, filePath: 'templates/sprint-retro.md' },
+    });
+    expect(GitHubService.updateFile).toHaveBeenCalledWith(
+      'me', 'repo', 'templates/sprint-retro.md',
+      expect.any(String),
+      expect.stringContaining('Update template'),
+      'main',
+      undefined,
+    );
+  });
+
+  test('deleteTemplateFromGitHub fetches sha when one is not supplied', async () => {
+    const result = await deleteTemplateFromGitHub({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: 'templates/sprint-retro.md',
+      name: 'Sprint Retro',
+    });
+    expect(result.success).toBe(true);
+    expect(GitHubService.getFileSha).toHaveBeenCalled();
+    expect(GitHubService.deleteFile).toHaveBeenCalled();
+  });
+
+  test('returns failure when GitHub is not authenticated', async () => {
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValueOnce(false);
+    const result = await syncTemplateToGitHub({
+      repoPath: 'me/repo',
+      branch: 'main',
+      template: baseTemplate,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/__tests__/template-markdown.test.ts
+++ b/__tests__/template-markdown.test.ts
@@ -1,0 +1,63 @@
+import {
+  serializeTemplate,
+  parseTemplateMarkdown,
+  templateSlug,
+} from '../src/services/TemplateMarkdownService';
+import type { NoteTemplate } from '../src/services/TemplateService';
+
+const t: NoteTemplate = {
+  id: 'custom-abc',
+  name: 'Sprint Retro',
+  icon: 'clipboard-outline',
+  description: 'Retrospective notes',
+  title: 'Retro - ',
+  content: '## What went well\n- \n',
+  tags: ['retro', 'team'],
+  isCustom: true,
+  createdAt: 1714780000000,
+  updatedAt: 1714780000000,
+};
+
+describe('TemplateMarkdownService', () => {
+  test('templateSlug produces a kebab-case filename stem', () => {
+    expect(templateSlug('Sprint Retro')).toBe('sprint-retro');
+    expect(templateSlug('  Hello / World!  ')).toBe('hello-world');
+    expect(templateSlug('')).toBe('untitled');
+  });
+
+  test('serializeTemplate writes YAML frontmatter then body', () => {
+    const md = serializeTemplate(t);
+    expect(md.startsWith('---\n')).toBe(true);
+    expect(md).toContain('name: Sprint Retro');
+    expect(md).toContain('icon: clipboard-outline');
+    expect(md).toContain('tags: [retro, team]');
+    expect(md).toContain("title: 'Retro - '");
+    expect(md.endsWith('## What went well\n- \n')).toBe(true);
+  });
+
+  test('parseTemplateMarkdown round-trips serializeTemplate', () => {
+    const md = serializeTemplate(t);
+    const parsed = parseTemplateMarkdown('templates/sprint-retro.md', md);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.id).toBe('custom-abc');
+    expect(parsed!.name).toBe('Sprint Retro');
+    expect(parsed!.icon).toBe('clipboard-outline');
+    expect(parsed!.tags).toEqual(['retro', 'team']);
+    expect(parsed!.title).toBe('Retro - ');
+    expect(parsed!.content).toBe('## What went well\n- \n');
+    expect(parsed!.filePath).toBe('templates/sprint-retro.md');
+    expect(parsed!.isCustom).toBe(true);
+  });
+
+  test('parseTemplateMarkdown returns null when no frontmatter', () => {
+    expect(parseTemplateMarkdown('templates/x.md', 'no frontmatter here')).toBeNull();
+  });
+
+  test('parseTemplateMarkdown derives id+name from filename when frontmatter omits them', () => {
+    const md = '---\nicon: document-outline\n---\n\nhello\n';
+    const parsed = parseTemplateMarkdown('templates/my-template.md', md);
+    expect(parsed!.name).toBe('my template');
+    expect(parsed!.id).toMatch(/^custom-/);
+    expect(parsed!.content).toBe('hello\n');
+  });
+});

--- a/__tests__/template-repo-preference.test.ts
+++ b/__tests__/template-repo-preference.test.ts
@@ -1,0 +1,33 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TemplateRepoPreferenceService } from '../src/services/TemplateRepoPreferenceService';
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (k: string) => store[k] ?? null),
+      setItem: jest.fn(async (k: string, v: string) => { store[k] = v; }),
+      removeItem: jest.fn(async (k: string) => { delete store[k]; }),
+    },
+  };
+});
+
+describe('TemplateRepoPreferenceService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('returns null when unset', async () => {
+    expect(await TemplateRepoPreferenceService.get()).toBeNull();
+  });
+
+  test('round-trips repoPath + branch', async () => {
+    await TemplateRepoPreferenceService.set({ repoPath: 'me/repo', branch: 'main' });
+    expect(await TemplateRepoPreferenceService.get()).toEqual({ repoPath: 'me/repo', branch: 'main' });
+  });
+
+  test('clear removes the pointer', async () => {
+    await TemplateRepoPreferenceService.set({ repoPath: 'me/repo', branch: 'main' });
+    await TemplateRepoPreferenceService.clear();
+    expect(await TemplateRepoPreferenceService.get()).toBeNull();
+  });
+});

--- a/__tests__/template-repo-preference.test.ts
+++ b/__tests__/template-repo-preference.test.ts
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { TemplateRepoPreferenceService } from '../src/services/TemplateRepoPreferenceService';
 
 jest.mock('@react-native-async-storage/async-storage', () => {

--- a/__tests__/template-repo-sync.test.ts
+++ b/__tests__/template-repo-sync.test.ts
@@ -1,0 +1,60 @@
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    loadCustomTemplates: jest.fn(async () => []),
+    loadTemplatePins: jest.fn(async () => []),
+    saveCustomTemplates: jest.fn(async () => undefined),
+    saveTemplatePins: jest.fn(async () => undefined),
+  },
+}));
+jest.mock('../src/services/TemplateRepoPreferenceService', () => ({
+  TemplateRepoPreferenceService: {
+    get: jest.fn(async () => ({ repoPath: 'me/repo', branch: 'main' })),
+  },
+}));
+const mockSyncTemplateToGitHub = jest.fn(async () => ({ success: true, filePath: 'templates/x.md' }));
+const mockDeleteTemplateFromGitHub = jest.fn(async () => ({ success: true }));
+jest.mock('../src/services/TemplateGitHubSyncService', () => ({
+  syncTemplateToGitHub: (...a: any[]) => mockSyncTemplateToGitHub(...a),
+  deleteTemplateFromGitHub: (...a: any[]) => mockDeleteTemplateFromGitHub(...a),
+}));
+
+import { useTemplateStore } from '../src/stores/templateStore';
+
+describe('templateStore repo sync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useTemplateStore.setState({ customTemplates: [], pinnedIds: [], isLoading: false });
+  });
+
+  test('createTemplate writes to GitHub and stores returned filePath', async () => {
+    const t = await useTemplateStore.getState().createTemplate({
+      name: 'X', icon: 'document-outline', description: '', content: 'body', tags: [],
+    });
+    expect(mockSyncTemplateToGitHub).toHaveBeenCalledTimes(1);
+    expect(useTemplateStore.getState().customTemplates[0].filePath).toBe('templates/x.md');
+    expect(t.filePath).toBe('templates/x.md');
+  });
+
+  test('updateTemplate calls sync with merged template', async () => {
+    await useTemplateStore.getState().createTemplate({
+      name: 'X', icon: 'document-outline', description: '', content: 'body', tags: [],
+    });
+    mockSyncTemplateToGitHub.mockClear();
+    const id = useTemplateStore.getState().customTemplates[0].id;
+    await useTemplateStore.getState().updateTemplate(id, { content: 'new body' });
+    expect(mockSyncTemplateToGitHub).toHaveBeenCalledTimes(1);
+    const arg = mockSyncTemplateToGitHub.mock.calls[0][0];
+    expect(arg.template.content).toBe('new body');
+  });
+
+  test('deleteTemplate calls deleteTemplateFromGitHub when filePath is known', async () => {
+    await useTemplateStore.getState().createTemplate({
+      name: 'X', icon: 'document-outline', description: '', content: 'body', tags: [],
+    });
+    const id = useTemplateStore.getState().customTemplates[0].id;
+    await useTemplateStore.getState().deleteTemplate(id);
+    expect(mockDeleteTemplateFromGitHub).toHaveBeenCalledWith(expect.objectContaining({
+      repoPath: 'me/repo', branch: 'main', filePath: 'templates/x.md', name: 'X',
+    }));
+  });
+});

--- a/__tests__/template-repo-sync.test.ts
+++ b/__tests__/template-repo-sync.test.ts
@@ -11,8 +11,8 @@ jest.mock('../src/services/TemplateRepoPreferenceService', () => ({
     get: jest.fn(async () => ({ repoPath: 'me/repo', branch: 'main' })),
   },
 }));
-const mockSyncTemplateToGitHub = jest.fn(async () => ({ success: true, filePath: 'templates/x.md' }));
-const mockDeleteTemplateFromGitHub = jest.fn(async () => ({ success: true }));
+const mockSyncTemplateToGitHub = jest.fn(async (..._args: any[]) => ({ success: true, filePath: 'templates/x.md' }));
+const mockDeleteTemplateFromGitHub = jest.fn(async (..._args: any[]) => ({ success: true }));
 jest.mock('../src/services/TemplateGitHubSyncService', () => ({
   syncTemplateToGitHub: (...a: any[]) => mockSyncTemplateToGitHub(...a),
   deleteTemplateFromGitHub: (...a: any[]) => mockDeleteTemplateFromGitHub(...a),

--- a/__tests__/template-repo-sync.test.ts
+++ b/__tests__/template-repo-sync.test.ts
@@ -11,8 +11,9 @@ jest.mock('../src/services/TemplateRepoPreferenceService', () => ({
     get: jest.fn(async () => ({ repoPath: 'me/repo', branch: 'main' })),
   },
 }));
-const mockSyncTemplateToGitHub = jest.fn(async (..._args: any[]) => ({ success: true, filePath: 'templates/x.md' }));
-const mockDeleteTemplateFromGitHub = jest.fn(async (..._args: any[]) => ({ success: true }));
+type SyncResult = { success: boolean; filePath?: string; error?: string };
+const mockSyncTemplateToGitHub = jest.fn(async (..._args: any[]): Promise<SyncResult> => ({ success: true, filePath: 'templates/x.md' }));
+const mockDeleteTemplateFromGitHub = jest.fn(async (..._args: any[]): Promise<SyncResult> => ({ success: true }));
 jest.mock('../src/services/TemplateGitHubSyncService', () => ({
   syncTemplateToGitHub: (...a: any[]) => mockSyncTemplateToGitHub(...a),
   deleteTemplateFromGitHub: (...a: any[]) => mockDeleteTemplateFromGitHub(...a),
@@ -56,5 +57,19 @@ describe('templateStore repo sync', () => {
     expect(mockDeleteTemplateFromGitHub).toHaveBeenCalledWith(expect.objectContaining({
       repoPath: 'me/repo', branch: 'main', filePath: 'templates/x.md', name: 'X',
     }));
+  });
+
+  test('createTemplate persists locally without filePath when sync fails', async () => {
+    mockSyncTemplateToGitHub.mockResolvedValueOnce({ success: false, error: 'GitHub unavailable' });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const t = await useTemplateStore.getState().createTemplate({
+      name: 'Y', icon: 'document-outline', description: '', content: 'body', tags: [],
+    });
+    expect(t.filePath).toBeUndefined();
+    expect(useTemplateStore.getState().customTemplates).toHaveLength(1);
+    expect(useTemplateStore.getState().customTemplates[0].filePath).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Failed to sync template'));
+    warn.mockRestore();
   });
 });

--- a/__tests__/templates-pull.test.ts
+++ b/__tests__/templates-pull.test.ts
@@ -1,0 +1,73 @@
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getTreeRecursiveOrThrow: jest.fn(),
+    getFileContent: jest.fn(),
+  },
+}));
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    loadCustomTemplates: jest.fn(async () => []),
+    saveCustomTemplates: jest.fn(async () => undefined),
+  },
+}));
+jest.mock('../src/services/TemplateRepoPreferenceService', () => ({
+  TemplateRepoPreferenceService: {
+    get: jest.fn(async () => ({ repoPath: 'me/repo', branch: 'main' })),
+  },
+}));
+
+import { GitHubService } from '../src/services/GitHubService';
+import { StorageService } from '../src/services/StorageService';
+import { pullTemplatesFromConfiguredRepo } from '../src/services/RepoPullService';
+
+describe('pullTemplatesFromConfiguredRepo', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('inserts a template fetched from templates/<slug>.md', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
+      { type: 'blob', path: 'templates/sprint-retro.md', sha: 's1' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue(
+      '---\nid: custom-abc\nname: Sprint Retro\nicon: clipboard-outline\ntags: [retro]\n---\n\nbody\n',
+    );
+
+    const pulled = await pullTemplatesFromConfiguredRepo();
+    expect(pulled).toBe(1);
+    expect(StorageService.saveCustomTemplates).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({
+        id: 'custom-abc', name: 'Sprint Retro', filePath: 'templates/sprint-retro.md',
+      })]),
+    );
+  });
+
+  test('reconciles a deleted remote file by removing the local entry', async () => {
+    (StorageService.loadCustomTemplates as jest.Mock).mockResolvedValueOnce([
+      { id: 'custom-abc', name: 'Old', icon: 'document-outline', description: '', content: '', tags: [], isCustom: true, filePath: 'templates/old.md' },
+    ]);
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue(null);
+
+    await pullTemplatesFromConfiguredRepo();
+    const lastSaveArgs = (StorageService.saveCustomTemplates as jest.Mock).mock.calls.at(-1)![0];
+    expect(lastSaveArgs.find((t: any) => t.id === 'custom-abc')).toBeUndefined();
+  });
+
+  test('preserves a local-only custom template (no filePath)', async () => {
+    (StorageService.loadCustomTemplates as jest.Mock).mockResolvedValueOnce([
+      { id: 'custom-local', name: 'Local Only', icon: 'document-outline', description: '', content: '', tags: [], isCustom: true },
+    ]);
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue(null);
+
+    await pullTemplatesFromConfiguredRepo();
+    const lastSaveArgs = (StorageService.saveCustomTemplates as jest.Mock).mock.calls.at(-1)![0];
+    expect(lastSaveArgs.find((t: any) => t.id === 'custom-local')).toBeDefined();
+  });
+
+  test('returns 0 when no templates repo is configured', async () => {
+    const { TemplateRepoPreferenceService } = require('../src/services/TemplateRepoPreferenceService');
+    (TemplateRepoPreferenceService.get as jest.Mock).mockResolvedValueOnce(null);
+    expect(await pullTemplatesFromConfiguredRepo()).toBe(0);
+  });
+});

--- a/__tests__/templates-pull.test.ts
+++ b/__tests__/templates-pull.test.ts
@@ -49,7 +49,8 @@ describe('pullTemplatesFromConfiguredRepo', () => {
     (GitHubService.getFileContent as jest.Mock).mockResolvedValue(null);
 
     await pullTemplatesFromConfiguredRepo();
-    const lastSaveArgs = (StorageService.saveCustomTemplates as jest.Mock).mock.calls.at(-1)![0];
+    const calls = (StorageService.saveCustomTemplates as jest.Mock).mock.calls;
+    const lastSaveArgs = calls[calls.length - 1][0];
     expect(lastSaveArgs.find((t: any) => t.id === 'custom-abc')).toBeUndefined();
   });
 
@@ -61,7 +62,8 @@ describe('pullTemplatesFromConfiguredRepo', () => {
     (GitHubService.getFileContent as jest.Mock).mockResolvedValue(null);
 
     await pullTemplatesFromConfiguredRepo();
-    const lastSaveArgs = (StorageService.saveCustomTemplates as jest.Mock).mock.calls.at(-1)![0];
+    const calls = (StorageService.saveCustomTemplates as jest.Mock).mock.calls;
+    const lastSaveArgs = calls[calls.length - 1][0];
     expect(lastSaveArgs.find((t: any) => t.id === 'custom-local')).toBeDefined();
   });
 

--- a/__tests__/templates-pull.test.ts
+++ b/__tests__/templates-pull.test.ts
@@ -67,6 +67,18 @@ describe('pullTemplatesFromConfiguredRepo', () => {
     expect(lastSaveArgs.find((t: any) => t.id === 'custom-local')).toBeDefined();
   });
 
+  test('preserves repo-backed locals when getTreeRecursiveOrThrow throws (transient API failure)', async () => {
+    (StorageService.loadCustomTemplates as jest.Mock).mockResolvedValueOnce([
+      { id: 'custom-keep', name: 'Keep', icon: 'document-outline', description: '', content: '', tags: [], isCustom: true, filePath: 'templates/keep.md' },
+    ]);
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockRejectedValueOnce(new Error('network'));
+
+    const pulled = await pullTemplatesFromConfiguredRepo();
+    expect(pulled).toBe(0);
+    // Save must NOT have been called — local entries survive
+    expect(StorageService.saveCustomTemplates).not.toHaveBeenCalled();
+  });
+
   test('returns 0 when no templates repo is configured', async () => {
     const { TemplateRepoPreferenceService } = require('../src/services/TemplateRepoPreferenceService');
     (TemplateRepoPreferenceService.get as jest.Mock).mockResolvedValueOnce(null);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -160,7 +160,11 @@ export default function SettingsScreen() {
     } finally {
       setIsSyncingExistingTemplates(false);
     }
-    HapticService.success();
+    if (failed === 0) {
+      HapticService.success();
+    } else {
+      HapticService.error();
+    }
     Alert.alert(
       'Done',
       failed === 0

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
@@ -26,6 +26,7 @@ import { GitRepository } from '../services/GitService';
 import { GitHubService, GitHubRepository } from '../services/GitHubService';
 import { RepoFileSyncService } from '../services/RepoFileSyncService';
 import { pullFromSingleRepo } from '../services/RepoPullService';
+import { TemplateRepoPreferenceService, TemplateRepoPreference } from '../services/TemplateRepoPreferenceService';
 import { useCanvases } from '../contexts/CanvasContext';
 import { useTodos } from '../contexts/TodoContext';
 import { OnboardingService } from '../services/OnboardingService';
@@ -105,6 +106,28 @@ export default function SettingsScreen() {
   }, [tokenInput]);
 
   const [syncingRepo, setSyncingRepo] = useState<string | null>(null);
+
+  const [templatesRepoPref, setTemplatesRepoPref] = useState<TemplateRepoPreference | null>(null);
+  const [showTemplatesRepoPicker, setShowTemplatesRepoPicker] = useState(false);
+
+  useEffect(() => {
+    TemplateRepoPreferenceService.get().then(setTemplatesRepoPref);
+  }, []);
+
+  const handlePickTemplatesRepo = useCallback(async (repo: GitRepository) => {
+    const branch = repo.branch || 'main';
+    const next = { repoPath: repo.path, branch };
+    await TemplateRepoPreferenceService.set(next);
+    setTemplatesRepoPref(next);
+    setShowTemplatesRepoPicker(false);
+    HapticService.success();
+  }, []);
+
+  const handleClearTemplatesRepo = useCallback(async () => {
+    await TemplateRepoPreferenceService.clear();
+    setTemplatesRepoPref(null);
+    HapticService.success();
+  }, []);
 
   const selectedModelName = providers
     .flatMap((provider) => provider.models)
@@ -519,6 +542,38 @@ export default function SettingsScreen() {
           </TouchableOpacity>
         </View>
 
+        {/* ── Templates ── */}
+        <View style={[styles.section, { backgroundColor: colors.surface }]}>
+          <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Templates</Text>
+
+          <TouchableOpacity
+            testID="templates-repo-picker-row"
+            style={[styles.settingItem, { borderBottomColor: colors.border }]}
+            onPress={() => setShowTemplatesRepoPicker(true)}
+          >
+            <View style={styles.settingLeft}>
+              <Ionicons name="document-text-outline" size={20} color={colors.text} />
+              <View style={{ marginLeft: 12, flexShrink: 1 }}>
+                <Text style={[styles.settingLabel, { color: colors.text }]}>Templates repository</Text>
+                <Text style={[styles.settingValue ?? { fontSize: 12, marginTop: 2 }, { color: colors.textSecondary }]} numberOfLines={1}>
+                  {templatesRepoPref ? `${templatesRepoPref.repoPath}@${templatesRepoPref.branch}` : 'Not set'}
+                </Text>
+              </View>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
+          </TouchableOpacity>
+
+          {templatesRepoPref ? (
+            <TouchableOpacity
+              testID="templates-repo-clear"
+              style={[styles.settingItem, { borderBottomColor: colors.border }]}
+              onPress={handleClearTemplatesRepo}
+            >
+              <Text style={[styles.settingLabel, { color: colors.error }]}>Disconnect templates repo</Text>
+            </TouchableOpacity>
+          ) : null}
+        </View>
+
         {/* ── Note rendering ── */}
         <View style={[styles.section, { backgroundColor: colors.surface }]}>
           <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Note rendering</Text>
@@ -763,6 +818,48 @@ export default function SettingsScreen() {
                     );
                   })()}
                 </>
+              )}
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+
+      {/* Templates repo picker modal */}
+      <Modal visible={showTemplatesRepoPicker} transparent animationType="slide">
+        <View style={styles.modalOverlay}>
+          <View style={[styles.modalSheet, { backgroundColor: colors.surface }]}>
+            <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
+              <Text style={[styles.modalTitle, { color: colors.text }]}>Templates repository</Text>
+              <TouchableOpacity onPress={() => setShowTemplatesRepoPicker(false)}>
+                <Ionicons name="close" size={24} color={colors.textSecondary} />
+              </TouchableOpacity>
+            </View>
+            <ScrollView keyboardShouldPersistTaps="handled">
+              {repositories.length === 0 ? (
+                <Text style={[styles.pickerEmpty, { color: colors.textSecondary }]}>
+                  Add a repository first under Repositories to choose it as the templates repo.
+                </Text>
+              ) : (
+                repositories.map((repo) => {
+                  const selected = templatesRepoPref?.repoPath === repo.path;
+                  return (
+                    <TouchableOpacity
+                      key={repo.id}
+                      testID={`templates-repo-option-${repo.path}`}
+                      style={[styles.pickerItem, { borderBottomColor: colors.border }]}
+                      onPress={() => handlePickTemplatesRepo(repo)}
+                    >
+                      <Ionicons name="git-branch-outline" size={18} color={colors.primary} />
+                      <View style={styles.pickerItemInfo}>
+                        <Text style={[styles.pickerItemName, { color: colors.text }]} numberOfLines={1}>{repo.path}</Text>
+                        <Text style={[styles.pickerItemDesc, { color: colors.textSecondary }]} numberOfLines={1}>
+                          Branch: {repo.branch || 'main'}
+                        </Text>
+                      </View>
+                      {selected ? <Ionicons name="checkmark-circle" size={18} color={colors.primary} /> : null}
+                    </TouchableOpacity>
+                  );
+                })
               )}
             </ScrollView>
           </View>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -27,6 +27,8 @@ import { GitHubService, GitHubRepository } from '../services/GitHubService';
 import { RepoFileSyncService } from '../services/RepoFileSyncService';
 import { pullFromSingleRepo } from '../services/RepoPullService';
 import { TemplateRepoPreferenceService, TemplateRepoPreference } from '../services/TemplateRepoPreferenceService';
+import { syncTemplateToGitHub } from '../services/TemplateGitHubSyncService';
+import { useTemplateStore } from '../stores/templateStore';
 import { useCanvases } from '../contexts/CanvasContext';
 import { useTodos } from '../contexts/TodoContext';
 import { OnboardingService } from '../services/OnboardingService';
@@ -128,6 +130,44 @@ export default function SettingsScreen() {
     setTemplatesRepoPref(null);
     HapticService.success();
   }, []);
+
+  const [isSyncingExistingTemplates, setIsSyncingExistingTemplates] = useState(false);
+  const handleSyncExistingTemplates = useCallback(async () => {
+    if (!templatesRepoPref) return;
+    const customs = useTemplateStore.getState().customTemplates;
+    const unsynced = customs.filter((t) => !t.filePath);
+    if (unsynced.length === 0) {
+      Alert.alert('Nothing to sync', 'All custom templates are already in the templates repo.');
+      return;
+    }
+    setIsSyncingExistingTemplates(true);
+    let synced = 0;
+    let failed = 0;
+    try {
+      for (const t of unsynced) {
+        const res = await syncTemplateToGitHub({
+          repoPath: templatesRepoPref.repoPath,
+          branch: templatesRepoPref.branch,
+          template: t,
+        });
+        if (res.success && res.filePath) {
+          await useTemplateStore.getState().updateTemplate(t.id, { filePath: res.filePath });
+          synced++;
+        } else {
+          failed++;
+        }
+      }
+    } finally {
+      setIsSyncingExistingTemplates(false);
+    }
+    HapticService.success();
+    Alert.alert(
+      'Done',
+      failed === 0
+        ? `Synced ${synced} template(s) to ${templatesRepoPref.repoPath}.`
+        : `Synced ${synced} template(s); ${failed} failed.`,
+    );
+  }, [templatesRepoPref]);
 
   const selectedModelName = providers
     .flatMap((provider) => provider.models)
@@ -564,13 +604,31 @@ export default function SettingsScreen() {
           </TouchableOpacity>
 
           {templatesRepoPref ? (
-            <TouchableOpacity
-              testID="templates-repo-clear"
-              style={[styles.settingItem, { borderBottomColor: colors.border }]}
-              onPress={handleClearTemplatesRepo}
-            >
-              <Text style={[styles.settingLabel, { color: colors.error }]}>Disconnect templates repo</Text>
-            </TouchableOpacity>
+            <>
+              <TouchableOpacity
+                testID="templates-sync-existing"
+                style={[styles.settingItem, { borderBottomColor: colors.border }]}
+                onPress={handleSyncExistingTemplates}
+                disabled={isSyncingExistingTemplates}
+              >
+                <View style={styles.settingLeft}>
+                  <Ionicons name="cloud-upload-outline" size={20} color={colors.text} />
+                  <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12 }]}>
+                    Sync existing custom templates to repo
+                  </Text>
+                </View>
+                {isSyncingExistingTemplates ? (
+                  <ActivityIndicator size="small" color={colors.primary} />
+                ) : null}
+              </TouchableOpacity>
+              <TouchableOpacity
+                testID="templates-repo-clear"
+                style={[styles.settingItem, { borderBottomColor: colors.border }]}
+                onPress={handleClearTemplatesRepo}
+              >
+                <Text style={[styles.settingLabel, { color: colors.error }]}>Disconnect templates repo</Text>
+              </TouchableOpacity>
+            </>
           ) : null}
         </View>
 

--- a/src/screens/TemplateManagerScreen.tsx
+++ b/src/screens/TemplateManagerScreen.tsx
@@ -9,6 +9,7 @@ import {
   Alert,
   KeyboardAvoidingView,
   Platform,
+  RefreshControl,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -19,6 +20,8 @@ import { ScreenHeader, IconButton, Modal, useScreenHeaderHeight } from '../compo
 import { useTemplateStore } from '../stores/templateStore';
 import { NoteTemplate } from '../services/TemplateService';
 import { HapticService } from '../utils/haptics';
+import { TemplateRepoPreferenceService, TemplateRepoPreference } from '../services/TemplateRepoPreferenceService';
+import { pullTemplatesFromConfiguredRepo } from '../services/RepoPullService';
 
 export default function TemplateManagerScreen() {
   const navigation = useNavigation();
@@ -38,9 +41,22 @@ export default function TemplateManagerScreen() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftName, setDraftName] = useState('');
   const [draftContent, setDraftContent] = useState('');
+  const [templatesRepoPref, setTemplatesRepoPref] = useState<TemplateRepoPreference | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   useEffect(() => {
     loadTemplates();
+    TemplateRepoPreferenceService.get().then(setTemplatesRepoPref);
+  }, [loadTemplates]);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      await pullTemplatesFromConfiguredRepo();
+      await loadTemplates();
+    } finally {
+      setIsRefreshing(false);
+    }
   }, [loadTemplates]);
 
   // Recompute on store changes (customTemplates / pinnedIds in deps).
@@ -196,6 +212,11 @@ export default function TemplateManagerScreen() {
         style={styles.scroll}
         contentContainerStyle={[styles.scrollContent, { paddingTop: headerHeight }]}
         keyboardShouldPersistTaps="handled"
+        refreshControl={
+          templatesRepoPref ? (
+            <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={colors.primary} />
+          ) : undefined
+        }
       >
         <TouchableOpacity
           testID="template-create-cta"
@@ -281,7 +302,11 @@ export default function TemplateManagerScreen() {
       </Modal>
       <ScreenHeader
         title="Templates"
-        subtitle={`${allTemplates.length} total · ${customCount} custom`}
+        subtitle={
+          templatesRepoPref
+            ? `${allTemplates.length} total · ${customCount} custom · ${templatesRepoPref.repoPath}`
+            : `${allTemplates.length} total · ${customCount} custom`
+        }
         onBack={handleBack}
         actions={
           <IconButton size="sm" onPress={handleOpenCreate} accessibilityLabel="New template">
@@ -296,7 +321,7 @@ export default function TemplateManagerScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   scroll: { flex: 1 },
-  scrollContent: { padding: 16, paddingBottom: 40, gap: 10 },
+  scrollContent: { padding: 16, paddingBottom: 40, gap: 10, flexGrow: 1 },
   createCta: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -317,7 +317,13 @@ class GitHubServiceClass {
   ): Promise<{ path: string; type: 'blob' | 'tree'; sha: string; size?: number }[]> {
     const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
     const data = await this.request(url);
-    if (!Array.isArray(data?.tree)) return [];
+    // Match the "OrThrow" contract: a 200 with a malformed body is *not*
+    // authoritative evidence that the repo has zero entries. Returning [] here
+    // would let reconcilers (#508 templates, notes pull) wipe local entries on
+    // a transient API hiccup. Throw instead so callers' outer catch returns 0.
+    if (!Array.isArray(data?.tree)) {
+      throw new Error('GitHub tree response missing tree array');
+    }
     return data.tree.map((item: any) => ({
       path: item.path,
       type: item.type,

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -6,6 +6,9 @@ import { createCanvas, updateCanvas, CanvasScene } from '../models/Canvas';
 import { createTodoItem, applyTodoUpdate, reorderTodos } from '../models/Todo';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { canPersistNoteTags } from '../utils/noteTagSupport';
+import { TemplateRepoPreferenceService } from './TemplateRepoPreferenceService';
+import { parseTemplateMarkdown } from './TemplateMarkdownService';
+import type { NoteTemplate } from './TemplateService';
 
 async function fetchDirectoryFiles(
   owner: string,
@@ -412,27 +415,95 @@ async function pullTodosFromRepo(
   return pulled;
 }
 
+const TEMPLATE_EXTS = ['md', 'markdown'] as const;
+
+async function pullTemplatesFromRepo(
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<number> {
+  try {
+    const tree = await GitHubService.getTreeRecursiveOrThrow(owner, repo, branch);
+    const blobs = tree.filter((item) => {
+      if (item.type !== 'blob') return false;
+      if (!item.path.startsWith('templates/')) return false;
+      const ext = item.path.split('.').pop()?.toLowerCase();
+      return TEMPLATE_EXTS.includes(ext as (typeof TEMPLATE_EXTS)[number]);
+    });
+
+    const fetched = await fetchInBatches(
+      blobs,
+      async (b) => {
+        const content = await GitHubService.getFileContent(owner, repo, b.path, branch);
+        return content === null ? null : { path: b.path, content };
+      },
+      FILE_FETCH_CONCURRENCY,
+    );
+
+    const remote: NoteTemplate[] = [];
+    for (const f of fetched) {
+      if (!f) continue;
+      const parsed = parseTemplateMarkdown(f.path, f.content);
+      if (parsed) remote.push(parsed);
+    }
+
+    const remotePaths = new Set(blobs.map((b) => b.path));
+    const local = await StorageService.loadCustomTemplates();
+
+    // Reconcile: drop locals that originated in this repo (have filePath) and
+    // are no longer on the remote. Local-only customs (no filePath) stay.
+    const survivors = local.filter((t) => !t.filePath || remotePaths.has(t.filePath));
+
+    const byId = new Map<string, NoteTemplate>();
+    for (const t of survivors) byId.set(t.id, t);
+    let count = 0;
+    for (const t of remote) {
+      const existing = byId.get(t.id);
+      if (!existing || existing.content !== t.content || existing.name !== t.name) {
+        byId.set(t.id, { ...existing, ...t, isCustom: true });
+        count++;
+      }
+    }
+
+    await StorageService.saveCustomTemplates([...byId.values()]);
+    return count;
+  } catch {
+    console.warn(`[RepoPullService] Failed to pull templates from ${owner}/${repo}`);
+    return 0;
+  }
+}
+
+export async function pullTemplatesFromConfiguredRepo(): Promise<number> {
+  if (!GitHubService.isAuthenticated()) return 0;
+  const pref = await TemplateRepoPreferenceService.get();
+  if (!pref) return 0;
+  const info = parseRepoPath(pref.repoPath);
+  if (!info) return 0;
+  return pullTemplatesFromRepo(info.owner, info.repo, pref.branch);
+}
+
 export interface PullResult {
   repos: number;
   notes: number;
   canvases: number;
   todos: number;
+  templates: number;
 }
 
 export async function pullFromSingleRepo(repoPath: string): Promise<PullResult> {
   if (!GitHubService.isAuthenticated()) {
-    return { repos: 0, notes: 0, canvases: 0, todos: 0 };
+    return { repos: 0, notes: 0, canvases: 0, todos: 0, templates: 0 };
   }
 
   const repos = await StorageService.getSavedRepositories();
   const repo = repos.find((r) => r.path === repoPath);
   if (!repo) {
-    return { repos: 0, notes: 0, canvases: 0, todos: 0 };
+    return { repos: 0, notes: 0, canvases: 0, todos: 0, templates: 0 };
   }
 
   const repoInfo = parseRepoPath(repo.path);
   if (!repoInfo) {
-    return { repos: 0, notes: 0, canvases: 0, todos: 0 };
+    return { repos: 0, notes: 0, canvases: 0, todos: 0, templates: 0 };
   }
   const branch = repo.branch || 'main';
 
@@ -442,12 +513,15 @@ export async function pullFromSingleRepo(repoPath: string): Promise<PullResult> 
     pullTodosFromRepo(repoInfo.owner, repoInfo.repo, repo.path, branch),
   ]);
 
-  return { repos: 1, notes, canvases, todos };
+  const pref = await TemplateRepoPreferenceService.get();
+  const templates =
+    pref && pref.repoPath === repoPath ? await pullTemplatesFromConfiguredRepo() : 0;
+  return { repos: 1, notes, canvases, todos, templates };
 }
 
 export async function pullAllFromRepos(): Promise<PullResult> {
   if (!GitHubService.isAuthenticated()) {
-    return { repos: 0, notes: 0, canvases: 0, todos: 0 };
+    return { repos: 0, notes: 0, canvases: 0, todos: 0, templates: 0 };
   }
 
   const repos = await StorageService.getSavedRepositories();
@@ -474,5 +548,6 @@ export async function pullAllFromRepos(): Promise<PullResult> {
     reposProcessed++;
   }
 
-  return { repos: reposProcessed, notes: totalNotes, canvases: totalCanvases, todos: totalTodos };
+  const templates = await pullTemplatesFromConfiguredRepo();
+  return { repos: reposProcessed, notes: totalNotes, canvases: totalCanvases, todos: totalTodos, templates };
 }

--- a/src/services/StorageBootstrap.ts
+++ b/src/services/StorageBootstrap.ts
@@ -22,6 +22,7 @@ const STARTUP_KEYS = [
   '@gitnotes:remember_format',
   '@gitnotes:sync_queue',
   '@gitnotes:backlinks_index',
+  '@gitnotes:templates_repo',
 ] as const;
 
 type StartupKey = (typeof STARTUP_KEYS)[number];

--- a/src/services/TemplateGitHubSyncService.ts
+++ b/src/services/TemplateGitHubSyncService.ts
@@ -1,0 +1,74 @@
+import { GitHubService } from './GitHubService';
+import { parseRepoPath } from '../utils/gitPathParser';
+import { serializeTemplate, templateSlug } from './TemplateMarkdownService';
+import type { NoteTemplate } from './TemplateService';
+
+export interface TemplateSyncResult {
+  success: boolean;
+  filePath?: string;
+  error?: string;
+}
+
+export async function syncTemplateToGitHub(params: {
+  repoPath: string;
+  branch: string;
+  template: NoteTemplate;
+}): Promise<TemplateSyncResult> {
+  const { repoPath, branch, template } = params;
+
+  if (!GitHubService.isAuthenticated()) {
+    return { success: false, error: 'GitHub not authenticated' };
+  }
+  const info = parseRepoPath(repoPath);
+  if (!info) return { success: false, error: `Invalid repo path: ${repoPath}` };
+
+  const targetPath = template.filePath || `templates/${templateSlug(template.name)}.md`;
+  const isUpdate = Boolean(template.filePath);
+  const message = `${isUpdate ? 'Update' : 'Add'} template ${template.name}`;
+  const body = serializeTemplate({ ...template, filePath: undefined });
+
+  try {
+    const result = await GitHubService.updateFile(
+      info.owner, info.repo, targetPath, body, message, branch, undefined,
+    );
+    if (!result) return { success: false, error: 'GitHub API returned no result' };
+    return { success: true, filePath: targetPath };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Unknown error' };
+  }
+}
+
+export async function deleteTemplateFromGitHub(params: {
+  repoPath: string;
+  branch: string;
+  filePath: string;
+  name: string;
+  sha?: string;
+}): Promise<TemplateSyncResult> {
+  const { repoPath, branch, filePath, name, sha } = params;
+
+  if (!GitHubService.isAuthenticated()) {
+    return { success: false, error: 'GitHub not authenticated' };
+  }
+  const info = parseRepoPath(repoPath);
+  if (!info) return { success: false, error: `Invalid repo path: ${repoPath}` };
+
+  let resolvedSha = sha;
+  if (!resolvedSha) {
+    resolvedSha = (await GitHubService.getFileSha(info.owner, info.repo, filePath, branch)) ?? undefined;
+    if (!resolvedSha) {
+      // File already gone on the remote — treat as success.
+      return { success: true, filePath };
+    }
+  }
+
+  try {
+    const result = await GitHubService.deleteFile(
+      info.owner, info.repo, filePath, `Delete template ${name}`, resolvedSha, branch,
+    );
+    if (!result) return { success: false, error: 'GitHub API returned no result' };
+    return { success: true, filePath };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Unknown error' };
+  }
+}

--- a/src/services/TemplateMarkdownService.ts
+++ b/src/services/TemplateMarkdownService.ts
@@ -1,0 +1,104 @@
+import type { NoteTemplate, NoteTemplateIcon } from './TemplateService';
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
+
+export function templateSlug(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'untitled';
+}
+
+function quoteIfNeeded(value: string): string {
+  if (value === '') return "''";
+  if (/[:#\-?&*!|>'"%@`,\[\]{}]/.test(value) || /^\s|\s$/.test(value)) {
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+  return value;
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    return trimmed.slice(1, -1).replace(/''/g, "'");
+  }
+  return trimmed;
+}
+
+export function serializeTemplate(t: NoteTemplate): string {
+  const lines: string[] = ['---'];
+  lines.push(`id: ${t.id}`);
+  lines.push(`name: ${quoteIfNeeded(t.name)}`);
+  lines.push(`icon: ${t.icon}`);
+  if (t.description) lines.push(`description: ${quoteIfNeeded(t.description)}`);
+  if (t.title) lines.push(`title: ${quoteIfNeeded(t.title)}`);
+  const tagList = (t.tags ?? []).map((tag) => quoteIfNeeded(tag)).join(', ');
+  lines.push(`tags: [${tagList}]`);
+  if (t.createdAt) lines.push(`createdAt: ${t.createdAt}`);
+  if (t.updatedAt) lines.push(`updatedAt: ${t.updatedAt}`);
+  lines.push('---');
+  lines.push('');
+  return lines.join('\n') + t.content;
+}
+
+function parseTagList(raw: string): string[] {
+  const inner = raw.trim().replace(/^\[/, '').replace(/\]$/, '').trim();
+  if (!inner) return [];
+  return inner
+    .split(',')
+    .map((tag) => unquote(tag))
+    .filter((tag) => tag.length > 0);
+}
+
+function nameFromPath(path: string): string {
+  return path
+    .replace(/^templates\//, '')
+    .replace(/\.[^.]+$/, '')
+    .replace(/[-_]/g, ' ');
+}
+
+export function parseTemplateMarkdown(path: string, raw: string): NoteTemplate | null {
+  const match = raw.match(FRONTMATTER_RE);
+  if (!match) return null;
+
+  const fields = new Map<string, string>();
+  for (const line of match[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    const k = line.slice(0, idx).trim().toLowerCase();
+    const v = line.slice(idx + 1);
+    fields.set(k, v);
+  }
+
+  const fallbackName = nameFromPath(path);
+  const id = fields.has('id') ? unquote(fields.get('id')!) : `custom-${fallbackName.replace(/\s+/g, '-')}`;
+  const name = fields.has('name') ? unquote(fields.get('name')!) : fallbackName;
+  const icon = (fields.has('icon') ? unquote(fields.get('icon')!) : 'document-outline') as NoteTemplateIcon;
+  const description = fields.has('description') ? unquote(fields.get('description')!) : '';
+  const title = fields.has('title') ? unquote(fields.get('title')!) : undefined;
+  const tags = fields.has('tags') ? parseTagList(fields.get('tags')!) : [];
+  const createdAt = fields.has('createdat') ? Number(fields.get('createdat')) : undefined;
+  const updatedAt = fields.has('updatedat') ? Number(fields.get('updatedat')) : undefined;
+
+  const rawContent = raw.slice(match[0].length);
+  const content = rawContent.startsWith('\n') ? rawContent.slice(1) : rawContent;
+
+  return {
+    id,
+    name,
+    icon,
+    description,
+    title,
+    tags,
+    content,
+    isCustom: true,
+    filePath: path,
+    createdAt: Number.isFinite(createdAt) ? createdAt : undefined,
+    updatedAt: Number.isFinite(updatedAt) ? updatedAt : undefined,
+  };
+}

--- a/src/services/TemplateRepoPreferenceService.ts
+++ b/src/services/TemplateRepoPreferenceService.ts
@@ -1,0 +1,30 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY = '@gitnotes:templates_repo';
+
+export interface TemplateRepoPreference {
+  repoPath: string; // canonical "owner/repo" — same shape as GitRepository.path
+  branch: string;
+}
+
+export class TemplateRepoPreferenceService {
+  static async get(): Promise<TemplateRepoPreference | null> {
+    const raw = await AsyncStorage.getItem(KEY);
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw) as TemplateRepoPreference;
+      if (!parsed?.repoPath || !parsed?.branch) return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  static async set(pref: TemplateRepoPreference): Promise<void> {
+    await AsyncStorage.setItem(KEY, JSON.stringify(pref));
+  }
+
+  static async clear(): Promise<void> {
+    await AsyncStorage.removeItem(KEY);
+  }
+}

--- a/src/services/TemplateService.ts
+++ b/src/services/TemplateService.ts
@@ -14,6 +14,7 @@ export interface NoteTemplate {
   isPinned?: boolean;
   createdAt?: number;
   updatedAt?: number;
+  filePath?: string; // set when the template was loaded from / written to a repo file
 }
 
 export const NOTE_TEMPLATES: NoteTemplate[] = [

--- a/src/stores/templateStore.ts
+++ b/src/stores/templateStore.ts
@@ -53,6 +53,8 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
       });
       if (result.success && result.filePath) {
         synced = { ...template, filePath: result.filePath };
+      } else if (!result.success) {
+        console.warn(`[templateStore] Failed to sync template "${template.name}" to GitHub: ${result.error ?? 'unknown error'}`);
       }
     }
 
@@ -77,6 +79,8 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
       });
       if (result.success && result.filePath) {
         merged.filePath = result.filePath;
+      } else if (!result.success) {
+        console.warn(`[templateStore] Failed to sync template "${merged.name}" to GitHub: ${result.error ?? 'unknown error'}`);
       }
     }
 
@@ -91,12 +95,15 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
 
     const pref = await TemplateRepoPreferenceService.get();
     if (pref && template.filePath) {
-      await deleteTemplateFromGitHub({
+      const delResult = await deleteTemplateFromGitHub({
         repoPath: pref.repoPath,
         branch: pref.branch,
         filePath: template.filePath,
         name: template.name,
       });
+      if (!delResult.success) {
+        console.warn(`[templateStore] Failed to delete template "${template.name}" from GitHub: ${delResult.error ?? 'unknown error'}`);
+      }
     }
 
     const next = get().customTemplates.filter((t) => t.id !== id);

--- a/src/stores/templateStore.ts
+++ b/src/stores/templateStore.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 import { NoteTemplate, NOTE_TEMPLATES } from '../services/TemplateService';
 import { StorageService } from '../services/StorageService';
+import { TemplateRepoPreferenceService } from '../services/TemplateRepoPreferenceService';
+import {
+  syncTemplateToGitHub,
+  deleteTemplateFromGitHub,
+} from '../services/TemplateGitHubSyncService';
 import { generateId } from '../utils/ids';
 
 interface TemplateState {
@@ -37,14 +42,45 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };
-    const next = [...get().customTemplates, template];
+
+    let synced = template;
+    const pref = await TemplateRepoPreferenceService.get();
+    if (pref) {
+      const result = await syncTemplateToGitHub({
+        repoPath: pref.repoPath,
+        branch: pref.branch,
+        template,
+      });
+      if (result.success && result.filePath) {
+        synced = { ...template, filePath: result.filePath };
+      }
+    }
+
+    const next = [...get().customTemplates, synced];
     await StorageService.saveCustomTemplates(next);
     set({ customTemplates: next });
-    return template;
+    return synced;
   },
 
   updateTemplate: async (id, updates) => {
-    const next = get().customTemplates.map((t) => (t.id === id ? { ...t, ...updates, updatedAt: Date.now() } : t));
+    const current = get().customTemplates.find((t) => t.id === id);
+    if (!current) return;
+
+    const merged: NoteTemplate = { ...current, ...updates, updatedAt: Date.now() };
+
+    const pref = await TemplateRepoPreferenceService.get();
+    if (pref) {
+      const result = await syncTemplateToGitHub({
+        repoPath: pref.repoPath,
+        branch: pref.branch,
+        template: merged,
+      });
+      if (result.success && result.filePath) {
+        merged.filePath = result.filePath;
+      }
+    }
+
+    const next = get().customTemplates.map((t) => (t.id === id ? merged : t));
     await StorageService.saveCustomTemplates(next);
     set({ customTemplates: next });
   },
@@ -52,6 +88,17 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
   deleteTemplate: async (id) => {
     const template = get().customTemplates.find((t) => t.id === id);
     if (!template?.isCustom) return;
+
+    const pref = await TemplateRepoPreferenceService.get();
+    if (pref && template.filePath) {
+      await deleteTemplateFromGitHub({
+        repoPath: pref.repoPath,
+        branch: pref.branch,
+        filePath: template.filePath,
+        name: template.name,
+      });
+    }
+
     const next = get().customTemplates.filter((t) => t.id !== id);
     await StorageService.saveCustomTemplates(next);
     set({ customTemplates: next });


### PR DESCRIPTION
## Summary
- Custom templates persist as markdown files in a user-selected repo's `templates/<slug>.md`, with YAML frontmatter for metadata
- Built-in `NOTE_TEMPLATES` stay in code and are merged in at read time — never duplicated, never written to git
- New `RepoPullService.pullTemplatesFromConfiguredRepo` pulls + reconciles deletions; transient API failures preserve local data
- Settings: new "Templates" section with repo picker, disconnect, and a one-shot "Sync existing custom templates to repo" action
- TemplateManagerScreen: pull-to-refresh + repo subtitle hint
- Bug fix from user screenshot: `flexGrow: 1` on TemplateManager scrollContent so the background paints behind the list when row count is small

Closes #508. Related: #489 (delete sync), #494 (pull reconcile).

## Architecture
- `TemplateRepoPreferenceService` — persisted `{ repoPath, branch }` pointer (mirrors `NoteFormatPreferenceService`)
- `TemplateMarkdownService` — frontmatter (de)serialization (no `js-yaml` dep)
- `TemplateGitHubSyncService` — write/delete via existing `GitHubService.updateFile`/`deleteFile` (mirrors `TodoGitHubSyncService`)
- `templateStore` CRUD fans out to GitHub when a templates repo is configured; warns on failure but never loses local data
- `getTreeRecursiveOrThrow` now throws on a malformed 200 body so reconcilers can't wipe locals on a transient hiccup

## Test plan
- [x] `npx jest` — 359/359 pass (5 new test files, 17 new tests)
- [x] `npx tsc --noEmit` — clean
- [ ] Manually: pick a templates repo in Settings, create / edit / delete a custom template, verify files appear in the repo's `templates/` folder and survive a fresh install via pull-to-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)