### PR TITLE
feat(git): full git clone sync mode end-to-end (#514, phases 1-7)

### DIFF
--- a/__tests__/notes-pull-clone-mode.test.ts
+++ b/__tests__/notes-pull-clone-mode.test.ts
@@ -43,6 +43,7 @@ jest.mock('../src/services/git/GitFsService', () => ({
     isCloned: jest.fn(async () => false),
     clone: jest.fn(async () => undefined),
     fetch: jest.fn(async () => undefined),
+    pullWithFastForward: jest.fn(async () => ({ ok: true })),
     listTree: jest.fn(async () => [
       { path: 'notes/foo.md', type: 'blob', sha: 'aa' },
       { path: 'notes/images/cover.png', type: 'blob', sha: 'bb' },
@@ -82,13 +83,26 @@ describe('pullNotesFromRepo via clone mode', () => {
 
     (GitFsService.isCloned as jest.Mock).mockResolvedValueOnce(true);
     (GitFsService.clone as jest.Mock).mockClear();
+    (GitFsService.pullWithFastForward as jest.Mock).mockClear();
     await pullFromSingleRepo('me/gitnotes');
     expect(GitFsService.clone).not.toHaveBeenCalled();
-    expect(GitFsService.fetch).toHaveBeenCalledWith({
+    expect(GitFsService.pullWithFastForward).toHaveBeenCalledWith({
       repoPath: 'me/gitnotes',
       branch: 'main',
       token: 'tok-abc',
     });
+  });
+
+  test('diverged local commits abort pull (no reconcile, saveAllNotes not called)', async () => {
+    (GitFsService.isCloned as jest.Mock).mockResolvedValue(true);
+    (GitFsService.pullWithFastForward as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      reason: 'diverged',
+    });
+    const result = await pullFromSingleRepo('me/gitnotes');
+    expect(result.notes).toBe(0);
+    expect(StorageService.saveAllNotes).not.toHaveBeenCalled();
+    expect(GitFsService.listTree).not.toHaveBeenCalled();
   });
 
   test('listTree + readFile go through GitFsService, not GitHubService', async () => {

--- a/__tests__/notes-pull-clone-mode.test.ts
+++ b/__tests__/notes-pull-clone-mode.test.ts
@@ -1,0 +1,132 @@
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: {
+    addEventListener: jest.fn(() => jest.fn()),
+    fetch: jest.fn(async () => ({ isConnected: true, isInternetReachable: true })),
+  },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getTreeRecursiveOrThrow: jest.fn(),
+    getFileContent: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    getAllNotes: jest.fn(async () => []),
+    saveAllNotes: jest.fn(async () => undefined),
+    getSavedRepositories: jest.fn(async () => [
+      { id: '1', name: 'gitnotes', path: 'me/gitnotes', branch: 'main' },
+    ]),
+  },
+}));
+
+jest.mock('../src/services/GitService', () => ({
+  GitService: {
+    invalidateRepoFoldersCache: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock('../src/services/AuthService', () => ({
+  AuthService: { getToken: jest.fn(async () => 'tok-abc') },
+}));
+
+jest.mock('../src/services/SyncEngineService', () => ({
+  SyncEngineService: { getMode: jest.fn(async () => 'clone') },
+}));
+
+jest.mock('../src/services/git/GitFsService', () => ({
+  GitFsService: {
+    isCloned: jest.fn(async () => false),
+    clone: jest.fn(async () => undefined),
+    fetch: jest.fn(async () => undefined),
+    listTree: jest.fn(async () => [
+      { path: 'notes/foo.md', type: 'blob', sha: 'aa' },
+      { path: 'notes/images/cover.png', type: 'blob', sha: 'bb' },
+    ]),
+    readFile: jest.fn(async (opts: { filepath: string }) => {
+      if (opts.filepath === 'notes/foo.md') return 'hello body';
+      return null;
+    }),
+  },
+}));
+
+import { GitFsService } from '../src/services/git/GitFsService';
+import { GitHubService } from '../src/services/GitHubService';
+import { StorageService } from '../src/services/StorageService';
+import { SyncEngineService } from '../src/services/SyncEngineService';
+import { pullFromSingleRepo } from '../src/services/RepoPullService';
+
+describe('pullNotesFromRepo via clone mode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([]);
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([
+      { id: '1', name: 'gitnotes', path: 'me/gitnotes', branch: 'main' },
+    ]);
+    (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
+    (GitFsService.isCloned as jest.Mock).mockResolvedValue(false);
+  });
+
+  test('first pull clones the repo, subsequent pulls fetch only', async () => {
+    await pullFromSingleRepo('me/gitnotes');
+    expect(GitFsService.clone).toHaveBeenCalledWith({
+      repoPath: 'me/gitnotes',
+      branch: 'main',
+      token: 'tok-abc',
+    });
+    expect(GitFsService.fetch).not.toHaveBeenCalled();
+
+    (GitFsService.isCloned as jest.Mock).mockResolvedValueOnce(true);
+    (GitFsService.clone as jest.Mock).mockClear();
+    await pullFromSingleRepo('me/gitnotes');
+    expect(GitFsService.clone).not.toHaveBeenCalled();
+    expect(GitFsService.fetch).toHaveBeenCalledWith({
+      repoPath: 'me/gitnotes',
+      branch: 'main',
+      token: 'tok-abc',
+    });
+  });
+
+  test('listTree + readFile go through GitFsService, not GitHubService', async () => {
+    await pullFromSingleRepo('me/gitnotes');
+    expect(GitFsService.listTree).toHaveBeenCalledWith({
+      repoPath: 'me/gitnotes',
+      ref: 'main',
+    });
+    // Only the non-image .md is fetched — images/ subpath is filtered out.
+    expect(GitFsService.readFile).toHaveBeenCalledTimes(1);
+    expect(GitFsService.readFile).toHaveBeenCalledWith({
+      repoPath: 'me/gitnotes',
+      ref: 'main',
+      filepath: 'notes/foo.md',
+    });
+    // The Contents API path must not be touched in clone mode.
+    expect(GitHubService.getTreeRecursiveOrThrow).not.toHaveBeenCalled();
+    expect(GitHubService.getFileContent).not.toHaveBeenCalled();
+  });
+
+  test('api mode keeps using GitHubService (no clone-mode side effects)', async () => {
+    (SyncEngineService.getMode as jest.Mock).mockResolvedValueOnce('api');
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValueOnce([
+      { path: 'notes/foo.md', type: 'blob', sha: 'aa' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValueOnce('hello');
+
+    await pullFromSingleRepo('me/gitnotes');
+    expect(GitFsService.clone).not.toHaveBeenCalled();
+    expect(GitFsService.fetch).not.toHaveBeenCalled();
+    expect(GitFsService.listTree).not.toHaveBeenCalled();
+    expect(GitHubService.getTreeRecursiveOrThrow).toHaveBeenCalledWith('me', 'gitnotes', 'main');
+  });
+
+  test('clone failure returns 0 and skips reconcile (saveAllNotes not called)', async () => {
+    (GitFsService.clone as jest.Mock).mockRejectedValueOnce(new Error('network'));
+    const result = await pullFromSingleRepo('me/gitnotes');
+    expect(result.notes).toBe(0);
+    expect(StorageService.saveAllNotes).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/git/cloneMigration.test.ts
+++ b/__tests__/services/git/cloneMigration.test.ts
@@ -1,0 +1,134 @@
+jest.mock('../../../src/services/git/LocalGitWriter', () => {
+  const writeAndCommit = jest.fn(async () => ({ success: true }));
+  const push = jest.fn(async () => ({ success: true }));
+  (globalThis as any).__lgwForMigrationTest = { writeAndCommit, push };
+  return {
+    LocalGitWriter: { writeAndCommit, push },
+  };
+});
+
+jest.mock('../../../src/services/StorageService', () => ({
+  StorageService: {
+    getAllNotes: jest.fn(async () => [
+      {
+        id: 'n1',
+        title: 'Local note',
+        content: 'body',
+        repo: 'me/repo',
+        filePath: 'notes/local.md',
+        format: 'markdown',
+        tags: [],
+      },
+      {
+        id: 'n2',
+        title: 'Other repo',
+        content: 'x',
+        repo: 'other/repo',
+        filePath: 'notes/x.md',
+      },
+      // No filePath — never persisted to a repo, must be skipped.
+      { id: 'n3', title: 'Draft', content: 'unsaved', repo: 'me/repo' },
+    ]),
+    getAllTodos: jest.fn(async () => [
+      { id: 't1', text: 'do thing', repo: 'me/repo', filePath: 'todos/do-thing.json' },
+    ]),
+    mutateCanvases: jest.fn(async (mutator: any) => {
+      const list = [
+        { id: 'c1', title: 'Diagram', scene: { nodes: [] }, repo: 'me/repo', filePath: 'canvases/d.json' },
+      ];
+      mutator(list);
+    }),
+  },
+}));
+
+jest.mock('../../../src/services/GitHubService', () => ({
+  GitHubService: {
+    getUser: jest.fn(() => ({ login: 'me', name: 'Me User', email: 'me@example.com' })),
+  },
+}));
+
+jest.mock('../../../src/services/AuthService', () => ({
+  AuthService: { getToken: jest.fn(async () => 'tok') },
+}));
+
+jest.mock('../../../src/services/TemplateRepoPreferenceService', () => ({
+  TemplateRepoPreferenceService: { get: jest.fn(async () => null) },
+}));
+
+jest.mock('../../../src/stores/templateStore', () => ({
+  useTemplateStore: { getState: () => ({ customTemplates: [] }) },
+}));
+
+jest.mock('../../../src/services/NoteGitHubSyncService', () => ({
+  applyNoteTagsToContent: (content: string) => content,
+  applyNoteColorToContent: (content: string) => content,
+}));
+
+jest.mock('../../../src/services/TemplateMarkdownService', () => ({
+  serializeTemplate: () => '---\n---\n',
+  templateSlug: (s: string) => s,
+}));
+
+import { CloneMigrationService } from '../../../src/services/git/CloneMigrationService';
+
+function getLgwMocks() {
+  return (globalThis as any).__lgwForMigrationTest as {
+    writeAndCommit: jest.Mock;
+    push: jest.Mock;
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  const m = getLgwMocks();
+  m.writeAndCommit.mockResolvedValue({ success: true });
+  m.push.mockResolvedValue({ success: true });
+});
+
+describe('CloneMigrationService.migrateRepo', () => {
+  test('writes only items whose repo matches and which have a filePath', async () => {
+    const report = await CloneMigrationService.migrateRepo('me/repo', 'main');
+    expect(report.notes).toBe(1); // n1 in repo with filePath; n2 wrong repo; n3 no filePath
+    expect(report.todos).toBe(1);
+    expect(report.canvases).toBe(1);
+    expect(report.failures).toEqual([]);
+    expect(report.success).toBe(true);
+
+    expect(getLgwMocks().writeAndCommit).toHaveBeenCalledTimes(3);
+    // All writeAndCommit calls must be staged-only (push:false) so the final
+    // push flushes everything in one round-trip.
+    for (const call of getLgwMocks().writeAndCommit.mock.calls) {
+      expect(call[0].push).toBe(false);
+    }
+    expect(getLgwMocks().push).toHaveBeenCalledTimes(1);
+  });
+
+  test('reports failures and still pushes the successful commits', async () => {
+    getLgwMocks().writeAndCommit.mockResolvedValueOnce({
+      success: false,
+      error: 'disk full',
+    });
+    const report = await CloneMigrationService.migrateRepo('me/repo', 'main');
+    // First call (the note) failed; todo + canvas succeeded.
+    expect(report.notes).toBe(0);
+    expect(report.todos).toBe(1);
+    expect(report.canvases).toBe(1);
+    expect(report.failures).toEqual([
+      { kind: 'note', filePath: 'notes/local.md', error: 'disk full' },
+    ]);
+    // Two successes → push still runs.
+    expect(getLgwMocks().push).toHaveBeenCalledTimes(1);
+  });
+
+  test('skips push when nothing migrated', async () => {
+    const Storage = require('../../../src/services/StorageService').StorageService;
+    Storage.getAllNotes.mockResolvedValueOnce([]);
+    Storage.getAllTodos.mockResolvedValueOnce([]);
+    Storage.mutateCanvases.mockImplementationOnce(async (mutator: any) => mutator([]));
+    const report = await CloneMigrationService.migrateRepo('empty/repo', 'main');
+    expect(report.notes).toBe(0);
+    expect(report.todos).toBe(0);
+    expect(report.canvases).toBe(0);
+    expect(getLgwMocks().push).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/git/gitFs.test.ts
+++ b/__tests__/services/git/gitFs.test.ts
@@ -1,0 +1,187 @@
+// In-memory stub for expo-file-system/legacy. The store hangs off `globalThis`
+// so the jest.mock factory (which can't close over locals) reads the same Map
+// the test setup mutates.
+
+interface Entry {
+  type: 'file' | 'dir';
+  data?: string;
+  encoding?: 'utf8' | 'base64';
+  size?: number;
+  mtime?: number;
+}
+
+jest.mock('expo-file-system/legacy', () => {
+  const EncodingType = { Base64: 'base64' as const, UTF8: 'utf8' as const };
+  // The store lives inside the factory closure (jest.mock factories can't
+  // reference outer locals). We pin a reference on globalThis so the test body
+  // can read/clear it via a lazy getter.
+  const store = new Map<string, Entry>();
+  (globalThis as any).__gitFsTestStore = store;
+
+  return {
+    __esModule: true,
+    documentDirectory: 'file:///doc/',
+    EncodingType,
+    async getInfoAsync(uri: string) {
+      const e = store.get(uri);
+      if (!e) return { exists: false, uri };
+      return {
+        exists: true,
+        uri,
+        isDirectory: e.type === 'dir',
+        size: e.size ?? 0,
+        modificationTime: e.mtime ?? 0,
+      };
+    },
+    async readAsStringAsync(uri: string, opts?: { encoding?: string }) {
+      const e = store.get(uri);
+      if (!e || e.type !== 'file') throw new Error(`not found: ${uri}`);
+      const wantBase64 = opts?.encoding === EncodingType.Base64;
+      if (wantBase64 && e.encoding === 'base64') return e.data;
+      if (!wantBase64 && e.encoding === 'utf8') return e.data;
+      if (wantBase64 && e.encoding === 'utf8') {
+        const bytes = new TextEncoder().encode(e.data!);
+        let bin = '';
+        for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+        return globalThis.btoa(bin);
+      }
+      const bin = globalThis.atob(e.data!);
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      return new TextDecoder('utf-8').decode(bytes);
+    },
+    async writeAsStringAsync(uri: string, contents: string, opts?: { encoding?: string }) {
+      const encoding = opts?.encoding === EncodingType.Base64 ? 'base64' : 'utf8';
+      const size =
+        encoding === 'utf8'
+          ? new TextEncoder().encode(contents).length
+          : globalThis.atob(contents).length;
+      store.set(uri, { type: 'file', data: contents, encoding, size, mtime: Date.now() / 1000 });
+    },
+    async deleteAsync(uri: string, opts?: { idempotent?: boolean }) {
+      if (!store.has(uri) && !opts?.idempotent) throw new Error(`delete: not found ${uri}`);
+      const e = store.get(uri);
+      if (e?.type === 'dir') {
+        const prefix = uri.endsWith('/') ? uri : uri + '/';
+        for (const k of [...store.keys()]) {
+          if (k.startsWith(prefix)) store.delete(k);
+        }
+      }
+      store.delete(uri);
+    },
+    async readDirectoryAsync(uri: string) {
+      const prefix = uri.endsWith('/') ? uri : uri + '/';
+      const out: string[] = [];
+      for (const k of store.keys()) {
+        if (k.startsWith(prefix)) {
+          const rest = k.slice(prefix.length);
+          const head = rest.split('/')[0];
+          if (head && !out.includes(head)) out.push(head);
+        }
+      }
+      return out;
+    },
+    async makeDirectoryAsync(uri: string) {
+      const trimmed = uri.replace(/\/$/, '');
+      store.set(trimmed, { type: 'dir' });
+    },
+  };
+});
+
+import { makeGitFs, FsError } from '../../../src/services/git/gitFs';
+
+function getStore(): Map<string, Entry> {
+  return (globalThis as any).__gitFsTestStore;
+}
+
+beforeEach(() => {
+  const s = getStore();
+  s.clear();
+  s.set('file:///doc/git/', { type: 'dir' });
+});
+
+describe('gitFs adapter', () => {
+  test('writeFile + readFile (utf8) round-trips strings', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    await fs.promises.writeFile('/hello.txt', 'world');
+    const data = await fs.promises.readFile('/hello.txt', { encoding: 'utf8' });
+    expect(data).toBe('world');
+  });
+
+  test('writeFile + readFile (binary) round-trips Uint8Array', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    const bytes = new Uint8Array([0, 1, 2, 3, 254, 255]);
+    await fs.promises.writeFile('/bin', bytes);
+    const data = await fs.promises.readFile('/bin');
+    expect(data).toBeInstanceOf(Uint8Array);
+    expect(Array.from(data as Uint8Array)).toEqual([0, 1, 2, 3, 254, 255]);
+  });
+
+  test('readFile throws ENOENT for missing path', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    const err = await fs.promises.readFile('/missing').catch((e: any) => e);
+    expect(err).toBeInstanceOf(FsError);
+    expect(err.code).toBe('ENOENT');
+  });
+
+  test('mkdir then readdir lists children', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    await fs.promises.mkdir('/sub');
+    await fs.promises.writeFile('/sub/a.txt', 'a');
+    await fs.promises.writeFile('/sub/b.txt', 'b');
+    const entries = await fs.promises.readdir('/sub');
+    expect(entries.sort()).toEqual(['a.txt', 'b.txt']);
+  });
+
+  test('mkdir on existing path throws EEXIST', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    await fs.promises.mkdir('/x');
+    const err = await fs.promises.mkdir('/x').catch((e: any) => e);
+    expect(err.code).toBe('EEXIST');
+  });
+
+  test('readdir throws ENOTDIR on a file', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    await fs.promises.writeFile('/f.txt', 'x');
+    const err = await fs.promises.readdir('/f.txt').catch((e: any) => e);
+    expect(err.code).toBe('ENOTDIR');
+  });
+
+  test('unlink removes the file', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    await fs.promises.writeFile('/g.txt', 'x');
+    await fs.promises.unlink('/g.txt');
+    const err = await fs.promises.readFile('/g.txt').catch((e: any) => e);
+    expect(err.code).toBe('ENOENT');
+  });
+
+  test('stat returns file shape with isomorphic-git Stat fields', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    await fs.promises.writeFile('/note.txt', 'hello');
+    const s = await fs.promises.stat('/note.txt');
+    expect(s.type).toBe('file');
+    expect(s.size).toBe(5);
+    expect(typeof s.mtimeSeconds).toBe('number');
+    expect(s.mode).toBe(0o100644);
+  });
+
+  test('stat on dir returns dir mode', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    await fs.promises.mkdir('/d');
+    const s = await fs.promises.stat('/d');
+    expect(s.type).toBe('dir');
+    expect(s.mode).toBe(0o40755);
+  });
+
+  test('readlink/symlink throw — not supported on the sandbox', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    expect(typeof fs.promises.readlink).toBe('function');
+    expect(typeof fs.promises.symlink).toBe('function');
+    await expect(fs.promises.readlink!('/x')).rejects.toBeInstanceOf(FsError);
+    await expect(fs.promises.symlink!('/a', '/b')).rejects.toBeInstanceOf(FsError);
+  });
+
+  test('constructor rejects roots without trailing slash', () => {
+    expect(() => makeGitFs('file:///doc/git')).toThrow(/end with/);
+  });
+});

--- a/__tests__/services/git/gitFsService.test.ts
+++ b/__tests__/services/git/gitFsService.test.ts
@@ -1,0 +1,197 @@
+// Mock isomorphic-git and expo-file-system/legacy so the service can be
+// exercised without touching the network or the device FS.
+
+jest.mock('isomorphic-git', () => {
+  // Build the mocks inside the factory so jest.mock hoisting doesn't strand
+  // us with `undefined` const refs (the const declarations below the import
+  // would otherwise be evaluated AFTER the factory's first invocation).
+  const mocks = {
+    clone: jest.fn(async (..._args: any[]) => undefined),
+    fetch: jest.fn(async (..._args: any[]) => ({ defaultBranch: 'main' })),
+    walk: jest.fn(async (..._args: any[]): Promise<any[]> => []),
+    resolveRef: jest.fn(async (..._args: any[]) => 'oid-deadbeef'),
+    readBlob: jest.fn(async (..._args: any[]) => ({
+      oid: 'oid',
+      blob: new TextEncoder().encode('hello body'),
+    })),
+    TREE: jest.fn((opts: { ref: string }) => ({ __tree: opts.ref })),
+  };
+  (globalThis as any).__isomorphicGitMocks = mocks;
+  return {
+    __esModule: true,
+    default: {
+      clone: mocks.clone,
+      fetch: mocks.fetch,
+      walk: mocks.walk,
+      resolveRef: mocks.resolveRef,
+      readBlob: mocks.readBlob,
+    },
+    TREE: mocks.TREE,
+  };
+});
+
+function getGitMocks() {
+  return (globalThis as any).__isomorphicGitMocks as {
+    clone: jest.Mock;
+    fetch: jest.Mock;
+    walk: jest.Mock;
+    resolveRef: jest.Mock;
+    readBlob: jest.Mock;
+    TREE: jest.Mock;
+  };
+}
+
+jest.mock('expo-file-system/legacy', () => {
+  const fsStore = new Map<string, { type: 'file' | 'dir' }>();
+  (globalThis as any).__gitFsServiceTestFsStore = fsStore;
+  return {
+    __esModule: true,
+    documentDirectory: 'file:///doc/',
+    EncodingType: { Base64: 'base64', UTF8: 'utf8' },
+    async getInfoAsync(uri: string) {
+      const e = fsStore.get(uri);
+      return e ? { exists: true, uri, isDirectory: e.type === 'dir' } : { exists: false, uri };
+    },
+    async deleteAsync(uri: string) {
+      fsStore.delete(uri);
+    },
+  };
+});
+
+function getFsStore(): Map<string, { type: 'file' | 'dir' }> {
+  return (globalThis as any).__gitFsServiceTestFsStore;
+}
+
+import { GitFsService } from '../../../src/services/git/GitFsService';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getFsStore().clear();
+});
+
+describe('GitFsService', () => {
+  test('clone forwards owner/repo + shallow defaults to isomorphic-git', async () => {
+    await GitFsService.clone({ repoPath: 'me/repo', branch: 'main', token: 'tok' });
+
+    expect(getGitMocks().clone).toHaveBeenCalledTimes(1);
+    const args = getGitMocks().clone.mock.calls[0][0];
+    expect(args.url).toBe('https://github.com/me/repo.git');
+    expect(args.dir).toBe('/me/repo');
+    expect(args.ref).toBe('main');
+    expect(args.singleBranch).toBe(true);
+    expect(args.depth).toBe(1);
+    expect(typeof args.onAuth).toBe('function');
+    const auth = args.onAuth();
+    expect(auth).toEqual({ username: 'x-access-token', password: 'tok' });
+  });
+
+  test('clone passes through custom depth and skips onAuth when no token', async () => {
+    await GitFsService.clone({ repoPath: 'me/repo', branch: 'main', depth: 50 });
+    const args = getGitMocks().clone.mock.calls[0][0];
+    expect(args.depth).toBe(50);
+    expect(args.onAuth).toBeUndefined();
+  });
+
+  test('clone rejects on invalid repoPath', async () => {
+    await expect(
+      GitFsService.clone({ repoPath: 'not-a-repo', branch: 'main' }),
+    ).rejects.toThrow(/Invalid repo path/);
+    expect(getGitMocks().clone).not.toHaveBeenCalled();
+  });
+
+  test('fetch forwards branch + depth + token-derived auth', async () => {
+    await GitFsService.fetch({ repoPath: 'me/repo', branch: 'feature/x', token: 'tok', depth: 2 });
+    expect(getGitMocks().fetch).toHaveBeenCalledTimes(1);
+    const args = getGitMocks().fetch.mock.calls[0][0];
+    expect(args.dir).toBe('/me/repo');
+    expect(args.ref).toBe('feature/x');
+    expect(args.depth).toBe(2);
+    expect(args.tags).toBe(false);
+    expect(args.onAuth()).toEqual({ username: 'x-access-token', password: 'tok' });
+  });
+
+  test('listTree maps walk entries into the tree-entry shape (matches GitHubService)', async () => {
+    getGitMocks().walk.mockImplementationOnce(async (opts: any) => {
+      const entries = [
+        { name: '.', type: 'tree', oid: 'root' },
+        { name: 'notes/foo.md', type: 'blob', oid: 'aa' },
+        { name: 'notes', type: 'tree', oid: 'bb' },
+      ];
+      const collected: any[] = [];
+      for (const e of entries) {
+        const got = await opts.map(e.name, [
+          {
+            type: async () => e.type,
+            oid: async () => e.oid,
+          },
+        ]);
+        if (got !== undefined) collected.push(got);
+      }
+      return collected;
+    });
+
+    const tree = await GitFsService.listTree({ repoPath: 'me/repo', ref: 'main' });
+    expect(tree).toEqual([
+      { path: 'notes/foo.md', type: 'blob', sha: 'aa' },
+      { path: 'notes', type: 'tree', sha: 'bb' },
+    ]);
+    expect(getGitMocks().TREE).toHaveBeenCalledWith({ ref: 'main' });
+  });
+
+  test('readFile resolves ref then reads blob and decodes utf-8', async () => {
+    const contents = await GitFsService.readFile({
+      repoPath: 'me/repo',
+      ref: 'main',
+      filepath: 'notes/x.md',
+    });
+    expect(getGitMocks().resolveRef).toHaveBeenCalledWith({
+      fs: expect.any(Object),
+      dir: '/me/repo',
+      ref: 'main',
+    });
+    expect(getGitMocks().readBlob).toHaveBeenCalledWith({
+      fs: expect.any(Object),
+      dir: '/me/repo',
+      oid: 'oid-deadbeef',
+      filepath: 'notes/x.md',
+    });
+    expect(contents).toBe('hello body');
+  });
+
+  test('readFile returns null when isomorphic-git throws NotFoundError', async () => {
+    getGitMocks().readBlob.mockRejectedValueOnce(Object.assign(new Error('nope'), { code: 'NotFoundError' }));
+    const contents = await GitFsService.readFile({
+      repoPath: 'me/repo',
+      ref: 'main',
+      filepath: 'missing.md',
+    });
+    expect(contents).toBeNull();
+  });
+
+  test('readFile rethrows non-not-found errors', async () => {
+    getGitMocks().readBlob.mockRejectedValueOnce(Object.assign(new Error('boom'), { code: 'Other' }));
+    await expect(
+      GitFsService.readFile({ repoPath: 'me/repo', ref: 'main', filepath: 'x.md' }),
+    ).rejects.toThrow(/boom/);
+  });
+
+  test('isCloned reflects the on-disk presence of <root>/.git/HEAD', async () => {
+    expect(await GitFsService.isCloned({ repoPath: 'me/repo' })).toBe(false);
+    getFsStore().set('file:///doc/gitnotes-clones/me/repo/.git/HEAD', { type: 'file' });
+    expect(await GitFsService.isCloned({ repoPath: 'me/repo' })).toBe(true);
+  });
+
+  test('removeRepo deletes the on-disk dir and is idempotent', async () => {
+    getFsStore().set('file:///doc/gitnotes-clones/me/repo', { type: 'dir' });
+    await GitFsService.removeRepo({ repoPath: 'me/repo' });
+    expect(getFsStore().has('file:///doc/gitnotes-clones/me/repo')).toBe(false);
+    // Second call must not throw.
+    await GitFsService.removeRepo({ repoPath: 'me/repo' });
+  });
+
+  test('workingTreeUri returns the absolute URI', () => {
+    expect(GitFsService.workingTreeUri({ repoPath: 'me/repo' })).toBe(
+      'file:///doc/gitnotes-clones/me/repo',
+    );
+  });
+});

--- a/__tests__/services/git/gitFsService.test.ts
+++ b/__tests__/services/git/gitFsService.test.ts
@@ -8,6 +8,7 @@ jest.mock('isomorphic-git', () => {
   const mocks = {
     clone: jest.fn(async (..._args: any[]) => undefined),
     fetch: jest.fn(async (..._args: any[]) => ({ defaultBranch: 'main' })),
+    fastForward: jest.fn(async (..._args: any[]) => undefined),
     walk: jest.fn(async (..._args: any[]): Promise<any[]> => []),
     resolveRef: jest.fn(async (..._args: any[]) => 'oid-deadbeef'),
     readBlob: jest.fn(async (..._args: any[]) => ({
@@ -22,6 +23,7 @@ jest.mock('isomorphic-git', () => {
     default: {
       clone: mocks.clone,
       fetch: mocks.fetch,
+      fastForward: mocks.fastForward,
       walk: mocks.walk,
       resolveRef: mocks.resolveRef,
       readBlob: mocks.readBlob,
@@ -34,6 +36,7 @@ function getGitMocks() {
   return (globalThis as any).__isomorphicGitMocks as {
     clone: jest.Mock;
     fetch: jest.Mock;
+    fastForward: jest.Mock;
     walk: jest.Mock;
     resolveRef: jest.Mock;
     readBlob: jest.Mock;
@@ -193,5 +196,42 @@ describe('GitFsService', () => {
     expect(GitFsService.workingTreeUri({ repoPath: 'me/repo' })).toBe(
       'file:///doc/gitnotes-clones/me/repo',
     );
+  });
+
+  test('pullWithFastForward fetches then fast-forwards on success', async () => {
+    const result = await GitFsService.pullWithFastForward({
+      repoPath: 'me/repo',
+      branch: 'main',
+      token: 'tok',
+    });
+    expect(result.ok).toBe(true);
+    expect(getGitMocks().fetch).toHaveBeenCalled();
+    expect(getGitMocks().fastForward).toHaveBeenCalled();
+  });
+
+  test('pullWithFastForward returns diverged when fast-forward fails', async () => {
+    getGitMocks().fastForward.mockRejectedValueOnce(
+      Object.assign(new Error('not fast-forwardable'), { code: 'FastForwardError' }),
+    );
+    const result = await GitFsService.pullWithFastForward({
+      repoPath: 'me/repo',
+      branch: 'main',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('diverged');
+    }
+  });
+
+  test('pullWithFastForward classifies network failure as unknown', async () => {
+    getGitMocks().fetch.mockRejectedValueOnce(new Error('network'));
+    const result = await GitFsService.pullWithFastForward({
+      repoPath: 'me/repo',
+      branch: 'main',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('unknown');
+    }
   });
 });

--- a/__tests__/services/git/localGitWriter.test.ts
+++ b/__tests__/services/git/localGitWriter.test.ts
@@ -1,0 +1,170 @@
+jest.mock('isomorphic-git', () => {
+  const mocks = {
+    add: jest.fn(async (..._a: any[]) => undefined),
+    remove: jest.fn(async (..._a: any[]) => undefined),
+    commit: jest.fn(async (..._a: any[]) => 'commit-sha-1'),
+    push: jest.fn(async (..._a: any[]) => ({ ok: true })),
+  };
+  (globalThis as any).__lgwGitMocks = mocks;
+  return {
+    __esModule: true,
+    default: mocks,
+  };
+});
+
+jest.mock('expo-file-system/legacy', () => {
+  const fsStore = new Map<string, { type: 'file' | 'dir' }>();
+  (globalThis as any).__lgwFsStore = fsStore;
+  return {
+    __esModule: true,
+    documentDirectory: 'file:///doc/',
+    EncodingType: { Base64: 'base64', UTF8: 'utf8' },
+    async getInfoAsync(uri: string) {
+      const e = fsStore.get(uri);
+      return e ? { exists: true, uri, isDirectory: e.type === 'dir' } : { exists: false, uri };
+    },
+    async writeAsStringAsync(uri: string) {
+      fsStore.set(uri, { type: 'file' });
+    },
+    async deleteAsync(uri: string) {
+      fsStore.delete(uri);
+    },
+    async makeDirectoryAsync(uri: string) {
+      fsStore.set(uri, { type: 'dir' });
+    },
+  };
+});
+
+import { LocalGitWriter } from '../../../src/services/git/LocalGitWriter';
+
+function getGitMocks() {
+  return (globalThis as any).__lgwGitMocks as {
+    add: jest.Mock;
+    remove: jest.Mock;
+    commit: jest.Mock;
+    push: jest.Mock;
+  };
+}
+
+function getFsStore() {
+  return (globalThis as any).__lgwFsStore as Map<string, { type: 'file' | 'dir' }>;
+}
+
+const author = { name: 'Test', email: 'test@example.com' };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getFsStore().clear();
+});
+
+describe('LocalGitWriter', () => {
+  test('writeAndCommit writes file, stages, commits, pushes by default', async () => {
+    const result = await LocalGitWriter.writeAndCommit({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: 'notes/foo.md',
+      content: 'hello',
+      message: 'Add note: foo',
+      author,
+      token: 'tok',
+    });
+    expect(result.success).toBe(true);
+    expect(result.filePath).toBe('notes/foo.md');
+
+    expect(getFsStore().has('file:///doc/gitnotes-clones/me/repo/notes/foo.md')).toBe(true);
+
+    expect(getGitMocks().add).toHaveBeenCalledWith({
+      fs: expect.any(Object),
+      dir: '/me/repo',
+      filepath: 'notes/foo.md',
+    });
+    expect(getGitMocks().commit).toHaveBeenCalledWith({
+      fs: expect.any(Object),
+      dir: '/me/repo',
+      message: 'Add note: foo',
+      author,
+    });
+    expect(getGitMocks().push).toHaveBeenCalledWith(
+      expect.objectContaining({ dir: '/me/repo', ref: 'main', remoteRef: 'main' }),
+    );
+    const pushArgs = getGitMocks().push.mock.calls[0][0];
+    expect(pushArgs.onAuth()).toEqual({ username: 'x-access-token', password: 'tok' });
+  });
+
+  test('writeAndCommit with push:false stages + commits but does not push', async () => {
+    const result = await LocalGitWriter.writeAndCommit({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: 'notes/bar.md',
+      content: 'x',
+      message: 'm',
+      author,
+      push: false,
+    });
+    expect(result.success).toBe(true);
+    expect(getGitMocks().commit).toHaveBeenCalledTimes(1);
+    expect(getGitMocks().push).not.toHaveBeenCalled();
+  });
+
+  test('writeAndCommit returns failure when commit throws', async () => {
+    getGitMocks().commit.mockRejectedValueOnce(new Error('nothing to commit'));
+    const result = await LocalGitWriter.writeAndCommit({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: 'notes/x.md',
+      content: 'x',
+      message: 'm',
+      author,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/nothing to commit/);
+    expect(getGitMocks().push).not.toHaveBeenCalled();
+  });
+
+  test('deleteAndCommit removes the on-disk file, runs git remove + commit + push', async () => {
+    getFsStore().set('file:///doc/gitnotes-clones/me/repo/notes/old.md', { type: 'file' });
+    const result = await LocalGitWriter.deleteAndCommit({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: 'notes/old.md',
+      message: 'Delete note: old',
+      author,
+      token: 'tok',
+    });
+    expect(result.success).toBe(true);
+    expect(getFsStore().has('file:///doc/gitnotes-clones/me/repo/notes/old.md')).toBe(false);
+    expect(getGitMocks().remove).toHaveBeenCalledWith({
+      fs: expect.any(Object),
+      dir: '/me/repo',
+      filepath: 'notes/old.md',
+    });
+    expect(getGitMocks().commit).toHaveBeenCalled();
+    expect(getGitMocks().push).toHaveBeenCalled();
+  });
+
+  test('push only flushes pending commits without staging anything new', async () => {
+    const result = await LocalGitWriter.push({
+      repoPath: 'me/repo',
+      branch: 'main',
+      token: 'tok',
+    });
+    expect(result.success).toBe(true);
+    expect(getGitMocks().add).not.toHaveBeenCalled();
+    expect(getGitMocks().commit).not.toHaveBeenCalled();
+    expect(getGitMocks().push).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects an invalid repoPath without touching the FS or git', async () => {
+    const result = await LocalGitWriter.writeAndCommit({
+      repoPath: 'not-a-repo',
+      branch: 'main',
+      filePath: 'x.md',
+      content: 'x',
+      message: 'm',
+      author,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Invalid repo path/);
+    expect(getGitMocks().add).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/syncEngineService.test.ts
+++ b/__tests__/syncEngineService.test.ts
@@ -1,0 +1,58 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (k: string) => store[k] ?? null),
+      setItem: jest.fn(async (k: string, v: string) => {
+        store[k] = v;
+      }),
+      removeItem: jest.fn(async (k: string) => {
+        delete store[k];
+      }),
+    },
+  };
+});
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { SyncEngineService } from '../src/services/SyncEngineService';
+
+describe('SyncEngineService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset the in-memory store between tests via the public API.
+    AsyncStorage.setItem('@gitnotes:sync_engine_modes', '{}');
+  });
+
+  test('default mode is api', async () => {
+    expect(await SyncEngineService.getMode('me/repo')).toBe('api');
+    expect(SyncEngineService.DEFAULT_MODE).toBe('api');
+  });
+
+  test('setMode persists clone overrides per repo', async () => {
+    await SyncEngineService.setMode('me/repo', 'clone');
+    expect(await SyncEngineService.getMode('me/repo')).toBe('clone');
+    expect(await SyncEngineService.getMode('other/repo')).toBe('api');
+  });
+
+  test('setting back to api removes the entry', async () => {
+    await SyncEngineService.setMode('me/repo', 'clone');
+    await SyncEngineService.setMode('me/repo', 'api');
+    const overrides = await SyncEngineService.listOverrides();
+    expect(overrides).toEqual({});
+  });
+
+  test('clear is equivalent to setMode("api")', async () => {
+    await SyncEngineService.setMode('me/repo', 'clone');
+    await SyncEngineService.clear('me/repo');
+    expect(await SyncEngineService.getMode('me/repo')).toBe('api');
+  });
+
+  test('listOverrides returns only non-default repos', async () => {
+    await SyncEngineService.setMode('a/x', 'clone');
+    await SyncEngineService.setMode('b/y', 'clone');
+    await SyncEngineService.setMode('c/z', 'api');
+    const overrides = await SyncEngineService.listOverrides();
+    expect(overrides).toEqual({ 'a/x': 'clone', 'b/y': 'clone' });
+  });
+});

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -31,6 +31,7 @@ import { syncTemplateToGitHub } from '../services/TemplateGitHubSyncService';
 import { useTemplateStore } from '../stores/templateStore';
 import { SyncEngineService, SyncEngineMode } from '../services/SyncEngineService';
 import { GitFsService } from '../services/git/GitFsService';
+import { CloneMigrationService } from '../services/git/CloneMigrationService';
 import { AuthService } from '../services/AuthService';
 import { useCanvases } from '../contexts/CanvasContext';
 import { useTodos } from '../contexts/TodoContext';
@@ -169,7 +170,46 @@ export default function SettingsScreen() {
         await SyncEngineService.setMode(repo.path, 'clone');
         setSyncModes((prev) => ({ ...prev, [repo.path]: 'clone' }));
         HapticService.success();
-        Alert.alert('Clone mode enabled', `${repo.name} now syncs through a local working tree.`);
+        Alert.alert(
+          'Clone mode enabled',
+          `${repo.name} now syncs through a local working tree.\n\nPush any offline edits up to this clone now?`,
+          [
+            { text: 'Skip', style: 'cancel' },
+            {
+              text: 'Push edits',
+              onPress: async () => {
+                try {
+                  const branch = repo.branch || 'main';
+                  const report = await CloneMigrationService.migrateRepo(repo.path, branch);
+                  const total =
+                    report.notes + report.todos + report.canvases + report.templates;
+                  if (report.failures.length > 0) {
+                    HapticService.error();
+                    Alert.alert(
+                      'Migration finished with issues',
+                      `Pushed ${total} item(s); ${report.failures.length} failed (see console).`,
+                    );
+                    report.failures.forEach((f) =>
+                      console.warn('[CloneMigration]', f.kind, f.filePath, f.error),
+                    );
+                  } else {
+                    HapticService.success();
+                    Alert.alert(
+                      'Pushed offline edits',
+                      `${total} item(s) committed and pushed to ${repo.name}.`,
+                    );
+                  }
+                } catch (e) {
+                  HapticService.error();
+                  Alert.alert(
+                    'Migration failed',
+                    e instanceof Error ? e.message : String(e),
+                  );
+                }
+              },
+            },
+          ],
+        );
       } catch (e) {
         HapticService.error();
         Alert.alert('Clone failed', e instanceof Error ? e.message : String(e));

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -29,6 +29,9 @@ import { pullFromSingleRepo } from '../services/RepoPullService';
 import { TemplateRepoPreferenceService, TemplateRepoPreference } from '../services/TemplateRepoPreferenceService';
 import { syncTemplateToGitHub } from '../services/TemplateGitHubSyncService';
 import { useTemplateStore } from '../stores/templateStore';
+import { SyncEngineService, SyncEngineMode } from '../services/SyncEngineService';
+import { GitFsService } from '../services/git/GitFsService';
+import { AuthService } from '../services/AuthService';
 import { useCanvases } from '../contexts/CanvasContext';
 import { useTodos } from '../contexts/TodoContext';
 import { OnboardingService } from '../services/OnboardingService';
@@ -130,6 +133,75 @@ export default function SettingsScreen() {
     setTemplatesRepoPref(null);
     HapticService.success();
   }, []);
+
+  // ── Sync-engine toggle (#514) ─────────────────────────────────────────────
+  const [syncModes, setSyncModes] = useState<Record<string, SyncEngineMode>>({});
+  const [cloningRepo, setCloningRepo] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const next: Record<string, SyncEngineMode> = {};
+      for (const repo of repositories) {
+        next[repo.path] = await SyncEngineService.getMode(repo.path);
+      }
+      if (!cancelled) setSyncModes(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [repositories]);
+
+  const handleEnableCloneMode = useCallback(
+    async (repo: GitRepository) => {
+      if (!GitHubService.isAuthenticated()) {
+        Alert.alert('GitHub required', 'Connect a GitHub account before enabling clone mode.');
+        return;
+      }
+      setCloningRepo(repo.path);
+      try {
+        const token = (await AuthService.getToken()) ?? undefined;
+        const branch = repo.branch || 'main';
+        const already = await GitFsService.isCloned({ repoPath: repo.path });
+        if (!already) {
+          await GitFsService.clone({ repoPath: repo.path, branch, token });
+        }
+        await SyncEngineService.setMode(repo.path, 'clone');
+        setSyncModes((prev) => ({ ...prev, [repo.path]: 'clone' }));
+        HapticService.success();
+        Alert.alert('Clone mode enabled', `${repo.name} now syncs through a local working tree.`);
+      } catch (e) {
+        HapticService.error();
+        Alert.alert('Clone failed', e instanceof Error ? e.message : String(e));
+      } finally {
+        setCloningRepo(null);
+      }
+    },
+    [],
+  );
+
+  const handleDisableCloneMode = useCallback(
+    (repo: GitRepository) => {
+      Alert.alert(
+        'Switch to API mode?',
+        `This will remove the local clone of ${repo.name} and revert to the GitHub Contents API.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Switch',
+            style: 'destructive',
+            onPress: async () => {
+              await GitFsService.removeRepo({ repoPath: repo.path });
+              await SyncEngineService.setMode(repo.path, 'api');
+              setSyncModes((prev) => ({ ...prev, [repo.path]: 'api' }));
+              HapticService.success();
+            },
+          },
+        ],
+      );
+    },
+    [],
+  );
 
   const [isSyncingExistingTemplates, setIsSyncingExistingTemplates] = useState(false);
   const handleSyncExistingTemplates = useCallback(async () => {
@@ -585,6 +657,67 @@ export default function SettingsScreen() {
             <Text style={[styles.addRepoButtonText, { color: colors.primary }]}>Add Repository</Text>
           </TouchableOpacity>
         </View>
+
+        {/* ── Sync engine (per repo) ── */}
+        {repositories.length > 0 && (
+          <View style={[styles.section, { backgroundColor: colors.surface }]}>
+            <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
+              Sync engine
+            </Text>
+            {repositories.map((repo) => {
+              const mode = syncModes[repo.path] ?? 'api';
+              const isClone = mode === 'clone';
+              const isCloning = cloningRepo === repo.path;
+              return (
+                <View
+                  key={repo.id}
+                  style={[styles.repoItem, { borderBottomColor: colors.border }]}
+                  testID={`sync-engine-row-${repo.path}`}
+                >
+                  <Ionicons
+                    name={isClone ? 'cloud-done-outline' : 'cloud-outline'}
+                    size={18}
+                    color={isClone ? colors.primary : colors.textSecondary}
+                  />
+                  <View style={styles.repoInfo}>
+                    <Text style={[styles.repoName, { color: colors.text }]} numberOfLines={1}>
+                      {repo.name}
+                    </Text>
+                    <Text
+                      style={[styles.repoPath, { color: colors.textSecondary }]}
+                      numberOfLines={1}
+                    >
+                      {isClone ? 'Clone (local working tree)' : 'GitHub API (per-file)'}
+                    </Text>
+                  </View>
+                  {isCloning ? (
+                    <ActivityIndicator size="small" color={colors.primary} />
+                  ) : isClone ? (
+                    <TouchableOpacity
+                      testID={`sync-engine-disable-${repo.path}`}
+                      onPress={() => handleDisableCloneMode(repo)}
+                      style={styles.removeButton}
+                    >
+                      <Text style={[styles.settingLabel, { color: colors.error }]}>
+                        Use API
+                      </Text>
+                    </TouchableOpacity>
+                  ) : (
+                    <TouchableOpacity
+                      testID={`sync-engine-enable-${repo.path}`}
+                      onPress={() => handleEnableCloneMode(repo)}
+                      style={styles.removeButton}
+                    >
+                      <Text style={[styles.settingLabel, { color: colors.primary }]}>
+                        Clone
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              );
+            })}
+          </View>
+        )}
 
         {/* ── Templates ── */}
         <View style={[styles.section, { backgroundColor: colors.surface }]}>

--- a/src/services/CanvasGitHubSyncService.ts
+++ b/src/services/CanvasGitHubSyncService.ts
@@ -2,6 +2,8 @@ import { GitHubService } from './GitHubService';
 import { CanvasScene, slugifyCanvasTitle } from '../models/Canvas';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { AuthService } from './AuthService';
+import { SyncEngineService } from './SyncEngineService';
+import { LocalGitWriter } from './git/LocalGitWriter';
 
 async function resolveToken(accountId?: string): Promise<string | undefined> {
   if (!accountId) return undefined;
@@ -48,6 +50,30 @@ export async function syncCanvasToGitHub(params: {
   const message = filePath
     ? `Update canvas: ${title}`
     : `Create canvas: ${title}`;
+
+  // Clone-mode write path (#514).
+  const mode = await SyncEngineService.getMode(repoPath);
+  if (mode === 'clone') {
+    const user = GitHubService.getUser();
+    const author = {
+      name: user?.name || user?.login || 'gitnotes',
+      email: user?.email || `${user?.login ?? 'gitnotes'}@users.noreply.github.com`,
+    };
+    const tokenForPush = tokenOverride ?? (await AuthService.getToken()) ?? undefined;
+    const writeResult = await LocalGitWriter.writeAndCommit({
+      repoPath,
+      branch: targetBranch,
+      filePath: targetPath,
+      content,
+      message,
+      author,
+      token: tokenForPush,
+    });
+    if (writeResult.success) {
+      return { success: true, filePath: targetPath };
+    }
+    return { success: false, error: writeResult.error };
+  }
 
   try {
     const result = await GitHubService.updateFile(

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -3,6 +3,16 @@ import { NoteColor, NoteFormat } from '../models/Note';
 import * as FileSystem from 'expo-file-system/legacy';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { AuthService } from './AuthService';
+import { SyncEngineService } from './SyncEngineService';
+import { LocalGitWriter } from './git/LocalGitWriter';
+
+async function resolveAuthor(): Promise<{ name: string; email: string }> {
+  const user = GitHubService.getUser();
+  return {
+    name: user?.name || user?.login || 'gitnotes',
+    email: user?.email || `${user?.login ?? 'gitnotes'}@users.noreply.github.com`,
+  };
+}
 
 async function resolveToken(accountId?: string): Promise<string | undefined> {
   if (!accountId) return undefined;
@@ -293,6 +303,20 @@ export async function deleteNoteFromGitHub(params: {
   const targetBranch = branch || 'main';
   const opts = tokenOverride ? { tokenOverride } : undefined;
 
+  const mode = await SyncEngineService.getMode(repoPath);
+  if (mode === 'clone') {
+    const author = await resolveAuthor();
+    const tokenForPush = tokenOverride ?? (await AuthService.getToken()) ?? undefined;
+    return LocalGitWriter.deleteAndCommit({
+      repoPath,
+      branch: targetBranch,
+      filePath,
+      message: `Delete note: ${title || filePath}`,
+      author,
+      token: tokenForPush,
+    });
+  }
+
   try {
     const sha = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, filePath, targetBranch, opts);
     if (!sha) {
@@ -365,6 +389,29 @@ export async function syncNoteToGitHub(params: {
   }
 
   const message = filePath ? `Update note: ${title}` : `Create note: ${title}`;
+
+  // Clone-mode write path (#514). We deliberately use the same `targetPath`
+  // and `finalContent` as the API path, so the on-disk markdown is byte-
+  // identical to what the Contents API would publish — that means a user can
+  // flip modes without their next pull seeing churn.
+  const mode = await SyncEngineService.getMode(repoPath);
+  if (mode === 'clone') {
+    const author = await resolveAuthor();
+    const tokenForPush = tokenOverride ?? (await AuthService.getToken()) ?? undefined;
+    const writeResult = await LocalGitWriter.writeAndCommit({
+      repoPath,
+      branch: targetBranch,
+      filePath: targetPath,
+      content: finalContent,
+      message,
+      author,
+      token: tokenForPush,
+    });
+    if (writeResult.success) {
+      return { success: true, filePath: targetPath, finalContent };
+    }
+    return { success: false, error: writeResult.error };
+  }
 
   try {
     const result = await GitHubService.updateFile(

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -9,6 +9,50 @@ import { canPersistNoteTags } from '../utils/noteTagSupport';
 import { TemplateRepoPreferenceService } from './TemplateRepoPreferenceService';
 import { parseTemplateMarkdown } from './TemplateMarkdownService';
 import type { NoteTemplate } from './TemplateService';
+import { SyncEngineService } from './SyncEngineService';
+import { GitFsService } from './git/GitFsService';
+import { AuthService } from './AuthService';
+
+/**
+ * Picks the read transport for a repo based on the user's per-repo
+ * SyncEngineService toggle. In 'clone' mode the working copy is cloned
+ * lazily on first pull (and fetched on subsequent pulls); in 'api' mode the
+ * existing GitHub Contents API path is used. Output shapes match — both
+ * `listTree` returns `{ path, type, sha }[]` and `readFile` returns
+ * `string | null` — so callers can swap transports without branching.
+ */
+async function getRepoReader(
+  repoPath: string,
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<{
+  mode: 'api' | 'clone';
+  listTree: () => Promise<{ path: string; type: 'blob' | 'tree'; sha: string; size?: number }[]>;
+  readFile: (path: string) => Promise<string | null>;
+}> {
+  const mode = await SyncEngineService.getMode(repoPath);
+  if (mode === 'clone') {
+    const token = (await AuthService.getToken()) ?? undefined;
+    const cloned = await GitFsService.isCloned({ repoPath });
+    if (!cloned) {
+      await GitFsService.clone({ repoPath, branch, token });
+    } else {
+      await GitFsService.fetch({ repoPath, branch, token });
+    }
+    return {
+      mode,
+      listTree: () => GitFsService.listTree({ repoPath, ref: branch }),
+      readFile: (path: string) =>
+        GitFsService.readFile({ repoPath, ref: branch, filepath: path }),
+    };
+  }
+  return {
+    mode,
+    listTree: () => GitHubService.getTreeRecursiveOrThrow(owner, repo, branch),
+    readFile: (path: string) => GitHubService.getFileContent(owner, repo, path, branch),
+  };
+}
 
 async function fetchDirectoryFiles(
   owner: string,
@@ -135,12 +179,14 @@ async function pullNotesFromRepo(
   branch: string,
 ): Promise<number> {
   try {
-    // Use the strict variant so an actual API failure (auth/rate-limit/network)
-    // throws and is caught below, returning early *without* running the
-    // reconciliation pass. A successful fetch that returns zero note blobs is
-    // authoritative — the user has deleted every notes file on the remote — and
-    // must run reconcile so local copies for this scope are dropped.
-    const tree = await GitHubService.getTreeRecursiveOrThrow(owner, repo, branch);
+    const reader = await getRepoReader(repoPath, owner, repo, branch);
+    // Use the strict listTree contract so an actual API/clone failure (auth /
+    // rate-limit / network / fsck) throws and is caught below, returning early
+    // *without* running the reconciliation pass. A successful fetch that
+    // returns zero note blobs is authoritative — the user has deleted every
+    // notes file on the remote — and must run reconcile so local copies for
+    // this scope are dropped.
+    const tree = await reader.listTree();
     const noteBlobs = tree.filter((item) => {
       if (item.type !== 'blob') return false;
       if (!item.path.startsWith('notes/')) return false;
@@ -152,7 +198,7 @@ async function pullNotesFromRepo(
     const fetched = await fetchInBatches(
       noteBlobs,
       async (blob) => {
-        const content = await GitHubService.getFileContent(owner, repo, blob.path, branch);
+        const content = await reader.readFile(blob.path);
         return content === null ? null : { path: blob.path, content };
       },
       FILE_FETCH_CONCURRENCY,

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -38,7 +38,17 @@ async function getRepoReader(
     if (!cloned) {
       await GitFsService.clone({ repoPath, branch, token });
     } else {
-      await GitFsService.fetch({ repoPath, branch, token });
+      // Phase 5: fast-forward instead of bare fetch so local unpushed commits
+      // can't be silently shadowed by stale reconcile. If the local branch
+      // has diverged we throw — the outer try/catch in pullNotesFromRepo
+      // returns 0 without running reconcile, preserving local edits.
+      const result = await GitFsService.pullWithFastForward({ repoPath, branch, token });
+      if (!result.ok) {
+        throw new Error(
+          `Local repo ${repoPath}@${branch} has diverged from upstream (${result.reason}). ` +
+            `Push or reset your local commits before the next pull.`,
+        );
+      }
     }
     return {
       mode,

--- a/src/services/SyncEngineService.ts
+++ b/src/services/SyncEngineService.ts
@@ -1,0 +1,59 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY = '@gitnotes:sync_engine_modes';
+
+export type SyncEngineMode = 'api' | 'clone';
+
+type ModeMap = Record<string, SyncEngineMode>;
+
+async function readMap(): Promise<ModeMap> {
+  try {
+    const raw = await AsyncStorage.getItem(KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null ? (parsed as ModeMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeMap(map: ModeMap): Promise<void> {
+  await AsyncStorage.setItem(KEY, JSON.stringify(map));
+}
+
+/**
+ * Per-repo sync-engine selection. Default is 'api' (existing Contents-API
+ * path), and only repos the user explicitly opts into 'clone' mode store an
+ * entry. Phase 1 ships this service with no callers wired — the eventual
+ * caller in Phase 2 (RepoPullService.pullNotesFromRepo et al.) will branch on
+ * the returned mode.
+ */
+export class SyncEngineService {
+  static readonly DEFAULT_MODE: SyncEngineMode = 'api';
+
+  static async getMode(repoPath: string): Promise<SyncEngineMode> {
+    const map = await readMap();
+    return map[repoPath] ?? SyncEngineService.DEFAULT_MODE;
+  }
+
+  static async setMode(repoPath: string, mode: SyncEngineMode): Promise<void> {
+    const map = await readMap();
+    if (mode === SyncEngineService.DEFAULT_MODE) {
+      // Avoid persisting redundant defaults — keeps the dump small and makes
+      // export/import a clearer "things the user changed" surface.
+      delete map[repoPath];
+    } else {
+      map[repoPath] = mode;
+    }
+    await writeMap(map);
+  }
+
+  static async clear(repoPath: string): Promise<void> {
+    await SyncEngineService.setMode(repoPath, SyncEngineService.DEFAULT_MODE);
+  }
+
+  /** Snapshot of all repos currently on non-default modes. */
+  static async listOverrides(): Promise<ModeMap> {
+    return readMap();
+  }
+}

--- a/src/services/TemplateGitHubSyncService.ts
+++ b/src/services/TemplateGitHubSyncService.ts
@@ -2,6 +2,17 @@ import { GitHubService } from './GitHubService';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { serializeTemplate, templateSlug } from './TemplateMarkdownService';
 import type { NoteTemplate } from './TemplateService';
+import { SyncEngineService } from './SyncEngineService';
+import { LocalGitWriter } from './git/LocalGitWriter';
+import { AuthService } from './AuthService';
+
+function resolveAuthor() {
+  const user = GitHubService.getUser();
+  return {
+    name: user?.name || user?.login || 'gitnotes',
+    email: user?.email || `${user?.login ?? 'gitnotes'}@users.noreply.github.com`,
+  };
+}
 
 export interface TemplateSyncResult {
   success: boolean;
@@ -26,6 +37,25 @@ export async function syncTemplateToGitHub(params: {
   const isUpdate = Boolean(template.filePath);
   const message = `${isUpdate ? 'Update' : 'Add'} template ${template.name}`;
   const body = serializeTemplate({ ...template, filePath: undefined });
+
+  // Clone-mode write path (#514). Templates target their own configured repo
+  // (TemplateRepoPreferenceService), so the sync-engine flag we read is for
+  // *that* repo, not the editing repo.
+  const mode = await SyncEngineService.getMode(repoPath);
+  if (mode === 'clone') {
+    const tokenForPush = (await AuthService.getToken()) ?? undefined;
+    const writeResult = await LocalGitWriter.writeAndCommit({
+      repoPath,
+      branch,
+      filePath: targetPath,
+      content: body,
+      message,
+      author: resolveAuthor(),
+      token: tokenForPush,
+    });
+    if (writeResult.success) return { success: true, filePath: targetPath };
+    return { success: false, error: writeResult.error };
+  }
 
   try {
     const result = await GitHubService.updateFile(
@@ -52,6 +82,20 @@ export async function deleteTemplateFromGitHub(params: {
   }
   const info = parseRepoPath(repoPath);
   if (!info) return { success: false, error: `Invalid repo path: ${repoPath}` };
+
+  // Clone-mode delete path (#514).
+  const mode = await SyncEngineService.getMode(repoPath);
+  if (mode === 'clone') {
+    const tokenForPush = (await AuthService.getToken()) ?? undefined;
+    return LocalGitWriter.deleteAndCommit({
+      repoPath,
+      branch,
+      filePath,
+      message: `Delete template ${name}`,
+      author: resolveAuthor(),
+      token: tokenForPush,
+    });
+  }
 
   let resolvedSha = sha;
   if (!resolvedSha) {

--- a/src/services/TodoGitHubSyncService.ts
+++ b/src/services/TodoGitHubSyncService.ts
@@ -2,6 +2,8 @@ import { GitHubService } from './GitHubService';
 import { Todo } from '../models/Todo';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { AuthService } from './AuthService';
+import { SyncEngineService } from './SyncEngineService';
+import { LocalGitWriter } from './git/LocalGitWriter';
 
 async function resolveToken(accountId?: string): Promise<string | undefined> {
   if (!accountId) return undefined;
@@ -64,6 +66,31 @@ export async function syncTodoToGitHub(params: {
 
   const content = serializeTodo(todo);
   const message = filePath ? `Update todo: ${text}` : `Create todo: ${text}`;
+
+  // Clone-mode write path (#514). Same on-disk shape as the API path so a
+  // mode flip later doesn't surface a no-op churn commit.
+  const mode = await SyncEngineService.getMode(repoPath);
+  if (mode === 'clone') {
+    const user = GitHubService.getUser();
+    const author = {
+      name: user?.name || user?.login || 'gitnotes',
+      email: user?.email || `${user?.login ?? 'gitnotes'}@users.noreply.github.com`,
+    };
+    const tokenForPush = tokenOverride ?? (await AuthService.getToken()) ?? undefined;
+    const writeResult = await LocalGitWriter.writeAndCommit({
+      repoPath,
+      branch: targetBranch,
+      filePath: targetPath,
+      content,
+      message,
+      author,
+      token: tokenForPush,
+    });
+    if (writeResult.success) {
+      return { success: true, filePath: targetPath };
+    }
+    return { success: false, error: writeResult.error };
+  }
 
   try {
     const result = await GitHubService.updateFile(

--- a/src/services/git/CloneMigrationService.ts
+++ b/src/services/git/CloneMigrationService.ts
@@ -1,0 +1,190 @@
+import { StorageService } from '../StorageService';
+import { GitHubService } from '../GitHubService';
+import { AuthService } from '../AuthService';
+import { LocalGitWriter } from './LocalGitWriter';
+import { TemplateRepoPreferenceService } from '../TemplateRepoPreferenceService';
+import { useTemplateStore } from '../../stores/templateStore';
+import { serializeTemplate, templateSlug } from '../TemplateMarkdownService';
+import { applyNoteTagsToContent, applyNoteColorToContent } from '../NoteGitHubSyncService';
+import type { Note } from '../../models/Note';
+import type { Todo } from '../../models/Todo';
+import type { Canvas } from '../../models/Canvas';
+import type { NoteTemplate } from '../TemplateService';
+
+export interface MigrationReport {
+  success: boolean;
+  notes: number;
+  todos: number;
+  canvases: number;
+  templates: number;
+  failures: { kind: string; filePath: string; error: string }[];
+}
+
+function authorFromUser() {
+  const user = GitHubService.getUser();
+  return {
+    name: user?.name || user?.login || 'gitnotes',
+    email: user?.email || `${user?.login ?? 'gitnotes'}@users.noreply.github.com`,
+  };
+}
+
+function serializeTodo(todo: Partial<Todo>): string {
+  return JSON.stringify(
+    {
+      text: todo.text ?? '',
+      completed: todo.completed ?? false,
+      priority: todo.priority,
+      notes: todo.notes,
+      tags: todo.tags ?? [],
+      dueDate: todo.dueDate,
+      createdAt: todo.createdAt,
+      updatedAt: todo.updatedAt,
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * One-shot import that copies every locally-tracked file with `repo ===
+ * repoPath` into the cloned working tree, stages + commits each one without
+ * pushing, then pushes the whole batch in a single round-trip. The point is
+ * to lift offline edits (notes the user wrote in API mode that never reached
+ * the remote) into the new clone before the first pull-fast-forward — without
+ * this step the next pull would fast-forward over them.
+ *
+ * Safe to re-run: writeAndCommit is idempotent at the working-tree level
+ * (overwrites + git-add will produce a no-op commit if content matches HEAD).
+ *
+ * Caller must ensure `SyncEngineService.getMode(repoPath) === 'clone'` and
+ * the working copy already exists (the Settings "Clone" action does both).
+ */
+export class CloneMigrationService {
+  static async migrateRepo(repoPath: string, branch: string): Promise<MigrationReport> {
+    const report: MigrationReport = {
+      success: true,
+      notes: 0,
+      todos: 0,
+      canvases: 0,
+      templates: 0,
+      failures: [],
+    };
+
+    const author = authorFromUser();
+    const token = (await AuthService.getToken()) ?? undefined;
+
+    const allNotes = await StorageService.getAllNotes();
+    const localNotes = allNotes.filter((n: Note) => n.repo === repoPath && n.filePath);
+    for (const n of localNotes) {
+      let content = n.content ?? '';
+      content = applyNoteTagsToContent(content, n.format, n.tags ?? []);
+      content = applyNoteColorToContent(content, n.format, n.color);
+      const result = await LocalGitWriter.writeAndCommit({
+        repoPath,
+        branch,
+        filePath: n.filePath!,
+        content,
+        message: `Migrate note: ${n.title}`,
+        author,
+        push: false,
+      });
+      if (result.success) report.notes++;
+      else
+        report.failures.push({
+          kind: 'note',
+          filePath: n.filePath!,
+          error: result.error ?? 'unknown',
+        });
+    }
+
+    const allTodos = await StorageService.getAllTodos();
+    const localTodos = allTodos.filter((t: Todo) => t.repo === repoPath && t.filePath);
+    for (const t of localTodos) {
+      const result = await LocalGitWriter.writeAndCommit({
+        repoPath,
+        branch,
+        filePath: t.filePath!,
+        content: serializeTodo(t),
+        message: `Migrate todo: ${t.text}`,
+        author,
+        push: false,
+      });
+      if (result.success) report.todos++;
+      else
+        report.failures.push({
+          kind: 'todo',
+          filePath: t.filePath!,
+          error: result.error ?? 'unknown',
+        });
+    }
+
+    let allCanvases: Canvas[] = [];
+    await StorageService.mutateCanvases((cs) => {
+      allCanvases = [...cs];
+    });
+    const localCanvases = allCanvases.filter((c) => c.repo === repoPath && c.filePath);
+    for (const c of localCanvases) {
+      const result = await LocalGitWriter.writeAndCommit({
+        repoPath,
+        branch,
+        filePath: c.filePath!,
+        content: JSON.stringify(c.scene, null, 2),
+        message: `Migrate canvas: ${c.title}`,
+        author,
+        push: false,
+      });
+      if (result.success) report.canvases++;
+      else
+        report.failures.push({
+          kind: 'canvas',
+          filePath: c.filePath!,
+          error: result.error ?? 'unknown',
+        });
+    }
+
+    // Templates only migrate when the configured templates repo matches the
+    // repo we're enabling clone mode for. Otherwise the user's templates live
+    // elsewhere and aren't part of this migration.
+    const tplPref = await TemplateRepoPreferenceService.get();
+    if (tplPref?.repoPath === repoPath) {
+      const customs = useTemplateStore.getState().customTemplates;
+      for (const t of customs) {
+        const targetPath = t.filePath || `templates/${templateSlug(t.name)}.md`;
+        const body = serializeTemplate({ ...t, filePath: undefined } as NoteTemplate);
+        const result = await LocalGitWriter.writeAndCommit({
+          repoPath,
+          branch,
+          filePath: targetPath,
+          content: body,
+          message: `Migrate template ${t.name}`,
+          author,
+          push: false,
+        });
+        if (result.success) report.templates++;
+        else
+          report.failures.push({
+            kind: 'template',
+            filePath: targetPath,
+            error: result.error ?? 'unknown',
+          });
+      }
+    }
+
+    // Flush the batch in one push.
+    const total = report.notes + report.todos + report.canvases + report.templates;
+    if (total > 0) {
+      const pushResult = await LocalGitWriter.push({ repoPath, branch, token });
+      if (!pushResult.success) {
+        report.success = false;
+        report.failures.push({
+          kind: 'push',
+          filePath: '',
+          error: pushResult.error ?? 'unknown',
+        });
+      }
+    }
+
+    if (report.failures.length > 0) report.success = report.failures.length === 0;
+    return report;
+  }
+}

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -123,6 +123,62 @@ export class GitFsService {
   }
 
   /**
+   * Fetch from origin then fast-forward the local branch if possible. Returns
+   * `{ ok: true }` on success and `{ ok: false, reason }` when the local
+   * branch has diverged from upstream. The pull-side caller (#514 phase 5)
+   * uses this in place of a plain fetch so we never silently overwrite local
+   * write commits the user hasn't pushed yet.
+   *
+   * Real 3-way merge / rebase + multi-file conflict UI are deferred — phase 5
+   * deliberately stops at "detect divergence and skip reconcile" so a stale
+   * upstream snapshot can't drop in-flight local edits. Conflict resolution
+   * UX is a separate, larger product surface.
+   */
+  static async pullWithFastForward(opts: FetchOpts): Promise<
+    { ok: true } | { ok: false; reason: 'diverged' | 'unknown'; error?: string }
+  > {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) return { ok: false, reason: 'unknown', error: `Invalid repo path: ${opts.repoPath}` };
+    const dir = repoDirVirtual(info.owner, info.repo);
+    const fs = makeRepoFs();
+
+    try {
+      await git.fetch({
+        fs,
+        http: gitHttp,
+        dir,
+        ref: opts.branch,
+        singleBranch: true,
+        depth: opts.depth ?? 1,
+        tags: false,
+        onAuth: ensureToken(opts.token),
+      });
+      await git.fastForward({
+        fs,
+        http: gitHttp,
+        dir,
+        ref: opts.branch,
+        singleBranch: true,
+        onAuth: ensureToken(opts.token),
+      });
+      return { ok: true };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      // isomorphic-git surfaces fast-forward failure as MergeNotSupportedError
+      // / FastForwardError; treat both as "diverged".
+      const code = (e as { code?: string }).code;
+      if (
+        code === 'FastForwardError' ||
+        code === 'MergeNotSupportedError' ||
+        /not.*fast.?forward/i.test(message)
+      ) {
+        return { ok: false, reason: 'diverged', error: message };
+      }
+      return { ok: false, reason: 'unknown', error: message };
+    }
+  }
+
+  /**
    * Recursive tree listing at the given ref. Output mirrors
    * `GitHubService.getTreeRecursiveOrThrow` so the Phase 2 swap is a transport
    * change, not a shape change.

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -1,0 +1,204 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import git, { TREE } from 'isomorphic-git';
+import { parseRepoPath } from '../../utils/gitPathParser';
+import { makeGitFs } from './gitFs';
+import { gitHttp } from './gitHttp';
+
+const CLONES_SUBDIR = 'gitnotes-clones/';
+
+/**
+ * Tree entry shape that mirrors `GitHubService.getTreeRecursiveOrThrow` so
+ * later phases can swap one for the other behind the SyncEngine flag without
+ * the callers caring which transport produced the listing.
+ */
+export interface GitTreeEntry {
+  path: string;
+  type: 'blob' | 'tree';
+  sha: string;
+  size?: number;
+}
+
+interface RepoLocator {
+  /** "owner/repo" — same canonical shape as GitRepository.path */
+  repoPath: string;
+}
+
+interface CloneOpts extends RepoLocator {
+  branch: string;
+  token?: string;
+  depth?: number;
+  onProgress?: (phase: string, loaded: number, total: number | null) => void;
+}
+
+interface FetchOpts extends RepoLocator {
+  branch: string;
+  token?: string;
+  depth?: number;
+}
+
+interface ReadOpts extends RepoLocator {
+  ref: string;
+  filepath: string;
+}
+
+interface ListOpts extends RepoLocator {
+  ref: string;
+}
+
+function clonesRoot(): string {
+  const docDir = FileSystem.documentDirectory;
+  if (!docDir) {
+    throw new Error('expo-file-system documentDirectory is not available in this environment');
+  }
+  return docDir.endsWith('/') ? docDir + CLONES_SUBDIR : `${docDir}/${CLONES_SUBDIR}`;
+}
+
+function repoDirVirtual(owner: string, repo: string): string {
+  // Virtual path passed to isomorphic-git. Stays free of the `file://` prefix
+  // so any internal path normalisation (collapsing `//` etc.) doesn't damage
+  // the URI; the real prefix lives on the FS adapter's root and gets joined
+  // back on at FS-call time.
+  return `/${owner}/${repo}`;
+}
+
+function makeRepoFs() {
+  return makeGitFs(clonesRoot());
+}
+
+function ensureToken(token: string | undefined) {
+  // GitHub PAT auth via Basic with a sentinel username. Same convention the
+  // existing GitHubService uses through Authorization: Bearer; isomorphic-git
+  // wants a username/password pair.
+  if (!token) return undefined;
+  return () => ({ username: 'x-access-token', password: token });
+}
+
+function authedRemote(owner: string, repo: string): string {
+  return `https://github.com/${owner}/${repo}.git`;
+}
+
+export class GitFsService {
+  /**
+   * Clone a repo into the per-app document directory. Defaults to depth=1
+   * (shallow) — Phase 1 only consumes file contents, full history isn't
+   * needed and burns disk + bandwidth.
+   */
+  static async clone(opts: CloneOpts): Promise<void> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) throw new Error(`Invalid repo path: ${opts.repoPath}`);
+
+    const dir = repoDirVirtual(info.owner, info.repo);
+
+    await git.clone({
+      fs: makeRepoFs(),
+      http: gitHttp,
+      dir,
+      url: authedRemote(info.owner, info.repo),
+      ref: opts.branch,
+      singleBranch: true,
+      depth: opts.depth ?? 1,
+      onAuth: ensureToken(opts.token),
+      onProgress: opts.onProgress
+        ? (event) => opts.onProgress!(event.phase, event.loaded, event.total ?? null)
+        : undefined,
+    });
+  }
+
+  /** Fetch updates for the cloned repo. Caller must have run `clone` first. */
+  static async fetch(opts: FetchOpts): Promise<void> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) throw new Error(`Invalid repo path: ${opts.repoPath}`);
+    const dir = repoDirVirtual(info.owner, info.repo);
+
+    await git.fetch({
+      fs: makeRepoFs(),
+      http: gitHttp,
+      dir,
+      ref: opts.branch,
+      singleBranch: true,
+      depth: opts.depth ?? 1,
+      tags: false,
+      onAuth: ensureToken(opts.token),
+    });
+  }
+
+  /**
+   * Recursive tree listing at the given ref. Output mirrors
+   * `GitHubService.getTreeRecursiveOrThrow` so the Phase 2 swap is a transport
+   * change, not a shape change.
+   */
+  static async listTree(opts: ListOpts): Promise<GitTreeEntry[]> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) throw new Error(`Invalid repo path: ${opts.repoPath}`);
+    const dir = repoDirVirtual(info.owner, info.repo);
+
+    const fs = makeRepoFs();
+    const out: GitTreeEntry[] = [];
+    await git.walk({
+      fs,
+      dir,
+      trees: [TREE({ ref: opts.ref })],
+      map: async (filename, entries) => {
+        if (filename === '.') return;
+        const entry = entries?.[0];
+        if (!entry) return;
+        const type = await entry.type();
+        if (type !== 'blob' && type !== 'tree') return;
+        const sha = await entry.oid();
+        out.push({ path: filename, type, sha });
+      },
+    });
+    return out;
+  }
+
+  /**
+   * Read a single file's contents at a ref. Returns null when missing so
+   * callers can keep their existing `null === missing` shape.
+   */
+  static async readFile(opts: ReadOpts): Promise<string | null> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) throw new Error(`Invalid repo path: ${opts.repoPath}`);
+    const dir = repoDirVirtual(info.owner, info.repo);
+
+    try {
+      const oid = await git.resolveRef({ fs: makeRepoFs(), dir, ref: opts.ref });
+      const { blob } = await git.readBlob({
+        fs: makeRepoFs(),
+        dir,
+        oid,
+        filepath: opts.filepath,
+      });
+      return new TextDecoder('utf-8').decode(blob);
+    } catch (e) {
+      const code = (e as { code?: string }).code;
+      if (code === 'NotFoundError' || code === 'ENOENT') return null;
+      throw e;
+    }
+  }
+
+  /** Returns true when a clone exists locally for this repo. */
+  static async isCloned(opts: RepoLocator): Promise<boolean> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) return false;
+    const fsRoot = clonesRoot();
+    const head = `${fsRoot}${info.owner}/${info.repo}/.git/HEAD`;
+    const stat = await FileSystem.getInfoAsync(head);
+    return !!stat.exists && !stat.isDirectory;
+  }
+
+  /** Drop the on-disk clone for a repo. Idempotent. */
+  static async removeRepo(opts: RepoLocator): Promise<void> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) return;
+    const fsRoot = clonesRoot();
+    const dir = `${fsRoot}${info.owner}/${info.repo}`;
+    await FileSystem.deleteAsync(dir, { idempotent: true });
+  }
+
+  /** Absolute on-disk URI of a repo's working tree. */
+  static workingTreeUri(opts: RepoLocator): string {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) throw new Error(`Invalid repo path: ${opts.repoPath}`);
+    return `${clonesRoot()}${info.owner}/${info.repo}`;
+  }
+}

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -1,0 +1,198 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import git from 'isomorphic-git';
+import { parseRepoPath } from '../../utils/gitPathParser';
+import { makeGitFs as buildGitFs } from './gitFs';
+import { gitHttp } from './gitHttp';
+
+const CLONES_SUBDIR = 'gitnotes-clones/';
+
+/**
+ * Result shape kept identical to the existing GitHub-Contents-API write paths
+ * (`NoteGitHubSyncResult`, `TodoGitHubSyncResult`, …) so callers can swap
+ * transports behind the SyncEngine flag without juggling shapes.
+ */
+export interface LocalGitWriterResult {
+  success: boolean;
+  filePath?: string;
+  error?: string;
+}
+
+interface AuthorInfo {
+  name: string;
+  email: string;
+}
+
+interface BaseOpts {
+  repoPath: string;
+  branch: string;
+  message: string;
+  author: AuthorInfo;
+}
+
+interface WriteOpts extends BaseOpts {
+  filePath: string;
+  content: string;
+  /** When true, push immediately. Defaults to true; callers can batch by passing false. */
+  push?: boolean;
+  token?: string;
+}
+
+interface DeleteOpts extends BaseOpts {
+  filePath: string;
+  push?: boolean;
+  token?: string;
+}
+
+function clonesRoot(): string {
+  const docDir = FileSystem.documentDirectory;
+  if (!docDir) {
+    throw new Error('expo-file-system documentDirectory is not available');
+  }
+  return docDir.endsWith('/') ? docDir + CLONES_SUBDIR : `${docDir}/${CLONES_SUBDIR}`;
+}
+
+function repoDirVirtual(owner: string, repo: string): string {
+  return `/${owner}/${repo}`;
+}
+
+function makeRepoFs() {
+  return buildGitFs(clonesRoot());
+}
+
+function tokenAuth(token: string | undefined) {
+  if (!token) return undefined;
+  return () => ({ username: 'x-access-token', password: token });
+}
+
+async function ensureParentDirs(rootDir: string, virtualPath: string): Promise<void> {
+  // virtualPath is e.g. "/me/repo/notes/foo.md". The on-disk root prefix lives
+  // on the FS adapter; here we walk the path segments and `mkdir` each missing
+  // ancestor under the absolute clones root. expo-file-system doesn't auto-
+  // create parents on writeAsStringAsync.
+  const parts = virtualPath.split('/').filter(Boolean);
+  parts.pop(); // drop the file segment itself
+  let acc = rootDir;
+  for (const part of parts) {
+    acc = acc + (acc.endsWith('/') ? '' : '/') + part;
+    const info = await FileSystem.getInfoAsync(acc);
+    if (!info.exists) {
+      await FileSystem.makeDirectoryAsync(acc, { intermediates: true });
+    }
+  }
+}
+
+export class LocalGitWriter {
+  /**
+   * Write content into the working tree, stage + commit, optionally push.
+   * Caller must have already cloned the repo (Phase 3 toggle handles that).
+   * Returns the same `{ success, filePath?, error? }` shape the existing
+   * Contents-API writers return.
+   */
+  static async writeAndCommit(opts: WriteOpts): Promise<LocalGitWriterResult> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) return { success: false, error: `Invalid repo path: ${opts.repoPath}` };
+
+    const dir = repoDirVirtual(info.owner, info.repo);
+    const fs = makeRepoFs();
+    const fsRoot = clonesRoot();
+
+    try {
+      const absVirtual = `${dir}/${opts.filePath}`;
+      const absUri = `${fsRoot}${absVirtual.replace(/^\//, '')}`;
+      await ensureParentDirs(fsRoot, absVirtual);
+      await FileSystem.writeAsStringAsync(absUri, opts.content);
+
+      await git.add({ fs, dir, filepath: opts.filePath });
+      await git.commit({
+        fs,
+        dir,
+        message: opts.message,
+        author: { name: opts.author.name, email: opts.author.email },
+      });
+
+      if (opts.push !== false) {
+        await git.push({
+          fs,
+          dir,
+          http: gitHttp,
+          ref: opts.branch,
+          remoteRef: opts.branch,
+          onAuth: tokenAuth(opts.token),
+        });
+      }
+
+      return { success: true, filePath: opts.filePath };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
+  /**
+   * Remove a tracked file from the working tree, stage + commit, optionally
+   * push.
+   */
+  static async deleteAndCommit(opts: DeleteOpts): Promise<LocalGitWriterResult> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) return { success: false, error: `Invalid repo path: ${opts.repoPath}` };
+
+    const dir = repoDirVirtual(info.owner, info.repo);
+    const fs = makeRepoFs();
+    const fsRoot = clonesRoot();
+
+    try {
+      const absUri = `${fsRoot}${info.owner}/${info.repo}/${opts.filePath}`;
+      await FileSystem.deleteAsync(absUri, { idempotent: true });
+
+      await git.remove({ fs, dir, filepath: opts.filePath });
+      await git.commit({
+        fs,
+        dir,
+        message: opts.message,
+        author: { name: opts.author.name, email: opts.author.email },
+      });
+
+      if (opts.push !== false) {
+        await git.push({
+          fs,
+          dir,
+          http: gitHttp,
+          ref: opts.branch,
+          remoteRef: opts.branch,
+          onAuth: tokenAuth(opts.token),
+        });
+      }
+
+      return { success: true, filePath: opts.filePath };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
+  /**
+   * Push pending local commits to the remote without staging or committing
+   * anything new. Used to flush a debounced batch of write calls that ran
+   * with `push: false`.
+   */
+  static async push(opts: { repoPath: string; branch: string; token?: string }): Promise<
+    LocalGitWriterResult
+  > {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) return { success: false, error: `Invalid repo path: ${opts.repoPath}` };
+
+    const dir = repoDirVirtual(info.owner, info.repo);
+    const fs = makeRepoFs();
+    try {
+      await git.push({
+        fs,
+        dir,
+        http: gitHttp,
+        ref: opts.branch,
+        remoteRef: opts.branch,
+        onAuth: tokenAuth(opts.token),
+      });
+      return { success: true };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+}

--- a/src/services/git/gitFs.ts
+++ b/src/services/git/gitFs.ts
@@ -1,0 +1,195 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import type { PromiseFsClient } from 'isomorphic-git';
+
+// Node-style FS errors. isomorphic-git inspects `err.code` to decide whether a
+// missing path is a legitimate "not yet created" condition or a real failure.
+class FsError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = 'FsError';
+  }
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = globalThis.atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return globalThis.btoa(bin);
+}
+
+function joinUri(root: string, virtualPath: string): string {
+  // virtualPath is git's view: "/foo/bar" or "foo/bar". Map onto the on-disk
+  // root which already ends in "file:///.../<base>/".
+  const trimmed = virtualPath.replace(/^\/+/, '');
+  return root + trimmed;
+}
+
+interface ReadOpts {
+  encoding?: 'utf8' | string;
+}
+
+/**
+ * Build a PromiseFsClient that isomorphic-git can drive against
+ * `expo-file-system/legacy`. The `root` argument is the absolute on-disk URI
+ * (e.g. `file:///.../gitnotes-clones/`) to which all virtual git paths get
+ * appended. Keeping the root out of the virtual path avoids the `file://` →
+ * `file:/` collapsing that path-normalisers do on protocol-prefixed strings.
+ */
+export function makeGitFs(root: string): PromiseFsClient {
+  if (!root.endsWith('/')) {
+    throw new Error(`gitFs root must end with '/': ${root}`);
+  }
+
+  const promises = {
+    async readFile(filepath: string, opts?: ReadOpts | string): Promise<string | Uint8Array> {
+      const uri = joinUri(root, filepath);
+      const info = await FileSystem.getInfoAsync(uri);
+      if (!info.exists) {
+        throw new FsError('ENOENT', `ENOENT: no such file '${filepath}'`);
+      }
+      if (info.isDirectory) {
+        throw new FsError('EISDIR', `EISDIR: illegal operation on directory '${filepath}'`);
+      }
+      const encoding = typeof opts === 'string' ? opts : opts?.encoding;
+      if (encoding === 'utf8') {
+        return await FileSystem.readAsStringAsync(uri);
+      }
+      const b64 = await FileSystem.readAsStringAsync(uri, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+      return base64ToBytes(b64);
+    },
+
+    async writeFile(
+      filepath: string,
+      data: string | Uint8Array,
+      opts?: ReadOpts | string,
+    ): Promise<void> {
+      const uri = joinUri(root, filepath);
+      // Ensure the parent directory exists. isomorphic-git creates `.git` and
+      // its subdirectories itself, but emits writeFile calls into them
+      // without re-checking. expo-file-system only auto-creates parents when
+      // `intermediates: true` is passed to makeDirectoryAsync — writeFile
+      // expects the parent to already be there. That contract holds in
+      // practice; if it ever breaks, we'd see ENOENT here.
+      if (typeof data === 'string') {
+        const encoding = typeof opts === 'string' ? opts : opts?.encoding;
+        if (encoding && encoding !== 'utf8') {
+          // Caller passed a non-utf8 encoding for a string body — treat it as
+          // an explicit binary signal and fall through to base64 path.
+        }
+        await FileSystem.writeAsStringAsync(uri, data);
+      } else {
+        const b64 = bytesToBase64(data);
+        await FileSystem.writeAsStringAsync(uri, b64, {
+          encoding: FileSystem.EncodingType.Base64,
+        });
+      }
+    },
+
+    async unlink(filepath: string): Promise<void> {
+      const uri = joinUri(root, filepath);
+      const info = await FileSystem.getInfoAsync(uri);
+      if (!info.exists) {
+        throw new FsError('ENOENT', `ENOENT: no such file '${filepath}'`);
+      }
+      await FileSystem.deleteAsync(uri, { idempotent: true });
+    },
+
+    async readdir(filepath: string): Promise<string[]> {
+      const uri = joinUri(root, filepath);
+      const info = await FileSystem.getInfoAsync(uri);
+      if (!info.exists) {
+        throw new FsError('ENOENT', `ENOENT: no such directory '${filepath}'`);
+      }
+      if (!info.isDirectory) {
+        throw new FsError('ENOTDIR', `ENOTDIR: not a directory '${filepath}'`);
+      }
+      return await FileSystem.readDirectoryAsync(uri);
+    },
+
+    async mkdir(filepath: string): Promise<void> {
+      const uri = joinUri(root, filepath);
+      const info = await FileSystem.getInfoAsync(uri);
+      if (info.exists) {
+        throw new FsError('EEXIST', `EEXIST: file already exists '${filepath}'`);
+      }
+      await FileSystem.makeDirectoryAsync(uri, { intermediates: false });
+    },
+
+    async rmdir(filepath: string): Promise<void> {
+      const uri = joinUri(root, filepath);
+      const info = await FileSystem.getInfoAsync(uri);
+      if (!info.exists) {
+        throw new FsError('ENOENT', `ENOENT: no such directory '${filepath}'`);
+      }
+      if (!info.isDirectory) {
+        throw new FsError('ENOTDIR', `ENOTDIR: not a directory '${filepath}'`);
+      }
+      await FileSystem.deleteAsync(uri, { idempotent: false });
+    },
+
+    async stat(filepath: string): Promise<{
+      type: 'file' | 'dir';
+      mode: number;
+      size: number;
+      ino: number;
+      mtimeSeconds: number;
+      mtimeNanoseconds: number;
+      ctimeSeconds: number;
+      ctimeNanoseconds: number;
+      uid: number;
+      gid: number;
+      dev: number;
+    }> {
+      const uri = joinUri(root, filepath);
+      const info = await FileSystem.getInfoAsync(uri);
+      if (!info.exists) {
+        throw new FsError('ENOENT', `ENOENT: no such path '${filepath}'`);
+      }
+      const isDir = !!info.isDirectory;
+      // expo-file-system returns modificationTime in seconds. ctime isn't
+      // exposed; reuse mtime — git only cares about ordering, not which
+      // clock recorded it.
+      const mtimeSeconds = Math.floor(info.modificationTime ?? 0);
+      return {
+        type: isDir ? 'dir' : 'file',
+        mode: isDir ? 0o40755 : 0o100644,
+        size: isDir ? 0 : info.size ?? 0,
+        ino: 0,
+        mtimeSeconds,
+        mtimeNanoseconds: 0,
+        ctimeSeconds: mtimeSeconds,
+        ctimeNanoseconds: 0,
+        uid: 0,
+        gid: 0,
+        dev: 0,
+      };
+    },
+
+    async lstat(filepath: string) {
+      // No symlinks on iOS sandboxes anyway — lstat == stat.
+      return promises.stat(filepath);
+    },
+
+    async readlink(filepath: string): Promise<string> {
+      throw new FsError('EINVAL', `readlink not supported '${filepath}'`);
+    },
+
+    async symlink(_target: string, filepath: string): Promise<void> {
+      throw new FsError('EPERM', `symlink not supported '${filepath}'`);
+    },
+  };
+
+  return { promises };
+}
+
+export { FsError };

--- a/src/services/git/gitHttp.ts
+++ b/src/services/git/gitHttp.ts
@@ -1,0 +1,66 @@
+import type { GitHttpRequest, GitHttpResponse, HttpClient } from 'isomorphic-git';
+
+async function* yieldOnce(bytes: Uint8Array): AsyncIterableIterator<Uint8Array> {
+  yield bytes;
+}
+
+async function consumeBody(
+  body: GitHttpRequest['body'],
+): Promise<Uint8Array | undefined> {
+  if (!body) return undefined;
+  // Body is an iterable (sync or async) of Uint8Arrays. Concat to a single
+  // buffer — the streaming win isn't worth the platform-specific plumbing on
+  // RN for the request side, where bodies stay small (refspec advertisements,
+  // small packs from shallow clones).
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of body as Iterable<Uint8Array> | AsyncIterable<Uint8Array>) {
+    chunks.push(chunk);
+  }
+  let total = 0;
+  for (const c of chunks) total += c.length;
+  const merged = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    merged.set(c, off);
+    off += c.length;
+  }
+  return merged;
+}
+
+/**
+ * Minimal HTTP client for isomorphic-git built on `fetch`. RN/Hermes ships
+ * `fetch` natively; we deliberately avoid `isomorphic-git/http/web` because
+ * its body-streaming path leans on `ReadableStream` features that aren't
+ * universally polyfilled on the RN runtime we ship.
+ *
+ * Buffering the response body in memory is fine for the workloads Phase 1
+ * targets (shallow clones / refspec advertisements). When we wire push and
+ * deep clones in later phases, we can revisit and stream.
+ */
+export const gitHttp: HttpClient = {
+  async request(req: GitHttpRequest): Promise<GitHttpResponse> {
+    const body = await consumeBody(req.body);
+    const response = await fetch(req.url, {
+      method: req.method ?? 'GET',
+      headers: req.headers ?? {},
+      body: body as BodyInit | undefined,
+    });
+
+    const buffer = await response.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+
+    const headers: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+
+    return {
+      url: response.url || req.url,
+      method: req.method,
+      headers,
+      statusCode: response.status,
+      statusMessage: response.statusText,
+      body: yieldOnce(bytes),
+    };
+  },
+};


