### PR TITLE
feat(biometric): require auth on toggle + Face/Touch ID detection

### DIFF
--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -210,8 +210,10 @@ jest.mock('../../src/contexts/BiometricLockContext', () => ({
   useBiometricLock: () => ({
     isLockEnabled: false,
     isBiometricAvailable: true,
+    biometricKind: 'fingerprint',
+    biometricLabel: 'Touch ID',
     lockTimeout: 300_000,
-    setIsLockEnabled: jest.fn(async () => undefined),
+    setIsLockEnabled: jest.fn(async () => true),
     setLockTimeout: jest.fn(async () => undefined),
     isLocked: false,
     authenticate: jest.fn(async () => true),

--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -263,6 +263,13 @@ jest.mock('../../src/components/ui', () => {
         <Text>{accessibilityLabel}</Text>
       </Pressable>
     ),
+    Chip: ({ label, children }: any) => (
+      <View testID={`chip-${label ?? ''}`}>
+        {label !== undefined ? <Text>{label}</Text> : null}
+        {children}
+      </View>
+    ),
+    Modal: ({ visible, children }: any) => (visible ? <View testID="modal">{children}</View> : null),
   };
 });
 

--- a/src/components/settings/ImportSection.tsx
+++ b/src/components/settings/ImportSection.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useState } from 'react';
-import { Text, ActivityIndicator, Alert } from 'react-native';
+import { Text, View, ActivityIndicator, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system/legacy';
 import JSZip from 'jszip';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useNotes } from '../../contexts/NoteContext';
-import { Group, GroupRow } from '../ui';
+import { Chip, Group, GroupRow } from '../ui';
 import { parseGoogleKeepTakeout } from '../../services/import/GoogleKeepImporter';
 import { parseAppleNotesExport } from '../../services/import/AppleNotesImporter';
 import { ImportedFile } from '../../services/import/types';
@@ -144,7 +144,10 @@ export function ImportSection() {
         leading={<Ionicons name="logo-google" size={20} color={colors.text} />}
         trailing={importing === 'google' ? <ActivityIndicator size="small" color={colors.primary} /> : <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
       >
-        <Text style={{ fontSize: 16, color: colors.text }}>Import from Google Keep</Text>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <Text style={{ fontSize: 16, color: colors.text }}>Import from Google Keep</Text>
+          <Chip label="BETA" />
+        </View>
       </GroupRow>
       <GroupRow
         onPress={isImporting ? undefined : handleImportAppleNotes}
@@ -152,7 +155,10 @@ export function ImportSection() {
         leading={<Ionicons name="logo-apple" size={20} color={colors.text} />}
         trailing={importing === 'apple' ? <ActivityIndicator size="small" color={colors.primary} /> : <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
       >
-        <Text style={{ fontSize: 16, color: colors.text }}>Import from Apple Notes</Text>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <Text style={{ fontSize: 16, color: colors.text }}>Import from Apple Notes</Text>
+          <Chip label="BETA" />
+        </View>
       </GroupRow>
     </Group>
   );

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -16,7 +16,7 @@ import { settingsStyles as styles } from './settingsStyles';
 import type { GitRepository } from '../../services/GitService';
 import type { TemplateRepoPreference } from '../../services/TemplateRepoPreferenceService';
 import type { AIProviderConfig } from '../../models/AIProvider';
-import { TIMEOUT_OPTIONS, type LockTimeout } from '../../contexts/BiometricLockContext';
+import { TIMEOUT_OPTIONS, type BiometricKind, type LockTimeout } from '../../contexts/BiometricLockContext';
 
 type ThemeColors = {
   background: string;
@@ -88,6 +88,8 @@ type SettingsContentProps = {
   onAddProvider: () => void;
   isBiometricLockEnabled: boolean;
   isBiometricAvailable: boolean;
+  biometricKind: BiometricKind;
+  biometricLabel: string;
   lockTimeout: LockTimeout;
   onToggleBiometricLock: (v: boolean) => void;
   onSetLockTimeout: (v: LockTimeout) => void;
@@ -143,6 +145,8 @@ export function SettingsContent(props: SettingsContentProps) {
     onAddProvider,
     isBiometricLockEnabled,
     isBiometricAvailable,
+    biometricKind,
+    biometricLabel,
     lockTimeout,
     onToggleBiometricLock,
     onSetLockTimeout,
@@ -243,8 +247,12 @@ export function SettingsContent(props: SettingsContentProps) {
           }
         >
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-            <Ionicons name="finger-print-outline" size={20} color={colors.text} />
-            <Text style={[styles.settingLabel, { color: colors.text }]}>Biometric Lock</Text>
+            <Ionicons
+              name={biometricKind === 'face' ? 'scan-outline' : 'finger-print-outline'}
+              size={20}
+              color={colors.text}
+            />
+            <Text style={[styles.settingLabel, { color: colors.text }]}>{biometricLabel} Lock</Text>
           </View>
         </GroupRow>
         {isBiometricLockEnabled ? (

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -4,7 +4,7 @@ import { Image } from 'expo-image';
 import Constants from 'expo-constants';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
-import { Group, GroupRow, Toggle } from '../ui';
+import { Group, GroupRow, Modal, Toggle } from '../ui';
 import {
   SUPPORTED_LANGUAGES,
   getLanguagePreference,
@@ -151,12 +151,14 @@ export function SettingsContent(props: SettingsContentProps) {
   } = props;
   const { t } = useTranslation();
   const [languagePref, setLanguagePref] = useState<string>('system');
+  const [showTimeoutPicker, setShowTimeoutPicker] = useState(false);
 
   useEffect(() => {
     getLanguagePreference().then(setLanguagePref);
   }, []);
 
   return (
+    <>
     <ScrollView
       style={styles.scrollContent}
       keyboardShouldPersistTaps="handled"
@@ -247,228 +249,207 @@ export function SettingsContent(props: SettingsContentProps) {
         </GroupRow>
         {isBiometricLockEnabled ? (
           <GroupRow
+            onPress={() => setShowTimeoutPicker(true)}
             trailing={
-              <Text style={[styles.settingValue, { color: colors.textSecondary }]}>
-                {TIMEOUT_OPTIONS.find((o) => o.value === lockTimeout)?.label ?? '5 minutes'}
-              </Text>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                <Text style={[styles.settingValue, { color: colors.textSecondary }]}>
+                  {TIMEOUT_OPTIONS.find((o) => o.value === lockTimeout)?.label ?? '5 minutes'}
+                </Text>
+                <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
+              </View>
             }
           >
             <Text style={[styles.settingLabel, { color: colors.text }]}>Lock Timeout</Text>
           </GroupRow>
         ) : null}
-        {isBiometricLockEnabled ? (
-          <View style={{ paddingHorizontal: 16, paddingVertical: 8, flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
-            {TIMEOUT_OPTIONS.map((opt) => (
-              <TouchableOpacity
-                key={opt.value}
-                onPress={() => onSetLockTimeout(opt.value)}
-                style={{
-                  paddingVertical: 6,
-                  paddingHorizontal: 12,
-                  borderRadius: 8,
-                  backgroundColor: lockTimeout === opt.value ? colors.accent : colors.background,
-                  borderWidth: 1,
-                  borderColor: lockTimeout === opt.value ? colors.accent : colors.border,
-                }}
-              >
-                <Text style={{ color: lockTimeout === opt.value ? '#fff' : colors.text, fontSize: 13, fontWeight: '500' }}>
-                  {opt.label}
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </View>
-        ) : null}
       </Group>
 
-      <View style={[styles.section, { backgroundColor: colors.surface }]}> 
-        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}> 
-          {accounts.length >= 2 ? 'GitHub Accounts' : 'GitHub Account'}
-        </Text>
-
+      <Group title={accounts.length >= 2 ? 'GitHub Accounts' : 'GitHub Account'}>
         {authState.isAuthenticated ? (
           <>
             {accounts.length >= 2 ? (
               accounts.map((account) => {
                 const isActive = account.id === activeAccountId;
                 return (
-                  <View key={account.id} style={[styles.settingItem, { borderBottomColor: colors.border }]}> 
-                    <TouchableOpacity
-                      style={[styles.authUserRow, { flex: 1 }]}
-                      onPress={() => void onSwitchAccount(account.id)}
-                      disabled={isActive}
-                    >
-                      {account.avatarUrl ? <Image source={{ uri: account.avatarUrl }} style={styles.avatar} /> : null}
-                      <View style={{ flex: 1 }}>
-                        <Text style={[styles.settingLabel, { color: colors.text }]}> 
-                          {account.name || account.login}
-                          {isActive ? '  ·  Active' : ''}
-                        </Text>
-                        <Text style={[styles.settingValue, { color: colors.textSecondary }]}>@{account.login}</Text>
-                      </View>
-                    </TouchableOpacity>
-                    <TouchableOpacity onPress={() => onRemoveAccount(account.id, account.login)} style={{ paddingHorizontal: 8 }}>
-                      <Ionicons name="trash-outline" size={18} color={colors.error} />
-                    </TouchableOpacity>
-                  </View>
+                  <GroupRow
+                    key={account.id}
+                    onPress={isActive ? undefined : () => void onSwitchAccount(account.id)}
+                    disabled={isActive}
+                    leading={account.avatarUrl ? <Image source={{ uri: account.avatarUrl }} style={styles.avatar} /> : null}
+                    trailing={
+                      <TouchableOpacity onPress={() => onRemoveAccount(account.id, account.login)} style={{ paddingHorizontal: 8 }}>
+                        <Ionicons name="trash-outline" size={18} color={colors.error} />
+                      </TouchableOpacity>
+                    }
+                  >
+                    <Text style={[styles.settingLabel, { color: colors.text }]}>
+                      {account.name || account.login}
+                      {isActive ? '  ·  Active' : ''}
+                    </Text>
+                    <Text style={[styles.settingValue, { color: colors.textSecondary }]}>@{account.login}</Text>
+                  </GroupRow>
                 );
               })
             ) : (
-              <View style={[styles.settingItem, { borderBottomColor: colors.border }]}> 
-                <View style={styles.authUserRow}>
-                  {authState.user?.avatar_url ? <Image source={{ uri: authState.user.avatar_url }} style={styles.avatar} /> : null}
-                  <View>
-                    <Text style={[styles.settingLabel, { color: colors.text }]}>{authState.user?.name || authState.user?.login}</Text>
-                    <Text style={[styles.settingValue, { color: colors.textSecondary }]}>@{authState.user?.login}</Text>
-                  </View>
-                </View>
-              </View>
+              <GroupRow
+                leading={authState.user?.avatar_url ? <Image source={{ uri: authState.user.avatar_url }} style={styles.avatar} /> : null}
+              >
+                <Text style={[styles.settingLabel, { color: colors.text }]}>{authState.user?.name || authState.user?.login}</Text>
+                <Text style={[styles.settingValue, { color: colors.textSecondary }]}>@{authState.user?.login}</Text>
+              </GroupRow>
             )}
 
-            <TouchableOpacity style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onOpenConnectToken}>
-              <View style={styles.settingLeft}>
-                <Ionicons name="key-outline" size={20} color={colors.text} />
-                <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12 }]}>
-                  {accounts.length >= 2 ? 'Replace Active Token' : 'Change Token'}
-                </Text>
-              </View>
-              <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
-            </TouchableOpacity>
+            <GroupRow
+              onPress={onOpenConnectToken}
+              leading={<Ionicons name="key-outline" size={20} color={colors.text} />}
+              trailing={<Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
+            >
+              <Text style={[styles.settingLabel, { color: colors.text }]}>
+                {accounts.length >= 2 ? 'Replace Active Token' : 'Change Token'}
+              </Text>
+            </GroupRow>
 
-            <TouchableOpacity style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onOpenAddAccount}>
-              <View style={styles.settingLeft}>
-                <Ionicons name="person-add-outline" size={20} color={colors.text} />
-                <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12 }]}>Add another account</Text>
-              </View>
-              <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
-            </TouchableOpacity>
+            <GroupRow
+              onPress={onOpenAddAccount}
+              leading={<Ionicons name="person-add-outline" size={20} color={colors.text} />}
+              trailing={<Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
+            >
+              <Text style={[styles.settingLabel, { color: colors.text }]}>Add another account</Text>
+            </GroupRow>
 
             {accounts.length < 2 ? (
-              <TouchableOpacity style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onRemoveToken}>
+              <GroupRow onPress={onRemoveToken}>
                 <Text style={[styles.settingLabel, { color: colors.error }]}>Remove GitHub Account</Text>
-              </TouchableOpacity>
+              </GroupRow>
             ) : null}
           </>
         ) : (
-          <TouchableOpacity style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onOpenConnectToken}>
-            <View style={styles.settingLeft}>
-              <Ionicons name="logo-github" size={20} color={colors.text} />
-              <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12 }]}>Connect GitHub</Text>
-            </View>
-            <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
-          </TouchableOpacity>
+          <GroupRow
+            onPress={onOpenConnectToken}
+            leading={<Ionicons name="logo-github" size={20} color={colors.text} />}
+            trailing={<Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
+          >
+            <Text style={[styles.settingLabel, { color: colors.text }]}>Connect GitHub</Text>
+          </GroupRow>
         )}
-      </View>
+      </Group>
 
-      <View style={[styles.section, { backgroundColor: colors.surface }]}> 
-        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Repositories</Text>
+      <Group title="Repositories">
         {repositories.length === 0 ? (
-          <View style={styles.emptyRepos}>
-            <Ionicons name="code-slash-outline" size={32} color={colors.textSecondary} />
-            <Text style={[styles.emptyReposText, { color: colors.textSecondary }]}>No repositories added yet</Text>
-          </View>
+          <GroupRow>
+            <View style={{ alignItems: 'center', gap: 6, paddingVertical: 8 }}>
+              <Ionicons name="code-slash-outline" size={32} color={colors.textSecondary} />
+              <Text style={[styles.emptyReposText, { color: colors.textSecondary }]}>No repositories added yet</Text>
+            </View>
+          </GroupRow>
         ) : (
           repositories.map((repo) => (
-            <View key={repo.id} style={[styles.repoItem, { borderBottomColor: colors.border }]}> 
-              <Ionicons name="git-branch-outline" size={18} color={colors.primary} />
-              <View style={styles.repoInfo}>
-                <Text style={[styles.repoName, { color: colors.text }]} numberOfLines={1}>{repo.name}</Text>
-                <Text style={[styles.repoPath, { color: colors.textSecondary }]} numberOfLines={1}>{repo.path}</Text>
-              </View>
-              {syncingRepo === repo.path ? (
-                <ActivityIndicator size="small" color={colors.primary} style={styles.syncSpinner} />
-              ) : (
-                <TouchableOpacity onPress={() => onSyncRepo(repo)} style={styles.syncButton} disabled={!!syncingRepo}>
-                  <Ionicons name="cloud-download-outline" size={18} color={colors.primary} />
-                </TouchableOpacity>
-              )}
-              <TouchableOpacity onPress={() => onRemoveRepo(repo)} style={styles.removeButton}>
-                <Ionicons name="trash-outline" size={18} color={colors.error} />
-              </TouchableOpacity>
-            </View>
+            <GroupRow
+              key={repo.id}
+              leading={<Ionicons name="git-branch-outline" size={18} color={colors.primary} />}
+              trailing={
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                  {syncingRepo === repo.path ? (
+                    <ActivityIndicator size="small" color={colors.primary} style={{ marginHorizontal: 8 }} />
+                  ) : (
+                    <TouchableOpacity onPress={() => onSyncRepo(repo)} style={{ padding: 8 }} disabled={!!syncingRepo}>
+                      <Ionicons name="cloud-download-outline" size={18} color={colors.primary} />
+                    </TouchableOpacity>
+                  )}
+                  <TouchableOpacity onPress={() => onRemoveRepo(repo)} style={{ padding: 4 }}>
+                    <Ionicons name="trash-outline" size={18} color={colors.error} />
+                  </TouchableOpacity>
+                </View>
+              }
+            >
+              <Text style={[styles.repoName, { color: colors.text }]} numberOfLines={1}>{repo.name}</Text>
+              <Text style={[styles.repoPath, { color: colors.textSecondary }]} numberOfLines={1}>{repo.path}</Text>
+            </GroupRow>
           ))
         )}
-        <TouchableOpacity style={[styles.addRepoButton, { borderColor: colors.primary }]} onPress={onOpenRepoPicker}>
-          <Ionicons name="add" size={20} color={colors.primary} />
-          <Text style={[styles.addRepoButtonText, { color: colors.primary }]}>Add Repository</Text>
-        </TouchableOpacity>
-      </View>
+        <GroupRow
+          onPress={onOpenRepoPicker}
+          leading={<Ionicons name="add" size={20} color={colors.primary} />}
+        >
+          <Text style={[styles.settingLabel, { color: colors.primary, fontWeight: '600' }]}>Add Repository</Text>
+        </GroupRow>
+      </Group>
 
       {repositories.length > 0 ? (
-        <View style={[styles.section, { backgroundColor: colors.surface }]}> 
-          <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Sync engine</Text>
+        <Group title="Sync engine">
           {repositories.map((repo) => {
             const mode = syncModes[repo.path] ?? 'api';
             const isClone = mode === 'clone';
             const isCloning = cloningRepo === repo.path;
             return (
-              <View key={repo.id} style={[styles.repoItem, { borderBottomColor: colors.border }]} testID={`sync-engine-row-${repo.path}`}>
-                <Ionicons name={isClone ? 'cloud-done-outline' : 'cloud-outline'} size={18} color={isClone ? colors.primary : colors.textSecondary} />
-                <View style={styles.repoInfo}>
-                  <Text style={[styles.repoName, { color: colors.text }]} numberOfLines={1}>{repo.name}</Text>
-                  <Text style={[styles.repoPath, { color: colors.textSecondary }]} numberOfLines={1}>
-                    {isClone ? 'Clone (local working tree)' : 'GitHub API (per-file)'}
-                  </Text>
-                </View>
-                {isCloning ? (
-                  <ActivityIndicator size="small" color={colors.primary} />
-                ) : isClone ? (
-                  <TouchableOpacity testID={`sync-engine-disable-${repo.path}`} onPress={() => onDisableCloneMode(repo)} style={styles.removeButton}>
-                    <Text style={[styles.settingLabel, { color: colors.error }]}>Use API</Text>
-                  </TouchableOpacity>
-                ) : (
-                  <TouchableOpacity testID={`sync-engine-enable-${repo.path}`} onPress={() => onEnableCloneMode(repo)} style={styles.removeButton}>
-                    <Text style={[styles.settingLabel, { color: colors.primary }]}>Clone</Text>
-                  </TouchableOpacity>
-                )}
-              </View>
+              <GroupRow
+                key={repo.id}
+                testID={`sync-engine-row-${repo.path}`}
+                leading={<Ionicons name={isClone ? 'cloud-done-outline' : 'cloud-outline'} size={18} color={isClone ? colors.primary : colors.textSecondary} />}
+                trailing={
+                  isCloning ? (
+                    <ActivityIndicator size="small" color={colors.primary} />
+                  ) : isClone ? (
+                    <TouchableOpacity testID={`sync-engine-disable-${repo.path}`} onPress={() => onDisableCloneMode(repo)} style={{ padding: 4 }}>
+                      <Text style={[styles.settingLabel, { color: colors.error }]}>Use API</Text>
+                    </TouchableOpacity>
+                  ) : (
+                    <TouchableOpacity testID={`sync-engine-enable-${repo.path}`} onPress={() => onEnableCloneMode(repo)} style={{ padding: 4 }}>
+                      <Text style={[styles.settingLabel, { color: colors.primary }]}>Clone</Text>
+                    </TouchableOpacity>
+                  )
+                }
+              >
+                <Text style={[styles.repoName, { color: colors.text }]} numberOfLines={1}>{repo.name}</Text>
+                <Text style={[styles.repoPath, { color: colors.textSecondary }]} numberOfLines={1}>
+                  {isClone ? 'Clone (local working tree)' : 'GitHub API (per-file)'}
+                </Text>
+              </GroupRow>
             );
           })}
-        </View>
+        </Group>
       ) : null}
 
-      <View style={[styles.section, { backgroundColor: colors.surface }]}> 
-        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Templates</Text>
-        <TouchableOpacity testID="templates-repo-picker-row" style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onOpenTemplatesRepoPicker}>
-          <View style={styles.settingLeft}>
-            <Ionicons name="document-text-outline" size={20} color={colors.text} />
-            <View style={{ marginLeft: 12, flexShrink: 1 }}>
-              <Text style={[styles.settingLabel, { color: colors.text }]}>Templates repository</Text>
-              <Text style={[styles.settingValue, { color: colors.textSecondary, fontSize: 12, marginTop: 2 }]} numberOfLines={1}>
-                {templatesRepoPref ? `${templatesRepoPref.repoPath}@${templatesRepoPref.branch}` : 'Not set'}
-              </Text>
-            </View>
-          </View>
-          <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
-        </TouchableOpacity>
+      <Group title="Templates">
+        <GroupRow
+          testID="templates-repo-picker-row"
+          onPress={onOpenTemplatesRepoPicker}
+          leading={<Ionicons name="document-text-outline" size={20} color={colors.text} />}
+          trailing={<Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
+        >
+          <Text style={[styles.settingLabel, { color: colors.text }]}>Templates repository</Text>
+          <Text style={[styles.settingValue, { color: colors.textSecondary, fontSize: 12, marginTop: 2 }]} numberOfLines={1}>
+            {templatesRepoPref ? `${templatesRepoPref.repoPath}@${templatesRepoPref.branch}` : 'Not set'}
+          </Text>
+        </GroupRow>
 
         {templatesRepoPref ? (
           <>
-            <TouchableOpacity testID="templates-sync-existing" style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onSyncExistingTemplates} disabled={isSyncingExistingTemplates}>
-              <View style={styles.settingLeft}>
-                <Ionicons name="cloud-upload-outline" size={20} color={colors.text} />
-                <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12, flexShrink: 1 }]} numberOfLines={1}>
-                  Sync custom templates
-                </Text>
-              </View>
-              {isSyncingExistingTemplates ? <ActivityIndicator size="small" color={colors.primary} /> : null}
-            </TouchableOpacity>
-            <TouchableOpacity testID="templates-repo-clear" style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onClearTemplatesRepo}>
+            <GroupRow
+              testID="templates-sync-existing"
+              onPress={onSyncExistingTemplates}
+              disabled={isSyncingExistingTemplates}
+              leading={<Ionicons name="cloud-upload-outline" size={20} color={colors.text} />}
+              trailing={isSyncingExistingTemplates ? <ActivityIndicator size="small" color={colors.primary} /> : null}
+            >
+              <Text style={[styles.settingLabel, { color: colors.text }]} numberOfLines={1}>Sync custom templates</Text>
+            </GroupRow>
+            <GroupRow testID="templates-repo-clear" onPress={onClearTemplatesRepo}>
               <Text style={[styles.settingLabel, { color: colors.error }]}>Disconnect templates repo</Text>
-            </TouchableOpacity>
+            </GroupRow>
           </>
         ) : null}
-      </View>
+      </Group>
 
-      <View style={[styles.section, { backgroundColor: colors.surface }]}> 
-        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Note rendering</Text>
-        <TouchableOpacity style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onOpenRenderStyleSettings}>
-          <View style={styles.settingLeft}>
-            <Ionicons name="color-palette-outline" size={20} color={colors.text} />
-            <Text style={[styles.settingLabel, { color: colors.text, marginLeft: 12 }]}>Customize render styles</Text>
-          </View>
-          <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
-        </TouchableOpacity>
-      </View>
+      <Group title="Note rendering">
+        <GroupRow
+          onPress={onOpenRenderStyleSettings}
+          leading={<Ionicons name="color-palette-outline" size={20} color={colors.text} />}
+          trailing={<Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
+        >
+          <Text style={[styles.settingLabel, { color: colors.text }]}>Customize render styles</Text>
+        </GroupRow>
+      </Group>
 
       <Group title="Sync" footer="Periodically sync notes in the background (every 15 min).">
         <GroupRow
@@ -487,28 +468,27 @@ export function SettingsContent(props: SettingsContentProps) {
         </GroupRow>
       </Group>
 
-      <View style={[styles.section, { backgroundColor: colors.surface }]}> 
-        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Data</Text>
-        <TouchableOpacity style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onClearData}>
+      <Group title="Data">
+        <GroupRow onPress={onClearData}>
           <Text style={[styles.settingLabel, { color: colors.error }]}>Clear All Notes</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onResetOnboarding}>
+        </GroupRow>
+        <GroupRow onPress={onResetOnboarding}>
           <Text style={[styles.settingLabel, { color: colors.text }]}>Reset Onboarding</Text>
-        </TouchableOpacity>
-      </View>
+        </GroupRow>
+      </Group>
 
       <ImportSection />
 
-      <View style={[styles.section, { backgroundColor: colors.surface }]}>
-        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>About</Text>
-        <View style={[styles.settingItem, { borderBottomColor: colors.border }]}>
+      <Group title="About">
+        <GroupRow
+          trailing={<Text style={[styles.settingValue, { color: colors.textSecondary }]}>{Constants.expoConfig?.version ?? '—'}</Text>}
+        >
           <Text style={[styles.settingLabel, { color: colors.text }]}>Version</Text>
-          <Text style={[styles.settingValue, { color: colors.textSecondary }]}>{Constants.expoConfig?.version ?? '—'}</Text>
-        </View>
-        <TouchableOpacity style={[styles.settingItem, { borderBottomColor: colors.border }]} onPress={onManageTemplates}>
+        </GroupRow>
+        <GroupRow onPress={onManageTemplates}>
           <Text style={[styles.settingLabel, { color: colors.text }]}>Manage templates</Text>
-        </TouchableOpacity>
-      </View>
+        </GroupRow>
+      </Group>
 
       <Group title={t('settings.artificialIntelligence')}>
         <GroupRow trailing={<Toggle value={isAIEnabled} onValueChange={onToggleAI} />}>
@@ -552,5 +532,37 @@ export function SettingsContent(props: SettingsContentProps) {
 
       <View style={styles.bottomPad} />
     </ScrollView>
+
+    <Modal
+      visible={showTimeoutPicker}
+      onRequestClose={() => setShowTimeoutPicker(false)}
+      bottomSheet
+      contentStyle={{ padding: 16, paddingBottom: 34 }}
+    >
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <Text style={{ color: colors.text, fontSize: 17, fontWeight: '600' }}>Lock Timeout</Text>
+        <TouchableOpacity onPress={() => setShowTimeoutPicker(false)} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <Ionicons name="close" size={22} color={colors.textSecondary} />
+        </TouchableOpacity>
+      </View>
+      <Group>
+        {TIMEOUT_OPTIONS.map((opt) => {
+          const isActive = opt.value === lockTimeout;
+          return (
+            <GroupRow
+              key={opt.value}
+              onPress={() => {
+                onSetLockTimeout(opt.value);
+                setShowTimeoutPicker(false);
+              }}
+              trailing={isActive ? <Ionicons name="checkmark" size={20} color={colors.primary} /> : null}
+            >
+              <Text style={{ color: isActive ? colors.primary : colors.text, fontSize: 16 }}>{opt.label}</Text>
+            </GroupRow>
+          );
+        })}
+      </Group>
+    </Modal>
+    </>
   );
 }

