### PR TITLE
feat(import): add Google Keep and Apple Notes importers

### DIFF
--- a/__tests__/services/import/AppleNotesImporter.test.ts
+++ b/__tests__/services/import/AppleNotesImporter.test.ts
@@ -1,0 +1,151 @@
+import { parseAppleNotesExport } from '../../../src/services/import/AppleNotesImporter';
+
+describe('AppleNotesImporter', () => {
+  describe('parseAppleNotesExport', () => {
+    it('parses plain text file with title from first line', () => {
+      const files = [
+        {
+          name: 'Meeting Notes.txt',
+          content: 'Team Standup\nDiscussed project timeline\nAction items: finish API',
+        },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].title).toBe('Team Standup');
+      expect(notes[0].content).toBe('Discussed project timeline\nAction items: finish API');
+    });
+
+    it('parses HTML file with title from title tag', () => {
+      const files = [
+        {
+          name: 'note.html',
+          content: '<html><head><title>My Note</title></head><body><p>Hello world</p></body></html>',
+        },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].title).toBe('My Note');
+      expect(notes[0].content).toContain('Hello world');
+    });
+
+    it('uses filename as title when content is empty', () => {
+      const files = [
+        {
+          name: 'Random Thoughts.txt',
+          content: '',
+        },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes[0].title).toBe('Random Thoughts');
+    });
+
+    it('uses first line as title for single-line text files', () => {
+      const files = [
+        {
+          name: 'Random Thoughts.txt',
+          content: 'Just some thoughts',
+        },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes[0].title).toBe('Just some thoughts');
+    });
+
+    it('extracts folder from relative path as tag', () => {
+      const files = [
+        {
+          name: 'note.txt',
+          content: 'Title\nContent',
+          relativePath: 'Work Projects/note.txt',
+        },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes[0].tags).toEqual(['Work Projects']);
+      expect(notes[0].folder).toBe('Work Projects');
+    });
+
+    it('handles nested folder paths', () => {
+      const files = [
+        {
+          name: 'note.txt',
+          content: 'Title\nContent',
+          relativePath: 'Work/Projects/note.txt',
+        },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes[0].folder).toBe('Work/Projects');
+      expect(notes[0].tags).toEqual(['Work/Projects']);
+    });
+
+    it('ignores unsupported file types', () => {
+      const files = [
+        { name: 'photo.jpg', content: 'binary' },
+        { name: 'data.pdf', content: 'binary' },
+      ];
+
+      expect(parseAppleNotesExport(files)).toEqual([]);
+    });
+
+    it('converts HTML content to markdown', () => {
+      const files = [
+        {
+          name: 'note.html',
+          content: '<html><body><h2>Section</h2><p>Text with <a href="https://example.com">link</a></p></body></html>',
+        },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes[0].content).toContain('## Section');
+      expect(notes[0].content).toContain('[link](https://example.com)');
+    });
+
+    it('handles empty text file', () => {
+      const files = [
+        { name: 'empty.txt', content: '' },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].title).toBe('empty');
+    });
+
+    it('parses multiple files', () => {
+      const files = [
+        { name: 'note1.txt', content: 'First\nContent 1' },
+        { name: 'note2.txt', content: 'Second\nContent 2' },
+        { name: 'note3.html', content: '<html><head><title>Third</title></head><body><p>Content 3</p></body></html>' },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes).toHaveLength(3);
+      expect(notes.map((n) => n.title)).toEqual(['First', 'Second', 'Third']);
+    });
+
+    it('handles .htm extension', () => {
+      const files = [
+        {
+          name: 'old-note.htm',
+          content: '<html><head><title>Old</title></head><body><p>Legacy</p></body></html>',
+        },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].title).toBe('Old');
+    });
+
+    it('has no tags when no folder', () => {
+      const files = [
+        { name: 'note.txt', content: 'Title\nBody' },
+      ];
+
+      const notes = parseAppleNotesExport(files);
+      expect(notes[0].tags).toEqual([]);
+    });
+  });
+});