### PR DESCRIPTION
End-to-end implementation of #514. **Default behaviour is unchanged for every existing user** — every code path branches on \`SyncEngineService.getMode(repoPath)\` which defaults to \`'api'\`. Only repos the user explicitly opts into 'clone' mode see the new behaviour.

## Roadmap, all landed

| Phase | What |
|-------|------|
| 1 | \`gitFs\` adapter + \`gitHttp\` client + \`GitFsService\` (clone / fetch / listTree / readFile / removeRepo) + \`SyncEngineService\` (per-repo toggle). No callers wired. |
| 2 | \`pullNotesFromRepo\` reads through \`GitFsService\` when clone mode is on. Lazy clone on first pull. |
| 3 | Settings → Sync engine: per-repo toggle. "Clone" runs the clone with a spinner; "Use API" removes the local working tree and reverts. |
| 4 | \`LocalGitWriter\` (\`writeAndCommit\` / \`deleteAndCommit\` / \`push\`). \`syncNoteToGitHub\` and \`deleteNoteFromGitHub\` route through it in clone mode. |
| 5 | Pull-side switches from bare \`fetch\` to \`pullWithFastForward\`: fetch then fast-forward, abort on divergence so unpushed local commits can't be silently shadowed by reconcile. |
| 6 | Same write path applied to \`syncTodoToGitHub\`, \`syncCanvasToGitHub\`, \`syncTemplateToGitHub\` + \`deleteTemplateFromGitHub\`. |
| 7 | \`CloneMigrationService.migrateRepo\` lifts existing locally-tracked files (notes / todos / canvases / templates) into the working tree as a single batched push. Settings prompts the user after a successful clone with "Push offline edits?". |

## Files

- \`src/services/git/gitFs.ts\` — PromiseFsClient over expo-file-system
- \`src/services/git/gitHttp.ts\` — fetch-based HttpClient
- \`src/services/git/GitFsService.ts\` — clone / fetch / pullWithFastForward / listTree / readFile / isCloned / removeRepo
- \`src/services/git/LocalGitWriter.ts\` — writeAndCommit / deleteAndCommit / push
- \`src/services/git/CloneMigrationService.ts\` — one-shot migrate existing local edits
- \`src/services/SyncEngineService.ts\` — per-repo \`{ api, clone }\` flag persisted under \`@gitnotes:sync_engine_modes\`
- \`src/services/RepoPullService.ts\` — \`getRepoReader\` helper that picks transport per repo
- \`src/services/{Note,Todo,Canvas,Template}GitHubSyncService.ts\` — clone-mode branches that route through LocalGitWriter
- \`src/screens/SettingsScreen.tsx\` — Sync engine section + post-clone migration prompt

## Tests

\`403/403\` jest pass, \`tsc\` clean. New tests:
- \`gitFs.test.ts\` — adapter contract (utf-8 + binary round-trips, ENOENT/ENOTDIR/EEXIST codes, Stat shape)
- \`gitFsService.test.ts\` — clone/fetch/listTree/readFile/isCloned/removeRepo + pullWithFastForward branching
- \`localGitWriter.test.ts\` — write/commit/push, push:false batching, commit-failure surface, idempotent delete, push-only flush
- \`syncEngineService.test.ts\` — default fallthrough, override persistence
- \`notes-pull-clone-mode.test.ts\` — clone mode dispatches through GitFs not GitHub, api mode keeps using GitHub, divergence aborts pull
- \`cloneMigration.test.ts\` — filters by repo + filePath, push:false batching with single flush push, per-item failure tolerance

## What stayed on the API path

Image uploads (\`uploadLocalImages\` via \`GitHubService.uploadBinaryFile\`) still go through the Contents API even in clone mode. Routing image writes through the working tree so they batch with their parent note's commit is a follow-up — not load-bearing for the offline-write win.

Pull-side parity for canvases / todos / templates listings (\`fetchDirectoryFiles\` via \`getRepoContents\`) stays on the API in clone mode. The pull win we *needed* — divergence safety on notes — landed in phase 5; the others are background pulls that don't conflict with offline writes.

A real 3-way merge / multi-file conflict UI is intentionally not in scope for this PR. Phase 5's "abort on divergence" is the safety property the rest of the system needs; conflict resolution UX is its own product surface and can layer on later without touching the contract here.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx jest\` 403/403 pass
- [ ] Manual: connect a real repo, toggle Sync engine → Clone, edit a note offline, reconnect, verify the commit lands
- [ ] Manual: with offline edits already in API mode, flip to Clone, accept "Push edits", verify the batched commit appears in repo history with the right author

🤖 Generated with [Claude Code](https://claude.com/claude-code)