### PR TITLE
feat: complete .norg and .org rendering overhaul

### DIFF
--- a/__tests__/NeorgContentParser.test.ts
+++ b/__tests__/NeorgContentParser.test.ts
@@ -350,4 +350,245 @@ print("code")
       expect(secondChecklist.checklistItems[0].checked).toBe(true);
     });
   });
+
+  describe('NeorgContentParser - Extended Norg Features', () => {
+    describe('Footnotes', () => {
+      test('parses ^ Label with content', () => {
+        const result = NeorgContentParser.parseContent('^ 1\n  This is a footnote');
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(1);
+        expect(result.blocks![0]).toMatchObject({
+          type: 'footnote',
+          footnote: { label: '1' },
+        });
+        expect(result.blocks![0].footnote!.content).toContain('This is a footnote');
+      });
+
+      test('parses footnote with multi-line content', () => {
+        const input = '^ mynote\n  First line\n  Second line\n\nParagraph after';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(2);
+        expect(result.blocks![0]).toMatchObject({
+          type: 'footnote',
+          footnote: { label: 'mynote' },
+        });
+        expect(result.blocks![1].type).toBe('paragraph');
+      });
+
+      test('parses multiple footnotes', () => {
+        const input = '^ note1\n  First footnote\n\n^ note2\n  Second footnote';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(2);
+        expect(result.blocks![0].footnote!.label).toBe('note1');
+        expect(result.blocks![1].footnote!.label).toBe('note2');
+      });
+    });
+
+    describe('Definition Lists', () => {
+      test('parses $ Term with definition text', () => {
+        const result = NeorgContentParser.parseContent('$ API\n  Application Programming Interface');
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(1);
+        expect(result.blocks![0]).toMatchObject({ type: 'definition' });
+        expect(result.blocks![0].definitionItems![0].term).toBe('API');
+      });
+
+      test('parses $ Term with multi-line definition', () => {
+        const input = '$ HTML\n  HyperText\n  Markup Language';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks![0].definitionItems![0].term).toBe('HTML');
+        expect(result.blocks![0].definitionItems![0].definition).toContain('HyperText');
+        expect(result.blocks![0].definitionItems![0].definition).toContain('Markup Language');
+      });
+
+      test('parses multiple definitions', () => {
+        const input = '$ Term1\n  Def1\n\n$ Term2\n  Def2';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(2);
+        expect(result.blocks![0].definitionItems![0].term).toBe('Term1');
+        expect(result.blocks![1].definitionItems![0].term).toBe('Term2');
+      });
+    });
+
+    describe('Indentation', () => {
+      test('treats --- as indentation reversion (not divider)', () => {
+        const input = '* Heading\n---\nParagraph after';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        const dividerBlocks = result.blocks!.filter(b => b.type === 'divider');
+        expect(dividerBlocks).toHaveLength(0);
+      });
+
+      test('treats ___ as horizontal divider', () => {
+        const result = NeorgContentParser.parseContent('___');
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(1);
+        expect(result.blocks![0].type).toBe('divider');
+      });
+
+      test('treats *** as divider', () => {
+        const result = NeorgContentParser.parseContent('***');
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(1);
+        expect(result.blocks![0].type).toBe('divider');
+      });
+    });
+
+    describe('Ranged Tags', () => {
+      test('parses |example ... |end as code-like block', () => {
+        const input = '|example\nsome code here\n|end';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(1);
+        expect(result.blocks![0]).toMatchObject({
+          type: 'code',
+          code: { content: 'some code here' },
+        });
+      });
+
+      test('skips |comment ... |end silently', () => {
+        const input = '|comment\nthis is hidden\n|end\nVisible text';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(1);
+        expect(result.blocks![0].type).toBe('paragraph');
+      });
+    });
+
+    describe('Org-specific syntax not parsed', () => {
+      test('does not parse #+BEGIN_SRC as block (org syntax)', () => {
+        const input = '#+BEGIN_SRC js\nconsole.log("hi");\n#+END_SRC';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        const codeBlocks = result.blocks!.filter(b => b.type === 'code');
+        expect(codeBlocks).toHaveLength(0);
+      });
+
+      test('does not parse :PROPERTIES: as drawer', () => {
+        const input = ':PROPERTIES:\n:CREATED: today\n:END:';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        const drawerBlocks = result.blocks!.filter(b => b.type === 'drawer');
+        expect(drawerBlocks).toHaveLength(0);
+      });
+
+      test('does not skip SCHEDULED: lines', () => {
+        const input = 'SCHEDULED: <2025-01-01>';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks!.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    describe('Mixed content', () => {
+      test('parses full norg document with all elements', () => {
+        const input = `* Heading 1
+
+Paragraph text.
+
+- List item one
+- List item two
+
+- [ ] Checklist item
+
+\`\`\`python
+print("hello")
+\`\`\`
+
+.quote
+Quote text
+.end
+
+___
+
+^ myfn
+A footnote`;
+
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        const types = result.blocks!.map(b => b.type);
+        expect(types).toContain('heading');
+        expect(types).toContain('paragraph');
+        expect(types).toContain('list');
+        expect(types).toContain('checklist');
+        expect(types).toContain('code');
+        expect(types).toContain('quote');
+        expect(types).toContain('divider');
+        expect(types).toContain('footnote');
+      });
+
+      test('handles empty content', () => {
+        const result = NeorgContentParser.parseContent('');
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(0);
+      });
+
+      test('handles content with only whitespace', () => {
+        const result = NeorgContentParser.parseContent('   \n   \n   ');
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(0);
+      });
+
+      test('parses norg tasks with all status types', () => {
+        const input = `(-) todo task
+(x) done task
+(!) important task
+(?) uncertain task
+(~) in-progress task
+(u) urgent task
+(-) cancelled task
+(_) on-hold task
+(+) recurring task`;
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(1);
+        expect(result.blocks![0].listItems).toHaveLength(9);
+        expect(result.blocks![0].listItems!.every(i => i.type === 'task')).toBe(true);
+      });
+
+      test('parses nested lists', () => {
+        const input = '- top\n  - nested\n    - deep';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks![0].listItems).toHaveLength(3);
+        expect(result.blocks![0].listItems![0]!.indentLevel).toBe(0);
+        expect(result.blocks![0].listItems![1]!.indentLevel).toBe(1);
+        expect(result.blocks![0].listItems![2]!.indentLevel).toBe(2);
+      });
+
+      test('parses code blocks with norg syntax =code.lang ... =', () => {
+        const input = '=code.python\nprint("hi")\n=';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(1);
+        expect(result.blocks![0]).toMatchObject({
+          type: 'code',
+          code: { language: 'python', content: 'print("hi")' },
+        });
+      });
+
+      test('parses .quote ranged tag', () => {
+        const input = '.quote\nSome quoted text\n.end';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(1);
+        expect(result.blocks![0]).toMatchObject({
+          type: 'quote',
+          text: 'Some quoted text',
+        });
+      });
+
+      test('parses inline markup in headings', () => {
+        const input = '* This is *bold* text';
+        const result = NeorgContentParser.parseContent(input);
+        expect(result.success).toBe(true);
+        expect(result.blocks).toHaveLength(1);
+        expect(result.blocks![0].heading!.text).toBe('This is *bold* text');
+      });
+    });
+  });
 });

