### PR TITLE
feat(templates): rich new-template modal with icon, description, tags, default title

### DIFF
--- a/__tests__/template-manager-screen.test.tsx
+++ b/__tests__/template-manager-screen.test.tsx
@@ -156,6 +156,78 @@ describe('TemplateManagerScreen', () => {
     expect(useTemplateStore.getState().customTemplates[0].id.startsWith('custom-')).toBe(true);
   });
 
+  it('persists icon, description, title, and tags from the create modal', async () => {
+    const { getByTestId, getByText } = render(<TemplateManagerScreen />);
+
+    await waitFor(() => expect(getByText('Templates')).toBeTruthy());
+
+    fireEvent.press(getByTestId('template-create-cta'));
+    fireEvent.changeText(getByTestId('template-name-input'), 'Retro');
+    fireEvent.press(getByTestId('template-icon-bulb-outline'));
+    fireEvent.changeText(getByTestId('template-description-input'), 'Weekly retrospective');
+    fireEvent.changeText(getByTestId('template-title-input'), 'Retro - ');
+    fireEvent.changeText(getByTestId('template-tag-input'), 'team, weekly,');
+    fireEvent.changeText(getByTestId('template-content-input'), '## Wins');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('template-save-btn'));
+    });
+
+    await waitFor(() => {
+      const created = useTemplateStore.getState().customTemplates[0];
+      expect(created).toBeTruthy();
+      expect(created.name).toBe('Retro');
+      expect(created.icon).toBe('bulb-outline');
+      expect(created.description).toBe('Weekly retrospective');
+      expect(created.title).toBe('Retro - ');
+      expect(created.tags).toEqual(['team', 'weekly']);
+      expect(created.content).toBe('## Wins');
+    });
+  });
+
+  it('preloads icon, description, title, and tags when editing', async () => {
+    await act(async () => {
+      await useTemplateStore.getState().createTemplate({
+        name: 'Editable',
+        icon: 'rocket-outline',
+        description: 'Original description',
+        title: 'Launch - ',
+        content: 'body',
+        tags: ['ship', 'launch'],
+      });
+    });
+
+    const created = useTemplateStore.getState().customTemplates[0];
+    const { getByTestId, getByText } = render(<TemplateManagerScreen />);
+
+    await waitFor(() => expect(getByText('Editable')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId(`template-edit-${created.id}`));
+    });
+
+    expect(getByTestId('template-name-input').props.value).toBe('Editable');
+    expect(getByTestId('template-description-input').props.value).toBe('Original description');
+    expect(getByTestId('template-title-input').props.value).toBe('Launch - ');
+    expect(getByTestId(`template-tag-chip-ship`)).toBeTruthy();
+    expect(getByTestId(`template-tag-chip-launch`)).toBeTruthy();
+    expect(getByTestId('template-icon-rocket-outline').props.accessibilityState).toMatchObject({ selected: true });
+
+    fireEvent.changeText(getByTestId('template-description-input'), 'Updated description');
+    fireEvent.press(getByTestId('template-tag-chip-ship'));
+
+    await act(async () => {
+      fireEvent.press(getByTestId('template-save-btn'));
+    });
+
+    await waitFor(() => {
+      const updated = useTemplateStore.getState().customTemplates[0];
+      expect(updated.description).toBe('Updated description');
+      expect(updated.tags).toEqual(['launch']);
+      expect(updated.icon).toBe('rocket-outline');
+    });
+  });
+
   it('toggles pin via the pin button and persists state', async () => {
     const { getByTestId, findByTestId } = render(<TemplateManagerScreen />);
 

--- a/__tests__/template-tags.test.ts
+++ b/__tests__/template-tags.test.ts
@@ -1,0 +1,90 @@
+import {
+  TEMPLATE_MAX_TAGS,
+  TEMPLATE_MAX_TAG_LENGTH,
+  commitPendingTag,
+  parseTagInput,
+} from '../src/utils/templateTags';
+
+describe('parseTagInput', () => {
+  it('keeps a typed-but-not-finalized tag in the remainder', () => {
+    const result = parseTagInput('foo', []);
+    expect(result.committed).toEqual([]);
+    expect(result.remainder).toBe('foo');
+  });
+
+  it('commits a tag when followed by a comma', () => {
+    const result = parseTagInput('foo,', []);
+    expect(result.committed).toEqual(['foo']);
+    expect(result.remainder).toBe('');
+  });
+
+  it('commits a tag when followed by a space', () => {
+    const result = parseTagInput('foo ', []);
+    expect(result.committed).toEqual(['foo']);
+    expect(result.remainder).toBe('');
+  });
+
+  it('commits multiple tags from one paste', () => {
+    const result = parseTagInput('alpha, beta gamma,', []);
+    expect(result.committed).toEqual(['alpha', 'beta', 'gamma']);
+    expect(result.remainder).toBe('');
+  });
+
+  it('preserves trailing in-progress text', () => {
+    const result = parseTagInput('alpha, bet', []);
+    expect(result.committed).toEqual(['alpha']);
+    expect(result.remainder).toBe('bet');
+  });
+
+  it('lowercases tags', () => {
+    const result = parseTagInput('FOO,Bar ', []);
+    expect(result.committed).toEqual(['foo', 'bar']);
+  });
+
+  it('dedupes against existing tags', () => {
+    const result = parseTagInput('foo,bar,', ['foo']);
+    expect(result.committed).toEqual(['foo', 'bar']);
+  });
+
+  it('respects max tag length', () => {
+    const long = 'a'.repeat(TEMPLATE_MAX_TAG_LENGTH + 10);
+    const result = parseTagInput(`${long},`, []);
+    expect(result.committed[0]).toHaveLength(TEMPLATE_MAX_TAG_LENGTH);
+  });
+
+  it('respects max tag count', () => {
+    const existing = Array.from({ length: TEMPLATE_MAX_TAGS }, (_, i) => `tag${i}`);
+    const result = parseTagInput('overflow,', existing);
+    expect(result.committed).toEqual(existing);
+  });
+
+  it('skips empty separators (consecutive commas)', () => {
+    const result = parseTagInput('foo,,bar,', []);
+    expect(result.committed).toEqual(['foo', 'bar']);
+  });
+});
+
+describe('commitPendingTag', () => {
+  it('commits a non-empty trimmed tag', () => {
+    expect(commitPendingTag('  foo  ', [])).toEqual(['foo']);
+  });
+
+  it('returns existing list for empty input', () => {
+    expect(commitPendingTag('   ', ['foo'])).toEqual(['foo']);
+  });
+
+  it('skips duplicates', () => {
+    expect(commitPendingTag('foo', ['foo'])).toEqual(['foo']);
+  });
+
+  it('respects max length', () => {
+    const long = 'a'.repeat(TEMPLATE_MAX_TAG_LENGTH + 5);
+    const result = commitPendingTag(long, []);
+    expect(result[0]).toHaveLength(TEMPLATE_MAX_TAG_LENGTH);
+  });
+
+  it('respects max count', () => {
+    const existing = Array.from({ length: TEMPLATE_MAX_TAGS }, (_, i) => `tag${i}`);
+    expect(commitPendingTag('overflow', existing)).toEqual(existing);
+  });
+});

--- a/src/screens/TemplateManagerScreen.tsx
+++ b/src/screens/TemplateManagerScreen.tsx
@@ -18,10 +18,33 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import { ScreenHeader, IconButton, Modal, useScreenHeaderHeight } from '../components/ui';
 import { useTemplateStore } from '../stores/templateStore';
-import { NoteTemplate } from '../services/TemplateService';
+import { NoteTemplate, NoteTemplateIcon } from '../services/TemplateService';
 import { HapticService } from '../utils/haptics';
 import { TemplateRepoPreferenceService, TemplateRepoPreference } from '../services/TemplateRepoPreferenceService';
 import { pullTemplatesFromConfiguredRepo } from '../services/RepoPullService';
+import {
+  TEMPLATE_MAX_TAGS,
+  TEMPLATE_MAX_TAG_LENGTH,
+  commitPendingTag,
+  parseTagInput,
+} from '../utils/templateTags';
+
+const ICON_OPTIONS: NoteTemplateIcon[] = [
+  'document-outline',
+  'people-outline',
+  'bulb-outline',
+  'code-slash-outline',
+  'book-outline',
+  'bug-outline',
+  'checkmark-done-outline',
+  'calendar-outline',
+  'pencil-outline',
+  'flask-outline',
+  'rocket-outline',
+  'flag-outline',
+];
+
+const DEFAULT_ICON: NoteTemplateIcon = 'document-outline';
 
 export default function TemplateManagerScreen() {
   const navigation = useNavigation();
@@ -41,6 +64,11 @@ export default function TemplateManagerScreen() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftName, setDraftName] = useState('');
   const [draftContent, setDraftContent] = useState('');
+  const [draftIcon, setDraftIcon] = useState<NoteTemplateIcon>(DEFAULT_ICON);
+  const [draftDescription, setDraftDescription] = useState('');
+  const [draftTitle, setDraftTitle] = useState('');
+  const [draftTags, setDraftTags] = useState<string[]>([]);
+  const [tagDraft, setTagDraft] = useState('');
   const [templatesRepoPref, setTemplatesRepoPref] = useState<TemplateRepoPreference | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -59,29 +87,63 @@ export default function TemplateManagerScreen() {
     }
   }, [loadTemplates]);
 
