### PR TITLE
fix(settings): shorten "Sync custom templates" label (#516)

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -790,8 +790,11 @@ export default function SettingsScreen() {
               >
                 <View style={styles.settingLeft}>
                   <Ionicons name="cloud-upload-outline" size={20} color={colors.text} />
-                  <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12 }]}>
-                    Sync existing custom templates to repo
+                  <Text
+                    style={[styles.settingLabel, { color: colors.text, marginLeft: 12, flexShrink: 1 }]}
+                    numberOfLines={1}
+                  >
+                    Sync custom templates
                   </Text>
                 </View>
                 {isSyncingExistingTemplates ? (


### PR DESCRIPTION
## Summary
Shortened the "Sync existing custom templates to repo" label to "Sync custom templates" to fix text clipping on narrow widths (iPhone SE) and when the loading spinner appears. Added `numberOfLines={1}` and `flexShrink: 1` as defensive measures against future translations that might lengthen the string.

Closes #516.