--- a/__tests__/components/StructuredRenderer.test.tsx
+++ b/__tests__/components/StructuredRenderer.test.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      text: '#000',
+      primary: '#0066cc',
+      textSecondary: '#666',
+      surfaceSecondary: '#f0f0f0',
+      border: '#ccc',
+      background: '#fff',
+      surface: '#fff',
+      error: '#ff0000',
+    },
+  }),
+}));
+
+jest.mock('../../src/stores/renderStyleStore', () => ({
+  useRenderStyle: () => ({}),
+}));
+
+import StructuredRenderer from '../../src/components/StructuredRenderer';
+import type { NeorgContentBlock } from '../../src/models/NeorgContent';
+
+function renderBlocks(blocks: NeorgContentBlock[], format: 'neorg' | 'org' = 'neorg') {
+  return render(<StructuredRenderer blocks={blocks} format={format} />);
+}
+
+describe('StructuredRenderer', () => {
+  test('renders heading', () => {
+    const { getByText } = renderBlocks([
+      { type: 'heading', heading: { level: 1, text: 'Hello World' } },
+    ]);
+    expect(getByText('Hello World')).toBeTruthy();
+  });
+
+  test('renders paragraph', () => {
+    const { getByText } = renderBlocks([
+      { type: 'paragraph', text: 'Some body text' },
+    ]);
+    expect(getByText('Some body text')).toBeTruthy();
+  });
+
+  test('renders code block', () => {
+    const { getByText } = renderBlocks([
+      { type: 'code', code: { language: 'js', content: 'const x = 1;' } },
+    ]);
+    expect(getByText('js')).toBeTruthy();
+    expect(getByText('const x = 1;')).toBeTruthy();
+  });
+
+  test('renders list items', () => {
+    const { getByText } = renderBlocks([
+      { type: 'list', listItems: [
+        { type: 'unordered', text: 'first', indentLevel: 0 },
+        { type: 'unordered', text: 'second', indentLevel: 0 },
+      ]},
+    ]);
+    expect(getByText('first')).toBeTruthy();
+    expect(getByText('second')).toBeTruthy();
+  });
+
+  test('renders checklist items', () => {
+    const { getByText } = renderBlocks([
+      { type: 'checklist', checklistItems: [
+        { text: 'done task', checked: true, indentLevel: 0 },
+        { text: 'pending task', checked: false, indentLevel: 0 },
+      ]},
+    ]);
+    expect(getByText('done task')).toBeTruthy();
+    expect(getByText('pending task')).toBeTruthy();
+  });
+
+  test('renders definition items', () => {
+    const { getByText } = renderBlocks([
+      { type: 'definition', definitionItems: [
+        { term: 'API', definition: 'Application Programming Interface', indentLevel: 0 },
+      ]},
+    ]);
+    expect(getByText('API')).toBeTruthy();
+    expect(getByText('Application Programming Interface')).toBeTruthy();
+  });
+
+  test('renders table', () => {
+    const { getByText } = renderBlocks([
+      { type: 'table', tableRows: [{ cells: ['Name', 'Age'] }, { cells: ['Alice', '30'] }], isHeaderRow: [true, false] },
+    ]);
+    expect(getByText('Name')).toBeTruthy();
+    expect(getByText('Alice')).toBeTruthy();
+  });
+
+  test('renders quote block', () => {
+    const { getByText } = renderBlocks([
+      { type: 'quote', text: 'To be or not to be' },
+    ]);
+    expect(getByText('To be or not to be')).toBeTruthy();
+  });
+
+  test('renders divider', () => {
+    const { toJSON } = renderBlocks([
+      { type: 'divider' },
+    ]);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  test('renders org heading with TODO badge', () => {
+    const { getByText } = renderBlocks([
+      { type: 'heading', heading: { level: 1, text: 'Task', todoState: 'TODO' } },
+    ], 'org');
+    expect(getByText('TODO')).toBeTruthy();
+    expect(getByText('Task')).toBeTruthy();
+  });
+
+  test('renders org heading with priority badge', () => {
+    const { getByText } = renderBlocks([
+      { type: 'heading', heading: { level: 1, text: 'Urgent', priority: 'A' } },
+    ], 'org');
+    expect(getByText('#A')).toBeTruthy();
+  });
+
+  test('renders org heading with tags', () => {
+    const { getByText } = renderBlocks([
+      { type: 'heading', heading: { level: 1, text: 'Tagged', tags: ['work', 'home'] } },
+    ], 'org');
+    expect(getByText('work')).toBeTruthy();
+    expect(getByText('home')).toBeTruthy();
+  });
+
+  test('renders org timestamp block', () => {
+    const { getByText } = renderBlocks([
+      { type: 'timestamp', timestamp: { type: 'scheduled', date: '2025-06-15' } },
+    ]);
+    expect(getByText(/SCHEDULED/)).toBeTruthy();
+    expect(getByText(/2025-06-15/)).toBeTruthy();
+  });
+
+  test('renders org drawer/properties', () => {
+    const { getByText } = renderBlocks([
+      { type: 'drawer', drawer: { name: 'PROPERTIES', properties: { CREATED: '[2025-01-01]' } } },
+    ]);
+    expect(getByText(':PROPERTIES:')).toBeTruthy();
+    expect(getByText(/CREATED/)).toBeTruthy();
+  });
+
+  test('renders fixed-width block', () => {
+    const { getByText } = renderBlocks([
+      { type: 'fixed-width', text: 'monospace text' },
+    ]);
+    expect(getByText('monospace text')).toBeTruthy();
+  });
+
+  test('renders footnote block', () => {
+    const { getByText } = renderBlocks([
+      { type: 'footnote', footnote: { label: '1', content: 'A footnote definition.' } },
+    ]);
+    expect(getByText('[^1]')).toBeTruthy();
+    expect(getByText('A footnote definition.')).toBeTruthy();
+  });
+
+  test('renders image placeholder', () => {
+    const { getByText } = renderBlocks([
+      { type: 'image', image: { path: '/img/photo.png', caption: 'A photo' } },
+    ]);
+    expect(getByText(/photo\.png/)).toBeTruthy();
+    expect(getByText('A photo')).toBeTruthy();
+  });
+
+  test('renders math block', () => {
+    const { getByText } = renderBlocks([
+      { type: 'math', math: { content: 'E = mc^2', inline: false } },
+    ]);
+    expect(getByText('MATH')).toBeTruthy();
+    expect(getByText('E = mc^2')).toBeTruthy();
+  });
+
+  test('renders comment block as null', () => {
+    const { toJSON } = renderBlocks([
+      { type: 'comment' },
+    ]);
+    const container = toJSON() as any;
+    const hasChildren = container.children && container.children.length > 0;
+    expect(hasChildren).toBeFalsy();
+  });
+
+  test('org heading badges only show for org format', () => {
+    const { queryByText } = renderBlocks([
+      { type: 'heading', heading: { level: 1, text: 'Task', todoState: 'TODO' } },
+    ], 'org');
+    expect(queryByText('TODO')).toBeTruthy();
+  });
+
+  test('norg format does not show org badges', () => {
+    const { queryByText } = renderBlocks([
+      { type: 'heading', heading: { level: 1, text: 'Task', todoState: 'TODO' } },
+    ], 'neorg');
+    expect(queryByText('TODO')).toBeNull();
+  });
+
+  test('handles empty blocks array', () => {
+    const { toJSON } = renderBlocks([]);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  test('handles null block gracefully', () => {
+    const { toJSON } = renderBlocks([
+      { type: 'heading' } as NeorgContentBlock,
+    ]);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  test('renders deadline timestamp', () => {
+    const { getByText } = renderBlocks([
+      { type: 'timestamp', timestamp: { type: 'deadline', date: '2025-12-31' } },
+    ]);
+    expect(getByText(/DEADLINE/)).toBeTruthy();
+  });
+
+  test('renders closed timestamp', () => {
+    const { getByText } = renderBlocks([
+      { type: 'timestamp', timestamp: { type: 'closed', date: '2025-01-01' } },
+    ]);
+    expect(getByText(/CLOSED/)).toBeTruthy();
+  });
+
+  test('renders ordered list items with numbers', () => {
+    const { getByText } = renderBlocks([
+      { type: 'list', listItems: [
+        { type: 'ordered', text: 'first', indentLevel: 0 },
+        { type: 'ordered', text: 'second', indentLevel: 0 },
+      ]},
+    ]);
+    expect(getByText(/1\./)).toBeTruthy();
+    expect(getByText(/2\./)).toBeTruthy();
+  });
+
+  test('renders task list items with status icons', () => {
+    const { getByText } = renderBlocks([
+      { type: 'list', listItems: [
+        { type: 'task', text: 'done task', status: 'done', indentLevel: 0 },
+        { type: 'task', text: 'todo task', status: 'todo', indentLevel: 0 },
+      ]},
+    ]);
+    expect(getByText(/done task/)).toBeTruthy();
+    expect(getByText(/todo task/)).toBeTruthy();
+  });
+});

--- a/__tests__/renderer-pipeline.test.ts
+++ b/__tests__/renderer-pipeline.test.ts
@@ -26,7 +26,7 @@ jest.mock('react-native-webview', () => ({
 }));
 
 import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
-import { createMemoizedNeorgInlineParser, parseNeorgInlineSegments } from '../src/components/NeorgRenderer';
+import { createMemoizedNeorgInlineParser, parseNeorgInlineSegments } from '../src/components/StructuredRenderer';
 import { NeorgContentParser } from '../src/services/NeorgContentParser';
 
 function renderNode(node: React.ReactNode) {

--- a/__tests__/save-loading-indicator.test.ts
+++ b/__tests__/save-loading-indicator.test.ts
@@ -180,7 +180,7 @@ jest.mock('../src/components/MarkdownEditor', () => () => {
   return require('react').createElement(Text, null, 'Markdown editor');
 });
 jest.mock('../src/components/GitContextPicker', () => () => null);
-jest.mock('../src/components/NeorgRenderer', () => () => null);
+jest.mock('../src/components/StructuredRenderer', () => () => null);
 jest.mock('../src/components/PdfViewer', () => () => null);
 jest.mock('../src/components/TagInput', () => () => null);
 jest.mock('../src/components/VoiceInputModal', () => () => null);

--- a/__tests__/selectable-preview.test.tsx
+++ b/__tests__/selectable-preview.test.tsx
@@ -3,7 +3,7 @@ import { Text, View } from 'react-native';
 import { render } from '@testing-library/react-native';
 
 import { NotePreviewRenderer } from '../src/utils/markdownRenderer';
-import NeorgRenderer from '../src/components/NeorgRenderer';
+import StructuredRenderer from '../src/components/StructuredRenderer';
 
 jest.mock('expo-image', () => ({
   Image: () => null,
@@ -74,7 +74,7 @@ describe('preview text selection', () => {
 
   it('marks neorg preview text selectable', () => {
     const screen = render(
-      <NeorgRenderer
+      <StructuredRenderer
         blocks={[
           { type: 'heading', heading: { level: 1, text: 'Heading *bold* `code`' } },
           { type: 'list', listItems: [{ type: 'ordered', indentLevel: 0, text: 'List item /italic/' }] },

--- a/__tests__/services/NeorgInlineParser.nested.test.ts
+++ b/__tests__/services/NeorgInlineParser.nested.test.ts
@@ -1,0 +1,77 @@
+import { NeorgInlineParser } from '../../src/services/NeorgInlineParser';
+
+describe('NeorgInlineParser - Nested Markup', () => {
+  test('parses */bold italic/* as bold wrapping italic', () => {
+    const result = NeorgInlineParser.parseInline('*/bold italic/*');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup!.type).toBe('bold');
+    expect(markups[0].markup!.content).toBe('/bold italic/');
+    expect(markups[0].markup!.children).toBeDefined();
+    expect(markups[0].markup!.children![0].type).toBe('italic');
+  });
+
+  test('parses _/underline italic/_ as underline wrapping italic', () => {
+    const result = NeorgInlineParser.parseInline('_/underline italic/_');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup!.type).toBe('underline');
+    expect(markups[0].markup!.children).toBeDefined();
+    expect(markups[0].markup!.children![0].type).toBe('italic');
+  });
+
+  test('handles escape: \\*not bold\\* renders literal', () => {
+    const result = NeorgInlineParser.parseInline('this is \\*not bold\\* ok');
+    const fullText = result.segments.map(s => s.type === 'text' ? s.text : s.markup?.content).join('');
+    expect(fullText).toContain('not bold');
+  });
+
+  test('handles escape: \\/not italic\\/ renders literal', () => {
+    const result = NeorgInlineParser.parseInline('this is \\/not italic\\/ ok');
+    const fullText = result.segments.map(s => s.type === 'text' ? s.text : s.markup?.content).join('');
+    expect(fullText).toContain('not italic');
+  });
+
+  test('single-level markup still works', () => {
+    const result = NeorgInlineParser.parseInline('*just bold*');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup!.type).toBe('bold');
+    expect(markups[0].markup!.content).toBe('just bold');
+  });
+
+  test('handles empty markup gracefully', () => {
+    const result = NeorgInlineParser.parseInline('before ** after');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(0);
+  });
+
+  test('handles unclosed markup as text', () => {
+    const result = NeorgInlineParser.parseInline('this *is not closed');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(0);
+    expect(result.segments[0].text).toBe('this *is not closed');
+  });
+
+  test('parses nested bold-italic with surrounding text', () => {
+    const result = NeorgInlineParser.parseInline('hello */nested world/* bye');
+    const textSegs = result.segments.filter(s => s.type === 'text');
+    expect(textSegs[0].text).toBe('hello ');
+    expect(textSegs[1].text).toBe(' bye');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup!.children).toBeDefined();
+  });
+
+  test('toMarkdown converts bold', () => {
+    const result = NeorgInlineParser.parseInline('*hello*');
+    const md = NeorgInlineParser.toMarkdown(result);
+    expect(md).toBe('**hello**');
+  });
+
+  test('toMarkdown converts code', () => {
+    const result = NeorgInlineParser.parseInline('`code`');
+    const md = NeorgInlineParser.toMarkdown(result);
+    expect(md).toBe('`code`');
+  });
+});

--- a/__tests__/services/OrgContentParser.test.ts
+++ b/__tests__/services/OrgContentParser.test.ts
@@ -1,0 +1,354 @@
+import { OrgContentParser } from '../../src/services/OrgContentParser';
+
+describe('OrgContentParser', () => {
+  describe('Headings', () => {
+    test('parses plain heading', () => {
+      const result = OrgContentParser.parseContent('* Hello world');
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0]).toMatchObject({
+        type: 'heading',
+        heading: { level: 1, text: 'Hello world' },
+      });
+    });
+
+    test('parses heading with TODO keyword', () => {
+      const result = OrgContentParser.parseContent('* TODO Buy groceries');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].heading).toMatchObject({
+        level: 1,
+        text: 'Buy groceries',
+        todoState: 'TODO',
+      });
+    });
+
+    test('parses heading with DONE keyword', () => {
+      const result = OrgContentParser.parseContent('* DONE Finish report');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].heading).toMatchObject({
+        text: 'Finish report',
+        todoState: 'DONE',
+      });
+    });
+
+    test('parses heading with priority [#A]', () => {
+      const result = OrgContentParser.parseContent('* TODO [#A] Urgent task');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].heading).toMatchObject({
+        text: 'Urgent task',
+        todoState: 'TODO',
+        priority: 'A',
+      });
+    });
+
+    test('parses heading with tags :tag1:tag2:', () => {
+      const result = OrgContentParser.parseContent('* Heading :work:urgent:');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].heading).toMatchObject({
+        text: 'Heading',
+        tags: ['work', 'urgent'],
+      });
+    });
+
+    test('parses heading with all metadata: TODO [#A] text :work:urgent:', () => {
+      const result = OrgContentParser.parseContent('* TODO [#A] Critical item :work:urgent:');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].heading).toMatchObject({
+        text: 'Critical item',
+        todoState: 'TODO',
+        priority: 'A',
+        tags: ['work', 'urgent'],
+      });
+    });
+
+    test('parses COMMENT heading', () => {
+      const result = OrgContentParser.parseContent('* COMMENT Hidden section');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].heading).toMatchObject({
+        text: 'Hidden section',
+        commented: true,
+      });
+    });
+
+    test('parses multi-level headings (** heading)', () => {
+      const input = '* Level 1\n** Level 2\n*** Level 3\n**** Level 4';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(4);
+      expect(result.blocks![0].heading!.level).toBe(1);
+      expect(result.blocks![1].heading!.level).toBe(2);
+      expect(result.blocks![2].heading!.level).toBe(3);
+      expect(result.blocks![3].heading!.level).toBe(4);
+    });
+  });
+
+  describe('Lists', () => {
+    test('parses - unordered items', () => {
+      const result = OrgContentParser.parseContent('- item one\n- item two');
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0]).toMatchObject({ type: 'list' });
+      expect(result.blocks![0].listItems).toHaveLength(2);
+      expect(result.blocks![0].listItems![0]).toMatchObject({ type: 'unordered', text: 'item one' });
+    });
+
+    test('parses + unordered items', () => {
+      const result = OrgContentParser.parseContent('+ item one\n+ item two');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].listItems![0]).toMatchObject({ type: 'unordered', text: 'item one' });
+    });
+
+    test('parses 1. ordered items', () => {
+      const result = OrgContentParser.parseContent('1. first\n2. second');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0]).toMatchObject({ type: 'list' });
+      expect(result.blocks![0].listItems![0]).toMatchObject({ type: 'ordered', text: 'first' });
+      expect(result.blocks![0].listItems![1]).toMatchObject({ type: 'ordered', text: 'second' });
+    });
+
+    test('parses 1) ordered items', () => {
+      const result = OrgContentParser.parseContent('1) first\n2) second');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].listItems![0]).toMatchObject({ type: 'ordered', text: 'first' });
+    });
+
+    test('parses - Term :: definition description lists', () => {
+      const result = OrgContentParser.parseContent('- Apple :: A fruit\n- Banana :: Another fruit');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0]).toMatchObject({ type: 'definition' });
+      expect(result.blocks![0].definitionItems).toHaveLength(2);
+      expect(result.blocks![0].definitionItems![0]).toMatchObject({ term: 'Apple', definition: 'A fruit' });
+    });
+
+    test('parses nested lists via indentation', () => {
+      const input = '- top\n  - nested\n    - deep';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].listItems).toHaveLength(3);
+      expect(result.blocks![0].listItems![0]!.indentLevel).toBe(0);
+      expect(result.blocks![0].listItems![1]!.indentLevel).toBe(1);
+      expect(result.blocks![0].listItems![2]!.indentLevel).toBe(2);
+    });
+  });
+
+  describe('Checklists', () => {
+    test('parses - [ ] unchecked', () => {
+      const result = OrgContentParser.parseContent('- [ ] Todo item');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0]).toMatchObject({ type: 'checklist' });
+      expect(result.blocks![0].checklistItems![0]).toMatchObject({ text: 'Todo item', checked: false });
+    });
+
+    test('parses - [X] checked', () => {
+      const result = OrgContentParser.parseContent('- [X] Done item');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].checklistItems![0]).toMatchObject({ text: 'Done item', checked: true });
+    });
+
+    test('parses - [-] partial', () => {
+      const result = OrgContentParser.parseContent('- [-] Partial item');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].checklistItems![0]).toMatchObject({ text: 'Partial item', checked: false });
+    });
+  });
+
+  describe('Block Elements', () => {
+    test('parses #+BEGIN_SRC with language', () => {
+      const input = '#+BEGIN_SRC javascript\nconsole.log("hi");\n#+END_SRC';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0]).toMatchObject({
+        type: 'code',
+        code: { language: 'javascript', content: 'console.log("hi");' },
+      });
+    });
+
+    test('parses #+BEGIN_QUOTE', () => {
+      const input = '#+BEGIN_QUOTE\nTo be or not to be.\n#+END_QUOTE';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0]).toMatchObject({
+        type: 'quote',
+        text: 'To be or not to be.',
+      });
+    });
+
+    test('parses #+BEGIN_VERSE as quote', () => {
+      const input = '#+BEGIN_VERSE\nRoses are red\n#+END_VERSE';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks![0]).toMatchObject({ type: 'quote' });
+    });
+
+    test('parses #+BEGIN_EXPORT as code', () => {
+      const input = '#+BEGIN_EXPORT html\n<div>hello</div>\n#+END_EXPORT';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks![0]).toMatchObject({
+        type: 'code',
+        code: { language: 'html', content: '<div>hello</div>' },
+      });
+    });
+
+    test('parses #+BEGIN_EXAMPLE as code', () => {
+      const input = '#+BEGIN_EXAMPLE\nsome example\n#+END_EXAMPLE';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks![0]).toMatchObject({
+        type: 'code',
+        code: { content: 'some example' },
+      });
+    });
+  });
+
+  describe('Drawers', () => {
+    test('parses :PROPERTIES: drawer with key-value pairs', () => {
+      const input = ':PROPERTIES:\n:CREATED: [2025-01-01]\n:END:';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0]).toMatchObject({ type: 'drawer' });
+      expect(result.blocks![0].drawer!.name).toBe('PROPERTIES');
+      expect(result.blocks![0].drawer!.properties).toMatchObject({ CREATED: '[2025-01-01]' });
+    });
+
+    test('parses custom drawer', () => {
+      const input = ':LOGBOOK:\n:Entry: Something happened\n:END:';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks![0].drawer!.name).toBe('LOGBOOK');
+      expect(result.blocks![0].drawer!.properties.Entry).toBe('Something happened');
+    });
+  });
+
+  describe('Timestamps', () => {
+    test('parses SCHEDULED timestamp', () => {
+      const result = OrgContentParser.parseContent('SCHEDULED: <2025-06-15>');
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0]).toMatchObject({
+        type: 'timestamp',
+        timestamp: { type: 'scheduled', date: '2025-06-15' },
+      });
+    });
+
+    test('parses DEADLINE timestamp', () => {
+      const result = OrgContentParser.parseContent('DEADLINE: <2025-12-31>');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0]).toMatchObject({
+        type: 'timestamp',
+        timestamp: { type: 'deadline', date: '2025-12-31' },
+      });
+    });
+
+    test('parses CLOSED timestamp', () => {
+      const result = OrgContentParser.parseContent('CLOSED: [2025-01-01]');
+      expect(result.success).toBe(true);
+      expect(result.blocks![0]).toMatchObject({
+        type: 'timestamp',
+        timestamp: { type: 'closed', date: '2025-01-01' },
+      });
+    });
+  });
+
+  describe('Skipped Elements', () => {
+    test('skips # comment lines', () => {
+      const result = OrgContentParser.parseContent('# This is a comment\nHello');
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0].type).toBe('paragraph');
+    });
+
+    test('skips #+TITLE: lines', () => {
+      const result = OrgContentParser.parseContent('#+TITLE: My Document\nHello');
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0].type).toBe('paragraph');
+      expect(result.blocks![0].text).toBe('Hello');
+    });
+
+    test('skips CLOCK: entries', () => {
+      const result = OrgContentParser.parseContent('CLOCK: [2025-01-01 Thu 10:00]--[2025-01-01 Thu 11:00] => 1:00\nHello');
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0].type).toBe('paragraph');
+    });
+
+    test('skips state change lines', () => {
+      const result = OrgContentParser.parseContent('- State "DONE" from "TODO" [2025-01-01]\nHello');
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0].type).toBe('paragraph');
+    });
+  });
+
+  describe('Other Elements', () => {
+    test('parses fixed-width : text lines', () => {
+      const input = ': This is fixed-width\n: Another line';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0]).toMatchObject({
+        type: 'fixed-width',
+        text: 'This is fixed-width\nAnother line',
+      });
+    });
+
+    test('parses tables with header', () => {
+      const input = '| Name | Age |\n|---+---|\n| Alice | 30 |';
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0]).toMatchObject({ type: 'table' });
+      expect(result.blocks![0].tableRows).toHaveLength(2);
+    });
+
+    test('parses horizontal rule ----- (5+ dashes)', () => {
+      const result = OrgContentParser.parseContent('-----');
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0].type).toBe('divider');
+    });
+
+    test('parses paragraphs', () => {
+      const result = OrgContentParser.parseContent('This is a paragraph.');
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks![0]).toMatchObject({ type: 'paragraph', text: 'This is a paragraph.' });
+    });
+
+    test('handles empty content', () => {
+      const result = OrgContentParser.parseContent('');
+      expect(result.success).toBe(true);
+      expect(result.blocks).toHaveLength(0);
+    });
+
+    test('handles mixed document', () => {
+      const input = `* TODO [#A] Project :work:
+
+SCHEDULED: <2025-06-01>
+
+- Task one
+- Task two
+
+#+BEGIN_SRC python
+print("hello")
+#+END_SRC
+
+Some paragraph text.
+
+-----`;
+      const result = OrgContentParser.parseContent(input);
+      expect(result.success).toBe(true);
+      const types = result.blocks!.map(b => b.type);
+      expect(types).toContain('heading');
+      expect(types).toContain('timestamp');
+      expect(types).toContain('list');
+      expect(types).toContain('code');
+      expect(types).toContain('paragraph');
+      expect(types).toContain('divider');
+    });
+  });
+});

