### PR TITLE
fix(links): stop misreading anchor URLs as tags + surface link errors

### DIFF
--- a/__tests__/hashtagParser.test.ts
+++ b/__tests__/hashtagParser.test.ts
@@ -54,4 +54,22 @@ describe('parseHashtags', () => {
   test('ignores url fragments', () => {
     expect(parseHashtags('http://example.com#frag and #real').tags).toEqual(['real']);
   });
+
+  test('ignores hash fragments inside markdown anchor links', () => {
+    expect(
+      parseHashtags(
+        '- [Chapter 1: PetDesk](#chapter-1-petdesk-what-the-company-actually-does)\n#real',
+      ).tags,
+    ).toEqual(['real']);
+  });
+
+  test('ignores cross-file fragments in markdown links', () => {
+    expect(
+      parseHashtags('See [details](other.md#deep-dive) for more.\n#actual').tags,
+    ).toEqual(['actual']);
+  });
+
+  test('ignores hashes inside image link URLs', () => {
+    expect(parseHashtags('![alt](pic.png#variant) #actual').tags).toEqual(['actual']);
+  });
 });

--- a/__tests__/link-routing.test.ts
+++ b/__tests__/link-routing.test.ts
@@ -41,6 +41,15 @@ describe('classifyHref', () => {
     expect(classifyHref('mailto:hello@example.com')).toEqual({ kind: 'mailto', target: 'hello@example.com' });
     expect(classifyHref('tel:+15551234567')).toEqual({ kind: 'mailto', target: '+15551234567' });
   });
