### PR TITLE
fix(lock): use scan icon on Face ID devices

### DIFF
--- a/src/components/BiometricLockScreen.tsx
+++ b/src/components/BiometricLockScreen.tsx
@@ -6,7 +6,7 @@ import { useBiometricLock } from '../contexts/BiometricLockContext';
 import { useTheme } from '../contexts/ThemeContext';
 
 export function BiometricLockScreen() {
-  const { isLocked, authenticate, isBiometricAvailable } = useBiometricLock();
+  const { isLocked, authenticate, isBiometricAvailable, biometricKind } = useBiometricLock();
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
 
@@ -32,7 +32,17 @@ export function BiometricLockScreen() {
           style={[styles.unlockButton, { backgroundColor: colors.accent }]}
           onPress={handleUnlock}
         >
-          <Ionicons name={isBiometricAvailable ? 'finger-print-outline' : 'keypad-outline'} size={22} color="#fff" />
+          <Ionicons
+            name={
+              !isBiometricAvailable
+                ? 'keypad-outline'
+                : biometricKind === 'face'
+                  ? 'scan-outline'
+                  : 'finger-print-outline'
+            }
+            size={22}
+            color="#fff"
+          />
           <Text style={styles.unlockText}>Unlock</Text>
         </Pressable>
       </View>


### PR DESCRIPTION
## Summary
- `BiometricLockScreen` hardcoded `finger-print-outline` on the unlock button regardless of the device's biometric kind, so Face ID iPhones showed a fingerprint icon.
- Now branches on `biometricKind` the same way `SettingsContent.tsx:249` already does: `face` → `scan-outline`, `fingerprint` → `finger-print-outline`, no biometrics → `keypad-outline`.

## Test plan
- [ ] Run `yarn ios` on a Face ID device, lock the app, confirm scan icon (was fingerprint).
- [ ] Run on a Touch ID device, confirm fingerprint icon.
- [ ] Run on a device with no biometrics enrolled, confirm keypad icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)