### PR TITLE
chore(settings): remove stale hardcoded build date

### DIFF
--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -505,10 +505,6 @@ export function SettingsContent(props: SettingsContentProps) {
           <Text style={[styles.settingLabel, { color: colors.text }]}>Version</Text>
           <Text style={[styles.settingValue, { color: colors.textSecondary }]}>{Constants.expoConfig?.version ?? '—'}</Text>
         </View>
-        <View style={[styles.settingItem, { borderBottomColor: colors.border }]}>
-          <Text style={[styles.settingLabel, { color: colors.text }]}>Build</Text>
-          <Text style={[styles.settingValue, { color: colors.textSecondary }]}>2026.04.07</Text>
-        </View>
         <TouchableOpacity style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onManageTemplates}>
           <Text style={[styles.settingLabel, { color: colors.text }]}>Manage templates</Text>
         </TouchableOpacity>


### PR DESCRIPTION
## Summary
- Remove the "Build 2026.04.07" row from Settings → About. The date was hardcoded and would silently rot on every future release.
- Version row stays (driven by `Constants.expoConfig?.version`).

## Test plan
- [ ] Open Settings → About; only Version + Manage templates remain under About
- [ ] Version still renders the value from `app.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)