--- a/src/contexts/BiometricLockContext.tsx
+++ b/src/contexts/BiometricLockContext.tsx
@@ -15,13 +15,25 @@ export const TIMEOUT_OPTIONS = [
 
 export type LockTimeout = (typeof TIMEOUT_OPTIONS)[number]['value'];
 
+export type BiometricKind = 'face' | 'fingerprint' | 'iris' | 'unknown';
+
 interface BiometricLockContextType {
   isLockEnabled: boolean;
-  setIsLockEnabled: (v: boolean) => void;
+  /**
+   * Toggles the lock setting after a successful biometric prompt. Resolves
+   * `true` when persisted, `false` when the user cancelled or auth failed.
+   * Required for both enable and disable so the setting can't be flipped
+   * by anyone with a briefly-unlocked device. (#544)
+   */
+  setIsLockEnabled: (v: boolean) => Promise<boolean>;
   lockTimeout: LockTimeout;
   setLockTimeout: (v: LockTimeout) => void;
   isLocked: boolean;
   isBiometricAvailable: boolean;
+  /** Detected biometric kind so UI can pick the right icon + copy. */
+  biometricKind: BiometricKind;
+  /** "Face ID" / "Touch ID" / "Biometrics" — for prompt + label text. */
+  biometricLabel: string;
   authenticate: () => Promise<boolean>;
 }
 
@@ -36,6 +48,9 @@ export function BiometricLockProvider({ children }: BiometricLockProviderProps) 
   const [lockTimeout, setLockTimeoutState] = useState<LockTimeout>(300_000);
   const [isLocked, setIsLocked] = useState(false);
   const [isBiometricAvailable, setIsBiometricAvailable] = useState(false);
+  const [supportedAuthTypes, setSupportedAuthTypes] = useState<
+    LocalAuthentication.AuthenticationType[]
+  >([]);
   const backgroundTimeRef = useRef<number | null>(null);
   const isInitializedRef = useRef(false);
 
@@ -44,8 +59,34 @@ export function BiometricLockProvider({ children }: BiometricLockProviderProps) 
       const compatible = await LocalAuthentication.hasHardwareAsync();
       const enrolled = await LocalAuthentication.isEnrolledAsync();
       setIsBiometricAvailable(compatible && enrolled);
+      if (compatible) {
+        const types = await LocalAuthentication.supportedAuthenticationTypesAsync();
+        setSupportedAuthTypes(types);
+      }
     })();
   }, []);
