### PR TITLE
fix(ui): bento spacing + todo swipe alignment (#569)

### DIFF
--- a/src/components/home/BentoRecent.tsx
+++ b/src/components/home/BentoRecent.tsx
@@ -56,7 +56,7 @@ export function BentoRecent({ items, onOpen }: Props) {
 const styles = StyleSheet.create({
   section: {
     marginTop: 8,
-    marginBottom: 16,
+    marginBottom: 24,
   },
   heading: {
     fontSize: 12,

--- a/src/components/todos/TodosSwipeActions.tsx
+++ b/src/components/todos/TodosSwipeActions.tsx
@@ -28,8 +28,7 @@ export function TodosSwipeActions({ onDelete }: TodosSwipeActionsProps) {
 const styles = StyleSheet.create({
   track: {
     width: 80,
-    marginVertical: 8,
-    marginLeft: 8,
+    marginBottom: 8,
   },
   action: {
     flex: 1,


### PR DESCRIPTION
## Summary

Closes #569.

Two small UI polish fixes:

- **Home / Recents bento**: bumped section `marginBottom` from 16 to 24 so the medium-tile rows no longer crowd the next home section.
- **Todo swipe-to-delete alignment**: dropped `marginVertical: 8` and `marginLeft: 8` on the swipe action track and replaced with a single `marginBottom: 8` so the revealed Delete button sits flush with the card's top edge and right side, matching the card's own 8px bottom gap.

## Test plan

- [ ] Open Home tab and confirm the Recents bento has visibly more breathing room before the next section.
- [ ] On the Todos tab, swipe a card left and confirm the red Delete reveal aligns flush with the card top, sits against the right edge with no left gap, and matches the card's bottom margin.
- [ ] `yarn ts:check` passes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>