--- a/__tests__/services/OrgInlineParser.test.ts
+++ b/__tests__/services/OrgInlineParser.test.ts
@@ -1,0 +1,113 @@
+import { OrgInlineParser } from '../../src/services/OrgInlineParser';
+
+describe('OrgInlineParser', () => {
+  test('parses +strikethrough+', () => {
+    const result = OrgInlineParser.parseInline('some +deleted+ text');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup).toMatchObject({ type: 'org-strike', content: 'deleted' });
+  });
+
+  test('parses =verbatim=', () => {
+    const result = OrgInlineParser.parseInline('this is =code= here');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup).toMatchObject({ type: 'verbatim', content: 'code' });
+  });
+
+  test('parses ~code~', () => {
+    const result = OrgInlineParser.parseInline('use ~console.log~ here');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup).toMatchObject({ type: 'org-code', content: 'console.log' });
+  });
+
+  test('parses *bold*', () => {
+    const result = OrgInlineParser.parseInline('this is *bold* text');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup).toMatchObject({ type: 'bold', content: 'bold' });
+  });
+
+  test('parses /italic/', () => {
+    const result = OrgInlineParser.parseInline('this is /italic/ text');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup).toMatchObject({ type: 'italic', content: 'italic' });
+  });
+
+  test('parses _underline_', () => {
+    const result = OrgInlineParser.parseInline('this is _underlined_ text');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup).toMatchObject({ type: 'underline', content: 'underlined' });
+  });
+
+  test('parses [[url][text]] link', () => {
+    const result = OrgInlineParser.parseInline('click [[https://example.com][here]] now');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup!.content).toBe('here');
+  });
+
+  test('parses [[url]] link', () => {
+    const result = OrgInlineParser.parseInline('visit [[https://example.com]] now');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup!.content).toBe('https://example.com');
+  });
+
+  test('parses [fn:1] footnote ref', () => {
+    const result = OrgInlineParser.parseInline('see [fn:1] for details');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(1);
+    expect(markups[0].markup!.content).toBe('[fn:1]');
+  });
+
+  test('respects PRE/POST boundary rules', () => {
+    const result = OrgInlineParser.parseInline('word*notbold*word');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(0);
+  });
+
+  test('handles mixed markup', () => {
+    const result = OrgInlineParser.parseInline('*bold* and /italic/ and =verbatim=');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(3);
+    expect(markups[0].markup!.type).toBe('bold');
+    expect(markups[1].markup!.type).toBe('italic');
+    expect(markups[2].markup!.type).toBe('verbatim');
+  });
+
+  test('handles text with no markup', () => {
+    const result = OrgInlineParser.parseInline('just plain text');
+    expect(result.segments).toHaveLength(1);
+    expect(result.segments[0].type).toBe('text');
+    expect(result.segments[0].text).toBe('just plain text');
+  });
+
+  test('handles escape: \\*not bold\\* renders literal', () => {
+    const result = OrgInlineParser.parseInline('this is \\*not bold\\* text');
+    const markups = result.segments.filter(s => s.type === 'markup');
+    expect(markups).toHaveLength(0);
+  });
+
+  test('toMarkdown converts bold', () => {
+    const result = OrgInlineParser.parseInline('*hello*');
+    const md = OrgInlineParser.toMarkdown(result);
+    expect(md).toBe('**hello**');
+  });
+
+  test('toMarkdown converts italic', () => {
+    const result = OrgInlineParser.parseInline('/hello/');
+    const md = OrgInlineParser.toMarkdown(result);
+    expect(md).toBe('*hello*');
+  });
+
+  test('toReactNativeProps returns correct styles', () => {
+    const result = OrgInlineParser.parseInline('*bold*');
+    const props = OrgInlineParser.toReactNativeProps(result);
+    expect(props).toHaveLength(1);
+    expect(props[0].style).toContain('bold');
+  });
+});

--- a/src/components/NeorgRenderer.tsx
+++ b/src/components/NeorgRenderer.tsx
@@ -20,6 +20,10 @@ type InlineSegment =
   | { type: 'code'; content: string }
   | { type: 'superscript'; content: string }
   | { type: 'subscript'; content: string }
+  | { type: 'verbatim'; content: string }
+  | { type: 'org-code'; content: string }
+  | { type: 'org-strike'; content: string }
+  | { type: 'footnote-ref'; label: string; content: string }
   | { type: 'link'; label: string; target: string }
   | { type: 'tag'; name: string };
 
@@ -259,12 +263,14 @@ export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendere
               );
             case 'tag':
               return (
-                <Text key={k} selectable style={[styles.tagBadge, { backgroundColor: colors.primary + '20', color: colors.primary }]}>
+                <Text key={k} selectable style={[styles.tagBadge, { backgroundColor: colors.primary + '20', color: colors.primary }]}> 
                   {seg.name}
                 </Text>
               );
+            case 'footnote-ref':
+              return <Text key={k} selectable style={styles.footnoteRef}>[{seg.label}]</Text>;
             default:
-              return <Text key={k} selectable>{seg.content}</Text>;
+              return 'content' in seg ? <Text key={k} selectable>{seg.content}</Text> : null;
           }
         })}
       </React.Fragment>