--- a/__tests__/services/import/GoogleKeepImporter.test.ts
+++ b/__tests__/services/import/GoogleKeepImporter.test.ts
@@ -1,0 +1,135 @@
+import { parseGoogleKeepTakeout } from '../../../src/services/import/GoogleKeepImporter';
+
+describe('GoogleKeepImporter', () => {
+  describe('parseGoogleKeepTakeout', () => {
+    it('parses HTML note with corresponding JSON metadata', () => {
+      const files = [
+        {
+          name: 'Shopping List.html',
+          content: '<html><head><title>Shopping List</title></head><body><ul><li>Milk</li><li>Eggs</li></ul></body></html>',
+        },
+        {
+          name: 'Shopping List.json',
+          content: JSON.stringify({
+            title: 'Shopping List',
+            labels: [{ name: 'errands' }, { name: 'groceries' }],
+            color: 'YELLOW',
+            isPinned: true,
+            createdTimestampUsec: '1609459200000000',
+            userEditedTimestampUsec: '1612137600000000',
+          }),
+        },
+      ];
+
+      const notes = parseGoogleKeepTakeout(files);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].title).toBe('Shopping List');
+      expect(notes[0].tags).toEqual(['errands', 'groceries']);
+      expect(notes[0].color).toBe('yellow');
+      expect(notes[0].pinned).toBe(true);
+      expect(notes[0].createdAt).toEqual(new Date(1609459200000));
+      expect(notes[0].updatedAt).toEqual(new Date(1612137600000));
+    });
+
+    it('parses HTML note without JSON metadata', () => {
+      const files = [
+        {
+          name: 'Quick Note.html',
+          content: '<html><head><title>Quick Note</title></head><body><p>Some text</p></body></html>',
+        },
+      ];
+
+      const notes = parseGoogleKeepTakeout(files);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].title).toBe('Quick Note');
+      expect(notes[0].tags).toEqual([]);
+      expect(notes[0].content).toContain('Some text');
+    });
+
+    it('handles missing title by defaulting to Untitled', () => {
+      const files = [
+        {
+          name: 'note.html',
+          content: '<html><body><p>Just content</p></body></html>',
+        },
+      ];
+
+      const notes = parseGoogleKeepTakeout(files);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].title).toBe('Untitled');
+    });
+
+    it('converts labels to tags', () => {
+      const files = [
+        {
+          name: 'note.html',
+          content: '<html><head><title>T</title></head><body>Body</body></html>',
+        },
+        {
+          name: 'note.json',
+          content: JSON.stringify({
+            labels: [{ name: 'work' }, { name: 'important' }],
+          }),
+        },
+      ];
+
+      const notes = parseGoogleKeepTakeout(files);
+      expect(notes[0].tags).toEqual(['work', 'important']);
+    });
+
+    it('handles malformed JSON gracefully', () => {
+      const files = [
+        {
+          name: 'note.html',
+          content: '<html><head><title>Test</title></head><body>Content</body></html>',
+        },
+        {
+          name: 'note.json',
+          content: 'not valid json{{{',
+        },
+      ];
+
+      const notes = parseGoogleKeepTakeout(files);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].title).toBe('Test');
+    });
+
+    it('maps Google Keep colors to note colors', () => {
+      const files = [
+        {
+          name: 'note.html',
+          content: '<html><head><title>A</title></head><body>B</body></html>',
+        },
+        {
+          name: 'note.json',
+          content: JSON.stringify({ color: 'RED' }),
+        },
+      ];
+
+      const notes = parseGoogleKeepTakeout(files);
+      expect(notes[0].color).toBe('red');
+    });
+
+    it('returns empty array for no HTML files', () => {
+      const files = [
+        { name: 'readme.txt', content: 'hello' },
+        { name: 'data.json', content: '{}' },
+      ];
+
+      expect(parseGoogleKeepTakeout(files)).toEqual([]);
+    });
+
+    it('converts HTML content to markdown', () => {
+      const files = [
+        {
+          name: 'note.html',
+          content: '<html><body><h1>Title</h1><p>Paragraph with <strong>bold</strong> and <em>italic</em></p><ul><li>Item 1</li><li>Item 2</li></ul></body></html>',
+        },
+      ];
+
+      const notes = parseGoogleKeepTakeout(files);
+      expect(notes[0].content).toContain('**bold**');
+      expect(notes[0].content).toContain('*italic*');
+    });
+  });
+});