-  // Recompute on store changes (customTemplates / pinnedIds in deps).
   const allTemplates = useMemo(
     () => getAllTemplates(),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [customTemplates, pinnedIds, getAllTemplates],
   );
 
-  const handleOpenCreate = useCallback(() => {
+  const resetDraft = useCallback(() => {
     setEditingId(null);
     setDraftName('');
     setDraftContent('');
-    setShowEditor(true);
+    setDraftIcon(DEFAULT_ICON);
+    setDraftDescription('');
+    setDraftTitle('');
+    setDraftTags([]);
+    setTagDraft('');
   }, []);
+
+  const handleOpenCreate = useCallback(() => {
+    resetDraft();
+    setShowEditor(true);
+  }, [resetDraft]);
 
   const handleOpenEdit = useCallback((template: NoteTemplate) => {
     setEditingId(template.id);
     setDraftName(template.name);
     setDraftContent(template.content);
+    setDraftIcon(template.icon ?? DEFAULT_ICON);
+    setDraftDescription(template.description ?? '');
+    setDraftTitle(template.title ?? '');
+    setDraftTags(template.tags ?? []);
+    setTagDraft('');
     setShowEditor(true);
   }, []);
 
   const handleCloseEditor = useCallback(() => {
     setShowEditor(false);
+  }, []);
+
+  const handleTagInputChange = useCallback(
+    (text: string) => {
+      const { committed, remainder } = parseTagInput(text, draftTags);
+      if (committed.length !== draftTags.length) {
+        setDraftTags(committed);
+      }
+      setTagDraft(remainder);
+    },
+    [draftTags],
+  );
+
+  const handleTagSubmit = useCallback(() => {
+    const next = commitPendingTag(tagDraft, draftTags);
+    setDraftTags(next);
+    setTagDraft('');
+  }, [tagDraft, draftTags]);
+
+  const handleRemoveTag = useCallback((tag: string) => {
+    setDraftTags((prev) => prev.filter((t) => t !== tag));
   }, []);
 
   const handleSave = useCallback(async () => {
@@ -90,16 +152,29 @@ export default function TemplateManagerScreen() {
       Alert.alert('Name required', 'Please give your template a name.');
       return;
     }
+    const description = draftDescription.trim();
+    const trimmedTitle = draftTitle.trim();
+    const title = trimmedTitle ? draftTitle : '';
+    const finalTags = commitPendingTag(tagDraft, draftTags);
+
     try {
       if (editingId) {
-        await updateTemplate(editingId, { name, content: draftContent });
+        await updateTemplate(editingId, {
+          name,
+          icon: draftIcon,
+          description,
+          title: title || undefined,
+          content: draftContent,
+          tags: finalTags,
+        });
       } else {
         await createTemplate({
           name,
-          icon: 'document-outline',
-          description: 'Custom template',
+          icon: draftIcon,
+          description,
+          title: title || undefined,
           content: draftContent,
-          tags: [],
+          tags: finalTags,
         });
       }
       HapticService.success();
@@ -109,7 +184,18 @@ export default function TemplateManagerScreen() {
       HapticService.error();
       Alert.alert('Save failed', 'Could not save the template. Please try again.');
     }
-  }, [draftName, draftContent, editingId, createTemplate, updateTemplate]);
+  }, [
+    draftName,
+    draftDescription,
+    draftTitle,
+    draftIcon,
+    draftContent,
+    draftTags,
+    tagDraft,
+    editingId,
+    createTemplate,
+    updateTemplate,
+  ]);
 
   const handleDelete = useCallback(
     (template: NoteTemplate) => {
@@ -205,6 +291,9 @@ export default function TemplateManagerScreen() {
   };
 
   const customCount = customTemplates.length;
+  const previewName = draftName.trim() || (editingId ? 'Untitled template' : 'New template');
+  const previewDescription = draftDescription.trim() || 'No description yet';
+  const tagLimitReached = draftTags.length >= TEMPLATE_MAX_TAGS;
 
   return (
     <SafeAreaView edges={['bottom']} style={[styles.container, { backgroundColor: colors.background }]}>
@@ -241,7 +330,7 @@ export default function TemplateManagerScreen() {
         )}
       </ScrollView>
 
-      <Modal visible={showEditor} onRequestClose={handleCloseEditor}>
+      <Modal visible={showEditor} onRequestClose={handleCloseEditor} contentStyle={styles.modalSurface}>
         <KeyboardAvoidingView
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
           style={styles.editorContainer}
@@ -249,36 +338,180 @@ export default function TemplateManagerScreen() {
           <Text style={[styles.editorTitle, { color: colors.text }]}>
             {editingId ? 'Edit template' : 'New template'}
           </Text>
-          <Text style={[styles.label, { color: colors.textSecondary }]}>Name</Text>
-          <TextInput
-            testID="template-name-input"
-            value={draftName}
-            onChangeText={setDraftName}
-            placeholder="My template"
-            placeholderTextColor={colors.textSecondary}
-            style={[
-              styles.nameInput,
-              { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
-            ]}
-            maxLength={60}
-          />
 
-          <Text style={[styles.label, { color: colors.textSecondary, marginTop: 12 }]}>
-            Initial content
-          </Text>
-          <TextInput
-            testID="template-content-input"
-            value={draftContent}
-            onChangeText={setDraftContent}
-            placeholder={'## Heading\n\nWrite something...'}
-            placeholderTextColor={colors.textSecondary}
-            multiline
-            textAlignVertical="top"
-            style={[
-              styles.contentInput,
-              { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
-            ]}
-          />
+          <ScrollView
+            style={styles.editorScroll}
+            contentContainerStyle={styles.editorScrollContent}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <View
+              testID="template-preview-card"
+              style={[styles.previewCard, { backgroundColor: colors.surface, borderColor: colors.border }]}
+            >
+              <View style={[styles.previewIcon, { backgroundColor: colors.primary + '20' }]}>
+                <Ionicons name={draftIcon} size={22} color={colors.primary} />
+              </View>
+              <View style={styles.previewMeta}>
+                <Text style={[styles.previewName, { color: colors.text }]} numberOfLines={1}>
+                  {previewName}
+                </Text>
+                <Text
+                  style={[styles.previewDesc, { color: colors.textSecondary }]}
+                  numberOfLines={2}
+                >
+                  {previewDescription}
+                </Text>
+                {draftTags.length > 0 && (
+                  <View style={styles.previewTags}>
+                    {draftTags.map((tag) => (
+                      <View
+                        key={`preview-${tag}`}
+                        style={[styles.previewTagChip, { backgroundColor: colors.surfaceSecondary }]}
+                      >
+                        <Text style={[styles.previewTagText, { color: colors.textSecondary }]}>
+                          {tag}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+              </View>
+            </View>
+
+            <Text style={[styles.label, { color: colors.textSecondary }]}>Name</Text>
+            <TextInput
+              testID="template-name-input"
+              value={draftName}
+              onChangeText={setDraftName}
+              placeholder="My template"
+              placeholderTextColor={colors.textSecondary}
+              style={[
+                styles.nameInput,
+                { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+              ]}
+              maxLength={60}
+            />
+
+            <Text style={[styles.label, { color: colors.textSecondary, marginTop: 14 }]}>Icon</Text>
+            <View style={styles.iconGrid} testID="template-icon-grid">
+              {ICON_OPTIONS.map((icon) => {
+                const selected = icon === draftIcon;
+                return (
+                  <TouchableOpacity
+                    key={icon}
+                    testID={`template-icon-${icon}`}
+                    accessibilityLabel={`Select ${icon} icon`}
+                    accessibilityState={{ selected }}
+                    onPress={() => setDraftIcon(icon)}
+                    style={[
+                      styles.iconCell,
+                      {
+                        backgroundColor: selected ? colors.primary : colors.surfaceSecondary,
+                        borderColor: selected ? colors.primary : colors.border,
+                      },
+                    ]}
+                  >
+                    <Ionicons
+                      name={icon}
+                      size={20}
+                      color={selected ? '#fff' : colors.textSecondary}
+                    />
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            <Text style={[styles.label, { color: colors.textSecondary, marginTop: 14 }]}>
+              Description
+            </Text>
+            <TextInput
+              testID="template-description-input"
+              value={draftDescription}
+              onChangeText={setDraftDescription}
+              placeholder="e.g. Weekly retrospective"
+              placeholderTextColor={colors.textSecondary}
+              style={[
+                styles.nameInput,
+                { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+              ]}
+              maxLength={120}
+            />
+
+            <Text style={[styles.label, { color: colors.textSecondary, marginTop: 14 }]}>
+              Default note title (optional)
+            </Text>
+            <TextInput
+              testID="template-title-input"
+              value={draftTitle}
+              onChangeText={setDraftTitle}
+              placeholder="e.g. Standup - "
+              placeholderTextColor={colors.textSecondary}
+              style={[
+                styles.nameInput,
+                { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+              ]}
+              maxLength={80}
+            />
+
+            <Text style={[styles.label, { color: colors.textSecondary, marginTop: 14 }]}>Tags</Text>
+            {draftTags.length > 0 && (
+              <View style={styles.tagChipRow} testID="template-tag-chips">
+                {draftTags.map((tag) => (
+                  <TouchableOpacity
+                    key={tag}
+                    testID={`template-tag-chip-${tag}`}
+                    accessibilityLabel={`Remove tag ${tag}`}
+                    onPress={() => handleRemoveTag(tag)}
+                    style={[styles.tagChip, { backgroundColor: colors.primary + '20', borderColor: colors.primary + '40' }]}
+                    activeOpacity={0.7}
+                  >
+                    <Text style={[styles.tagChipText, { color: colors.primary }]}>{tag}</Text>
+                    <Ionicons name="close" size={14} color={colors.primary} />
+                  </TouchableOpacity>
+                ))}
+              </View>
+            )}
+            <TextInput
+              testID="template-tag-input"
+              value={tagDraft}
+              onChangeText={handleTagInputChange}
+              onSubmitEditing={handleTagSubmit}
+              onBlur={handleTagSubmit}
+              placeholder={
+                tagLimitReached
+                  ? `Max ${TEMPLATE_MAX_TAGS} tags`
+                  : 'Add tags (comma or space to separate)'
+              }
+              placeholderTextColor={colors.textSecondary}
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!tagLimitReached}
+              maxLength={TEMPLATE_MAX_TAG_LENGTH + 1}
+              style={[
+                styles.nameInput,
+                { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+              ]}
+              returnKeyType="done"
+            />
+
+            <Text style={[styles.label, { color: colors.textSecondary, marginTop: 14 }]}>
+              Initial content
+            </Text>
+            <TextInput
+              testID="template-content-input"
+              value={draftContent}
+              onChangeText={setDraftContent}
+              placeholder={'## Heading\n\nWrite something...'}
+              placeholderTextColor={colors.textSecondary}
+              multiline
+              textAlignVertical="top"
+              style={[
+                styles.contentInput,
+                { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+              ]}
+            />
+          </ScrollView>
 
           <View style={styles.editorActions}>
             <TouchableOpacity
@@ -387,8 +620,20 @@ const styles = StyleSheet.create({
     marginTop: 4,
     textAlign: 'center',
   },
+  modalSurface: {
+    width: '100%',
+    maxWidth: 480,
+    flex: 1,
+  },
   editorContainer: {
+    flex: 1,
     paddingTop: 4,
+  },
+  editorScroll: {
+    flex: 1,
+  },
+  editorScrollContent: {
+    paddingBottom: 16,
   },
   editorTitle: {
     fontSize: 18,
@@ -415,14 +660,14 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 10,
     fontSize: 14,
-    minHeight: 160,
+    minHeight: 220,
     fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }),
   },
   editorActions: {
     flexDirection: 'row',
     justifyContent: 'flex-end',
     gap: 10,
-    marginTop: 16,
+    marginTop: 12,
   },
   btn: {
     paddingHorizontal: 16,
@@ -437,5 +682,79 @@ const styles = StyleSheet.create({
   btnText: {
     fontSize: 15,
     fontWeight: '600',
+  },
+  previewCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 16,
+  },
+  previewIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  previewMeta: {
+    flex: 1,
+    minWidth: 0,
+  },
+  previewName: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  previewDesc: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  previewTags: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 4,
+    marginTop: 6,
+  },
+  previewTagChip: {
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  previewTagText: {
+    fontSize: 11,
+  },
+  iconGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  iconCell: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  tagChipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginBottom: 8,
+  },
+  tagChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 14,
+    borderWidth: 1,
+  },
+  tagChipText: {
+    fontSize: 13,
+    fontWeight: '500',
   },
 });

--- a/src/utils/templateTags.ts
+++ b/src/utils/templateTags.ts
@@ -1,0 +1,62 @@
+export const TEMPLATE_MAX_TAGS = 8;
+export const TEMPLATE_MAX_TAG_LENGTH = 24;
+
+export interface ParsedTagInput {
+  committed: string[];
+  remainder: string;
+}
+
+function normalize(tag: string): string {
+  return tag.trim().toLowerCase();
+}
+
+function isAllowedSeparator(ch: string): boolean {
+  return ch === ',' || ch === ' ' || ch === '\t' || ch === '\n';
+}
+
+export function parseTagInput(
+  raw: string,
+  existing: string[],
+  options: { maxTags?: number; maxTagLength?: number } = {},
+): ParsedTagInput {
+  const maxTags = options.maxTags ?? TEMPLATE_MAX_TAGS;
+  const maxTagLength = options.maxTagLength ?? TEMPLATE_MAX_TAG_LENGTH;
+
+  const committed = [...existing];
+  let buffer = '';
+  let lastCharWasSeparator = false;
+
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (isAllowedSeparator(ch)) {
+      lastCharWasSeparator = true;
+      const candidate = normalize(buffer).slice(0, maxTagLength);
+      buffer = '';
+      if (!candidate) continue;
+      if (committed.includes(candidate)) continue;
+      if (committed.length >= maxTags) continue;
+      committed.push(candidate);
+    } else {
+      lastCharWasSeparator = false;
+      buffer += ch;
+    }
+  }
+
+  const remainder = lastCharWasSeparator ? '' : buffer.slice(0, maxTagLength);
+
+  return { committed, remainder };
+}
+
+export function commitPendingTag(
+  pending: string,
+  existing: string[],
+  options: { maxTags?: number; maxTagLength?: number } = {},
+): string[] {
+  const maxTags = options.maxTags ?? TEMPLATE_MAX_TAGS;
+  const maxTagLength = options.maxTagLength ?? TEMPLATE_MAX_TAG_LENGTH;
+  const candidate = normalize(pending).slice(0, maxTagLength);
+  if (!candidate) return existing;
+  if (existing.includes(candidate)) return existing;
+  if (existing.length >= maxTags) return existing;
+  return [...existing, candidate];
+}


### PR DESCRIPTION
## Summary
- TemplateManagerScreen's create/edit modal now collects icon, description, default title, and tags instead of hardcoding `icon='document-outline'` and `description='Custom template'`. Custom templates land in the picker with the same fidelity as built-ins.
- New modal layout: scrollable inside the sheet, live preview card at top (icon + name + description + tag chips), curated 12-icon picker, tag chip input (comma/space-separated, tap chip to remove, max 8 tags / 24 chars), and a taller content editor.
- Edit flow preloads all the new fields. Existing custom templates without these fields keep working — fields default to the previous hardcoded values.
- TemplateSelector already rendered `item.icon`, `item.description`, and `item.tags` generically, so the picker reflects user choices automatically — no changes needed there.

## Notes
- `NoteTemplate` does not currently carry a `format` (markdown/org/neorg) field, so the format-selector item from the issue's "while we're here" list is deferred to a separate ticket as the issue explicitly allowed.
- Live Markdown preview of `content` and import-from-existing-note are out of scope per the issue.

## Test plan
- [x] `npx jest` — 426 passed (added `__tests__/template-tags.test.ts` with 14 cases for the parser, plus 2 new cases in `template-manager-screen.test.tsx` covering icon/description/title/tag persistence and edit-flow preload).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: create a custom template with non-default icon, description, tags, and default title; confirm it shows up in the TemplateSelector with chips and the chosen icon.
- [ ] Manual: edit an existing custom template and confirm the modal preloads icon, description, title, and tag chips.
- [ ] Manual: pre-existing custom templates (created before this change) still load and edit correctly with default fallbacks.

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)