@@ -486,6 +492,10 @@ const styles = StyleSheet.create({
     paddingVertical: 2,
     borderRadius: 10,
     overflow: 'hidden',
+  },
+  footnoteRef: {
+    fontSize: 12,
+    lineHeight: 16,
   },
   paragraph: {
     fontSize: 16,

--- a/src/components/StructuredRenderer.tsx
+++ b/src/components/StructuredRenderer.tsx
@@ -5,9 +5,8 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useRenderStyle } from '../stores/renderStyleStore';
 import type { RenderFormat } from '../types/RenderStyle';
 
-interface NeorgRendererProps {
+interface StructuredRendererProps {
   blocks: NeorgContentBlock[];
-  /** Which format's render-style overrides to apply. Defaults to 'neorg'. */
   format?: RenderFormat;
 }
 
@@ -95,6 +94,9 @@ const inlinePatterns: InlinePattern[] = [
     regex: /,([^,]+),/g,
     handler: (m) => ({ type: 'subscript', content: m[1] }),
   },
+  { regex: /\+([^+\s][^+]*[^+\s]?)\+/g, handler: (m) => ({ type: 'org-strike', content: m[1] }) },
+  { regex: /=([^=\s][^=]*[^=\s]?)=/g, handler: (m) => ({ type: 'verbatim', content: m[1] }) },
+  { regex: /~([^~\s][^~]*[^~\s]?)~/g, handler: (m) => ({ type: 'org-code', content: m[1] }) },
 ];
 
 function findOuterDelimitedMatch(text: string, delimiter: '*' | '/'): { length: number; segment: InlineSegment } | null {
@@ -189,7 +191,7 @@ export function createMemoizedNeorgInlineParser(
   };
 }
 
-export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendererProps) {
+export default function StructuredRenderer({ blocks, format = 'neorg' }: StructuredRendererProps) {
   const { colors } = useTheme();
   const overrides = useRenderStyle(format);
 
@@ -215,6 +217,24 @@ export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendere
   const quoteText = overrides.blockquote?.text ?? colors.text;
   const dividerColor = overrides.divider?.color ?? colors.border;
 
+  const todoColor = (state: string): string => {
+    switch (state) {
+      case 'TODO': return '#F97316';
+      case 'DONE': return '#22C55E';
+      case 'IN-PROGRESS': return '#3B82F6';
+      case 'WAITING': return '#EAB308';
+      default: return '#9CA3AF';
+    }
+  };
+  const priorityColor = (p: string): string => {
+    switch (p) {
+      case 'A': return '#EF4444';
+      case 'B': return '#F59E0B';
+      case 'C': return '#22C55E';
+      default: return '#9CA3AF';
+    }
+  };
+
   const parseInline = useMemo(() => createMemoizedNeorgInlineParser(), []);
 
   const segKey = (seg: InlineSegment, i: number): string =>
@@ -237,6 +257,12 @@ export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendere
               return <Text key={k} selectable style={styles.underline}>{renderInline(seg.content)}</Text>;
             case 'strikethrough':
               return <Text key={k} selectable style={styles.strikethrough}>{renderInline(seg.content)}</Text>;
+            case 'verbatim':
+              return <Text key={k} selectable style={[styles.inlineCode, { backgroundColor: inlineBg ?? colors.surfaceSecondary }]}>{seg.content}</Text>;
+            case 'org-code':
+              return <Text key={k} selectable style={[styles.inlineCode, { backgroundColor: inlineBg ?? colors.surfaceSecondary }, inlineText ? { color: inlineText } : null]}>{seg.content}</Text>;
+            case 'org-strike':
+              return <Text key={k} selectable style={styles.strikethrough}>{seg.content}</Text>;
             case 'code':
               return (
                 <Text
@@ -268,7 +294,7 @@ export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendere
                 </Text>
               );
             case 'footnote-ref':
-              return <Text key={k} selectable style={styles.footnoteRef}>[{seg.label}]</Text>;
+              return <Text key={k} selectable style={{ fontSize: 11, lineHeight: 14, color: linkColor }}>{seg.label}</Text>;
             default:
               return 'content' in seg ? <Text key={k} selectable>{seg.content}</Text> : null;
           }
@@ -295,17 +321,33 @@ export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendere
     const fontSize = 32 - (heading.level - 1) * 4;
     const fontWeight = headingWeightFor(heading.level);
     return (
-      <Text
-        key={`heading-${blockIndex}`}
-        selectable
-        style={[
-          styles.heading,
-          { fontSize, color: headingColorFor(heading.level), marginTop: heading.level === 1 ? 16 : 12 },
-          fontWeight ? { fontWeight } : null,
-        ]}
-      >
-        {renderInline(heading.text)}
-      </Text>
+      <View key={`heading-${blockIndex}`} style={{ flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', marginTop: heading.level === 1 ? 16 : 12, marginBottom: 8 }}>
+        {format === 'org' && heading.todoState && (
+          <Text style={[styles.todoBadge, { backgroundColor: todoColor(heading.todoState) + '20', color: todoColor(heading.todoState) }]}>
+            {heading.todoState}
+          </Text>
+        )}
+        {format === 'org' && heading.priority && (
+          <Text style={[styles.priorityBadge, { backgroundColor: priorityColor(heading.priority) + '30', color: priorityColor(heading.priority) }]}>
+            #{heading.priority}
+          </Text>
+        )}
+        <Text
+          selectable
+          style={[
+            styles.heading,
+            { fontSize, color: headingColorFor(heading.level) },
+            fontWeight ? { fontWeight } : null,
+          ]}
+        >
+          {renderInline(heading.text)}
+        </Text>
+        {format === 'org' && heading.tags && heading.tags.map((tag, ti) => (
+          <Text key={`tag-${ti}`} style={[styles.tagChip, { backgroundColor: colors.primary + '15', color: colors.primary }]}>
+            {tag}
+          </Text>
+        ))}
+      </View>
     );
   };
 
@@ -436,6 +478,64 @@ export default function NeorgRenderer({ blocks, format = 'neorg' }: NeorgRendere
         return block.text ? renderQuote(block.text, index) : null;
       case 'divider':
         return renderDivider(index);
+      case 'timestamp':
+        return block.timestamp ? (
+          <View key={`ts-${index}`} style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Text selectable style={{ fontSize: 14, color: colors.textSecondary }}>
+              {block.timestamp.type === 'scheduled' ? '📅 SCHEDULED' :
+               block.timestamp.type === 'deadline' ? '⏰ DEADLINE' :
+               block.timestamp.type === 'closed' ? '✅ CLOSED' :
+               block.timestamp.type === 'active' ? '📆' : '📋'} {block.timestamp.date}
+              {block.timestamp.time ? ` ${block.timestamp.time}` : ''}
+            </Text>
+          </View>
+        ) : null;
+      case 'footnote':
+        return block.footnote ? (
+          <View key={`fn-${index}`} style={{ marginBottom: 8, paddingLeft: 16 }}>
+            <Text selectable style={{ fontSize: 12, fontWeight: '600', color: colors.primary }}>
+              [^{block.footnote.label}]
+            </Text>
+            <Text selectable style={{ fontSize: 14, lineHeight: 20, marginLeft: 16, marginTop: 2, color: colors.textSecondary }}>
+              {block.footnote.content}
+            </Text>
+          </View>
+        ) : null;
+      case 'drawer':
+        return block.drawer ? (
+          <View key={`dr-${index}`} style={{ padding: 8, borderRadius: 4, marginVertical: 4, backgroundColor: colors.surfaceSecondary, opacity: 0.7 }}>
+            <Text selectable style={{ fontSize: 12, fontWeight: '600', color: colors.textSecondary, marginBottom: 4 }}>
+              :{block.drawer.name}:
+            </Text>
+            {Object.entries(block.drawer.properties).map(([key, value]) => (
+              <Text key={key} selectable style={{ fontSize: 12, fontFamily: 'monospace', color: colors.textSecondary }}>
+                :{key}: {value}
+              </Text>
+            ))}
+          </View>
+        ) : null;
+      case 'fixed-width':
+        return block.text ? (
+          <Text key={`fw-${index}`} selectable style={{ fontFamily: 'monospace', fontSize: 14, paddingVertical: 2, color: colors.text }}>
+            {block.text}
+          </Text>
+        ) : null;
+      case 'image':
+        return block.image ? (
+          <View key={`img-${index}`} style={{ padding: 8, borderRadius: 4, marginVertical: 4, backgroundColor: colors.surfaceSecondary, alignItems: 'center' }}>
+            <Text selectable style={{ fontSize: 14, color: colors.text }}>📷 {block.image.path}</Text>
+            {block.image.caption ? <Text selectable style={{ fontSize: 12, color: colors.textSecondary }}>{block.image.caption}</Text> : null}
+          </View>
+        ) : null;
+      case 'math':
+        return block.math ? (
+          <View key={`math-${index}`} style={[styles.codeBlock, { backgroundColor: codeBg }]}>
+            <Text selectable style={{ fontSize: 12, fontWeight: '600', color: colors.textSecondary, marginBottom: 4 }}>MATH</Text>
+            <Text selectable style={{ fontFamily: 'monospace', fontSize: 14, color: codeText }}>{block.math.content}</Text>
+          </View>
+        ) : null;
+      case 'comment':
+        return null;
       default:
         return null;
     }
@@ -572,4 +672,7 @@ const styles = StyleSheet.create({
     height: 1,
     marginVertical: 16,
   },
+  todoBadge: { fontSize: 12, paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4, overflow: 'hidden' },
+  priorityBadge: { fontSize: 11, paddingHorizontal: 4, paddingVertical: 1, borderRadius: 3, overflow: 'hidden' },
+  tagChip: { fontSize: 11, paddingHorizontal: 6, paddingVertical: 2, borderRadius: 10, overflow: 'hidden' },
 });

--- a/src/components/editor/NotePreviewPane.tsx
+++ b/src/components/editor/NotePreviewPane.tsx
@@ -12,7 +12,7 @@ import { BlurView } from 'expo-blur';
 
 import { useTheme } from '../../contexts/ThemeContext';
 import { NoteFormat } from '../../models/Note';
-import NeorgRenderer from '../NeorgRenderer';
+import StructuredRenderer from '../StructuredRenderer';
 import PdfViewer from '../PdfViewer';
 import { MarkdownBody } from './MarkdownBody';
 
@@ -116,7 +116,7 @@ export function NotePreviewPane({
               <MarkdownBody value={previewContent} styles={markdownStyles} renderer={notePreviewRenderer} />
             )
           ) : parsedStructuredContent ? (
-            <NeorgRenderer blocks={parsedStructuredContent as never} format={noteFormat === 'org' ? 'org' : 'neorg'} />
+            <StructuredRenderer blocks={parsedStructuredContent as never} format={noteFormat === 'org' ? 'org' : 'neorg'} />
           ) : (
             <Text style={[styles.structuredFallback, { color: colors.text }]}>{previewContent}</Text>
           )

--- a/src/components/editor/useNoteEditorPreview.ts
+++ b/src/components/editor/useNoteEditorPreview.ts
@@ -6,6 +6,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../navigation/types';
 import { Note, NoteFormat } from '../../models/Note';
 import { NeorgContentParser } from '../../services/NeorgContentParser';
+import { OrgContentParser } from '../../services/OrgContentParser';
 import { PositionMemoryService } from '../../services/PositionMemoryService';
 import { HapticService } from '../../utils/haptics';
 import { getMarkdownStyles } from '../../utils/preview';
@@ -81,7 +82,8 @@ export function useNoteEditorPreview({
 
   const parsedStructuredContent = useMemo(() => {
     if (noteFormat === 'markdown' || noteFormat === 'pdf') return null;
-    const parsed = NeorgContentParser.parseContent(previewContent);
+    const parser = noteFormat === 'org' ? OrgContentParser : NeorgContentParser;
+    const parsed = parser.parseContent(previewContent);
     if (!parsed.success || !parsed.blocks || parsed.blocks.length === 0) return null;
     return parsed.blocks;
   }, [noteFormat, previewContent]);

--- a/src/models/NeorgContent.ts
+++ b/src/models/NeorgContent.ts
@@ -2,6 +2,39 @@ export interface NeorgHeading {
   level: number;
   text: string;
   children?: NeorgHeading[];
+  // New org-mode heading metadata:
+  todoState?: string;
+  priority?: string;
+  tags?: string[];
+  commented?: boolean;
+}
+
+export interface NeorgFootnote {
+  label: string;
+  content: string;
+}
+
+export interface NeorgTimestamp {
+  type: 'active' | 'inactive' | 'scheduled' | 'deadline' | 'closed';
+  date: string;
+  time?: string;
+}
+
+export interface NeorgDrawer {
+  name: string;
+  properties: Record<string, string>;
+}
+
+export interface NeorgImage {
+  path: string;
+  caption?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface NeorgMath {
+  content: string;
+  inline: boolean;
 }
 
 export interface NeorgListItem {
@@ -29,7 +62,7 @@ export interface NeorgTableRow {
 }
 
 export interface NeorgContentBlock {
-  type: 'heading' | 'list' | 'paragraph' | 'code' | 'checklist' | 'table' | 'quote' | 'divider' | 'definition';
+  type: 'heading' | 'list' | 'paragraph' | 'code' | 'checklist' | 'table' | 'quote' | 'divider' | 'definition' | 'footnote' | 'timestamp' | 'drawer' | 'image' | 'math' | 'fixed-width' | 'comment';
   heading?: NeorgHeading;
   listItems?: NeorgListItem[];
   checklistItems?: NeorgChecklistItem[];
@@ -41,6 +74,11 @@ export interface NeorgContentBlock {
   };
   tableRows?: NeorgTableRow[];
   isHeaderRow?: boolean[];
+  footnote?: NeorgFootnote;
+  timestamp?: NeorgTimestamp;
+  drawer?: NeorgDrawer;
+  image?: NeorgImage;
+  math?: NeorgMath;
 }
 
 export interface NeorgContentParseResult {

--- a/src/models/NeorgInline.ts
+++ b/src/models/NeorgInline.ts
@@ -6,7 +6,10 @@ export type MarkupType =
   | 'spoiler'
   | 'code'
   | 'superscript'
-  | 'subscript';
+  | 'subscript'
+  | 'verbatim'
+  | 'org-code'
+  | 'org-strike';
 
 export interface InlineMarkup {
   type: MarkupType;

--- a/src/screens/FileViewerScreen.tsx
+++ b/src/screens/FileViewerScreen.tsx
@@ -16,7 +16,7 @@ import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../contexts/ThemeContext';
 import { GitHubService } from '../services/GitHubService';
 import { NeorgContentParser } from '../services/NeorgContentParser';
-import NeorgRenderer from '../components/NeorgRenderer';
+import StructuredRenderer from '../components/StructuredRenderer';
 import { JsonRenderer } from '../components/JsonRenderer';
 import { HapticService } from '../utils/haptics';
 import { getMarkdownStyles, stripTopMetadata } from '../utils/preview';
@@ -156,7 +156,7 @@ export default function FileViewerScreen() {
           ) : mode === 'json' ? (
             <JsonRenderer content={renderContent} />
           ) : (mode === 'neorg' || mode === 'org') && parsedNeorg ? (
-            <NeorgRenderer blocks={parsedNeorg} format={mode === 'org' ? 'org' : 'neorg'} />
+            <StructuredRenderer blocks={parsedNeorg} format={mode === 'org' ? 'org' : 'neorg'} />
           ) : (
             <Text
               style={[

--- a/src/screens/FileViewerScreen.tsx
+++ b/src/screens/FileViewerScreen.tsx
@@ -16,6 +16,7 @@ import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../contexts/ThemeContext';
 import { GitHubService } from '../services/GitHubService';
 import { NeorgContentParser } from '../services/NeorgContentParser';
+import { OrgContentParser } from '../services/OrgContentParser';
 import StructuredRenderer from '../components/StructuredRenderer';
 import { JsonRenderer } from '../components/JsonRenderer';
 import { HapticService } from '../utils/haptics';
@@ -106,7 +107,8 @@ export default function FileViewerScreen() {
   const parsedNeorg = useMemo(() => {
     if (!renderContent) return null;
     if (mode !== 'neorg' && mode !== 'org') return null;
-    const parsed = NeorgContentParser.parseContent(renderContent);
+    const parser = mode === 'org' ? OrgContentParser : NeorgContentParser;
+    const parsed = parser.parseContent(renderContent);
     return parsed.success && parsed.blocks ? parsed.blocks : null;
   }, [renderContent, mode]);
 

--- a/src/screens/RenderStyleEditorScreen.tsx
+++ b/src/screens/RenderStyleEditorScreen.tsx
@@ -18,7 +18,7 @@ import type { RouteProp } from '@react-navigation/native';
 
 import { useTheme } from '../contexts/ThemeContext';
 import { useRenderStyleStore } from '../stores/renderStyleStore';
-import NeorgRenderer from '../components/NeorgRenderer';
+import StructuredRenderer from '../components/StructuredRenderer';
 import HexColorPickerModal from '../components/HexColorPickerModal';
 import { NeorgContentParser } from '../services/NeorgContentParser';
 import { getMarkdownStyles } from '../utils/preview';
@@ -99,7 +99,7 @@ function MarkdownPreview({ value, format, overrides }: { value: string; format: 
   if (!parsed.success || !parsed.blocks) {
     return <Text style={{ color: colors.textSecondary }}>(preview unavailable)</Text>;
   }
-  return <NeorgRenderer blocks={parsed.blocks} format={format} />;
+  return <StructuredRenderer blocks={parsed.blocks} format={format} />;
 }
 
 function MarkdownNodes({ value, styles2 }: { value: string; styles2: ReturnType<typeof getMarkdownStyles> }) {

--- a/src/screens/RenderStyleEditorScreen.tsx
+++ b/src/screens/RenderStyleEditorScreen.tsx
@@ -21,6 +21,7 @@ import { useRenderStyleStore } from '../stores/renderStyleStore';
 import StructuredRenderer from '../components/StructuredRenderer';
 import HexColorPickerModal from '../components/HexColorPickerModal';
 import { NeorgContentParser } from '../services/NeorgContentParser';
+import { OrgContentParser } from '../services/OrgContentParser';
 import { getMarkdownStyles } from '../utils/preview';
 import type { FormatRenderStyle, RenderFormat } from '../types/RenderStyle';
 import { formatLabel } from '../types/RenderStyle';
@@ -31,8 +32,8 @@ type Nav = NativeStackNavigationProp<RootStackParamList, 'RenderStyleEditor'>;
 type RouteParams = RouteProp<RootStackParamList, 'RenderStyleEditor'>;
 
 const SAMPLE_MARKDOWN = `# Heading 1\n## Heading 2\n### Heading 3\n\nBody text with a [link](https://example.com) and \`inline code\`.\n\n> Blockquote line.\n\n\`\`\`\nfenced code block\nlet x = 42;\n\`\`\`\n\n---\n`;
-const SAMPLE_NEORG = `* Heading 1\n** Heading 2\n*** Heading 3\n\nBody text with a {https://example.com}[link] and \`inline code\`.\n\n> Blockquote line.\n\n@code\nfenced code block\nlet x = 42;\n@end\n\n___\n`;
-const SAMPLE_ORG = `* Heading 1\n** Heading 2\n*** Heading 3\n\nBody text with a [[https://example.com][link]] and =inline code=.\n\n#+BEGIN_QUOTE\nBlockquote line.\n#+END_QUOTE\n\n#+BEGIN_SRC\nfenced code block\nlet x = 42;\n#+END_SRC\n\n-----\n`;
+const SAMPLE_NEORG = `* Heading 1\n** Heading 2\n*** Heading 3\n\nBody text with a {https://example.com}[link] and \`inline code\`.\n\n- Unordered item\n- Another item\n\n> Blockquote line.\n\n@code\nfenced code block\nlet x = 42;\n@end\n\n___\n`;
+const SAMPLE_ORG = `* TODO Heading 1\n** DONE Heading 2\n*** Heading 3\n\nBody text with a [[https://example.com][link]] and =inline code= and +strikethrough+.\n\n- Unordered item\n- Another item\n\n#+BEGIN_QUOTE\nBlockquote line.\n#+END_QUOTE\n\n#+BEGIN_SRC javascript\nfenced code block\nlet x = 42;\n#+END_SRC\n\nSCHEDULED: <2025-01-15>\n[fn:1] A footnote definition.\n\n-----\n`;
 
 function sampleFor(format: RenderFormat): string {
   if (format === 'markdown') return SAMPLE_MARKDOWN;
@@ -95,7 +96,8 @@ function MarkdownPreview({ value, format, overrides }: { value: string; format: 
   if (format === 'markdown') {
     return <MarkdownNodes value={value} styles2={styles2} />;
   }
-  const parsed = NeorgContentParser.parseContent(value);
+  const parser = format === 'org' ? OrgContentParser : NeorgContentParser;
+  const parsed = parser.parseContent(value);
   if (!parsed.success || !parsed.blocks) {
     return <Text style={{ color: colors.textSecondary }}>(preview unavailable)</Text>;
   }

--- a/src/services/NeorgContentParser.ts
+++ b/src/services/NeorgContentParser.ts
@@ -18,10 +18,7 @@ export class NeorgContentParser {
       let checklistIndentWidth: number | null = null;
       let definitionIndentWidth: number | null = null;
       let tableHasHeader: boolean[] = [];
-      let inOrgDrawer = false;
-      let inOrgBlock = false;
-      let orgBlockType = '';
-      let orgBlockLines: string[] = [];
+      let pendingParagraphLines: string[] = [];
 
       const flushList = () => {
         if (currentList) {
@@ -55,8 +52,6 @@ export class NeorgContentParser {
         definitionIndentWidth = null;
       };
 
-      let pendingParagraphLines: string[] = [];
-
       const flushParagraph = () => {
         if (pendingParagraphLines.length > 0) {
           const joined = pendingParagraphLines.join(' ').trim();
@@ -78,51 +73,6 @@ export class NeorgContentParser {
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         const trimmed = line.trim();
-
-        if (/^:\s*(PROPERTIES|LOGBOOK|END)\s*:\s*$/.test(trimmed)) {
-          if (trimmed.includes(':END:')) {
-            inOrgDrawer = false;
-          } else {
-            flushAll();
-            inOrgDrawer = true;
-          }
-          continue;
-        }
-        if (inOrgDrawer) continue;
-
-        const orgBlockBegin = trimmed.match(/^#\+BEGIN_(\w+)\s*(.*)$/i);
-        if (orgBlockBegin) {
-          flushAll();
-          orgBlockType = orgBlockBegin[1].toUpperCase();
-          orgBlockLines = [];
-          inOrgBlock = true;
-          continue;
-        }
-
-        if (inOrgBlock && /^#\+END_\w+\s*$/i.test(trimmed)) {
-          if (orgBlockType === 'QUOTE' || orgBlockType === 'ABSTRACT') {
-            blocks.push({ type: 'quote', text: orgBlockLines.join('\n').trim() });
-          } else {
-            blocks.push({
-              type: 'code',
-              code: { content: orgBlockLines.join('\n') },
-            });
-          }
-          inOrgBlock = false;
-          orgBlockLines = [];
-          continue;
-        }
-        if (inOrgBlock) {
-          orgBlockLines.push(line);
-          continue;
-        }
-
-        if (/^(SCHEDULED|DEADLINE|CLOSED)\s*:/i.test(trimmed)) continue;
-        if (/^#\+(NAME|TBLFM|RESULTS|ATTR|CAPTION|OPTIONS|STARTUP|PROPERTY|SEQ_TODO|TAGS|LANGUAGE|EMAIL|AUTHOR|DATE|SETUPFILE|INCLUDE|MACRO|LINK)\s*:/i.test(trimmed)) continue;
-        if (/^#\+LINK\s*:/i.test(trimmed)) continue;
-
-        if (/^CLOCK\s*:/i.test(trimmed)) continue;
-        if (/^-\s+State\s+"/i.test(trimmed)) continue;
 
         if (!trimmed) {
           if (currentCodeBlock) {
@@ -169,13 +119,17 @@ export class NeorgContentParser {
           continue;
         }
 
-        if (/^-{3,}\s*$/.test(trimmed)) {
+        if (trimmed === '---') {
+          continue;
+        }
+
+        if (/^_{3,}\s*$/.test(trimmed) || /^\*{3,}\s*$/.test(trimmed)) {
           flushAll();
           blocks.push({ type: 'divider' });
           continue;
         }
 
-        if (/^\.(quote|aside|footnote)\s*$/.test(trimmed)) {
+        if (/^\.(quote|aside)\s*$/.test(trimmed)) {
           flushAll();
           const collected: string[] = [];
           for (let j = i + 1; j < lines.length; j++) {
@@ -191,6 +145,38 @@ export class NeorgContentParser {
           continue;
         }
 
+        const rangedTagMatch = trimmed.match(/^\|([A-Za-z][\w-]*)\b.*$/);
+        if (rangedTagMatch && !/^\|.+\|\s*$/.test(trimmed)) {
+          flushAll();
+          const tagName = rangedTagMatch[1].toLowerCase();
+          const collected: string[] = [];
+          for (let j = i + 1; j < lines.length; j++) {
+            if (/^\|end\s*$/.test(lines[j].trim())) {
+              i = j;
+              break;
+            }
+            collected.push(lines[j]);
+          }
+
+          if (tagName === 'comment') {
+            continue;
+          }
+
+          if (tagName === 'example') {
+            blocks.push({
+              type: 'code',
+              code: { content: collected.join('\n') },
+            });
+            continue;
+          }
+
+          const text = collected.join('\n').trim();
+          if (text) {
+            blocks.push({ type: 'quote', text });
+          }
+          continue;
+        }
+
         if (/^\|.+\|\s*$/.test(trimmed)) {
           if (/^\|[\s\-+:]+\|\s*$/.test(trimmed)) {
             if (currentTableRows) {
@@ -201,6 +187,7 @@ export class NeorgContentParser {
           flushParagraph();
           flushList();
           flushChecklist();
+          flushDefinitions();
           const cells = trimmed.split('|').filter((_, idx, arr) => idx > 0 && idx < arr.length - 1).map(c => c.trim());
           if (!currentTableRows) {
             currentTableRows = [];
@@ -229,6 +216,32 @@ export class NeorgContentParser {
           continue;
         }
 
+        const footnoteMatch = line.match(/^(\s*)\^\s+(.+)$/);
+        if (footnoteMatch) {
+          flushAll();
+          const baseIndent = footnoteMatch[1].length;
+          const contentLines: string[] = [];
+          let j = i + 1;
+
+          for (; j < lines.length; j++) {
+            const candidate = lines[j];
+            const candidateTrimmed = candidate.trim();
+            if (!candidateTrimmed) break;
+            if (this.isStructuralLine(candidate) && this.getLeadingWhitespaceWidth(candidate) <= baseIndent) break;
+            contentLines.push(candidate.trim());
+          }
+
+          blocks.push({
+            type: 'footnote',
+            footnote: {
+              label: footnoteMatch[2].trim(),
+              content: contentLines.join('\n').trim(),
+            },
+          });
+          i = j - 1;
+          continue;
+        }
+
         const nextListIndentWidth = this.resolveIndentWidth(listIndentWidth, line);
         const listItem = this.parseListItem(line, nextListIndentWidth ?? undefined);
         if (listItem) {
@@ -247,15 +260,37 @@ export class NeorgContentParser {
           flushParagraph();
           flushList();
           flushChecklist();
+          flushTable();
+
+          const baseIndent = this.getLeadingWhitespaceWidth(line);
+          const definitionLines: string[] = [];
+          let j = i + 1;
+
+          for (; j < lines.length; j++) {
+            const candidate = lines[j];
+            const candidateTrimmed = candidate.trim();
+            if (!candidateTrimmed) break;
+
+            const candidateIndent = this.getLeadingWhitespaceWidth(candidate);
+            if (candidateIndent <= baseIndent) break;
+            if (this.isStructuralLine(candidate)) break;
+
+            definitionLines.push(candidate.trim());
+          }
+
+          definitionItem.definition = definitionLines.join('\n').trim();
+
           if (!currentDefinitions) currentDefinitions = [];
           definitionIndentWidth = nextDefinitionIndentWidth;
           currentDefinitions.push(definitionItem);
+          i = j - 1;
           continue;
         }
 
         flushList();
         flushChecklist();
         flushTable();
+        flushDefinitions();
 
         pendingParagraphLines.push(trimmed);
       }
@@ -280,18 +315,9 @@ export class NeorgContentParser {
   static parseHeading(line: string): NeorgHeading | null {
     const starMatch = line.match(/^(\*{1,7})\s+(.+)$/);
     if (starMatch) {
-      const level = starMatch[1].length;
-      let text = starMatch[2].trim();
-      // Strip org task keywords
-      text = text.replace(/^(TODO|DONE|IN-PROGRESS|WAITING|CANCELED|CANCELLED|SCHEDULED)\s+/i, '');
-      // Strip priority cookie [#A]
-      text = text.replace(/^\[#[A-C]\]\s*/i, '');
-      // Strip trailing tags :tag1:tag2: (tags have colons on both sides)
-      text = text.replace(/\s+:[\w@]+(:[\w@]+)*:\s*$/, '');
-      return { level, text: text || starMatch[2].trim() };
+      return { level: starMatch[1].length, text: starMatch[2].trim() };
     }
 
-    // Markdown: # heading
     const mdMatch = line.match(/^(#{1,6})\s+(.+)$/);
     if (mdMatch) {
       return { level: mdMatch[1].length, text: mdMatch[2].trim() };
@@ -324,11 +350,37 @@ export class NeorgContentParser {
     return level;
   }
 
+  private static getLeadingWhitespaceWidth(line: string): number {
+    const spaces = line.match(/^(\s*)/)?.[1] ?? '';
+    return spaces.replace(/\t/g, '  ').length;
+  }
+
   private static resolveIndentWidth(currentIndentWidth: number | null, line: string): number | null {
     if (currentIndentWidth) return currentIndentWidth;
     const spaces = line.match(/^(\s*)/)?.[1] ?? '';
     if (!spaces || spaces.includes('\t')) return currentIndentWidth;
     return spaces.length > 0 ? spaces.length : currentIndentWidth;
+  }
+
+  private static isStructuralLine(line: string): boolean {
+    const trimmed = line.trim();
+
+    if (!trimmed) return false;
+    if (trimmed === '---' || trimmed === '=') return true;
+    if (/^=(code|raw|embed)(?:\.(\w+))?\s*$/.test(trimmed)) return true;
+    if (/^```(\w*)$/.test(line)) return true;
+    if (/^\.(quote|aside)\s*$/.test(trimmed) || /^\.end\s*$/.test(trimmed)) return true;
+    if (/^\|end\s*$/.test(trimmed)) return true;
+    if (/^\|([A-Za-z][\w-]*)\b.*$/.test(trimmed) && !/^\|.+\|\s*$/.test(trimmed)) return true;
+    if (/^\|.+\|\s*$/.test(trimmed)) return true;
+    if (/^_{3,}\s*$/.test(trimmed) || /^\*{3,}\s*$/.test(trimmed)) return true;
+    if (this.parseHeading(line)) return true;
+    if (this.parseChecklistItem(line)) return true;
+    if (this.parseListItem(line)) return true;
+    if (this.parseDefinitionItem(line)) return true;
+    if (/^(\s*)\^\s+(.+)$/.test(line)) return true;
+
+    return false;
   }
 
   static parseListItem(line: string, indentWidth = 2): NeorgListItem | null {
@@ -339,31 +391,26 @@ export class NeorgContentParser {
     const indentLevel = this.getIndentLevel(spaces, indentWidth);
     const content = indentMatch[2];
 
-    // Unordered: - item
-    const unorderedMatch = content.match(/^-\s+(.+)$/);
+    const unorderedMatch = content.match(/^\-\s+(.+)$/);
     if (unorderedMatch) {
       return { type: 'unordered', text: unorderedMatch[1].trim(), indentLevel };
     }
 
-    // Norg ordered: ~ item
     const norgOrdered = content.match(/^~\s+(.+)$/);
     if (norgOrdered) {
       return { type: 'ordered', text: norgOrdered[1].trim(), indentLevel };
     }
 
-    // Norg counter list: ~~ item
     const counterMatch = content.match(/^~~\s+(.+)$/);
     if (counterMatch) {
       return { type: 'ordered', text: counterMatch[1].trim(), indentLevel };
     }
 
-    // Numeric ordered: 1. item or 1) item
     const numericMatch = content.match(/^(\d+)[.)]\s+(.+)$/);
     if (numericMatch) {
       return { type: 'ordered', text: numericMatch[2].trim(), indentLevel };
     }
 
-    // Norg task: ( ) item, (x) item, (!) item, (?) item, (~) in-progress, (u) urgent, (-) cancelled, (_) on-hold, (+) recurring
     const taskMatch = content.match(/^\(([ x!?~u\-_+])\)\s+(.+)$/);
     if (taskMatch) {
       const statusMap: Record<string, 'todo' | 'done' | 'important' | 'uncertain' | 'in-progress' | 'urgent' | 'cancelled' | 'on-hold' | 'recurring'> = {
@@ -384,13 +431,12 @@ export class NeorgContentParser {
     const indentLevel = this.getIndentLevel(spaces, indentWidth);
     const content = indentMatch[2];
 
-    // - [ ] or - [x] (markdown and norg task syntax)
-    const uncheckedMatch = content.match(/^-\s*\[\s\]\s*(.*)$/);
+    const uncheckedMatch = content.match(/^\-\s*\[\s\]\s*(.*)$/);
     if (uncheckedMatch) {
       return { text: uncheckedMatch[1].trim(), checked: false, indentLevel };
     }
 
-    const checkedMatch = content.match(/^-\s*\[x\]\s*(.*)$/i);
+    const checkedMatch = content.match(/^\-\s*\[x\]\s*(.*)$/i);
     if (checkedMatch) {
       return { text: checkedMatch[1].trim(), checked: true, indentLevel };
     }
@@ -406,8 +452,6 @@ export class NeorgContentParser {
     const indentLevel = this.getIndentLevel(spaces, indentWidth);
     const content = indentMatch[2];
 
-    // Neorg definition: $ Term
-    //   Definition text
     const defMatch = content.match(/^\$\s+(.+)$/);
     if (defMatch) {
       return { term: defMatch[1].trim(), definition: '', indentLevel };
@@ -459,6 +503,8 @@ export class NeorgContentParser {
         case 'definition': return block.definitionItems
           ? block.definitionItems.map(d => `**${d.term}**: ${d.definition}`).join('\n')
           : '';
+        case 'footnote': return block.footnote ? `[^${block.footnote.label}]: ${block.footnote.content}` : '';
+        case 'comment': return '';
         default: return '';
       }
     }).join('\n\n');

--- a/src/services/NeorgInlineParser.ts
+++ b/src/services/NeorgInlineParser.ts
@@ -1,4 +1,4 @@
-import { MarkupType, InlineMarkup, TextSegment, ParsedInline } from '../models/NeorgInline';
+import { MarkupType, TextSegment, ParsedInline } from '../models/NeorgInline';
 
 export class NeorgInlineParser {
   private static markupPatterns: Array<{

--- a/src/services/NeorgInlineParser.ts
+++ b/src/services/NeorgInlineParser.ts
@@ -149,6 +149,9 @@ export class NeorgInlineParser {
         code: ['mono'],
         superscript: ['superscript'],
         subscript: ['subscript'],
+        verbatim: ['mono'],
+        'org-code': ['mono'],
+        'org-strike': ['lineThrough'],
       };
 
       return {

--- a/src/services/NeorgInlineParser.ts
+++ b/src/services/NeorgInlineParser.ts
@@ -1,22 +1,59 @@
-import { MarkupType, TextSegment, ParsedInline } from '../models/NeorgInline';
+import { MarkupType, TextSegment, ParsedInline, InlineMarkup } from '../models/NeorgInline';
+
+const ESCAPE_PLACEHOLDER = '\x00ESC_';
+
+function replaceEscapes(text: string): { text: string; map: Map<number, string> } {
+  const map = new Map<number, string>();
+  let result = '';
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] === '\\' && i + 1 < text.length) {
+      const ch = text[i + 1];
+      if ('*/_!`^,-'.includes(ch)) {
+        const placeholder = `${ESCAPE_PLACEHOLDER}${result.length}_`;
+        map.set(result.length, ch);
+        result += placeholder;
+        i += 2;
+        continue;
+      }
+    }
+    result += text[i];
+    i++;
+  }
+  return { text: result, map };
+}
+
+function restoreEscapes(text: string, map: Map<number, string>): string {
+  if (map.size === 0) return text;
+  let result = text;
+  const entries = Array.from(map.entries()).sort((a, b) => b[0] - a[0]);
+  for (const [pos, ch] of entries) {
+    const placeholder = `${ESCAPE_PLACEHOLDER}${pos}_`;
+    result = result.replace(placeholder, ch);
+  }
+  return result;
+}
 
 export class NeorgInlineParser {
   private static markupPatterns: Array<{
     type: MarkupType;
     pattern: RegExp;
     delimiter: string;
+    verbatim: boolean;
   }> = [
-    { type: 'bold', pattern: /\*([^*]+)\*/g, delimiter: '*' },
-    { type: 'italic', pattern: /\/([^/]+)\//g, delimiter: '/' },
-    { type: 'underline', pattern: /_([^_]+)_/g, delimiter: '_' },
-    { type: 'strikethrough', pattern: /-([^-]+)-/g, delimiter: '-' },
-    { type: 'spoiler', pattern: /!([^!]+)!/g, delimiter: '!' },
-    { type: 'code', pattern: /`([^`]+)`/g, delimiter: '`' },
-    { type: 'superscript', pattern: /\^([^^]+)\^/g, delimiter: '^' },
-    { type: 'subscript', pattern: /,([^,]+),/g, delimiter: ',' },
+    { type: 'code', pattern: /`([^`]+)`/g, delimiter: '`', verbatim: true },
+    { type: 'bold', pattern: /\*([^*]+)\*/g, delimiter: '*', verbatim: false },
+    { type: 'italic', pattern: /\/([^/]+)\//g, delimiter: '/', verbatim: false },
+    { type: 'underline', pattern: /_([^_]+)_/g, delimiter: '_', verbatim: false },
+    { type: 'strikethrough', pattern: /-([^-]+)-/g, delimiter: '-', verbatim: false },
+    { type: 'spoiler', pattern: /!([^!]+)!/g, delimiter: '!', verbatim: false },
+    { type: 'superscript', pattern: /\^([^^]+)\^/g, delimiter: '^', verbatim: false },
+    { type: 'subscript', pattern: /,([^,]+),/g, delimiter: ',', verbatim: false },
   ];
 
   static parseInline(text: string): ParsedInline {
+    const { text: processedText, map: escapeMap } = replaceEscapes(text);
+
     const segments: TextSegment[] = [];
     let currentIndex = 0;
     const matches: Array<{
@@ -24,21 +61,23 @@ export class NeorgInlineParser {
       start: number;
       end: number;
       content: string;
+      verbatim: boolean;
     }> = [];
 
-    for (const { type, pattern } of this.markupPatterns) {
+    for (const { type, pattern, verbatim } of this.markupPatterns) {
       const regex = new RegExp(pattern.source, pattern.flags);
       regex.lastIndex = 0;
-      let match: RegExpExecArray | null = regex.exec(text);
-      
+      let match: RegExpExecArray | null = regex.exec(processedText);
+
       while (match !== null) {
         matches.push({
           type,
           start: match.index,
           end: regex.lastIndex,
           content: match[1],
+          verbatim,
         });
-        match = regex.exec(text);
+        match = regex.exec(processedText);
       }
     }
 
@@ -48,7 +87,7 @@ export class NeorgInlineParser {
     for (let i = 0; i < matches.length; i++) {
       const current = matches[i];
       let overlaps = false;
-      
+
       for (const existing of filteredMatches) {
         if (
           (current.start >= existing.start && current.start < existing.end) ||
@@ -58,7 +97,7 @@ export class NeorgInlineParser {
           break;
         }
       }
-      
+
       if (!overlaps) {
         filteredMatches.push(current);
       }
@@ -68,25 +107,23 @@ export class NeorgInlineParser {
       if (match.start > currentIndex) {
         segments.push({
           type: 'text',
-          text: text.substring(currentIndex, match.start),
+          text: restoreEscapes(
+            processedText.substring(currentIndex, match.start),
+            escapeMap,
+          ),
         });
       }
 
-      segments.push({
-        type: 'markup',
-        markup: {
-          type: match.type,
-          content: match.content,
-        },
-      });
+      const markup = this.buildMarkup(match.type, match.content, match.verbatim, escapeMap);
+      segments.push({ type: 'markup', markup });
 
       currentIndex = match.end;
     }
 
-    if (currentIndex < text.length) {
+    if (currentIndex < processedText.length) {
       segments.push({
         type: 'text',
-        text: text.substring(currentIndex),
+        text: restoreEscapes(processedText.substring(currentIndex), escapeMap),
       });
     }
 
@@ -94,6 +131,30 @@ export class NeorgInlineParser {
       segments: segments.length > 0 ? segments : [{ type: 'text', text }],
       originalText: text,
     };
+  }
+
+  private static buildMarkup(
+    type: MarkupType,
+    content: string,
+    verbatim: boolean,
+    escapeMap: Map<number, string>,
+  ): InlineMarkup {
+    const restoredContent = restoreEscapes(content, escapeMap);
+
+    if (verbatim) {
+      return { type, content: restoredContent };
+    }
+
+    const nestedParsed = this.parseInline(restoredContent);
+    const childMarkups = nestedParsed.segments
+      .filter((s): s is TextSegment & { type: 'markup' } => s.type === 'markup')
+      .map((s) => s.markup!);
+
+    if (childMarkups.length > 0) {
+      return { type, content: restoredContent, children: childMarkups };
+    }
+
+    return { type, content: restoredContent };
   }
 
   static toMarkdown(parsed: ParsedInline): string {

--- a/src/services/OrgContentParser.ts
+++ b/src/services/OrgContentParser.ts
@@ -1,0 +1,568 @@
+import {
+  NeorgChecklistItem,
+  NeorgContentBlock,
+  NeorgContentParseResult,
+  NeorgDefinitionItem,
+  NeorgDrawer,
+  NeorgHeading,
+  NeorgListItem,
+  NeorgTableRow,
+  NeorgTimestamp,
+} from '../models/NeorgContent';
+
+type OrgCodeBlock = {
+  kind: 'code' | 'quote' | 'paragraph';
+  language?: string;
+  lines: string[];
+};
+
+type OrgDrawerState = {
+  name: string;
+  lines: string[];
+};
+
+export class OrgContentParser {
+  private static readonly TODO_STATES = [
+    'TODO',
+    'DONE',
+    'IN-PROGRESS',
+    'WAITING',
+    'CANCELED',
+    'CANCELLED',
+    'SCHEDULED',
+    'HOLD',
+    'PROJ',
+  ] as const;
+
+  static parseContent(content: string): NeorgContentParseResult {
+    if (typeof content !== 'string') {
+      return { success: false, blocks: [], error: 'Invalid content: expected string' };
+    }
+
+    try {
+      const lines = content.split('\n');
+      const blocks: NeorgContentBlock[] = [];
+      let currentList: NeorgListItem[] | null = null;
+      let currentChecklist: NeorgChecklistItem[] | null = null;
+      let currentDefinitions: NeorgDefinitionItem[] | null = null;
+      let currentTableRows: NeorgTableRow[] | null = null;
+      let tableHasHeader: boolean[] = [];
+      let currentFixedWidth: string[] | null = null;
+      let currentBlock: OrgCodeBlock | null = null;
+      let currentDrawer: OrgDrawerState | null = null;
+      let listIndentWidth: number | null = null;
+      let checklistIndentWidth: number | null = null;
+      let definitionIndentWidth: number | null = null;
+      let pendingParagraphLines: string[] = [];
+
+      const flushList = () => {
+        if (currentList) {
+          blocks.push({ type: 'list', listItems: currentList });
+          currentList = null;
+        }
+        listIndentWidth = null;
+      };
+
+      const flushChecklist = () => {
+        if (currentChecklist) {
+          blocks.push({ type: 'checklist', checklistItems: currentChecklist });
+          currentChecklist = null;
+        }
+        checklistIndentWidth = null;
+      };
+
+      const flushDefinitions = () => {
+        if (currentDefinitions) {
+          blocks.push({ type: 'definition', definitionItems: currentDefinitions });
+          currentDefinitions = null;
+        }
+        definitionIndentWidth = null;
+      };
+
+      const flushTable = () => {
+        if (currentTableRows && currentTableRows.length > 0) {
+          blocks.push({ type: 'table', tableRows: currentTableRows, isHeaderRow: tableHasHeader });
+          currentTableRows = null;
+          tableHasHeader = [];
+        }
+      };
+
+      const flushParagraph = () => {
+        if (pendingParagraphLines.length > 0) {
+          const text = pendingParagraphLines.join(' ').trim();
+          if (text) {
+            blocks.push({ type: 'paragraph', text });
+          }
+          pendingParagraphLines = [];
+        }
+      };
+
+      const flushFixedWidth = () => {
+        if (currentFixedWidth && currentFixedWidth.length > 0) {
+          blocks.push({ type: 'fixed-width', text: currentFixedWidth.join('\n') });
+        }
+        currentFixedWidth = null;
+      };
+
+      const flushAll = () => {
+        flushParagraph();
+        flushList();
+        flushChecklist();
+        flushDefinitions();
+        flushTable();
+        flushFixedWidth();
+      };
+
+      for (let i = 0; i < lines.length; i += 1) {
+        const line = lines[i];
+        const trimmed = line.trim();
+
+        if (currentDrawer) {
+          if (/^:END:\s*$/i.test(trimmed)) {
+            flushFixedWidth();
+            blocks.push({ type: 'drawer', drawer: this.finalizeDrawer(currentDrawer) });
+            currentDrawer = null;
+          } else {
+            currentDrawer.lines.push(line);
+          }
+          continue;
+        }
+
+        if (currentBlock) {
+          if (/^#\+END_\w+\s*$/i.test(trimmed)) {
+            blocks.push(this.finalizeBlock(currentBlock));
+            currentBlock = null;
+          } else {
+            currentBlock.lines.push(line);
+          }
+          continue;
+        }
+
+        if (!trimmed) {
+          flushAll();
+          continue;
+        }
+
+        if (this.shouldSkipLine(trimmed)) {
+          flushAll();
+          continue;
+        }
+
+        const drawerMatch = trimmed.match(/^:([A-Z0-9_@#%]+):\s*$/i);
+        if (drawerMatch && !/^:[^\s]+\s+/.test(trimmed)) {
+          flushAll();
+          currentDrawer = { name: drawerMatch[1], lines: [] };
+          continue;
+        }
+
+        const blockStart = this.parseBlockStart(trimmed);
+        if (blockStart) {
+          flushAll();
+          currentBlock = blockStart;
+          continue;
+        }
+
+        const heading = this.parseHeading(line);
+        if (heading) {
+          flushAll();
+          blocks.push({ type: 'heading', heading });
+          continue;
+        }
+
+        const timestamp = this.parseTimestampLine(trimmed);
+        if (timestamp) {
+          flushAll();
+          blocks.push({ type: 'timestamp', timestamp });
+          continue;
+        }
+
+        if (/^\|.+\|\s*$/.test(trimmed)) {
+          flushParagraph();
+          flushList();
+          flushChecklist();
+          flushDefinitions();
+          flushFixedWidth();
+
+          if (/^\|[\s\-+:]+\|\s*$/.test(trimmed)) {
+            if (currentTableRows && currentTableRows.length > 0) {
+              tableHasHeader[currentTableRows.length - 1] = true;
+            }
+            continue;
+          }
+
+          const cells = trimmed
+            .split('|')
+            .filter((_, index, values) => index > 0 && index < values.length - 1)
+            .map(cell => cell.trim());
+
+          if (!currentTableRows) {
+            currentTableRows = [];
+            tableHasHeader = [];
+          }
+
+          currentTableRows.push({ cells });
+          if (tableHasHeader.length < currentTableRows.length) {
+            tableHasHeader.push(false);
+          }
+          continue;
+        }
+
+        if (/^-{5,}\s*$/.test(trimmed)) {
+          flushAll();
+          blocks.push({ type: 'divider' });
+          continue;
+        }
+
+        if (/^:\s+/.test(line)) {
+          flushParagraph();
+          flushList();
+          flushChecklist();
+          flushDefinitions();
+          flushTable();
+          if (!currentFixedWidth) {
+            currentFixedWidth = [];
+          }
+          currentFixedWidth.push(line.replace(/^:\s?/, ''));
+          continue;
+        }
+
+        const nextDefinitionIndentWidth = this.resolveIndentWidth(definitionIndentWidth, line);
+        const definitionItem = this.parseDefinitionItem(line, nextDefinitionIndentWidth ?? undefined);
+        if (definitionItem) {
+          flushParagraph();
+          flushList();
+          flushChecklist();
+          flushTable();
+          flushFixedWidth();
+          if (!currentDefinitions) {
+            currentDefinitions = [];
+          }
+          definitionIndentWidth = nextDefinitionIndentWidth;
+          currentDefinitions.push(definitionItem);
+          continue;
+        }
+
+        const nextChecklistIndentWidth = this.resolveIndentWidth(checklistIndentWidth, line);
+        const checklistItem = this.parseChecklistItem(line, nextChecklistIndentWidth ?? undefined);
+        if (checklistItem) {
+          flushParagraph();
+          flushList();
+          flushDefinitions();
+          flushTable();
+          flushFixedWidth();
+          if (!currentChecklist) {
+            currentChecklist = [];
+          }
+          checklistIndentWidth = nextChecklistIndentWidth;
+          currentChecklist.push(checklistItem);
+          continue;
+        }
+
+        const nextListIndentWidth = this.resolveIndentWidth(listIndentWidth, line);
+        const listItem = this.parseListItem(line, nextListIndentWidth ?? undefined);
+        if (listItem) {
+          flushParagraph();
+          flushChecklist();
+          flushDefinitions();
+          flushTable();
+          flushFixedWidth();
+          if (!currentList) {
+            currentList = [];
+          }
+          listIndentWidth = nextListIndentWidth;
+          currentList.push(listItem);
+          continue;
+        }
+
+        flushList();
+        flushChecklist();
+        flushDefinitions();
+        flushTable();
+        flushFixedWidth();
+        pendingParagraphLines.push(trimmed);
+      }
+
+      flushAll();
+
+      if (currentBlock) {
+        blocks.push(this.finalizeBlock(currentBlock));
+      }
+
+      if (currentDrawer) {
+        blocks.push({ type: 'drawer', drawer: this.finalizeDrawer(currentDrawer) });
+      }
+
+      return { success: true, blocks };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown parsing error',
+      };
+    }
+  }
+
+  static parseHeading(line: string): NeorgHeading | null {
+    const match = line.match(/^(\*{1,7})\s+(.+)$/);
+    if (!match) {
+      return null;
+    }
+
+    const level = match[1].length;
+    let text = match[2].trim();
+    let commented = false;
+    let todoState: string | undefined;
+    let priority: string | undefined;
+    let tags: string[] | undefined;
+
+    const tagMatch = text.match(/\s+:(?:[^\s:]+:)+\s*$/);
+    if (tagMatch) {
+      const tagText = tagMatch[0].trim();
+      tags = tagText.split(':').filter(Boolean);
+      text = text.slice(0, text.length - tagMatch[0].length).trim();
+    }
+
+    if (/^COMMENT\b/i.test(text)) {
+      commented = true;
+      text = text.replace(/^COMMENT\s+/i, '').trim();
+    }
+
+    const todoPattern = new RegExp(`^(${this.TODO_STATES.join('|')})\\b`, 'i');
+    const todoMatch = text.match(todoPattern);
+    if (todoMatch) {
+      todoState = todoMatch[1].toUpperCase();
+      text = text.slice(todoMatch[0].length).trim();
+    }
+
+    const priorityMatch = text.match(/^\[#([A-C])\]\s*/i);
+    if (priorityMatch) {
+      priority = priorityMatch[1].toUpperCase();
+      text = text.slice(priorityMatch[0].length).trim();
+    }
+
+    return {
+      level,
+      text,
+      ...(todoState ? { todoState } : {}),
+      ...(priority ? { priority } : {}),
+      ...(tags && tags.length > 0 ? { tags } : {}),
+      ...(commented ? { commented: true } : {}),
+    };
+  }
+
+  static parseListItem(line: string, indentWidth = 2): NeorgListItem | null {
+    const indentMatch = line.match(/^(\s*)(.*)$/);
+    if (!indentMatch) {
+      return null;
+    }
+
+    const indentLevel = this.getIndentLevel(indentMatch[1], indentWidth);
+    const content = indentMatch[2];
+
+    const unorderedMatch = content.match(/^([-+])\s+(.+)$/);
+    if (unorderedMatch) {
+      return { type: 'unordered', text: unorderedMatch[2].trim(), indentLevel };
+    }
+
+    const orderedMatch = content.match(/^(\d+)[.)]\s+(.+)$/);
+    if (orderedMatch) {
+      return { type: 'ordered', text: orderedMatch[2].trim(), indentLevel };
+    }
+
+    return null;
+  }
+
+  static parseChecklistItem(line: string, indentWidth = 2): NeorgChecklistItem | null {
+    const indentMatch = line.match(/^(\s*)(.*)$/);
+    if (!indentMatch) {
+      return null;
+    }
+
+    const indentLevel = this.getIndentLevel(indentMatch[1], indentWidth);
+    const content = indentMatch[2];
+
+    const match = content.match(/^[-+]\s+\[([ Xx\-])\]\s*(.*)$/);
+    if (!match) {
+      return null;
+    }
+
+    const marker = match[1].toUpperCase();
+    return {
+      text: match[2].trim(),
+      checked: marker === 'X',
+      indentLevel,
+    };
+  }
+
+  static parseDefinitionItem(line: string, indentWidth = 2): NeorgDefinitionItem | null {
+    const indentMatch = line.match(/^(\s*)(.*)$/);
+    if (!indentMatch) {
+      return null;
+    }
+
+    const indentLevel = this.getIndentLevel(indentMatch[1], indentWidth);
+    const content = indentMatch[2];
+    const match = content.match(/^[-+]\s+(.+?)\s+::\s+(.+)$/);
+
+    if (!match) {
+      return null;
+    }
+
+    return {
+      term: match[1].trim(),
+      definition: match[2].trim(),
+      indentLevel,
+    };
+  }
+
+  static parseTimestampLine(line: string): NeorgTimestamp | null {
+    const keywordMatch = line.match(/^(SCHEDULED|DEADLINE|CLOSED):\s*([<[].*[>\]])\s*$/i);
+    if (keywordMatch) {
+      const parsed = this.parseTimestampToken(keywordMatch[2]);
+      if (!parsed) {
+        return null;
+      }
+
+      const typeMap: Record<string, NeorgTimestamp['type']> = {
+        SCHEDULED: 'scheduled',
+        DEADLINE: 'deadline',
+        CLOSED: 'closed',
+      };
+
+      return {
+        ...parsed,
+        type: typeMap[keywordMatch[1].toUpperCase()],
+      };
+    }
+
+    return this.parseTimestampToken(line);
+  }
+
+  private static parseTimestampToken(token: string): NeorgTimestamp | null {
+    const trimmed = token.trim();
+    const match = trimmed.match(/^([<\[])(\d{4}-\d{2}-\d{2})(?:\s+[^>\]]+)?([>\]])$/);
+    if (!match) {
+      return null;
+    }
+
+    return {
+      type: match[1] === '<' ? 'active' : 'inactive',
+      date: match[2],
+    };
+  }
+
+  private static parseBlockStart(line: string): OrgCodeBlock | null {
+    const match = line.match(/^#\+BEGIN_(SRC|QUOTE|VERSE|EXPORT|CENTER|EXAMPLE)\b\s*(.*)$/i);
+    if (!match) {
+      return null;
+    }
+
+    const blockType = match[1].toUpperCase();
+    const args = match[2].trim();
+
+    if (blockType === 'SRC') {
+      const language = args.split(/\s+/).filter(Boolean)[0];
+      return { kind: 'code', language: language || undefined, lines: [] };
+    }
+
+    if (blockType === 'QUOTE' || blockType === 'VERSE') {
+      return { kind: 'quote', lines: [] };
+    }
+
+    if (blockType === 'CENTER') {
+      return { kind: 'paragraph', lines: [] };
+    }
+
+    if (blockType === 'EXPORT') {
+      const language = args.split(/\s+/).filter(Boolean)[0];
+      return { kind: 'code', language: language || undefined, lines: [] };
+    }
+
+    return { kind: 'code', lines: [] };
+  }
+
+  private static finalizeBlock(block: OrgCodeBlock): NeorgContentBlock {
+    if (block.kind === 'quote') {
+      return { type: 'quote', text: block.lines.join('\n').trim() };
+    }
+
+    if (block.kind === 'paragraph') {
+      return { type: 'paragraph', text: block.lines.join(' ').trim() };
+    }
+
+    return {
+      type: 'code',
+      code: {
+        ...(block.language ? { language: block.language } : {}),
+        content: block.lines.join('\n'),
+      },
+    };
+  }
+
+  private static finalizeDrawer(drawer: OrgDrawerState): NeorgDrawer {
+    const properties: Record<string, string> = {};
+
+    drawer.lines.forEach((line, index) => {
+      const trimmed = line.trim();
+      const propertyMatch = trimmed.match(/^:([^:\s]+):\s*(.*)$/);
+      if (propertyMatch) {
+        properties[propertyMatch[1]] = propertyMatch[2].trim();
+        return;
+      }
+
+      if (trimmed) {
+        properties[`LINE_${index + 1}`] = trimmed;
+      }
+    });
+
+    return {
+      name: drawer.name,
+      properties,
+    };
+  }
+
+  private static shouldSkipLine(line: string): boolean {
+    return (
+      /^#\s/.test(line) ||
+      /^#\+(?!BEGIN_)(?!END_)(TITLE|AUTHOR|DATE|NAME|OPTIONS|TBLFM|RESULTS|ATTR(?:_[A-Z]+)?|CAPTION|STARTUP|PROPERTY|SEQ_TODO|TAGS|LANGUAGE|EMAIL|SETUPFILE|INCLUDE|MACRO|LINK|FILETAGS|DESCRIPTION|SUBTITLE):/i.test(line) ||
+      /^CLOCK:/i.test(line) ||
+      /^-\s+State\s+"/i.test(line)
+    );
+  }
+
+  private static getIndentLevel(spaces: string, indentWidth = 2): number {
+    let level = 0;
+    let consecutiveSpaces = 0;
+
+    for (const char of spaces) {
+      if (char === '\t') {
+        level += 1;
+        consecutiveSpaces = 0;
+      } else {
+        consecutiveSpaces += 1;
+        if (consecutiveSpaces >= indentWidth) {
+          level += 1;
+          consecutiveSpaces = 0;
+        }
+      }
+    }
+
+    if (consecutiveSpaces > 0) {
+      level += 1;
+    }
+
+    return level;
+  }
+
+  private static resolveIndentWidth(currentIndentWidth: number | null, line: string): number | null {
+    if (currentIndentWidth) {
+      return currentIndentWidth;
+    }
+
+    const spaces = line.match(/^(\s*)/)?.[1] ?? '';
+    if (!spaces || spaces.includes('\t')) {
+      return currentIndentWidth;
+    }
+
+    return spaces.length > 0 ? spaces.length : currentIndentWidth;
+  }
+}

--- a/src/services/OrgInlineParser.ts
+++ b/src/services/OrgInlineParser.ts
@@ -1,0 +1,270 @@
+import { MarkupType, InlineMarkup, TextSegment, ParsedInline } from '../models/NeorgInline';
+
+const PRE_CHARS = new Set([' ', '\t', '\n', '\r', '(', '{', "'", '"']);
+const POST_CHARS = new Set([' ', '\t', '\n', '\r', '.', ',', ';', ':', '!', '?', "'", ')', '}', '"']);
+
+type OrgMarkupDef = {
+  type: MarkupType;
+  delimiter: string;
+  verbatim: boolean;
+};
+
+const ORG_MARKUP_DEFS: OrgMarkupDef[] = [
+  { type: 'verbatim', delimiter: '=', verbatim: true },
+  { type: 'org-code', delimiter: '~', verbatim: true },
+  { type: 'bold', delimiter: '*', verbatim: false },
+  { type: 'italic', delimiter: '/', verbatim: false },
+  { type: 'underline', delimiter: '_', verbatim: false },
+  { type: 'org-strike', delimiter: '+', verbatim: false },
+];
+
+interface RawMatch {
+  type: MarkupType;
+  start: number;
+  end: number;
+  content: string;
+  verbatim: boolean;
+}
+
+function isPre(text: string, pos: number): boolean {
+  if (pos <= 0) return true;
+  return PRE_CHARS.has(text[pos - 1]);
+}
+
+function isPost(text: string, pos: number): boolean {
+  if (pos >= text.length) return true;
+  return POST_CHARS.has(text[pos]);
+}
+
+function findDelimiterMatch(
+  text: string,
+  delimiter: string,
+  startPos: number,
+): number | null {
+  for (let i = startPos; i < text.length; i++) {
+    if (text[i] === delimiter && i > startPos) {
+      return i;
+    }
+  }
+  return null;
+}
+
+function findOrgLinks(text: string): RawMatch[] {
+  const results: RawMatch[] = [];
+  const linkRegex = /\[\[([^\]]+)\](?:\[([^\]]*)\])?\]/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = linkRegex.exec(text)) !== null) {
+    const target = match[1];
+    const label = match[2] ?? target;
+    results.push({
+      type: 'bold',
+      start: match.index,
+      end: match.index + match[0].length,
+      content: label,
+      verbatim: true,
+    });
+  }
+
+  return results;
+}
+
+function findFootnoteRefs(text: string): RawMatch[] {
+  const results: RawMatch[] = [];
+  const fnRegex = /\[fn:([^\]]+)\]/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = fnRegex.exec(text)) !== null) {
+    const label = match[1];
+    if (!label) continue;
+    results.push({
+      type: 'bold',
+      start: match.index,
+      end: match.index + match[0].length,
+      content: `[fn:${label}]`,
+      verbatim: true,
+    });
+  }
+
+  return results;
+}
+
+function findMarkupMatches(text: string, def: OrgMarkupDef): RawMatch[] {
+  const results: RawMatch[] = [];
+  const d = def.delimiter;
+
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== d) continue;
+    if (i > 0 && text[i - 1] === '\\') continue;
+    if (!isPre(text, i)) continue;
+
+    const closingPos = findDelimiterMatch(text, d, i + 1);
+    if (closingPos === null) continue;
+
+    const content = text.slice(i + 1, closingPos);
+    if (!content) continue;
+    if (content.includes('\n')) continue;
+
+    if (!isPost(text, closingPos + 1)) continue;
+
+    results.push({
+      type: def.type,
+      start: i,
+      end: closingPos + 1,
+      content,
+      verbatim: def.verbatim,
+    });
+  }
+
+  return results;
+}
+
+export class OrgInlineParser {
+  static parseInline(text: string): ParsedInline {
+    const unescaped = text.replace(/\\([*/_=~+])/g, (_, ch) => `\x00ESCAPED_${ch.charCodeAt(0)}\x00`);
+
+    let allMatches: RawMatch[] = [];
+
+    const links = findOrgLinks(unescaped);
+    const footnotes = findFootnoteRefs(unescaped);
+    allMatches.push(...links, ...footnotes);
+
+    for (const def of ORG_MARKUP_DEFS) {
+      allMatches.push(...findMarkupMatches(unescaped, def));
+    }
+
+    allMatches.sort((a, b) => a.start - b.start);
+
+    const filtered: RawMatch[] = [];
+    for (const match of allMatches) {
+      let overlaps = false;
+      for (const existing of filtered) {
+        if (
+          (match.start >= existing.start && match.start < existing.end) ||
+          (match.end > existing.start && match.end <= existing.end) ||
+          (match.start <= existing.start && match.end >= existing.end)
+        ) {
+          overlaps = true;
+          break;
+        }
+      }
+      if (!overlaps) {
+        filtered.push(match);
+      }
+    }
+
+    const segments: TextSegment[] = [];
+    let currentIndex = 0;
+
+    for (const match of filtered) {
+      if (match.start > currentIndex) {
+        segments.push({
+          type: 'text',
+          text: restoreEscapes(unescaped.substring(currentIndex, match.start)),
+        });
+      }
+
+      const markup = this.buildMarkup(match.type, match.content, match.verbatim);
+      segments.push({ type: 'markup', markup });
+
+      currentIndex = match.end;
+    }
+
+    if (currentIndex < unescaped.length) {
+      segments.push({
+        type: 'text',
+        text: restoreEscapes(unescaped.substring(currentIndex)),
+      });
+    }
+
+    return {
+      segments: segments.length > 0 ? segments : [{ type: 'text', text: restoreEscapes(text) }],
+      originalText: text,
+    };
+  }
+
+  private static buildMarkup(type: MarkupType, content: string, verbatim: boolean): InlineMarkup {
+    const restoredContent = restoreEscapes(content);
+
+    if (verbatim) {
+      return { type, content: restoredContent };
+    }
+
+    const nestedParsed = this.parseInline(content);
+    const childMarkups = nestedParsed.segments
+      .filter((s): s is TextSegment & { type: 'markup' } => s.type === 'markup')
+      .map((s) => s.markup!);
+
+    if (childMarkups.length > 0) {
+      return { type, content: restoredContent, children: childMarkups };
+    }
+
+    return { type, content: restoredContent };
+  }
+
+  static toMarkdown(parsed: ParsedInline): string {
+    return parsed.segments.map((segment) => {
+      if (segment.type === 'text') {
+        return segment.text || '';
+      }
+
+      const markup = segment.markup;
+      if (!markup) return '';
+
+      switch (markup.type) {
+        case 'bold':
+          return `**${markup.content}**`;
+        case 'italic':
+          return `*${markup.content}*`;
+        case 'underline':
+          return `<u>${markup.content}</u>`;
+        case 'org-strike':
+          return `~~${markup.content}~~`;
+        case 'verbatim':
+          return `\`${markup.content}\``;
+        case 'org-code':
+          return `\`${markup.content}\``;
+        default:
+          return markup.content;
+      }
+    }).join('');
+  }
+
+  static toReactNativeProps(
+    parsed: ParsedInline,
+  ): Array<{ text: string; style?: string[] }> {
+    return parsed.segments.map((segment) => {
+      if (segment.type === 'text') {
+        return { text: segment.text || '', style: [] };
+      }
+
+      const markup = segment.markup;
+      if (!markup) return { text: '', style: [] };
+
+      const styleMap: Record<MarkupType, string[]> = {
+        bold: ['bold'],
+        italic: ['italic'],
+        underline: ['underline'],
+        strikethrough: ['lineThrough'],
+        spoiler: [],
+        code: ['mono'],
+        superscript: ['superscript'],
+        subscript: ['subscript'],
+        verbatim: ['mono'],
+        'org-code': ['mono'],
+        'org-strike': ['lineThrough'],
+      };
+
+      return {
+        text: markup.content,
+        style: styleMap[markup.type] || [],
+      };
+    });
+  }
+}
+
+function restoreEscapes(text: string): string {
+  return text.replace(/\x00ESCAPED_(\d+)\x00/g, (_, code) =>
+    String.fromCharCode(parseInt(code, 10)),
+  );
+}

--- a/src/services/OrgInlineParser.ts
+++ b/src/services/OrgInlineParser.ts
@@ -264,6 +264,7 @@ export class OrgInlineParser {
 }
 
 function restoreEscapes(text: string): string {
+  // eslint-disable-next-line no-control-regex
   return text.replace(/\x00ESCAPED_(\d+)\x00/g, (_, code) =>
     String.fromCharCode(parseInt(code, 10)),
   );


### PR DESCRIPTION
## Summary

Complete rewrite of the .norg and .org rendering pipeline to provide format-aware parsing and full element support for both formats.

### Core Changes

**Format-aware parsers** (split from shared parser):
- New `OrgContentParser` — full org-mode structural parsing (headings with TODO/priority/tags, drawers, timestamps, blocks, lists, etc.)
- Rewritten `NeorgContentParser` — norg-only syntax (removed org-specific code, added footnotes, definition text capture, ranged tags, indentation reversion)

**Inline markup parsers**:
- New `OrgInlineParser` — org-specific delimiters (`+strike+`, `=verbatim=`, `~code~`) with PRE/POST boundary rules
- Enhanced `NeorgInlineParser` — nested markup support (`*/bold italic/*`), escape characters (`\*not bold\*`)

**Extended renderer**:
- Renamed `NeorgRenderer` → `StructuredRenderer` (reflects multi-format support)
- New block types: timestamps, footnotes, drawers, fixed-width, images, math, comments
- Org heading metadata: TODO badges, priority badges, tag chips (format-aware)
- Org inline rendering: verbatim, org-code, org-strike, footnote-ref

**Integration**:
- Format-aware parser selection in FileViewerScreen, NotePreviewPane, RenderStyleEditorScreen
- Updated render style editor samples with comprehensive org/norg examples

### Files Changed (19 files, +2274 -134 lines)

**New files:**
- `src/services/OrgContentParser.ts` (568 lines) — org-mode structural parser
- `src/services/OrgInlineParser.ts` (270 lines) — org inline markup parser
- `__tests__/services/OrgContentParser.test.ts` (35 tests)
- `__tests__/services/OrgInlineParser.test.ts` (16 tests)
- `__tests__/services/NeorgInlineParser.nested.test.ts` (10 tests)
- `__tests__/components/StructuredRenderer.test.tsx` (26 tests)

**Modified files:**
- `src/models/NeorgContent.ts` — extended with footnote, timestamp, drawer, image, math types
- `src/models/NeorgInline.ts` — added verbatim, org-code, org-strike markup types
- `src/services/NeorgContentParser.ts` — rewritten for norg-only (footnotes, definitions, ranged tags)
- `src/services/NeorgInlineParser.ts` — nested markup + escape support
- `src/components/StructuredRenderer.tsx` (renamed from NeorgRenderer.tsx) — extended renderer
- `src/screens/FileViewerScreen.tsx` — format-aware parser selection
- `src/screens/RenderStyleEditorScreen.tsx` — format-aware parser + updated samples
- `src/components/editor/useNoteEditorPreview.ts` — format-aware parser selection

### Test Results
- **825 tests pass** (114 new tests added)
- `yarn ts:check` — 0 errors
- All existing tests continue to pass

### What This Fixes
- Org files with `~code~`, `=verbatim=`, `+strike+` now render correctly
- Org headings show TODO state, priority, and tags visually
- Org timestamps (SCHEDULED, DEADLINE, CLOSED) are rendered
- Norg footnotes are parsed and rendered
- Norg nested markup `*/bold italic/*` works
- Norg `---` no longer misinterpreted as divider (now treated as indentation reversion)
- Definition lists capture both term AND definition text