+
+  const biometricKind = useMemo<BiometricKind>(() => {
+    if (
+      supportedAuthTypes.includes(LocalAuthentication.AuthenticationType.FACIAL_RECOGNITION)
+    ) {
+      return 'face';
+    }
+    if (supportedAuthTypes.includes(LocalAuthentication.AuthenticationType.FINGERPRINT)) {
+      return 'fingerprint';
+    }
+    if (supportedAuthTypes.includes(LocalAuthentication.AuthenticationType.IRIS)) {
+      return 'iris';
+    }
+    return 'unknown';
+  }, [supportedAuthTypes]);
+
+  const biometricLabel = useMemo(() => {
+    if (biometricKind === 'face') return 'Face ID';
+    if (biometricKind === 'fingerprint') return 'Touch ID';
+    if (biometricKind === 'iris') return 'Iris';
+    return 'Biometrics';
+  }, [biometricKind]);
 
   useEffect(() => {
     (async () => {
@@ -64,13 +105,30 @@ export function BiometricLockProvider({ children }: BiometricLockProviderProps) 
     })();
   }, []);
 
-  const setIsLockEnabled = useCallback(async (v: boolean) => {
-    setIsLockEnabledState(v);
-    await AsyncStorage.setItem(STORAGE_KEY_ENABLED, String(v));
-    if (!v) {
-      setIsLocked(false);
-    }
-  }, []);
+  const setIsLockEnabled = useCallback(
+    async (v: boolean): Promise<boolean> => {
+      // #544: require biometric auth before flipping the setting in either
+      // direction so anyone with a briefly-unlocked device can't bypass the
+      // lock by toggling it off.
+      try {
+        const result = await LocalAuthentication.authenticateAsync({
+          promptMessage: v
+            ? `Enable ${biometricLabel} lock`
+            : `Disable ${biometricLabel} lock`,
+          fallbackLabel: 'Use passcode',
+          cancelLabel: 'Cancel',
+        });
+        if (!result.success) return false;
+      } catch {
+        return false;
+      }
+      setIsLockEnabledState(v);
+      await AsyncStorage.setItem(STORAGE_KEY_ENABLED, String(v));
+      if (!v) setIsLocked(false);
+      return true;
+    },
+    [biometricLabel],
+  );
 
   const setLockTimeout = useCallback(async (v: LockTimeout) => {
     setLockTimeoutState(v);
@@ -80,7 +138,7 @@ export function BiometricLockProvider({ children }: BiometricLockProviderProps) 
   const authenticate = useCallback(async (): Promise<boolean> => {
     try {
       const result = await LocalAuthentication.authenticateAsync({
-        promptMessage: 'Unlock GitNotēs',
+        promptMessage: `Unlock GitNotēs with ${biometricLabel}`,
         fallbackLabel: 'Use passcode',
         cancelLabel: 'Cancel',
       });
@@ -92,7 +150,7 @@ export function BiometricLockProvider({ children }: BiometricLockProviderProps) 
     } catch {
       return false;
     }
-  }, []);
+  }, [biometricLabel]);
 
   useEffect(() => {
     const handleAppState = (nextState: AppStateStatus) => {
@@ -121,9 +179,21 @@ export function BiometricLockProvider({ children }: BiometricLockProviderProps) 
       setLockTimeout,
       isLocked,
       isBiometricAvailable,
+      biometricKind,
+      biometricLabel,
       authenticate,
     }),
-    [isLockEnabled, setIsLockEnabled, lockTimeout, setLockTimeout, isLocked, isBiometricAvailable, authenticate],
+    [
+      isLockEnabled,
+      setIsLockEnabled,
+      lockTimeout,
+      setLockTimeout,
+      isLocked,
+      isBiometricAvailable,
+      biometricKind,
+      biometricLabel,
+      authenticate,
+    ],
   );
 
   return (

--- a/src/screens/RenderStyleSettingsScreen.tsx
+++ b/src/screens/RenderStyleSettingsScreen.tsx
@@ -19,6 +19,7 @@ import { useRenderStyleStore } from '../stores/renderStyleStore';
 import { RenderStyleService, DiscoveredBinding } from '../services/RenderStyleService';
 import { RENDER_FORMATS, formatLabel } from '../types/RenderStyle';
 import { GitHubService } from '../services/GitHubService';
+import { Chip } from '../components/ui';
 import type { RootStackParamList } from '../navigation/types';
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'RenderStyleSettings'>;
@@ -119,6 +120,7 @@ export default function RenderStyleSettingsScreen() {
         <View style={[styles.section, { backgroundColor: colors.surface }]}>
           {RENDER_FORMATS.map((fmt) => {
             const hasOverrides = !!settings.formats[fmt] && Object.keys(settings.formats[fmt] ?? {}).length > 0;
+            const isBeta = fmt === 'neorg';
             return (
               <TouchableOpacity
                 key={fmt}
@@ -126,7 +128,10 @@ export default function RenderStyleSettingsScreen() {
                 onPress={() => navigation.navigate('RenderStyleEditor', { format: fmt })}
               >
                 <View style={{ flex: 1 }}>
-                  <Text style={[styles.rowLabel, { color: colors.text }]}>{formatLabel(fmt)}</Text>
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                    <Text style={[styles.rowLabel, { color: colors.text }]}>{formatLabel(fmt)}</Text>
+                    {isBeta ? <Chip label="BETA" /> : null}
+                  </View>
                   <Text style={[styles.rowSubLabel, { color: colors.textSecondary }]}>
                     {hasOverrides ? 'Custom overrides applied' : 'Theme defaults'}
                   </Text>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -48,7 +48,15 @@ export default function SettingsScreen() {
   const { refreshTodos } = useTodos();
   const { authState, accounts, activeAccountId, setToken, clearToken, addAccount, removeAccount, switchAccount } = useAuth();
   const { repositories, addRepository: addRepo, removeRepository: removeRepo } = useRepos();
-  const { isLockEnabled: isBiometricLockEnabled, isBiometricAvailable, lockTimeout, setIsLockEnabled, setLockTimeout } = useBiometricLock();
+  const {
+    isLockEnabled: isBiometricLockEnabled,
+    isBiometricAvailable,
+    biometricKind,
+    biometricLabel,
+    lockTimeout,
+    setIsLockEnabled,
+    setLockTimeout,
+  } = useBiometricLock();
   const { isEnabled: isBackgroundSyncEnabled, toggle: toggleBackgroundSync } = useBackgroundSync();
   const isAIEnabled = useAIStore((state) => state.isEnabled);
   const selectedModelId = useAIStore((state) => state.selectedModelId);
@@ -462,6 +470,8 @@ export default function SettingsScreen() {
         onAddProvider={() => { setEditingProvider(undefined); setShowProviderConfig(true); }}
         isBiometricLockEnabled={isBiometricLockEnabled}
         isBiometricAvailable={isBiometricAvailable}
+        biometricKind={biometricKind}
+        biometricLabel={biometricLabel}
         lockTimeout={lockTimeout}
         onToggleBiometricLock={(v) => void setIsLockEnabled(v)}
         onSetLockTimeout={(v) => void setLockTimeout(v)}


### PR DESCRIPTION
## Summary
Closes #544.

**Auth-on-toggle:** `setIsLockEnabled` now wraps the persistence call in `LocalAuthentication.authenticateAsync` for both enable and disable. Returns `Promise<boolean>` so callers can react to cancelled/failed prompts (the Toggle just snaps back since state doesn't change). Closes the bypass where anyone with a briefly-unlocked device could disable the lock from Settings.

**Face/Touch ID detection:** Probes `LocalAuthentication.supportedAuthenticationTypesAsync()` at provider mount and exposes:
- `biometricKind` — `'face' | 'fingerprint' | 'iris' | 'unknown'`
- `biometricLabel` — `'Face ID'` / `'Touch ID'` / `'Iris'` / `'Biometrics'`

Settings biometric row now uses:
- `scan-outline` icon for Face ID, `finger-print-outline` otherwise
- `"<label> Lock"` as the row title
- `"Enable <label> lock"` / `"Disable <label> lock"` in the auth prompt
- Lock-screen unlock prompt: `"Unlock GitNotēs with <label>"`

## Branch base
This PR is **based on `settings-polish` (PR #552)**, not `main`. The biometric row layout was restructured there into a `Group`/`GroupRow`. **Merge order:** #552 first, then rebase + merge this. Will trivially clean up once #552 lands.

## Test plan
- [x] `yarn ts:check` clean
- [x] `yarn jest __tests__/screens/SettingsScreen.test.tsx` 8/8 (mock updated)
- [x] Full test suite: 867 passed
- [ ] On Face ID device: Settings → row shows "Face ID Lock" with scan icon → toggle on → Face ID prompt fires → confirm → toggle stays on. Toggle off → Face ID prompt → confirm → off.
- [ ] On Touch ID device: same flow with "Touch ID Lock" + fingerprint icon.
- [ ] Cancel the Face ID prompt → toggle snaps back to original state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)