### PR TITLE
feat(journal): add daily journal mode with timeline view

### DIFF
--- a/__tests__/services/JournalService.test.ts
+++ b/__tests__/services/JournalService.test.ts
@@ -1,0 +1,168 @@
+import {
+  isJournalEntry,
+  getJournalEntries,
+  findJournalEntry,
+  journalNoteTitle,
+  formatJournalDate,
+  parseJournalDateFromTitle,
+  buildJournalNoteInput,
+} from '../../src/services/JournalService';
+import { Note } from '../../src/models/Note';
+
+const baseNote = (overrides: Partial<Note> = {}): Note => ({
+  id: 'n1',
+  title: 'T',
+  content: '',
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  tags: [],
+  ...overrides,
+});
+
+describe('formatJournalDate', () => {
+  test('formats date as YYYY-MM-DD', () => {
+    const date = new Date(2026, 4, 5);
+    expect(formatJournalDate(date)).toBe('2026-05-05');
+  });
+});
+
+describe('journalNoteTitle', () => {
+  test('prefixes formatted date with Journal', () => {
+    const date = new Date(2026, 4, 5);
+    expect(journalNoteTitle(date)).toBe('Journal 2026-05-05');
+  });
+});
+
+describe('isJournalEntry', () => {
+  test('returns true for notes with journal tag', () => {
+    const note = baseNote({ tags: ['journal'] });
+    expect(isJournalEntry(note)).toBe(true);
+  });
+
+  test('returns true for notes with journal among other tags', () => {
+    const note = baseNote({ tags: ['personal', 'journal', 'daily'] });
+    expect(isJournalEntry(note)).toBe(true);
+  });
+
+  test('returns false for notes without journal tag', () => {
+    const note = baseNote({ tags: ['personal'] });
+    expect(isJournalEntry(note)).toBe(false);
+  });
+
+  test('returns false for notes with no tags', () => {
+    const note = baseNote({ tags: [] });
+    expect(isJournalEntry(note)).toBe(false);
+  });
+});
+
+describe('parseJournalDateFromTitle', () => {
+  test('parses valid journal title', () => {
+    const result = parseJournalDateFromTitle('Journal 2026-05-05');
+    expect(result).not.toBeNull();
+    expect(result!.getFullYear()).toBe(2026);
+    expect(result!.getMonth()).toBe(4);
+    expect(result!.getDate()).toBe(5);
+  });
+
+  test('returns null for non-journal title', () => {
+    expect(parseJournalDateFromTitle('My Note')).toBeNull();
+  });
+
+  test('returns null for journal title with invalid date', () => {
+    expect(parseJournalDateFromTitle('Journal not-a-date')).toBeNull();
+  });
+});
+
+describe('findJournalEntry', () => {
+  test('finds existing entry for a given date', () => {
+    const note = baseNote({
+      title: 'Journal 2026-05-05',
+      tags: ['journal'],
+      createdAt: new Date(2026, 4, 5).getTime(),
+    });
+    const result = findJournalEntry([note], new Date(2026, 4, 5));
+    expect(result).toBe(note);
+  });
+
+  test('returns undefined when no entry exists for the date', () => {
+    const note = baseNote({
+      title: 'Journal 2026-05-04',
+      tags: ['journal'],
+    });
+    const result = findJournalEntry([note], new Date(2026, 4, 5));
+    expect(result).toBeUndefined();
+  });
+
+  test('does not match non-journal notes with same title', () => {
+    const note = baseNote({
+      title: 'Journal 2026-05-05',
+      tags: ['personal'],
+    });
+    const result = findJournalEntry([note], new Date(2026, 4, 5));
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('getJournalEntries', () => {
+  test('returns journal entries within date range', () => {
+    const may3 = baseNote({
+      id: 'may3',
+      title: 'Journal 2026-05-03',
+      tags: ['journal'],
+      createdAt: new Date(2026, 4, 3).getTime(),
+    });
+    const may5 = baseNote({
+      id: 'may5',
+      title: 'Journal 2026-05-05',
+      tags: ['journal'],
+      createdAt: new Date(2026, 4, 5).getTime(),
+    });
+    const may10 = baseNote({
+      id: 'may10',
+      title: 'Journal 2026-05-10',
+      tags: ['journal'],
+      createdAt: new Date(2026, 4, 10).getTime(),
+    });
+    const nonJournal = baseNote({
+      id: 'other',
+      title: 'Some other note',
+      tags: [],
+      createdAt: new Date(2026, 4, 4).getTime(),
+    });
+
+    const result = getJournalEntries(
+      [may3, may5, may10, nonJournal],
+      new Date(2026, 4, 1),
+      new Date(2026, 4, 7),
+    );
+    expect(result.map((n) => n.id)).toEqual(['may5', 'may3']);
+  });
+
+  test('returns empty array when no entries in range', () => {
+    const note = baseNote({
+      title: 'Journal 2026-01-01',
+      tags: ['journal'],
+      createdAt: new Date(2026, 0, 1).getTime(),
+    });
+    const result = getJournalEntries([note], new Date(2026, 4, 1), new Date(2026, 4, 7));
+    expect(result).toEqual([]);
+  });
+});
+
+describe('buildJournalNoteInput', () => {
+  test('builds correct input for a date', () => {
+    const date = new Date(2026, 4, 5);
+    const input = buildJournalNoteInput(date);
+    expect(input.title).toBe('Journal 2026-05-05');
+    expect(input.tags).toEqual(['journal']);
+    expect(input.folderPath).toBe('Journal');
+    expect(input.format).toBe('markdown');
+    expect(input.content).toBe('');
+  });
+
+  test('accepts initial content', () => {
+    const date = new Date(2026, 4, 5);
+    const input = buildJournalNoteInput(date, 'Hello world');
+    expect(input.content).toBe('Hello world');
+  });
+});

--- a/src/components/journal/JournalDateHeader.tsx
+++ b/src/components/journal/JournalDateHeader.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { format, isToday, isYesterday } from 'date-fns';
+import { useTheme } from '../../contexts/ThemeContext';
+
+interface JournalDateHeaderProps {
+  date: Date;
+}
+
+export function JournalDateHeader({ date }: JournalDateHeaderProps) {
+  const { colors } = useTheme();
+
+  let label: string;
+  if (isToday(date)) {
+    label = 'Today';
+  } else if (isYesterday(date)) {
+    label = 'Yesterday';
+  } else {
+    label = format(date, 'EEEE, MMMM d, yyyy');
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surface }]}>
+      <Text style={[styles.label, { color: colors.text }]}>
+        {label}
+      </Text>
+      {!isToday(date) && !isYesterday(date) && (
+        <Text style={[styles.subLabel, { color: colors.textSecondary }]}>
+          {format(date, 'MMMM d')}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    marginHorizontal: 16,
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  subLabel: {
+    fontSize: 12,
+    marginTop: 1,
+  },
+});

--- a/src/components/journal/JournalEntryCard.tsx
+++ b/src/components/journal/JournalEntryCard.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Note } from '../../models/Note';
+import { useTheme } from '../../contexts/ThemeContext';
+
+interface JournalEntryCardProps {
+  note: Note;
+  onPress: (note: Note) => void;
+}
+
+function getPreviewText(content: string): string {
+  const text = content
+    .replace(/^---\n[\s\S]*?\n---\n?/, '')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/\*{1,2}([^*\n]+)\*{1,2}/g, '$1')
+    .replace(/_{1,2}([^_\n]+)_{1,2}/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text;
+}
+
+function getWordCount(content: string): number {
+  const text = getPreviewText(content);
+  if (!text) return 0;
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+export function JournalEntryCard({ note, onPress }: JournalEntryCardProps) {
+  const { colors } = useTheme();
+  const preview = getPreviewText(note.content);
+  const wordCount = getWordCount(note.content);
+  const isEmpty = !preview;
+
+  return (
+    <TouchableOpacity
+      style={[styles.container, { backgroundColor: colors.surface }]}
+      onPress={() => onPress(note)}
+      activeOpacity={0.7}
+    >
+      <Text
+        style={[styles.title, { color: isEmpty ? colors.textSecondary : colors.text }]}
+        numberOfLines={1}
+      >
+        {isEmpty ? 'Empty entry' : note.title}
+      </Text>
+      {!isEmpty && (
+        <Text
+          style={[styles.preview, { color: colors.textSecondary }]}
+          numberOfLines={3}
+        >
+          {preview}
+        </Text>
+      )}
+      {wordCount > 0 && (
+        <Text style={[styles.wordCount, { color: colors.textSecondary }]}>
+          {wordCount} {wordCount === 1 ? 'word' : 'words'}
+        </Text>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 16,
+    marginBottom: 8,
+    padding: 14,
+    borderRadius: 10,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  preview: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  wordCount: {
+    fontSize: 11,
+    marginTop: 6,
+  },
+});

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -42,6 +42,7 @@ const linking: LinkingOptions<RootStackParamList> = {
           HomeTab: 'home',
           NotesTab: 'notes',
           ExploreTab: 'explore',
+          JournalTab: 'journal',
           SettingsTab: 'settings',
         },
       },

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -13,6 +13,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import HomeScreen from '../screens/HomeScreen';
 import NotesListScreen from '../screens/NotesListScreen';
 import ExploreScreen from '../screens/ExploreScreen';
+import JournalScreen from '../screens/JournalScreen';
 import TodoListScreen from '../screens/TodoListScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import { BottomTabParamList } from './types';
@@ -28,6 +29,7 @@ const TAB_ICONS: Record<string, { focused: IoniconName; outline: IoniconName; la
   HomeTab: { focused: 'home', outline: 'home-outline', label: 'Home' },
   NotesTab: { focused: 'document-text', outline: 'document-text-outline', label: 'Notes' },
   ExploreTab: { focused: 'compass', outline: 'compass-outline', label: 'Explore' },
+  JournalTab: { focused: 'calendar', outline: 'calendar-outline', label: 'Journal' },
   TodosTab: { focused: 'checkbox', outline: 'checkbox-outline', label: 'Todos' },
   SettingsTab: { focused: 'settings', outline: 'settings-outline', label: 'Settings' },
 };
@@ -174,6 +176,11 @@ export default function TabNavigator() {
         name="ExploreTab"
         component={ExploreScreen}
         options={{ title: 'Explore' }}
+      />
+      <Tab.Screen
+        name="JournalTab"
+        component={JournalScreen}
+        options={{ title: 'Journal' }}
       />
       <Tab.Screen
         name="TodosTab"

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -27,6 +27,7 @@ export type BottomTabParamList = {
   HomeTab: undefined;
   NotesTab: undefined;
   ExploreTab: undefined;
+  JournalTab: undefined;
   TodosTab: undefined;
   SettingsTab: undefined;
 };

--- a/src/screens/JournalScreen.tsx
+++ b/src/screens/JournalScreen.tsx
@@ -1,0 +1,376 @@
+import React, { useState, useCallback, useMemo, useRef } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+} from 'react-native';
+import { FlashList, FlashListRef } from '@shopify/flash-list';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Ionicons } from '@expo/vector-icons';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { format, subDays, startOfDay } from 'date-fns';
+
+import { useNotes } from '../contexts/NoteContext';
+import { useTheme } from '../contexts/ThemeContext';
+import { RootStackParamList } from '../navigation/types';
+import { Note } from '../models/Note';
+import { ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
+import { JournalDateHeader } from '../components/journal/JournalDateHeader';
+import { JournalEntryCard } from '../components/journal/JournalEntryCard';
+import {
+  isJournalEntry,
+  getJournalEntries,
+  findJournalEntry,
+  buildJournalNoteInput,
+  parseJournalDateFromTitle,
+} from '../services/JournalService';
+import { useResponsive } from '../hooks/useResponsive';
+import { HapticService } from '../utils/haptics';
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
+
+type JournalListItem =
+  | { type: 'header'; date: Date; id: string }
+  | { type: 'entry'; note: Note; id: string };
+
+export default function JournalScreen() {
+  const navigation = useNavigation<NavigationProp>();
+  const { colors } = useTheme();
+  const headerHeight = useScreenHeaderHeight();
+  const tabBarHeight = useTabBarHeight();
+  const { isTablet, maxContentWidth } = useResponsive();
+  const { notes, createNote, isLoading, refreshNotes } = useNotes();
+
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const listRef = useRef<FlashListRef<JournalListItem>>(null);
+
+  const journalNotes = useMemo(
+    () => notes.filter(isJournalEntry),
+    [notes],
+  );
+
+  const thirtyDaysAgo = useMemo(() => subDays(startOfDay(new Date()), 30), []);
+
+  const entriesInRange = useMemo(
+    () => getJournalEntries(notes, thirtyDaysAgo, new Date()),
+    [notes, thirtyDaysAgo],
+  );
+
+  const hasTodayEntry = useMemo(
+    () => Boolean(findJournalEntry(notes, new Date())),
+    [notes],
+  );
+
+  const listData = useMemo(() => {
+    const items: JournalListItem[] = [];
+
+    const todayHeader: JournalListItem = {
+      type: 'header',
+      date: new Date(),
+      id: 'header-today',
+    };
+    items.push(todayHeader);
+
+    const todayEntry = findJournalEntry(notes, new Date());
+    if (todayEntry) {
+      items.push({ type: 'entry', note: todayEntry, id: todayEntry.id });
+    }
+
+    const grouped = new Map<string, Note[]>();
+    for (const entry of entriesInRange) {
+      const entryDate = parseJournalDateFromTitle(entry.title);
+      if (!entryDate || format(entryDate, 'yyyy-MM-dd') === format(new Date(), 'yyyy-MM-dd')) {
+        continue;
+      }
+      const key = format(entryDate, 'yyyy-MM-dd');
+      const existing = grouped.get(key);
+      if (existing) {
+        existing.push(entry);
+      } else {
+        grouped.set(key, [entry]);
+      }
+    }
+
+    const sortedKeys = Array.from(grouped.keys()).sort((a, b) => b.localeCompare(a));
+    for (const key of sortedKeys) {
+      const dateParts = key.split('-').map(Number);
+      const date = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
+      items.push({ type: 'header', date, id: `header-${key}` });
+      for (const note of grouped.get(key)!) {
+        items.push({ type: 'entry', note, id: note.id });
+      }
+    }
+
+    return items;
+  }, [entriesInRange, notes]);
+
+  const handleNotePress = useCallback(
+    (note: Note) => {
+      navigation.navigate('NoteEditor', { noteId: note.id });
+    },
+    [navigation],
+  );
+
+  const handleCreateToday = useCallback(async () => {
+    if (isCreating) return;
+    setIsCreating(true);
+    try {
+      const input = buildJournalNoteInput(new Date());
+      const note = await createNote(input);
+      if (note) {
+        HapticService.light();
+        navigation.navigate('NoteEditor', { noteId: note.id });
+      }
+    } finally {
+      setIsCreating(false);
+    }
+  }, [createNote, navigation, isCreating]);
+
+  const handlePickDate = useCallback(
+    (_event: any, date?: Date) => {
+      setShowDatePicker(false);
+      if (!date) return;
+      HapticService.light();
+      const existing = findJournalEntry(notes, date);
+      if (existing) {
+        navigation.navigate('NoteEditor', { noteId: existing.id });
+      }
+    },
+    [notes, navigation],
+  );
+
+  const handleRefresh = useCallback(async () => {
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    try {
+      await refreshNotes();
+      HapticService.success();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [isRefreshing, refreshNotes]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: JournalListItem }) => {
+      if (item.type === 'header') {
+        return <JournalDateHeader date={item.date} />;
+      }
+      return <JournalEntryCard note={item.note} onPress={handleNotePress} />;
+    },
+    [handleNotePress],
+  );
+
+  const keyExtractor = useCallback((item: JournalListItem) => item.id, []);
+
+  const renderEmptyTodayPrompt = useCallback(() => {
+    if (hasTodayEntry) return null;
+    return (
+      <TouchableOpacity
+        style={[styles.todayPrompt, { backgroundColor: colors.surface }]}
+        onPress={handleCreateToday}
+        activeOpacity={0.7}
+        disabled={isCreating}
+      >
+        <Ionicons name="create-outline" size={20} color={colors.primary} />
+        <Text style={[styles.todayPromptText, { color: colors.primary }]}>
+          Write today's entry
+        </Text>
+        {isCreating && (
+          <ActivityIndicator size="small" color={colors.primary} style={styles.creatingSpinner} />
+        )}
+      </TouchableOpacity>
+    );
+  }, [hasTodayEntry, handleCreateToday, colors, isCreating]);
+
+  if (isLoading) {
+    return (
+      <View style={[styles.loadingContainer, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  const isEmpty = listData.length <= 1;
+
+  return (
+    <SafeAreaView
+      edges={[]}
+      style={[
+        styles.container,
+        { backgroundColor: colors.background },
+        isTablet && {
+          maxWidth: maxContentWidth,
+          alignSelf: 'center',
+          width: '100%',
+        },
+      ]}
+    >
+      <View style={{ paddingTop: headerHeight }}>
+        <ScreenHeader
+          title="Journal"
+          actions={
+            <TouchableOpacity
+              style={[styles.iconBtn, { backgroundColor: colors.surface }]}
+              onPress={() => {
+                HapticService.light();
+                setShowDatePicker(true);
+              }}
+            >
+              <Ionicons name="calendar-outline" size={20} color={colors.primary} />
+            </TouchableOpacity>
+          }
+        />
+      </View>
+
+      {isEmpty && (
+        <View style={styles.emptyContainer}>
+          <Ionicons name="book-outline" size={48} color={colors.textSecondary} />
+          <Text style={[styles.emptyTitle, { color: colors.text }]}>
+            Start your journal
+          </Text>
+          <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>
+            Capture your thoughts, one day at a time
+          </Text>
+          <TouchableOpacity
+            style={[styles.emptyCta, { backgroundColor: colors.primary }]}
+            onPress={handleCreateToday}
+            activeOpacity={0.7}
+            disabled={isCreating}
+          >
+            <Text style={styles.emptyCtaText}>Write today's entry</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {!isEmpty && (
+        <FlashList
+          ref={listRef}
+          data={listData}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          contentContainerStyle={{ paddingBottom: tabBarHeight + 16 }}
+          ListHeaderComponent={renderEmptyTodayPrompt}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefreshing}
+              onRefresh={handleRefresh}
+              tintColor={colors.primary}
+              colors={[colors.primary]}
+            />
+          }
+        />
+      )}
+
+      {!isEmpty && (
+        <TouchableOpacity
+          style={[styles.fab, { backgroundColor: colors.primary }]}
+          onPress={handleCreateToday}
+          activeOpacity={0.7}
+          disabled={isCreating}
+        >
+          {isCreating ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <Ionicons name="add" size={28} color="#fff" />
+          )}
+        </TouchableOpacity>
+      )}
+
+      {showDatePicker && (
+        <DateTimePicker
+          value={new Date()}
+          mode="date"
+          display="default"
+          onChange={handlePickDate}
+          maximumDate={new Date()}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  iconBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  todayPrompt: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 16,
+    marginTop: 8,
+    marginBottom: 4,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderRadius: 10,
+    gap: 8,
+  },
+  todayPromptText: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  creatingSpinner: {
+    marginLeft: 4,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 40,
+  },
+  emptyTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginTop: 16,
+  },
+  emptySubtext: {
+    fontSize: 15,
+    marginTop: 8,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  emptyCta: {
+    marginTop: 24,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  emptyCtaText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  fab: {
+    position: 'absolute',
+    right: 20,
+    bottom: 90,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+});

--- a/src/screens/JournalScreen.tsx
+++ b/src/screens/JournalScreen.tsx
@@ -12,7 +12,7 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import DateTimePicker from '@react-native/datetimepicker';
 import { format, subDays, startOfDay } from 'date-fns';
 
 import { useNotes } from '../contexts/NoteContext';

--- a/src/services/JournalService.ts
+++ b/src/services/JournalService.ts
@@ -1,0 +1,60 @@
+import { format, startOfDay, endOfDay, isWithinInterval, parseISO } from 'date-fns';
+import { Note, NoteCreateInput } from '../models/Note';
+
+const JOURNAL_TAG = 'journal';
+const JOURNAL_FOLDER = 'Journal';
+const JOURNAL_TITLE_PREFIX = 'Journal ';
+
+export function formatJournalDate(date: Date): string {
+  return format(date, 'yyyy-MM-dd');
+}
+
+export function journalNoteTitle(date: Date): string {
+  return `${JOURNAL_TITLE_PREFIX}${formatJournalDate(date)}`;
+}
+
+export function isJournalEntry(note: Note): boolean {
+  return note.tags.includes(JOURNAL_TAG);
+}
+
+export function getJournalEntries(notes: Note[], startDate: Date, endDate: Date): Note[] {
+  const start = startOfDay(startDate);
+  const end = endOfDay(endDate);
+  return notes
+    .filter((note) => {
+      if (!isJournalEntry(note)) return false;
+      const noteDate = parseJournalDateFromTitle(note.title);
+      if (!noteDate) return false;
+      return isWithinInterval(noteDate, { start, end });
+    })
+    .sort((a, b) => b.createdAt - a.createdAt);
+}
+
+export function parseJournalDateFromTitle(title: string): Date | null {
+  if (!title.startsWith(JOURNAL_TITLE_PREFIX)) return null;
+  const dateStr = title.slice(JOURNAL_TITLE_PREFIX.length);
+  try {
+    const parsed = parseISO(dateStr);
+    if (isNaN(parsed.getTime())) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function findJournalEntry(notes: Note[], date: Date): Note | undefined {
+  const title = journalNoteTitle(date);
+  return notes.find(
+    (note) => isJournalEntry(note) && note.title === title,
+  );
+}
+
+export function buildJournalNoteInput(date: Date, content: string = ''): NoteCreateInput {
+  return {
+    title: journalNoteTitle(date),
+    content,
+    tags: [JOURNAL_TAG],
+    folderPath: JOURNAL_FOLDER,
+    format: 'markdown',
+  };
+}


### PR DESCRIPTION
## Summary
Add a Journal mode — daily date-keyed notes with chronological timeline view.

### New files
- `src/services/JournalService.ts` — date-keyed note lookup/creation with `"journal"` tag + `"Journal/"` folder
- `src/screens/JournalScreen.tsx` — timeline view grouped by date, FAB for today's entry, date picker
- `src/components/journal/JournalDateHeader.tsx` — formatted date header ("Today", "Yesterday", etc.)
- `src/components/journal/JournalEntryCard.tsx` — entry preview with word count

### Features
- **Journal entries** are regular notes with "journal" tag, stored in Journal/ folder
- **Timeline view**: last 30 days grouped by date, today always at top
- **Quick entry**: FAB creates today's journal note and opens editor
- **Date picker**: jump to any date's entry
- **Journal tab**: Added between Explore and Todos in tab navigator

### Test plan
- [x] `yarn ts:check` — 0 errors
- [x] `yarn test` — 655 pass (16 new tests for JournalService)
- [x] Uses existing NoteContext — no separate storage