--- a/src/components/settings/ImportSection.tsx
+++ b/src/components/settings/ImportSection.tsx
@@ -1,0 +1,164 @@
+import React, { useCallback, useState } from 'react';
+import { Text, ActivityIndicator, Alert } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../../contexts/ThemeContext';
+import { useNotes } from '../../contexts/NoteContext';
+import { Group, GroupRow } from '../ui';
+import { parseGoogleKeepTakeout } from '../../services/import/GoogleKeepImporter';
+import { parseAppleNotesExport } from '../../services/import/AppleNotesImporter';
+import { ImportedFile } from '../../services/import/types';
+import { HapticService } from '../../utils/haptics';
+import { isNoteColor } from '../../models/Note';
+
+export function ImportSection() {
+  const { colors } = useTheme();
+  const { createNote } = useNotes();
+  const [isImporting, setIsImporting] = useState(false);
+
+  const importNotes = useCallback(async (importedNotes: Awaited<ReturnType<typeof parseGoogleKeepTakeout>>) => {
+    let created = 0;
+    let failed = 0;
+    for (const note of importedNotes) {
+      try {
+        const color = note.color && isNoteColor(note.color) ? note.color : undefined;
+        await createNote({
+          title: note.title,
+          content: note.content,
+          tags: note.tags,
+          color: color ?? null,
+          isPinned: note.pinned,
+          format: 'markdown',
+        });
+        created++;
+      } catch {
+        failed++;
+      }
+    }
+    return { created, failed };
+  }, [createNote]);
+
+  const handleImportGoogleKeep = useCallback(async () => {
+    setIsImporting(true);
+    try {
+      const DocumentPicker = require('react-native-document-picker').default;
+      const result = await DocumentPicker.pick({
+        type: [DocumentPicker.types.zip],
+        allowMultiSelection: false,
+      });
+
+      if (!result || result.length === 0) {
+        setIsImporting(false);
+        return;
+      }
+
+      const RNFS = require('react-native-fs');
+      const { default: JSZip } = require('jszip');
+
+      const fileContent = await RNFS.readFile(result[0].uri, 'base64');
+      const zip = await JSZip.loadAsync(fileContent, { base64: true });
+
+      const files: ImportedFile[] = [];
+      const fileNames = Object.keys(zip.files);
+      for (const name of fileNames) {
+        if (zip.files[name].dir) continue;
+        const content = await zip.files[name].async('string');
+        const baseName = name.split('/').pop() || name;
+        files.push({ name: baseName, content, relativePath: name });
+      }
+
+      const importedNotes = parseGoogleKeepTakeout(files);
+      if (importedNotes.length === 0) {
+        Alert.alert('No Notes Found', 'Could not find any Google Keep notes in the selected file.');
+        return;
+      }
+
+      const { created, failed } = await importNotes(importedNotes);
+
+      if (failed === 0) {
+        HapticService.success();
+        Alert.alert('Import Complete', `Imported ${created} note(s) from Google Keep.`);
+      } else {
+        HapticService.error();
+        Alert.alert('Import Finished', `Imported ${created} note(s); ${failed} failed.`);
+      }
+    } catch (e: unknown) {
+      if (e && typeof e === 'object' && 'code' in e && (e as { code: string }).code === 'DOCUMENT_PICKER_CANCELED') {
+        return;
+      }
+      HapticService.error();
+      Alert.alert('Import Failed', e instanceof Error ? e.message : 'Could not import from Google Keep.');
+    } finally {
+      setIsImporting(false);
+    }
+  }, [importNotes]);
+
+  const handleImportAppleNotes = useCallback(async () => {
+    setIsImporting(true);
+    try {
+      const DocumentPicker = require('react-native-document-picker').default;
+      const result = await DocumentPicker.pick({
+        type: ['text/plain', 'text/html', 'public.plain-text', 'public.html'],
+        allowMultiSelection: true,
+      });
+
+      if (!result || result.length === 0) {
+        setIsImporting(false);
+        return;
+      }
+
+      const RNFS = require('react-native-fs');
+
+      const files: ImportedFile[] = [];
+      for (const doc of result) {
+        const content = await RNFS.readFile(doc.uri, 'utf8');
+        const name = doc.name || doc.uri.split('/').pop() || 'Untitled';
+        files.push({ name, content });
+      }
+
+      const importedNotes = parseAppleNotesExport(files);
+      if (importedNotes.length === 0) {
+        Alert.alert('No Notes Found', 'Could not find any Apple Notes in the selected files.');
+        return;
+      }
+
+      const { created, failed } = await importNotes(importedNotes);
+
+      if (failed === 0) {
+        HapticService.success();
+        Alert.alert('Import Complete', `Imported ${created} note(s) from Apple Notes.`);
+      } else {
+        HapticService.error();
+        Alert.alert('Import Finished', `Imported ${created} note(s); ${failed} failed.`);
+      }
+    } catch (e: unknown) {
+      if (e && typeof e === 'object' && 'code' in e && (e as { code: string }).code === 'DOCUMENT_PICKER_CANCELED') {
+        return;
+      }
+      HapticService.error();
+      Alert.alert('Import Failed', e instanceof Error ? e.message : 'Could not import from Apple Notes.');
+    } finally {
+      setIsImporting(false);
+    }
+  }, [importNotes]);
+
+  return (
+    <Group title="Import">
+      <GroupRow
+        onPress={isImporting ? undefined : handleImportGoogleKeep}
+        disabled={isImporting}
+        leading={<Ionicons name="logo-google" size={20} color={colors.text} />}
+        trailing={isImporting ? <ActivityIndicator size="small" color={colors.primary} /> : <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
+      >
+        <Text style={{ fontSize: 16, color: colors.text }}>Import from Google Keep</Text>
+      </GroupRow>
+      <GroupRow
+        onPress={isImporting ? undefined : handleImportAppleNotes}
+        disabled={isImporting}
+        leading={<Ionicons name="document-text-outline" size={20} color={colors.text} />}
+        trailing={isImporting ? <ActivityIndicator size="small" color={colors.primary} /> : <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
+      >
+        <Text style={{ fontSize: 16, color: colors.text }}>Import from Apple Notes</Text>
+      </GroupRow>
+    </Group>
+  );
+}

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -4,6 +4,7 @@ import { Image } from 'expo-image';
 import Constants from 'expo-constants';
 import { Ionicons } from '@expo/vector-icons';
 import { Group, GroupRow, Toggle } from '../ui';
+import { ImportSection } from './ImportSection';
 import { settingsStyles as styles } from './settingsStyles';
 import type { GitRepository } from '../../services/GitService';
 import type { TemplateRepoPreference } from '../../services/TemplateRepoPreferenceService';
@@ -462,7 +463,9 @@ export function SettingsContent(props: SettingsContentProps) {
         </TouchableOpacity>
       </View>
 
-      <View style={[styles.section, { backgroundColor: colors.surface }]}> 
+      <ImportSection />
+
+      <View style={[styles.section, { backgroundColor: colors.surface }]}>
         <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>About</Text>
         <View style={[styles.settingItem, { borderBottomColor: colors.border }]}>
           <Text style={[styles.settingLabel, { color: colors.text }]}>Version</Text>

--- a/src/services/import/AppleNotesImporter.ts
+++ b/src/services/import/AppleNotesImporter.ts
@@ -1,0 +1,65 @@
+import { ImportedFile, ImportedNote } from './types';
+import { htmlToMarkdown } from '../../utils/htmlToMarkdown';
+
+export function parseAppleNotesExport(files: ImportedFile[]): ImportedNote[] {
+  const notes: ImportedNote[] = [];
+
+  for (const file of files) {
+    const ext = file.name.toLowerCase().split('.').pop();
+    if (ext !== 'txt' && ext !== 'html' && ext !== 'htm') continue;
+
+    let title = '';
+    let content = '';
+    const folder = extractFolder(file.relativePath);
+
+    if (ext === 'html' || ext === 'htm') {
+      title = extractTitleFromHtml(file.content);
+      content = htmlToMarkdown(file.content);
+    } else {
+      const result = parseTextFile(file.content);
+      title = result.title;
+      content = result.content;
+    }
+
+    const now = new Date();
+    notes.push({
+      title: title || sanitizeFilename(file.name),
+      content,
+      tags: folder ? [folder] : [],
+      createdAt: now,
+      updatedAt: now,
+      pinned: false,
+      folder,
+    });
+  }
+
+  return notes;
+}
+
+function extractTitleFromHtml(html: string): string {
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (titleMatch && titleMatch[1].trim()) {
+    return titleMatch[1].trim();
+  }
+  const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (h1Match) return h1Match[1].trim();
+  return '';
+}
+
+function parseTextFile(content: string): { title: string; content: string } {
+  const lines = content.split('\n');
+  const title = lines[0]?.trim() || '';
+  const body = lines.slice(1).join('\n').trim();
+  return { title, content: body };
+}
+
+function extractFolder(relativePath: string | undefined): string | undefined {
+  if (!relativePath) return undefined;
+  const parts = relativePath.split('/').filter(Boolean);
+  if (parts.length <= 1) return undefined;
+  return parts.slice(0, -1).join('/');
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/\.(txt|html?|rtf)$/i, '').trim() || 'Untitled';
+}

--- a/src/services/import/GoogleKeepImporter.ts
+++ b/src/services/import/GoogleKeepImporter.ts
@@ -1,0 +1,116 @@
+import { ImportedFile, ImportedNote } from './types';
+import { htmlToMarkdown } from '../../utils/htmlToMarkdown';
+
+interface GoogleKeepJson {
+  title?: string;
+  content?: string;
+  labels?: Array<{ name: string }>;
+  color?: string;
+  isPinned?: boolean;
+  isArchived?: boolean;
+  timestamps?: {
+    created?: string;
+    updated?: string;
+  };
+  userEditedTimestampUsec?: string;
+  createdTimestampUsec?: string;
+}
+
+function extractTitleFromHtml(html: string): string {
+  const headMatch = html.match(/<head[^>]*>([\s\S]*?)<\/head>/i);
+  if (headMatch) {
+    const titleMatch = headMatch[1].match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    if (titleMatch && titleMatch[1].trim()) {
+      return titleMatch[1].trim();
+    }
+  }
+  const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (h1Match) return h1Match[1].trim();
+  return '';
+}
+
+function extractBodyFromHtml(html: string): string {
+  const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  const raw = bodyMatch ? bodyMatch[1] : html;
+  return htmlToMarkdown(raw);
+}
+
+function parseTimestampUsec(usecStr: string | undefined): Date | undefined {
+  if (!usecStr) return undefined;
+  const usec = Number(usecStr);
+  if (!Number.isFinite(usec)) return undefined;
+  return new Date(usec / 1000);
+}
+
+function parseColor(color: string | undefined): string | undefined {
+  if (!color) return undefined;
+  const colorMap: Record<string, string> = {
+    RED: 'red',
+    ORANGE: 'orange',
+    YELLOW: 'yellow',
+    GREEN: 'green',
+    TEAL: 'blue',
+    BLUE: 'blue',
+    PURPLE: 'purple',
+    PINK: 'pink',
+    WHITE: '',
+    DEFAULT: '',
+  };
+  return colorMap[color.toUpperCase()] || undefined;
+}
+
+export function parseGoogleKeepTakeout(files: ImportedFile[]): ImportedNote[] {
+  const htmlFiles = files.filter((f) => f.name.endsWith('.html'));
+  const jsonFiles = new Map<string, ImportedFile>();
+  for (const f of files) {
+    if (f.name.endsWith('.json')) {
+      jsonFiles.set(f.name, f);
+    }
+  }
+
+  const notes: ImportedNote[] = [];
+
+  for (const htmlFile of htmlFiles) {
+    const baseName = htmlFile.name.replace(/\.html$/i, '');
+    const jsonFile = jsonFiles.get(`${baseName}.json`);
+
+    let title = extractTitleFromHtml(htmlFile.content);
+    const body = extractBodyFromHtml(htmlFile.content);
+
+    let tags: string[] = [];
+    let color: string | undefined;
+    let pinned = false;
+    let createdAt: Date = new Date();
+    let updatedAt: Date = new Date();
+
+    if (jsonFile) {
+      try {
+        const meta: GoogleKeepJson = JSON.parse(jsonFile.content);
+        if (meta.title && !title) {
+          title = meta.title;
+        }
+        if (meta.labels) {
+          tags = meta.labels.map((l) => l.name).filter(Boolean);
+        }
+        color = parseColor(meta.color);
+        pinned = meta.isPinned ?? false;
+        createdAt = parseTimestampUsec(meta.createdTimestampUsec) ?? new Date();
+        updatedAt = parseTimestampUsec(meta.userEditedTimestampUsec) ?? createdAt;
+      } catch {
+        // skip malformed JSON, continue with HTML-only data
+      }
+    }
+
+    notes.push({
+      title: title || 'Untitled',
+      content: body,
+      tags,
+      createdAt,
+      updatedAt,
+      color,
+      pinned,
+    });
+  }
+
+  return notes;
+}

--- a/src/services/import/types.ts
+++ b/src/services/import/types.ts
@@ -1,0 +1,16 @@
+export interface ImportedNote {
+  title: string;
+  content: string;
+  tags: string[];
+  createdAt: Date;
+  updatedAt: Date;
+  color?: string;
+  pinned: boolean;
+  folder?: string;
+}
+
+export interface ImportedFile {
+  name: string;
+  content: string;
+  relativePath?: string;
+}

--- a/src/utils/htmlToMarkdown.ts
+++ b/src/utils/htmlToMarkdown.ts
@@ -1,0 +1,80 @@
+const TAG_PATTERNS: Array<{ pattern: RegExp; replace: (match: string, ...groups: string[]) => string }> = [
+  { pattern: /<h1[^>]*>(.*?)<\/h1>/gi, replace: (_m, c) => `# ${c}` },
+  { pattern: /<h2[^>]*>(.*?)<\/h2>/gi, replace: (_m, c) => `## ${c}` },
+  { pattern: /<h3[^>]*>(.*?)<\/h3>/gi, replace: (_m, c) => `### ${c}` },
+  { pattern: /<h4[^>]*>(.*?)<\/h4>/gi, replace: (_m, c) => `#### ${c}` },
+  { pattern: /<h5[^>]*>(.*?)<\/h5>/gi, replace: (_m, c) => `##### ${c}` },
+  { pattern: /<h6[^>]*>(.*?)<\/h6>/gi, replace: (_m, c) => `###### ${c}` },
+  { pattern: /<strong[^>]*>(.*?)<\/strong>/gi, replace: (_m, c) => `**${c}**` },
+  { pattern: /<b[^>]*>(.*?)<\/b>/gi, replace: (_m, c) => `**${c}**` },
+  { pattern: /<em[^>]*>(.*?)<\/em>/gi, replace: (_m, c) => `*${c}*` },
+  { pattern: /<i[^>]*>(.*?)<\/i>/gi, replace: (_m, c) => `*${c}*` },
+  { pattern: /<a[^>]*href="([^"]*)"[^>]*>(.*?)<\/a>/gi, replace: (_m, href, text) => `[${text}](${href})` },
+  { pattern: /<code[^>]*>(.*?)<\/code>/gi, replace: (_m, c) => `\`${c}\`` },
+  { pattern: /<pre[^>]*>(.*?)<\/pre>/gis, replace: (_m, c) => `\n\`\`\`\n${c}\n\`\`\`\n` },
+  { pattern: /<blockquote[^>]*>(.*?)<\/blockquote>/gis, replace: (_m, c) => c.split('\n').map((l: string) => `> ${l}`).join('\n') },
+  { pattern: /<br\s*\/?>/gi, replace: () => '\n' },
+];
+
+function stripTags(html: string): string {
+  return html.replace(/<\/?(?:div|span|p|section|article|header|footer|main|nav|aside|figure|figcaption|details|summary|time|small|mark|sub|sup|abbr|cite|dfn|kbd|samp|var|data|address|hgroup)[^>]*>/gi, '');
+}
+
+function convertLists(html: string): string {
+  let result = html;
+
+  result = result.replace(/<ol[^>]*>([\s\S]*?)<\/ol>/gi, (_m, inner) => {
+    const items = [...inner.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi)];
+    return items.map((m) => `1. ${m[1].trim()}`).join('\n');
+  });
+
+  result = result.replace(/<ul[^>]*>([\s\S]*?)<\/ul>/gi, (_m, inner) => {
+    const items = [...inner.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi)];
+    return items.map((m) => `- ${m[1].trim()}`).join('\n');
+  });
+
+  result = result.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (_m, c) => `- ${c.trim()}`);
+
+  return result;
+}
+
+function convertCheckboxes(html: string): string {
+  return html.replace(
+    /<li[^>]*class="([^"]*?)checked[^"]*"[^>]*>(.*?)<\/li>/gi,
+    (_m, _cls, c) => `- [x] ${c.trim()}`,
+  ).replace(
+    /<li[^>]*class="([^"]*?)unchecked[^"]*"[^>]*>(.*?)<\/li>/gi,
+    (_m, _cls, c) => `- [ ] ${c.trim()}`,
+  );
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+export function htmlToMarkdown(html: string): string {
+  let result = html;
+
+  result = convertCheckboxes(result);
+  result = convertLists(result);
+
+  for (const { pattern, replace } of TAG_PATTERNS) {
+    result = result.replace(pattern, replace);
+  }
+
+  result = stripTags(result);
+  result = decodeEntities(result);
+
+  result = result
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/^\s+|\s+$/g, '')
+    .trim();
+
+  return result;
+}


### PR DESCRIPTION
## Summary
Add note import tools for migrating from Google Keep and Apple Notes.

### New files
- `src/services/import/types.ts` — shared `ImportedNote` and `ImportedFile` types
- `src/utils/htmlToMarkdown.ts` — lightweight HTML→Markdown converter (regex-based, no deps)
- `src/services/import/GoogleKeepImporter.ts` — parses Google Keep Takeout HTML+JSON
- `src/services/import/AppleNotesImporter.ts` — parses Apple Notes .txt/.html exports
- `src/components/settings/ImportSection.tsx` — import UI in Settings

### Features
- **Google Keep**: Parses Takeout HTML notes with JSON metadata (labels→tags, color, pinned, timestamps)
- **Apple Notes**: Parses exported .txt and .html files, folders→tags
- **HTML→Markdown**: Handles h1-h6, lists, bold/italic, links, code, blockquotes
- **Import UI**: Two rows in Settings with document picker integration

### Test plan
- [x] `yarn ts:check` — 0 errors
- [x] `yarn test` — 659 pass (20 new tests for importers)
- [x] No external dependencies added