### PR TITLE
feat(templates): "+ New custom template" CTA in the picker (#515)

### DIFF
--- a/__tests__/template-selector-cta.test.tsx
+++ b/__tests__/template-selector-cta.test.tsx
@@ -1,0 +1,88 @@
+// Stash the nav mock so it's accessible after jest.mock() hoisting.
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return { Ionicons: ({ name }: { name: string }) => React.createElement(Text, null, name) };
+});
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f4f4f4',
+      surfaceSecondary: '#eee',
+      elevated: '#fff',
+      card: '#fff',
+      shadow: '#000',
+      primary: '#2563eb',
+      text: '#111',
+      textSecondary: '#666',
+      border: '#ddd',
+    },
+  }),
+}));
+
+jest.mock('../src/components/ui', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    Modal: ({ visible, children }: any) => (visible ? <View>{children}</View> : null),
+  };
+});
+
+jest.mock('../src/services/TemplateService', () => ({
+  TemplateService: {
+    getAllTemplates: jest.fn(async () => []),
+    searchTemplates: jest.fn(async () => []),
+  },
+}));
+
+import React from 'react';
+import { act, render, fireEvent, waitFor } from '@testing-library/react-native';
+import TemplateSelector from '../src/components/TemplateSelector';
+
+describe('TemplateSelector CTA', () => {
+  const onClose = jest.fn();
+  const onSelect = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the "New custom template" CTA', async () => {
+    const { getByLabelText } = render(
+      <TemplateSelector visible={true} onClose={onClose} onSelect={onSelect} />
+    );
+
+    await waitFor(() => expect(getByLabelText('New custom template')).toBeTruthy());
+  });
+
+  it('calls onClose and navigates to TemplateManager when CTA is pressed', async () => {
+    const { getByLabelText } = render(
+      <TemplateSelector visible={true} onClose={onClose} onSelect={onSelect} />
+    );
+
+    await waitFor(() => expect(getByLabelText('New custom template')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByLabelText('New custom template'));
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('TemplateManager');
+  });
+
+  it('does not render the CTA when picker is not visible', () => {
+    const { queryByLabelText } = render(
+      <TemplateSelector visible={false} onClose={onClose} onSelect={onSelect} />
+    );
+
+    expect(queryByLabelText('New custom template')).toBeNull();
+  });
+});

--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -9,9 +9,12 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { ActivityIndicator } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { NoteTemplate, TemplateService } from '../services/TemplateService';
 import { useTheme } from '../contexts/ThemeContext';
 import { Modal } from './ui';
+import type { RootStackParamList } from '../navigation/types';
 
 interface TemplateSelectorProps {
   visible: boolean;
@@ -49,11 +52,19 @@ const TemplateListItem = ({ item, onSelect, colors }: TemplateListItemProps) => 
   );
 };
 
+type Nav = NativeStackNavigationProp<RootStackParamList>;
+
 export default function TemplateSelector({ visible, onClose, onSelect }: TemplateSelectorProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [templates, setTemplates] = useState<NoteTemplate[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const { colors } = useTheme();
+  const navigation = useNavigation<Nav>();
+
+  const handleCreateTemplate = useCallback(() => {
+    onClose();
+    navigation.navigate('TemplateManager');
+  }, [onClose, navigation]);
 
   const loadTemplates = useCallback(async () => {
     setIsLoading(true);
@@ -112,6 +123,22 @@ export default function TemplateSelector({ visible, onClose, onSelect }: Templat
           renderItem={renderTemplate}
           keyExtractor={(item) => item.id}
           contentContainerStyle={styles.listContent}
+          ListHeaderComponent={
+            <TouchableOpacity
+              accessibilityLabel="New custom template"
+              style={[styles.templateItem, { backgroundColor: colors.card, shadowColor: colors.shadow }]}
+              onPress={handleCreateTemplate}
+            >
+              <View style={[styles.templateIcon, { backgroundColor: colors.primary + '20' }]}>
+                <Ionicons name="add-circle-outline" size={24} color={colors.primary} />
+              </View>
+              <View style={styles.templateInfo}>
+                <Text style={[styles.templateName, { color: colors.primary }]}>New custom template</Text>
+                <Text style={[styles.templateDescription, { color: colors.textSecondary }]}>Create your own template</Text>
+              </View>
+              <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
+            </TouchableOpacity>
+          }
           ListEmptyComponent={
             isLoading ? (
               <View style={styles.emptyState}>


### PR DESCRIPTION
## Summary

- Adds a `ListHeaderComponent` to `TemplateSelector`'s `FlatList` with a tappable "+ New custom template" row pinned above the searchable template list.
- Tapping the CTA calls `onClose()` (dismisses the picker) then `navigation.navigate('TemplateManager')`, dropping users directly into the Template Manager to create their template.
- Visual style mirrors existing `templateItem` rows: same padding, icon slot (`add-circle-outline`), name in `primary` color, subtitle "Create your own template" styled like `templateDescription`.

## Test

New test file `__tests__/template-selector-cta.test.tsx` (3 tests):
1. CTA renders when picker is visible.
2. Pressing CTA calls `onClose` and navigates to `'TemplateManager'`.
3. CTA is absent when picker is not visible.

Full suite: 406 tests / 65 suites, all passing. `tsc --noEmit` clean.

Closes #515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)