### PR TITLE
fix(clone): resolve real default branch instead of hardcoded 'main'

### DIFF
--- a/__tests__/services/branchResolver.test.ts
+++ b/__tests__/services/branchResolver.test.ts
@@ -1,0 +1,91 @@
+import {
+  __resetBranchCacheForTests,
+  fetchGitHubDefaultBranch,
+  invalidateBranchCache,
+  resolveBranch,
+} from '../../src/services/git/branchResolver';
+import { GitFsService } from '../../src/services/git/GitFsService';
+
+jest.mock('../../src/services/git/GitFsService', () => ({
+  GitFsService: {
+    getCurrentBranch: jest.fn(),
+  },
+}));
+
+const mockedGetCurrentBranch = GitFsService.getCurrentBranch as jest.MockedFunction<
+  typeof GitFsService.getCurrentBranch
+>;
+
+beforeEach(() => {
+  __resetBranchCacheForTests();
+  mockedGetCurrentBranch.mockReset();
+  (global.fetch as jest.Mock | undefined)?.mockReset?.();
+});
+
+describe('resolveBranch', () => {
+  it('returns the hint when provided', async () => {
+    mockedGetCurrentBranch.mockResolvedValue('master');
+    const result = await resolveBranch('owner/repo', 'feature/x');
+    expect(result).toBe('feature/x');
+    expect(mockedGetCurrentBranch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to local clone HEAD when no hint', async () => {
+    mockedGetCurrentBranch.mockResolvedValue('master');
+    const result = await resolveBranch('owner/repo');
+    expect(result).toBe('master');
+  });
+
+  it('caches local lookup so a second call skips fs', async () => {
+    mockedGetCurrentBranch.mockResolvedValue('develop');
+    await resolveBranch('owner/repo');
+    await resolveBranch('owner/repo');
+    expect(mockedGetCurrentBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidateBranchCache forces a re-lookup', async () => {
+    mockedGetCurrentBranch.mockResolvedValue('main');
+    await resolveBranch('owner/repo');
+    invalidateBranchCache('owner/repo');
+    await resolveBranch('owner/repo');
+    expect(mockedGetCurrentBranch).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to GitHub default_branch when local clone missing', async () => {
+    mockedGetCurrentBranch.mockResolvedValue(null);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ default_branch: 'trunk' }),
+    }) as unknown as typeof fetch;
+    const result = await resolveBranch('owner/repo');
+    expect(result).toBe('trunk');
+  });
+
+  it('falls back to "main" when GitHub fetch fails', async () => {
+    mockedGetCurrentBranch.mockResolvedValue(null);
+    global.fetch = jest.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+    const result = await resolveBranch('owner/repo');
+    expect(result).toBe('main');
+  });
+
+  it('falls back to "main" when GitHub responds non-OK', async () => {
+    mockedGetCurrentBranch.mockResolvedValue(null);
+    global.fetch = jest.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch;
+    const result = await resolveBranch('owner/repo');
+    expect(result).toBe('main');
+  });
+});
+
+describe('fetchGitHubDefaultBranch', () => {
+  it('returns null on invalid path', async () => {
+    expect(await fetchGitHubDefaultBranch('nope')).toBeNull();
+  });
+
+  it('returns the parsed default_branch', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ default_branch: 'master' }),
+    }) as unknown as typeof fetch;
+    expect(await fetchGitHubDefaultBranch('foo/bar')).toBe('master');
+  });
+});

--- a/src/services/CanvasGitHubSyncService.ts
+++ b/src/services/CanvasGitHubSyncService.ts
@@ -4,6 +4,7 @@ import { parseRepoPath } from '../utils/gitPathParser';
 import { AuthService } from './AuthService';
 import { SyncEngineService } from './SyncEngineService';
 import { LocalGitWriter } from './git/LocalGitWriter';
+import { resolveBranch } from './git/branchResolver';
 
 async function resolveToken(accountId?: string): Promise<string | undefined> {
   if (!accountId) return undefined;
@@ -37,7 +38,7 @@ export async function syncCanvasToGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = branch || 'main';
+  const targetBranch = await resolveBranch(repoPath, branch);
   const opts = tokenOverride ? { tokenOverride } : undefined;
 
   let targetPath = filePath;
@@ -117,7 +118,7 @@ export async function deleteCanvasFromGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = branch || 'main';
+  const targetBranch = await resolveBranch(repoPath, branch);
   const opts = tokenOverride ? { tokenOverride } : undefined;
 
   const mode = await SyncEngineService.getMode(repoPath);

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StorageService } from './StorageService';
 import { GitHubService } from './GitHubService';
 import { parseRepoPath } from '../utils/gitPathParser';
