### PR TITLE
fix(ios): expose Documents dir to Files.app

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,7 +32,10 @@
         "NSMicrophoneUsageDescription": "GitNotēs needs access to your microphone for voice-to-text note input.",
         "ITSAppUsesNonExemptEncryption": false,
         "UIBackgroundModes": ["processing"],
-        "BGTaskSchedulerPermittedIdentifiers": ["com.expo.modules.backgroundtask.processing"]
+        "BGTaskSchedulerPermittedIdentifiers": ["com.expo.modules.backgroundtask.processing"],
+        "UIFileSharingEnabled": true,
+        "LSSupportsOpeningDocumentsInPlace": true,
+        "NSDocumentsFolderUsageDescription": "GitNotēs stores your cloned repositories and note files here so you can browse and back them up from the Files app."
       }
     },
     "android": {


### PR DESCRIPTION
## Summary
Closes #539. Cloned repos already write to the correct path (`documentDirectory/GitNotes/`), but iOS hides that directory from Files.app unless the Info.plist explicitly opts in.

Added to `app.json` ios.infoPlist:
- `UIFileSharingEnabled: true` — exposes the Documents dir
- `LSSupportsOpeningDocumentsInPlace: true` — lets Files.app browse in place rather than copy
- `NSDocumentsFolderUsageDescription` — privacy string (iOS 11+ requires this when accessing the user's Documents)

Expo regenerates the native Info.plist from this config at prebuild time, so no separate native edit needed.

## Test plan
- [ ] Build iOS app (EAS or local prebuild + Xcode)
- [ ] Settings → clone any repo
- [ ] Open Files.app → On My iPhone → GitNotēs → repo should appear under `GitNotes/<owner>/<repo>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)