+
+  it('classifies extension-less local paths as note candidates', () => {
+    expect(classifyHref('other-note', 'notes/current.md')).toEqual({ kind: 'note', target: 'notes/other-note' });
+    expect(classifyHref('sub/page', 'notes/current.md')).toEqual({ kind: 'note', target: 'notes/sub/page' });
+  });
+
+  it('returns null for bare domain-like hrefs so the UI can surface an alert', () => {
+    expect(classifyHref('home.com', 'notes/current.md')).toBeNull();
+  });
 });
 
 describe('NotePreviewRenderer link routing', () => {

--- a/src/components/editor/useNoteEditorPreview.ts
+++ b/src/components/editor/useNoteEditorPreview.ts
@@ -104,7 +104,35 @@ export function useNoteEditorPreview({
 
   const handleOpenLinkedNote = useCallback((targetPath: string, fragment?: string) => {
     const normalizedTargetPath = normalizeNotePathForLookup(targetPath);
-    const targetNote = notes.find((note) => note.filePath && normalizeNotePathForLookup(note.filePath) === normalizedTargetPath);
+    const matchByExact = (path: string): Note | undefined =>
+      notes.find((note) => note.filePath && normalizeNotePathForLookup(note.filePath) === path);
+
+    let targetNote = matchByExact(normalizedTargetPath);
+
+    // Extension-less link: try each known note extension before giving up
+    // (e.g. `[Other](other)` should resolve to `other.md`, `other.norg`, …).
+    if (!targetNote && !/\.[a-z0-9]+$/i.test(normalizedTargetPath)) {
+      for (const ext of ['md', 'norg', 'org', 'json', 'pdf']) {
+        targetNote = matchByExact(`${normalizedTargetPath}.${ext}`);
+        if (targetNote) break;
+      }
+    }
+
+    // Last-chance basename match for links written without a folder prefix.
+    if (!targetNote) {
+      const basename = normalizedTargetPath.split('/').pop() ?? '';
+      if (basename) {
+        targetNote = notes.find((note) => {
+          const fp = note.filePath;
+          if (!fp) return false;
+          const filename = fp.split('/').pop() ?? '';
+          if (filename === basename) return true;
+          const filenameNoExt = filename.replace(/\.[^.]+$/, '');
+          return filenameNoExt === basename;
+        });
+      }
+    }
+
     if (!targetNote?.id) return false;
     navigation.navigate('NoteEditor', { noteId: targetNote.id, anchor: fragment });
     return true;

--- a/src/utils/hashtagParser.ts
+++ b/src/utils/hashtagParser.ts
@@ -19,6 +19,26 @@ function isInsideRanges(index: number, ranges: Array<[number, number]>): boolean
   return ranges.some(([start, end]) => index >= start && index < end);
 }
 
+// Ranges of the URL portion of `[text](url)` and `![alt](url)` on a single
+// line. Used so that `#fragment` inside an anchor link isn't misread as a
+// content hashtag.
+function markdownLinkUrlRanges(line: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const regex = /!?\[[^\]]*\]\(([^)]*)\)/g;
+  let match: RegExpExecArray | null = regex.exec(line);
+  while (match !== null) {
+    const full = match[0];
+    const openParen = full.lastIndexOf('(');
+    if (openParen >= 0) {
+      const urlStart = match.index + openParen + 1;
+      const urlEnd = match.index + full.length - 1;
+      if (urlEnd > urlStart) ranges.push([urlStart, urlEnd]);
+    }
+    match = regex.exec(line);
+  }
+  return ranges;
+}
+
 function inlineCodeRanges(line: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
   let index = 0;
@@ -63,6 +83,7 @@ export function parseHashtags(text: string): ParsedHashtags {
       inCodeBlock = !inCodeBlock;
     } else if (!inCodeBlock) {
       const codeRanges = inlineCodeRanges(line);
+      const linkRanges = markdownLinkUrlRanges(line);
       HASHTAG_REGEX.lastIndex = 0;
 
       let match: RegExpExecArray | null = HASHTAG_REGEX.exec(line);
@@ -72,22 +93,18 @@ export function parseHashtags(text: string): ParsedHashtags {
         const tag = match[1]!.toLowerCase();
         const previousChar = localStart > 0 ? line[localStart - 1] : '';
         const isWordBoundaryBefore = localStart === 0 || !/[A-Za-z0-9_]/.test(previousChar);
-
-        if (
+        const isExtractable =
           isWordBoundaryBefore &&
           !isInsideRanges(localStart, codeRanges) &&
-          !isHexColor(tag) &&
-          !seen.has(tag)
-        ) {
+          !isInsideRanges(localStart, linkRanges) &&
+          !isHexColor(tag);
+
+        if (isExtractable && !seen.has(tag)) {
           seen.add(tag);
           tags.push(tag);
         }
 
-        if (
-          isWordBoundaryBefore &&
-          !isInsideRanges(localStart, codeRanges) &&
-          !isHexColor(tag)
-        ) {
+        if (isExtractable) {
           positions.push({
             start: lineStart + localStart,
             end: lineStart + localEnd,

--- a/src/utils/linkClassifier.ts
+++ b/src/utils/linkClassifier.ts
@@ -76,7 +76,26 @@ export function classifyHref(href: string, currentNotePath?: string): Classified
   const pathPart = hashIdx >= 0 ? trimmed.slice(0, hashIdx) : trimmed;
   const fragmentPart = hashIdx >= 0 ? trimmed.slice(hashIdx + 1) : '';
 
-  if (!/^[a-z][a-z0-9+.-]*:/i.test(pathPart) && /\.(md|norg|org|pdf|json)$/i.test(pathPart)) {
+  // Skip anything that looks like a URI scheme (e.g. `ftp:`, `data:`).
+  if (/^[a-z][a-z0-9+.-]*:/i.test(pathPart)) return null;
+
+  // Known note extensions: definitive note link.
+  if (/\.(md|norg|org|pdf|json)$/i.test(pathPart)) {
+    return {
+      kind: 'note',
+      target: resolveNotePath(pathPart, currentNotePath),
+      fragment: fragmentPart ? slugifyFragment(fragmentPart) : undefined,
+    };
+  }
+
+  // Extension-less local path (e.g. `[Other](other-note)`,
+  // `[Folder](sub/page)`). Treat as a note candidate when the shape looks
+  // path-like — either it contains a `/` or it has no dots at all. Strings
+  // with dots but no slashes (e.g. `home.com`) almost certainly aren't note
+  // names, so we leave them unclassified and let the renderer surface a
+  // visible "Can't open link" alert instead of silently doing nothing.
+  const looksLikePath = pathPart.includes('/') || !pathPart.includes('.');
+  if (pathPart && looksLikePath && /^[A-Za-z0-9._/\-]+$/.test(pathPart)) {
     return {
       kind: 'note',
       target: resolveNotePath(pathPart, currentNotePath),

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -338,9 +338,15 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
     const onPress = () => {
       if (!href) return;
 
+      const openExternal = (target: string) => {
+        Linking.openURL(target).catch(() => {
+          Alert.alert("Can't open link", target);
+        });
+      };
+
       const classified = classifyHref(href, this.deps.currentNotePath);
       if (!classified) {
-        Linking.openURL(href).catch(() => {});
+        Alert.alert("Can't open link", href);
         return;
       }
 
@@ -399,11 +405,14 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
 
         if (targetLine >= 0 && this.deps.previewScrollRef?.current) {
           this.deps.previewScrollRef.current.scrollTo({ y: targetLine * (this.deps.approxLinePx ?? 22), animated: true });
+          return;
         }
+
+        Alert.alert('Heading not found', `No heading matches #${slug} in this note.`);
         return;
       }
 
-      Linking.openURL(href).catch(() => {});
+      openExternal(classified.target);
     };
 
     return (


### PR DESCRIPTION
## Summary

Two related bugs reported as *"links don't work"*:

- **Note cards showed bogus `#chapter-1-...` chips.** The hashtag parser was walking into the URL of `[Text](#anchor)` links and extracting their fragments as content tags.
- **Clicking a link in the rendered markdown body sometimes did nothing.** `Linking.openURL` silently rejected unsupported hrefs and `classifyHref` returned `null` for extension-less local paths.

## Fixes

- `hashtagParser`: add a markdown-link-URL exclusion zone (sibling to the existing inline-code one) so `#fragment` inside `[X](#fragment)` and `[X](other.md#fragment)` is no longer harvested as a tag.
- `linkClassifier`: extension-less hrefs that look path-shaped (`[Other](other-note)`, `[Sub](sub/page)`) now classify as `note`. Bare domain-likes (`home.com`) stay unclassified so they trip the visible alert.
- `useNoteEditorPreview.handleOpenLinkedNote`: when an exact-path lookup misses, retry with each known note extension (`.md`, `.norg`, `.org`, `.json`, `.pdf`) and a basename-only match.
- `markdownRenderer.link.onPress`: replace the silent `.catch(() => {})` with a user-visible `Alert.alert("Can't open link", href)` for both unclassified hrefs and `Linking.openURL` rejections. Anchor links that don't match a heading now also surface a clear alert.

## Test plan

- [x] `yarn ts:check` — clean
- [x] `yarn test` — 755/755 passing
- [x] New unit tests:
  - `hashtagParser` ignores hashes inside `[X](#anchor)`, `[X](other.md#frag)`, and `![alt](pic.png#variant)`.
  - `classifyHref` resolves extension-less local paths to `note`, returns `null` for `home.com`.
- [ ] Manual smoke on simulator: open the `cv prep petdesk` note from the screenshot, confirm the bogus `#chapter-...` tag chips are gone and the table-of-contents anchor links scroll within the file.