### PR TITLE
fix(sync): purge orphan repo data + friendlier push errors

### DIFF
--- a/__tests__/services/git/localGitWriter.test.ts
+++ b/__tests__/services/git/localGitWriter.test.ts
@@ -4,6 +4,9 @@ jest.mock('isomorphic-git', () => {
     remove: jest.fn(async (..._a: any[]) => undefined),
     commit: jest.fn(async (..._a: any[]) => 'commit-sha-1'),
     push: jest.fn(async (..._a: any[]) => ({ ok: true })),
+    currentBranch: jest.fn(async (..._a: any[]) => 'main'),
+    checkout: jest.fn(async (..._a: any[]) => undefined),
+    fetch: jest.fn(async (..._a: any[]) => undefined),
   };
   (globalThis as any).__lgwGitMocks = mocks;
   return {
@@ -43,6 +46,9 @@ function getGitMocks() {
     remove: jest.Mock;
     commit: jest.Mock;
     push: jest.Mock;
+    currentBranch: jest.Mock;
+    checkout: jest.Mock;
+    fetch: jest.Mock;
   };
 }
 

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -279,6 +279,52 @@ export class StorageService {
     await this.saveRepositories(filtered);
   }
 
+  /**
+   * Drop every locally-cached note, canvas and todo whose `repo` matches
+   * `path`. Called after a repo is removed from settings so the lists in
+   * the UI stop showing ghost entries from a disconnected source.
+   *
+   * Local-only items (no `repo` field) are untouched; only remote-backed
+   * records tied to the now-orphaned repo path are cleared.
+   */
+  static async purgeRepoData(path: string): Promise<void> {
+    try {
+      const notes = await this.getAllNotes();
+      const survivingNotes = notes.filter((n) => n.repo !== path);
+      if (survivingNotes.length !== notes.length) {
+        const removedIds = notes
+          .filter((n) => n.repo === path)
+          .map((n) => noteKey(n.id));
+        if (removedIds.length > 0) {
+          await AsyncStorage.multiRemove(removedIds);
+        }
+        await this.saveNoteIndex(survivingNotes.map((n) => n.id));
+      }
+    } catch (error) {
+      console.error('Error purging notes for repo:', error);
+    }
+
+    try {
+      const todos = await this.getAllTodos();
+      const survivingTodos = todos.filter((t) => t.repo !== path);
+      if (survivingTodos.length !== todos.length) {
+        await this.saveAllTodos(survivingTodos);
+      }
+    } catch (error) {
+      console.error('Error purging todos for repo:', error);
+    }
+
+    try {
+      await this.mutateCanvases((canvases) => {
+        for (let i = canvases.length - 1; i >= 0; i--) {
+          if (canvases[i].repo === path) canvases.splice(i, 1);
+        }
+      });
+    } catch (error) {
+      console.error('Error purging canvases for repo:', error);
+    }
+  }
+
   static async getAllFolders(): Promise<Folder[]> {
     try {
       const boot = getBootValue('@gitnotes:folders');

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -81,6 +81,71 @@ async function ensureParentDirs(rootDir: string, virtualPath: string): Promise<v
   }
 }
 
+/**
+ * Make sure the working tree is on `branch` before we stage / commit /
+ * push. Without this, commit lands on whatever HEAD was last set to (often
+ * the branch the repo was originally cloned with, e.g. `master`) and the
+ * subsequent push to a different `ref` either no-ops or surfaces a stale
+ * `cannot lock ref 'refs/heads/master'` error from the server.
+ *
+ * If the branch ref is missing locally (single-branch clone of a different
+ * branch), we fetch it from origin first and then check out.
+ */
+async function ensureOnBranch(
+  fs: ReturnType<typeof makeRepoFs>,
+  dir: string,
+  branch: string,
+  token: string | undefined,
+): Promise<void> {
+  const current = await git.currentBranch({ fs, dir, fullname: false }).catch(() => null);
+  if (current === branch) return;
+
+  try {
+    await git.checkout({ fs, dir, ref: branch });
+    return;
+  } catch (error) {
+    void error;
+    // local branch ref is missing — fetch then retry checkout below.
+  }
+
+  await git.fetch({
+    fs,
+    http: gitHttp,
+    dir,
+    ref: branch,
+    singleBranch: true,
+    depth: 1,
+    tags: false,
+    onAuth: tokenAuth(token),
+  });
+  await git.checkout({ fs, dir, ref: branch });
+}
+
+/**
+ * Best-effort prettifier for the wall-of-text isomorphic-git produces on
+ * `git.push` failures. The raw text (`One or more branches were not
+ * updated: - refs/heads/master: cannot lock ref ...`) leaks server
+ * internals into the user-facing banner; we keep the raw message in the
+ * console log and surface a one-line summary to callers.
+ */
+export function summarizePushError(raw: string | undefined): string {
+  if (!raw) return 'Sync to GitHub failed';
+  const message = raw.toLowerCase();
+  if (message.includes('cannot lock ref')) {
+    return 'Sync to GitHub failed: branch is locked on the remote. Check your branch settings.';
+  }
+  if (message.includes('one or more branches were not updated')) {
+    return 'Sync to GitHub failed: the remote rejected the update. Pull and try again.';
+  }
+  if (message.includes('not authorized') || message.includes('401') || message.includes('403')) {
+    return 'Sync to GitHub failed: not authorized. Re-link your GitHub account.';
+  }
+  if (message.includes('network') || message.includes('fetch')) {
+    return 'Sync to GitHub failed: network error.';
+  }
+  return 'Sync to GitHub failed';
+}
+
 export class LocalGitWriter {
   /**
    * Write content into the working tree, stage + commit, optionally push.
@@ -97,6 +162,8 @@ export class LocalGitWriter {
     const fsRoot = clonesRoot();
 
     try {
+      await ensureOnBranch(fs, dir, opts.branch, opts.token);
+
       const absVirtual = `${dir}/${opts.filePath}`;
       const absUri = `${fsRoot}${absVirtual.replace(/^\//, '')}`;
       await ensureParentDirs(fsRoot, absVirtual);
@@ -123,7 +190,9 @@ export class LocalGitWriter {
 
       return { success: true, filePath: opts.filePath };
     } catch (e) {
-      return { success: false, error: e instanceof Error ? e.message : String(e) };
+      const raw = e instanceof Error ? e.message : String(e);
+      console.warn('[LocalGitWriter] writeAndCommit failed:', raw);
+      return { success: false, error: raw };
     }
   }
 
@@ -140,6 +209,8 @@ export class LocalGitWriter {
     const fsRoot = clonesRoot();
 
     try {
+      await ensureOnBranch(fs, dir, opts.branch, opts.token);
+
       const absUri = `${fsRoot}${info.owner}/${info.repo}/${opts.filePath}`;
       await FileSystem.deleteAsync(absUri, { idempotent: true });
 
@@ -164,7 +235,9 @@ export class LocalGitWriter {
 
       return { success: true, filePath: opts.filePath };
     } catch (e) {
-      return { success: false, error: e instanceof Error ? e.message : String(e) };
+      const raw = e instanceof Error ? e.message : String(e);
+      console.warn('[LocalGitWriter] deleteAndCommit failed:', raw);
+      return { success: false, error: raw };
     }
   }
 
@@ -182,6 +255,7 @@ export class LocalGitWriter {
     const dir = repoDirVirtual(info.owner, info.repo);
     const fs = makeRepoFs();
     try {
+      await ensureOnBranch(fs, dir, opts.branch, opts.token);
       await git.push({
         fs,
         dir,
@@ -192,7 +266,9 @@ export class LocalGitWriter {
       });
       return { success: true };
     } catch (e) {
-      return { success: false, error: e instanceof Error ? e.message : String(e) };
+      const raw = e instanceof Error ? e.message : String(e);
+      console.warn('[LocalGitWriter] push failed:', raw);
+      return { success: false, error: raw };
     }
   }
 }

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -4,6 +4,7 @@ import { Note, NoteCreateInput, NoteUpdateInput, sortNotesWithPinnedFirst, filte
 import { StorageService } from '../services/StorageService';
 import { deleteNoteFromGitHub } from '../services/NoteGitHubSyncService';
 import { GitHubService } from '../services/GitHubService';
+import { summarizePushError } from '../services/git/LocalGitWriter';
 
 interface NoteState {
   notes: Note[];
@@ -36,8 +37,21 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
   loadNotes: async () => {
     try {
       set({ isLoading: true, error: null });
-      const loadedNotes = await StorageService.getAllNotes();
-      set({ notes: sortNotesWithPinnedFirst(loadedNotes), isLoading: false });
+      const [loadedNotes, savedRepos] = await Promise.all([
+        StorageService.getAllNotes(),
+        StorageService.getSavedRepositories(),
+      ]);
+      // Drop notes whose backing repo was removed from settings on a build
+      // that didn't yet purge per-repo data (issue: ghost notes from a
+      // disconnected repo kept showing up in the list). Local-only notes
+      // (no `repo` field) are always kept.
+      const repoPaths = new Set(savedRepos.map((r) => r.path));
+      const orphans = loadedNotes.filter((n) => n.repo && !repoPaths.has(n.repo));
+      const survivors = loadedNotes.filter((n) => !n.repo || repoPaths.has(n.repo));
+      if (orphans.length > 0) {
+        await Promise.all(orphans.map((n) => StorageService.deleteNote(n.id)));
+      }
+      set({ notes: sortNotesWithPinnedFirst(survivors), isLoading: false });
     } catch (err) {
       set({ error: 'Failed to load notes', isLoading: false });
       console.error('Error loading notes:', err);
@@ -94,7 +108,8 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
           accountId: note.accountId,
         });
         if (!remote.success) {
-          set({ error: remote.error || 'Failed to delete from GitHub' });
+          if (remote.error) console.warn('[NoteStore] delete sync failed:', remote.error);
+          set({ error: summarizePushError(remote.error) });
           return false;
         }
       }

--- a/src/stores/repoStore.ts
+++ b/src/stores/repoStore.ts
@@ -1,6 +1,9 @@
 import { create } from 'zustand';
 import { GitRepository, GitService } from '../services/GitService';
 import { StorageService } from '../services/StorageService';
+import { useNoteStore } from './noteStore';
+import { useCanvasStore } from './canvasStore';
+import { useTodoStore } from './todoStore';
 
 interface RepoState {
   repositories: GitRepository[];
@@ -38,7 +41,17 @@ export const useRepoStore = create<RepoState & RepoActions>()((set, get) => ({
 
   removeRepository: async (path) => {
     await StorageService.removeRepository(path);
+    // Drop all locally-cached records that originated from the removed repo
+    // before refreshing the dependent stores. Without this, notes/canvases/
+    // todos from the now-disconnected repo keep showing up in their lists
+    // even though the repo is gone from settings.
+    await StorageService.purgeRepoData(path);
     set((state) => ({ repositories: state.repositories.filter((r) => r.path !== path) }));
+    await Promise.all([
+      useNoteStore.getState().refreshNotes(),
+      useCanvasStore.getState().refreshCanvases(),
+      useTodoStore.getState().refreshTodos(),
+    ]);
   },
 
   refreshRepos: async () => {


### PR DESCRIPTION
## Summary
- Removing a repo from settings now also drops every locally-cached note, canvas and todo whose `repo` matched, so disconnected sources stop showing in the list. Defensive prune at `noteStore.loadNotes` self-heals existing orphans on older installs.
- `LocalGitWriter` now `git.checkout`s (and fetches if needed) the target branch before stage/commit, so commits land on the branch we then push. Stops the stale `refs/heads/master` reaching the remote when the user has switched branches.
- Raw `GitPushError` text no longer leaks into the Notes banner — `summarizePushError` translates it into a one-line, actionable string. Full message still goes to console.

## Test plan
- [x] `yarn ts:check`
- [x] `yarn lint` (0 errors; pre-existing warnings unchanged)
- [x] `yarn test` — 876/876 passing, including updated `__tests__/services/git/localGitWriter.test.ts`
- [ ] Manual: remove a repo from settings, confirm its notes disappear immediately (check with notes both with and without filePath)
- [ ] Manual: trigger a push failure (e.g., locked branch on remote) and confirm the banner shows the friendly summary, not the raw push error wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)