+import { fetchGitHubDefaultBranch } from './git/branchResolver';
 
 export interface GitRepository {
   id: string;
@@ -67,10 +68,15 @@ export class GitService {
   static async addRepository(path: string, name?: string): Promise<GitRepository> {
     try {
       const repoName = name || path.split('/').pop() || path;
+      // Capture the remote's actual default branch at add-time so clone +
+      // sync paths don't fall back to a hardcoded 'main' (#543). Best-effort:
+      // offline / 404 leaves `branch` undefined; the resolver re-tries lazily.
+      const branch = (await fetchGitHubDefaultBranch(path)) ?? undefined;
       const repo: GitRepository = {
         id: Date.now().toString(),
         name: repoName,
         path: path,
+        branch,
       };
 
       await StorageService.addRepository(repo);

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -5,6 +5,7 @@ import { parseRepoPath } from '../utils/gitPathParser';
 import { AuthService } from './AuthService';
 import { SyncEngineService } from './SyncEngineService';
 import { LocalGitWriter } from './git/LocalGitWriter';
+import { resolveBranch } from './git/branchResolver';
 
 async function resolveAuthor(): Promise<{ name: string; email: string }> {
   const user = GitHubService.getUser();
@@ -300,7 +301,7 @@ export async function deleteNoteFromGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = branch || 'main';
+  const targetBranch = await resolveBranch(repoPath, branch);
   const opts = tokenOverride ? { tokenOverride } : undefined;
 
   const mode = await SyncEngineService.getMode(repoPath);
@@ -369,7 +370,7 @@ export async function syncNoteToGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = branch || 'main';
+  const targetBranch = await resolveBranch(repoPath, branch);
   const ext = getExtension(format);
   const opts = tokenOverride ? { tokenOverride } : undefined;
 

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -11,6 +11,7 @@ import { parseTemplateMarkdown } from './TemplateMarkdownService';
 import type { NoteTemplate } from './TemplateService';
 import { SyncEngineService } from './SyncEngineService';
 import { GitFsService } from './git/GitFsService';
+import { resolveBranch } from './git/branchResolver';
 import { AuthService } from './AuthService';
 
 /**
@@ -555,7 +556,7 @@ export async function pullFromSingleRepo(repoPath: string): Promise<PullResult> 
   if (!repoInfo) {
     return { repos: 0, notes: 0, canvases: 0, todos: 0, templates: 0 };
   }
-  const branch = repo.branch || 'main';
+  const branch = await resolveBranch(repo.path, repo.branch);
 
   const [notes, canvases, todos] = await Promise.all([
     pullNotesFromRepo(repoInfo.owner, repoInfo.repo, repo.path, branch),
@@ -584,7 +585,7 @@ export async function pullAllFromRepos(): Promise<PullResult> {
     const repoInfo = parseRepoPath(repo.path);
     if (!repoInfo) continue;
 
-    const branch = repo.branch || 'main';
+    const branch = await resolveBranch(repo.path, repo.branch);
 
     const [notes, canvases, todos] = await Promise.all([
       pullNotesFromRepo(repoInfo.owner, repoInfo.repo, repo.path, branch),

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -262,4 +262,22 @@ export class GitFsService {
     if (!info) throw new Error(`Invalid repo path: ${opts.repoPath}`);
     return `${clonesRoot()}${info.owner}/${info.repo}`;
   }
+
+  /**
+   * Resolves the local clone's current branch (HEAD ref). Returns null when
+   * the repo isn't cloned, HEAD is detached, or the lookup fails. Used by
+   * `resolveBranch` (#543) so clone-mode operations don't push to a
+   * hardcoded `main` ref the cloned repo may not have.
+   */
+  static async getCurrentBranch(opts: RepoLocator): Promise<string | null> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) return null;
+    const dir = repoDirVirtual(info.owner, info.repo);
+    try {
+      const branch = await git.currentBranch({ fs: makeRepoFs(), dir, fullname: false });
+      return branch ?? null;
+    } catch {
+      return null;
+    }
+  }
 }

--- a/src/services/git/branchResolver.ts
+++ b/src/services/git/branchResolver.ts
@@ -1,0 +1,67 @@
+import { parseRepoPath } from '../../utils/gitPathParser';
+import { GitFsService } from './GitFsService';
+
+const GITHUB_API_BASE = 'https://api.github.com';
+const FALLBACK_BRANCH = 'main';
+
+const sessionCache = new Map<string, string>();
+
+/**
+ * Best-effort resolution of the branch to use for a repo. Order:
+ *   1. `hint` (caller-provided, usually `repo.branch` / `note.branch`)
+ *   2. Local clone HEAD (clone-mode repos)
+ *   3. GitHub API `default_branch`
+ *   4. Hard fallback: 'main'
+ *
+ * Fixes #543: hardcoded `branch || 'main'` literals broke clone-mode
+ * delete + write + pull on repos whose default branch is not `main`.
+ */
+export async function resolveBranch(
+  repoPath: string,
+  hint?: string | null,
+): Promise<string> {
+  if (hint) return hint;
+
+  const cached = sessionCache.get(repoPath);
+  if (cached) return cached;
+
+  const local = await GitFsService.getCurrentBranch({ repoPath });
+  if (local) {
+    sessionCache.set(repoPath, local);
+    return local;
+  }
+
+  const remote = await fetchGitHubDefaultBranch(repoPath);
+  if (remote) {
+    sessionCache.set(repoPath, remote);
+    return remote;
+  }
+
+  return FALLBACK_BRANCH;
+}
+
+/** Forget any cached lookup for this repo. Call after the user re-binds or removes a repo. */
+export function invalidateBranchCache(repoPath: string): void {
+  sessionCache.delete(repoPath);
+}
+
+/** Test seam — clears the in-memory branch cache. */
+export function __resetBranchCacheForTests(): void {
+  sessionCache.clear();
+}
+
+export async function fetchGitHubDefaultBranch(repoPath: string): Promise<string | null> {
+  const info = parseRepoPath(repoPath);
+  if (!info) return null;
+  try {
+    const response = await fetch(
+      `${GITHUB_API_BASE}/repos/${info.owner}/${info.repo}`,
+      { headers: { Accept: 'application/vnd.github.v3+json' } },
+    );
+    if (!response.ok) return null;
+    const json = (await response.json()) as { default_branch?: string };
+    return json.default_branch ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Fixes the root cause of #543: hardcoded `branch || 'main'` literals broke clone-mode delete/write/pull on repos whose default branch isn't `main` (e.g. `master`).

User-visible symptoms:
- Persistent **"Could not find main."** banner on the Notes list
- **"Failed to delete note"** alert when swipe-deleting in a cloned repo

Both stem from isomorphic-git's `Could not find main.` error when the ref doesn't exist locally/remotely.

## Approach
- New `resolveBranch(repoPath, hint?)` helper. Resolution order:
  1. Caller hint (`repo.branch` / `note.branch`)
  2. Local clone HEAD via `git.currentBranch`
  3. GitHub API `default_branch`
  4. Hard fallback `'main'`
- Session cache so the resolver doesn't re-hit fs/network for the same repo each call.
- `GitService.addRepository` now captures the remote default branch at add-time so the resolver has a hot path on subsequent calls.
- Critical literals replaced at 4 sites: Note delete + write, Canvas delete + write, two pull paths.

## Out of scope
~40 other `'main'` literals in pure GitHub-API read paths (RepoFileBrowser, ContextPickerModal, viewers). Same root cause but they don't surface the visible bug. Worth a follow-up sweep but doesn't belong in the bug-fix PR.

## Test plan
- [x] `yarn ts:check` clean
- [x] `yarn jest __tests__/services/branchResolver.test.ts` 9/9 pass (covers precedence, caching, fallback chain)
- [x] Full test suite: 876 passed
- [ ] Manual on-device: clone a repo with default branch != `main` (try `master`), confirm:
  - Notes list opens without banner
  - Swipe-delete a note → succeeds
  - Edit a note → commit + push lands on the right branch on GitHub

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)