### PR TITLE
fix(sync): error sanitizer + delete reliability (#567 #568)

### DIFF
--- a/__tests__/services/RenderStyle.test.ts
+++ b/__tests__/services/RenderStyle.test.ts
@@ -12,6 +12,7 @@ jest.mock('../../src/services/GitHubService', () => ({
     getFileContent: jest.fn(),
     updateFile: jest.fn(),
     getFileSha: jest.fn(),
+    getFileShaOrNull: jest.fn(),
     getRepositories: jest.fn(),
   },
 }));
@@ -21,7 +22,7 @@ import { GitHubService } from '../../src/services/GitHubService';
 
 const mockGet = GitHubService.getFileContent as jest.Mock;
 const mockPut = GitHubService.updateFile as jest.Mock;
-const mockSha = GitHubService.getFileSha as jest.Mock;
+const mockSha = GitHubService.getFileShaOrNull as jest.Mock;
 const mockRepos = GitHubService.getRepositories as jest.Mock;
 
 describe('RenderStyle types', () => {

--- a/__tests__/template-github-sync.test.ts
+++ b/__tests__/template-github-sync.test.ts
@@ -3,7 +3,7 @@ jest.mock('../src/services/GitHubService', () => ({
     isAuthenticated: jest.fn(() => true),
     updateFile: jest.fn(async () => ({ content: { sha: 'abc' }, commit: { sha: 'xyz' } })),
     deleteFile: jest.fn(async () => ({ commit: { sha: 'del' } })),
-    getFileSha: jest.fn(async () => 'abc'),
+    getFileSha: jest.fn(async () => ({ kind: 'found', sha: 'abc' })),
   },
 }));
 

--- a/__tests__/todo-delete-sync.test.ts
+++ b/__tests__/todo-delete-sync.test.ts
@@ -53,7 +53,7 @@ describe('todo delete GitHub sync', () => {
       storageTodos = next;
       return true;
     });
-    (GitHubService.getFileSha as jest.Mock).mockResolvedValue('todo-sha-123');
+    (GitHubService.getFileSha as jest.Mock).mockResolvedValue({ kind: 'found', sha: 'todo-sha-123' });
     (GitHubService.deleteFile as jest.Mock).mockResolvedValue({
       content: { sha: 'deleted-sha' },
       commit: { sha: 'commit-sha' },
@@ -159,7 +159,7 @@ describe('todo delete GitHub sync', () => {
     // Reproduces the "Cannot delete todo: failed to look up remote file" bug —
     // a stale local row whose remote was already deleted should not be stuck
     // forever. Pull won't re-import a file that doesn't exist anymore.
-    (GitHubService.getFileSha as jest.Mock).mockResolvedValueOnce(null);
+    (GitHubService.getFileSha as jest.Mock).mockResolvedValueOnce({ kind: 'not-found' });
 
     const stale = {
       id: 'todo-stale',

--- a/src/components/MoveNoteDialog.tsx
+++ b/src/components/MoveNoteDialog.tsx
@@ -296,7 +296,7 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
         return;
       }
 
-      const sha = await GitHubService.getFileSha(
+      const sha = await GitHubService.getFileShaOrNull(
         repoInfo.owner, repoInfo.repo, note.filePath, note.branch || undefined,
       );
       if (!sha) {
@@ -344,7 +344,7 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
       );
       if (content === null) return;
 
-      const sha = await GitHubService.getFileSha(
+      const sha = await GitHubService.getFileShaOrNull(
         repoInfo.owner, repoInfo.repo, itemPath, note?.branch || undefined,
       );
       if (!sha) return;

--- a/src/components/RepoFileBrowser.tsx
+++ b/src/components/RepoFileBrowser.tsx
@@ -41,7 +41,11 @@ async function deleteFolderRecursive(
     if (item.type === 'dir') {
       await deleteFolderRecursive(owner, repo, item.path, branch);
     } else if (item.type === 'file' && item.sha) {
-      await GitHubService.deleteFile(owner, repo, item.path, `Delete ${item.path}`, item.sha, branch);
+      try {
+        await GitHubService.deleteFile(owner, repo, item.path, `Delete ${item.path}`, item.sha, branch);
+      } catch (deleteError) {
+        console.warn('[RepoFileBrowser] folder cleanup failed:', deleteError);
+      }
     }
   }
 }
@@ -62,9 +66,13 @@ async function moveFolderRecursive(
       if (fileContent === null) continue;
       const newPath = item.path.replace(oldBase, newBase);
       await GitHubService.createFile(owner, repo, newPath, fileContent, `Move ${item.path} to ${newPath}`, branch);
-      const sha = await GitHubService.getFileSha(owner, repo, item.path, branch);
+      const sha = await GitHubService.getFileShaOrNull(owner, repo, item.path, branch);
       if (sha) {
-        await GitHubService.deleteFile(owner, repo, item.path, `Remove old ${item.path}`, sha, branch);
+        try {
+          await GitHubService.deleteFile(owner, repo, item.path, `Remove old ${item.path}`, sha, branch);
+        } catch (cleanupError) {
+          console.warn('[RepoFileBrowser] move cleanup failed:', cleanupError);
+        }
       }
     }
   }

--- a/src/components/repo/RepoTreeItem.tsx
+++ b/src/components/repo/RepoTreeItem.tsx
@@ -70,7 +70,7 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
           Alert.alert('Error', 'Could not read file content.');
           return;
         }
-        const sha = await GitHubService.getFileSha(owner, repo, oldPath, branch);
+        const sha = await GitHubService.getFileShaOrNull(owner, repo, oldPath, branch);
         const moved = await GitHubService.moveFile(owner, repo, oldPath, newPath, content, `Rename: ${oldPath} → ${newPath}`, sha || '', branch || 'main');
         if (!moved) {
           Alert.alert('Error', 'Failed to rename file.');
@@ -97,7 +97,7 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
           Alert.alert('Error', 'Could not read file content.');
           return;
         }
-        const sha = await GitHubService.getFileSha(owner, repo, oldPath, branch);
+        const sha = await GitHubService.getFileShaOrNull(owner, repo, oldPath, branch);
         const moved = await GitHubService.moveFile(owner, repo, oldPath, newPath, content, `Move: ${oldPath} → ${newPath}`, sha || '', branch || 'main');
         if (!moved) {
           Alert.alert('Error', 'Failed to move file.');
@@ -125,7 +125,7 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
             if (isDir) {
               await deleteDirectory(owner, repo, branch, node.path);
             } else {
-              const sha = await GitHubService.getFileSha(owner, repo, node.path, branch);
+              const sha = await GitHubService.getFileShaOrNull(owner, repo, node.path, branch);
               if (sha) {
                 await GitHubService.deleteFile(owner, repo, node.path, `Delete: ${node.path}`, sha, branch || 'main');
               }

--- a/src/components/repo/repoTreeShared.ts
+++ b/src/components/repo/repoTreeShared.ts
@@ -101,7 +101,7 @@ export async function moveDirectory(
     } else {
       const content = await GitHubService.getFileContent(owner, repo, item.path, branch);
       if (content === null) continue;
-      const sha = await GitHubService.getFileSha(owner, repo, item.path, branch);
+      const sha = await GitHubService.getFileShaOrNull(owner, repo, item.path, branch);
       await GitHubService.moveFile(
         owner,
         repo,
@@ -115,12 +115,16 @@ export async function moveDirectory(
     }
   }
 
-  const oldSha = await GitHubService.getFileSha(owner, repo, oldDirPath, branch);
+  const oldSha = await GitHubService.getFileShaOrNull(owner, repo, oldDirPath, branch);
   if (oldSha) {
     const gitkeepPath = `${oldDirPath}/.gitkeep`;
-    const gitkeepSha = await GitHubService.getFileSha(owner, repo, gitkeepPath, branch);
+    const gitkeepSha = await GitHubService.getFileShaOrNull(owner, repo, gitkeepPath, branch);
     if (gitkeepSha) {
-      await GitHubService.deleteFile(owner, repo, gitkeepPath, `Clean up: ${gitkeepPath}`, gitkeepSha, targetBranch);
+      try {
+        await GitHubService.deleteFile(owner, repo, gitkeepPath, `Clean up: ${gitkeepPath}`, gitkeepSha, targetBranch);
+      } catch (cleanupError) {
+        console.warn('[repoTreeShared] gitkeep cleanup failed:', cleanupError);
+      }
     }
   }
 }
@@ -138,9 +142,13 @@ export async function deleteDirectory(
     if (item.type === 'dir') {
       await deleteDirectory(owner, repo, branch, item.path);
     } else {
-      const sha = await GitHubService.getFileSha(owner, repo, item.path, branch);
+      const sha = await GitHubService.getFileShaOrNull(owner, repo, item.path, branch);
       if (sha) {
-        await GitHubService.deleteFile(owner, repo, item.path, `Delete: ${item.path}`, sha, targetBranch);
+        try {
+          await GitHubService.deleteFile(owner, repo, item.path, `Delete: ${item.path}`, sha, targetBranch);
+        } catch (deleteError) {
+          console.warn('[repoTreeShared] delete failed:', deleteError);
+        }
       }
     }
   }

--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -4,6 +4,7 @@ import { StorageService } from '../services/StorageService';
 import { NotificationService } from '../services/NotificationService';
 import { useTodoStore } from '../stores/todoStore';
 import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
+import { formatSyncError } from '../services/git/formatSyncError';
 
 interface TodoContextValue {
   todos: Todo[];
@@ -120,7 +121,7 @@ export function useTodos(): TodoContextValue {
         todo: finalTodo,
       });
       if (!syncResult.success) {
-        console.warn('[TodoContext] GitHub sync failed:', syncResult.error);
+        console.warn('[TodoContext] GitHub sync failed:', formatSyncError(syncResult.error, 'upsert'));
       }
     }
 

--- a/src/hooks/useGitHubQueries.ts
+++ b/src/hooks/useGitHubQueries.ts
@@ -79,7 +79,7 @@ export function useGitHubUser() {
 export function useGitHubFileSha(owner: string, repo: string, path: string, branch?: string) {
   return useQuery({
     queryKey: ['github', 'sha', owner, repo, path, branch],
-    queryFn: () => GitHubService.getFileSha(owner, repo, path, branch),
+    queryFn: () => GitHubService.getFileShaOrNull(owner, repo, path, branch),
     staleTime: Infinity,
   });
 }

--- a/src/services/CanvasGitHubSyncService.ts
+++ b/src/services/CanvasGitHubSyncService.ts
@@ -140,11 +140,15 @@ export async function deleteCanvasFromGitHub(params: {
   }
 
   try {
-    // sha-null = remote already gone. Treat as success so the local row can
-    // delete cleanly; pull won't re-import a file that doesn't exist.
-    const sha = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, filePath, targetBranch, opts);
-    if (!sha) {
+    // not-found = remote already gone, treat as success so the local
+    // row deletes cleanly. error = couldn't reach GitHub, hold the row
+    // (#567 fix A) so the next pull doesn't re-import the upstream copy.
+    const lookup = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, filePath, targetBranch, opts);
+    if (lookup.kind === 'not-found') {
       return { success: true, filePath };
+    }
+    if (lookup.kind === 'error') {
+      return { success: false, error: lookup.message };
     }
 
     const result = await GitHubService.deleteFile(
@@ -152,7 +156,7 @@ export async function deleteCanvasFromGitHub(params: {
       repoInfo.repo,
       filePath,
       `Delete canvas: ${title || filePath}`,
-      sha,
+      lookup.sha,
       targetBranch,
       opts,
     );

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -152,6 +152,18 @@ export interface GitHubFileCommit {
   commit: { sha: string };
 }
 
+/**
+ * Tristate result of a sha lookup so callers can distinguish
+ * "definitely gone" from "couldn't tell". Critical for delete paths —
+ * see `deleteNoteFromGitHub`: when the lookup itself errors we must
+ * propagate so the local row stays put, otherwise the next pull
+ * resurrects the file we thought we'd cleaned up.
+ */
+export type ShaResult =
+  | { kind: 'found'; sha: string }
+  | { kind: 'not-found' }
+  | { kind: 'error'; status?: number; message: string };
+
 class GitHubServiceClass {
   private token: string | null = null;
   private user: GitHubUser | null = null;
@@ -355,22 +367,53 @@ class GitHubServiceClass {
     }
   }
 
+  /**
+   * Typed sha lookup so callers can distinguish "remote file is gone"
+   * (delete should soft-succeed) from "we couldn't reach GitHub" (delete
+   * must NOT short-circuit, otherwise the local row vanishes while the
+   * upstream copy lingers and gets re-synced on the next pull).
+   *
+   * `getFileShaOrNull` keeps the legacy `string | null` shape for the
+   * upsert paths that just need a sha-or-create decision.
+   */
   async getFileSha(
     owner: string,
     repo: string,
     path: string,
     ref?: string,
     opts?: TokenOpts,
-  ): Promise<string | null> {
+  ): Promise<ShaResult> {
     try {
       const encodedPath = path.split('/').map(encodeURIComponent).join('/');
       let url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
       if (ref) url += `?ref=${encodeURIComponent(ref)}`;
       const data = await this.request(url, 'GET', undefined, opts);
-      return data.sha || null;
-    } catch (error) { void error;
-      return null;
+      if (data?.sha) return { kind: 'found', sha: data.sha };
+      return { kind: 'not-found' };
+    } catch (error) {
+      const status = (error as { status?: number })?.status;
+      const message = error instanceof Error ? error.message : String(error);
+      if (status === 404) return { kind: 'not-found' };
+      return { kind: 'error', status, message };
     }
+  }
+
+  /**
+   * Convenience wrapper that preserves the prior `string | null` shape
+   * for upsert call sites (they only care about "exists, give me the
+   * sha" vs "create new"). Errors collapse to null here just like the
+   * old behavior — deletes go through `getFileSha` and handle the typed
+   * result themselves.
+   */
+  async getFileShaOrNull(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+    opts?: TokenOpts,
+  ): Promise<string | null> {
+    const result = await this.getFileSha(owner, repo, path, ref, opts);
+    return result.kind === 'found' ? result.sha : null;
   }
 
   async createFile(
@@ -413,7 +456,7 @@ class GitHubServiceClass {
     const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
 
     for (let attempt = 0; attempt < 3; attempt++) {
-      const existingSha = await this.getFileSha(owner, repo, path, branch);
+      const existingSha = await this.getFileShaOrNull(owner, repo, path, branch);
       try {
         const body: Record<string, string> = {
           message,
@@ -440,6 +483,18 @@ class GitHubServiceClass {
     return null;
   }
 
+  /**
+   * Delete a remote file with bounded retries. The 409 path mirrors the
+   * `updateFile` recovery loop — when the upstream sha drifts mid-flight
+   * we re-fetch it and re-DELETE up to 3 attempts. Transient network
+   * failures get one extra retry with backoff so flaky cellular doesn't
+   * leave a half-deleted note (#567 fix B).
+   *
+   * Throws on terminal failure so callers can distinguish "could not
+   * delete" from "deleted nothing because already gone" — matters for
+   * the typed sha gating in `deleteNoteFromGitHub`. Pre-existing callers
+   * that want the legacy null-on-failure shape should wrap in try/catch.
+   */
   async deleteFile(
     owner: string,
     repo: string,
@@ -449,14 +504,55 @@ class GitHubServiceClass {
     branch: string = 'main',
     opts?: TokenOpts,
   ): Promise<GitHubFileCommit | null> {
-    try {
-      const encodedPath = path.split('/').map(encodeURIComponent).join('/');
-      const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
-      return await this.request(url, 'DELETE', { message, sha, branch }, opts);
-    } catch (error) {
-      console.warn('[GitHubService] Failed to delete file:', error);
-      return null;
+    const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+    const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
+
+    let currentSha = sha;
+    let networkRetried = false;
+    let lastError: unknown = null;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        return await this.request(url, 'DELETE', { message, sha: currentSha, branch }, opts);
+      } catch (error) {
+        lastError = error;
+        const status = (error as { status?: number })?.status;
+
+        if (status === 404) {
+          // Already gone upstream — synthetic success so callers can
+          // treat the deletion as complete.
+          return { content: null, commit: { sha: '' } };
+        }
+
+        if (status === 409 && attempt < 2) {
+          const refreshed = await this.getFileSha(owner, repo, path, branch, opts);
+          if (refreshed.kind === 'not-found') {
+            return { content: null, commit: { sha: '' } };
+          }
+          if (refreshed.kind === 'found') {
+            currentSha = refreshed.sha;
+            continue;
+          }
+          // refresh itself errored — bubble up so caller doesn't soft-succeed.
+          throw new Error(refreshed.message);
+        }
+
+        if (!status && !networkRetried && attempt < 2) {
+          networkRetried = true;
+          await new Promise<void>((resolve) => setTimeout(resolve, attempt === 0 ? 250 : 1000));
+          continue;
+        }
+
+        // No retry path applies (or we exhausted attempts). Bubble out so
+        // the delete sync helper can hold the local row.
+        console.warn('[GitHubService] Failed to delete file:', error);
+        throw error instanceof Error ? error : new Error(String(error));
+      }
     }
+    if (lastError) {
+      throw lastError instanceof Error ? lastError : new Error(String(lastError));
+    }
+    return null;
   }
 
   async createFolder(
@@ -489,7 +585,7 @@ class GitHubServiceClass {
 
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
-        const sha = await this.getFileSha(owner, repo, path, branch, opts);
+        const sha = await this.getFileShaOrNull(owner, repo, path, branch, opts);
         if (!sha) {
           return this.createFile(owner, repo, path, content, message, branch, opts);
         }
@@ -525,7 +621,14 @@ class GitHubServiceClass {
   ): Promise<boolean> {
     const createResult = await this.createFile(owner, repo, newPath, content, message, branch, opts);
     if (!createResult) return false;
-    await this.deleteFile(owner, repo, oldPath, message, oldSha, branch, opts);
+    try {
+      await this.deleteFile(owner, repo, oldPath, message, oldSha, branch, opts);
+    } catch (error) {
+      // Move semantics: the new path landed; failing to clean up the old
+      // path leaves a duplicate but is not catastrophic. Surface the
+      // failure in logs so it can be retried via the file browser.
+      console.warn('[GitHubService] moveFile cleanup failed for', oldPath, error);
+    }
     return true;
   }
 

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -319,9 +319,21 @@ export async function deleteNoteFromGitHub(params: {
   }
 
   try {
-    const sha = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, filePath, targetBranch, opts);
-    if (!sha) {
+    const lookup = await GitHubService.getFileSha(
+      repoInfo.owner,
+      repoInfo.repo,
+      filePath,
+      targetBranch,
+      opts,
+    );
+    if (lookup.kind === 'not-found') {
       return { success: true, filePath };
+    }
+    if (lookup.kind === 'error') {
+      // Sha lookup itself failed (network blip, 5xx, …). Do NOT
+      // soft-succeed — letting the local row delete here would let the
+      // upstream copy come back on the next pull (#567 fix A).
+      return { success: false, error: lookup.message };
     }
 
     const result = await GitHubService.deleteFile(
@@ -329,7 +341,7 @@ export async function deleteNoteFromGitHub(params: {
       repoInfo.repo,
       filePath,
       `Delete note: ${title || filePath}`,
-      sha,
+      lookup.sha,
       targetBranch,
       opts,
     );

--- a/src/services/RenderStyleService.ts
+++ b/src/services/RenderStyleService.ts
@@ -75,7 +75,7 @@ export class RenderStyleService {
     await Promise.all(
       repos.map(async (repo) => {
         try {
-          const sha = await GitHubService.getFileSha(
+          const sha = await GitHubService.getFileShaOrNull(
             repo.owner.login,
             repo.name,
             RENDER_STYLE_PATH,

--- a/src/services/TemplateGitHubSyncService.ts
+++ b/src/services/TemplateGitHubSyncService.ts
@@ -99,11 +99,17 @@ export async function deleteTemplateFromGitHub(params: {
 
   let resolvedSha = sha;
   if (!resolvedSha) {
-    resolvedSha = (await GitHubService.getFileSha(info.owner, info.repo, filePath, branch)) ?? undefined;
-    if (!resolvedSha) {
+    const lookup = await GitHubService.getFileSha(info.owner, info.repo, filePath, branch);
+    if (lookup.kind === 'not-found') {
       // File already gone on the remote — treat as success.
       return { success: true, filePath };
     }
+    if (lookup.kind === 'error') {
+      // Don't drop the local row — we couldn't tell if the upstream
+      // copy still exists. Surface so caller can retry / queue.
+      return { success: false, error: lookup.message };
+    }
+    resolvedSha = lookup.sha;
   }
 
   try {

--- a/src/services/TodoGitHubSyncService.ts
+++ b/src/services/TodoGitHubSyncService.ts
@@ -156,11 +156,15 @@ export async function deleteTodoFromGitHub(params: {
   }
 
   try {
-    // sha-null = remote already gone. Treat as success so the local row can
-    // delete cleanly; pull won't re-import a file that doesn't exist.
-    const sha = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, filePath, targetBranch, opts);
-    if (!sha) {
+    // not-found = remote already gone, treat as success so the local
+    // row deletes cleanly. error = couldn't reach GitHub, hold the row
+    // (#567 fix A) so the next pull doesn't re-import the upstream copy.
+    const lookup = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, filePath, targetBranch, opts);
+    if (lookup.kind === 'not-found') {
       return { success: true, filePath };
+    }
+    if (lookup.kind === 'error') {
+      return { success: false, error: lookup.message };
     }
 
     const result = await GitHubService.deleteFile(
@@ -168,7 +172,7 @@ export async function deleteTodoFromGitHub(params: {
       repoInfo.repo,
       filePath,
       `Delete todo: ${text || filePath}`,
-      sha,
+      lookup.sha,
       targetBranch,
       opts,
     );

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -3,6 +3,8 @@ import git from 'isomorphic-git';
 import { parseRepoPath } from '../../utils/gitPathParser';
 import { makeGitFs as buildGitFs } from './gitFs';
 import { gitHttp } from './gitHttp';
+import { formatSyncError } from './formatSyncError';
+import { GitFsService } from './GitFsService';
 
 const CLONES_SUBDIR = 'GitNotes/';
 
@@ -122,28 +124,28 @@ async function ensureOnBranch(
 }
 
 /**
- * Best-effort prettifier for the wall-of-text isomorphic-git produces on
- * `git.push` failures. The raw text (`One or more branches were not
- * updated: - refs/heads/master: cannot lock ref ...`) leaks server
- * internals into the user-facing banner; we keep the raw message in the
- * console log and surface a one-line summary to callers.
+ * Backwards-compatible thin re-export of the shared sanitizer. New
+ * callers should use `formatSyncError` directly from
+ * `services/git/formatSyncError`; this wrapper keeps the existing import
+ * path in `noteStore` working without a refactor cascade.
  */
 export function summarizePushError(raw: string | undefined): string {
-  if (!raw) return 'Sync to GitHub failed';
-  const message = raw.toLowerCase();
-  if (message.includes('cannot lock ref')) {
-    return 'Sync to GitHub failed: branch is locked on the remote. Check your branch settings.';
-  }
-  if (message.includes('one or more branches were not updated')) {
-    return 'Sync to GitHub failed: the remote rejected the update. Pull and try again.';
-  }
-  if (message.includes('not authorized') || message.includes('401') || message.includes('403')) {
-    return 'Sync to GitHub failed: not authorized. Re-link your GitHub account.';
-  }
-  if (message.includes('network') || message.includes('fetch')) {
-    return 'Sync to GitHub failed: network error.';
-  }
-  return 'Sync to GitHub failed';
+  return formatSyncError(raw);
+}
+
+/**
+ * Detects the family of push errors isomorphic-git surfaces when the
+ * remote rejects a non-fast-forward push. Used to decide when to
+ * pull-and-retry inside `deleteAndCommit`.
+ */
+function isPushRejected(raw: string): boolean {
+  const m = raw.toLowerCase();
+  return (
+    m.includes('push rejected') ||
+    m.includes('not a simple fast-forward') ||
+    m.includes('non-fast-forward') ||
+    m.includes('one or more branches were not updated')
+  );
 }
 
 export class LocalGitWriter {
@@ -178,14 +180,36 @@ export class LocalGitWriter {
       });
 
       if (opts.push !== false) {
-        await git.push({
-          fs,
-          dir,
-          http: gitHttp,
-          ref: opts.branch,
-          remoteRef: opts.branch,
-          onAuth: tokenAuth(opts.token),
-        });
+        try {
+          await git.push({
+            fs,
+            dir,
+            http: gitHttp,
+            ref: opts.branch,
+            remoteRef: opts.branch,
+            onAuth: tokenAuth(opts.token),
+          });
+        } catch (pushError) {
+          // Same pull-then-retry shape as deleteAndCommit: when the
+          // remote rejects as non-fast-forward, pull once and try the
+          // push again. Doesn't re-stage / re-write — the local commit
+          // is already made and a clean fast-forward will replay it.
+          const raw = pushError instanceof Error ? pushError.message : String(pushError);
+          if (!isPushRejected(raw)) throw pushError;
+          await GitFsService.pullWithFastForward({
+            repoPath: opts.repoPath,
+            branch: opts.branch,
+            token: opts.token,
+          });
+          await git.push({
+            fs,
+            dir,
+            http: gitHttp,
+            ref: opts.branch,
+            remoteRef: opts.branch,
+            onAuth: tokenAuth(opts.token),
+          });
+        }
       }
 
       return { success: true, filePath: opts.filePath };
@@ -197,8 +221,14 @@ export class LocalGitWriter {
   }
 
   /**
-   * Remove a tracked file from the working tree, stage + commit, optionally
-   * push.
+   * Remove a tracked file from the working tree, stage + commit,
+   * optionally push. Pulls upstream first so the delete commit lands on
+   * top of any concurrent edits — otherwise the push gets rejected as
+   * non-fast-forward and the local row gets stranded (#567 fix C, the
+   * single most common clone-mode delete failure).
+   *
+   * Push gets one auto-retry after a fresh pull when the server returns
+   * a fast-forward / push-rejected error.
    */
   static async deleteAndCommit(opts: DeleteOpts): Promise<LocalGitWriterResult> {
     const info = parseRepoPath(opts.repoPath);
@@ -211,10 +241,35 @@ export class LocalGitWriter {
     try {
       await ensureOnBranch(fs, dir, opts.branch, opts.token);
 
+      // Best-effort pull so we delete from the latest tree state. Diverged
+      // local commits keep the existing path (commit lands locally and
+      // push will retry with a stricter error if the server rejects).
+      try {
+        await GitFsService.pullWithFastForward({
+          repoPath: opts.repoPath,
+          branch: opts.branch,
+          token: opts.token,
+        });
+      } catch (pullError) {
+        console.warn('[LocalGitWriter] deleteAndCommit pull failed (continuing):', pullError);
+      }
+
       const absUri = `${fsRoot}${info.owner}/${info.repo}/${opts.filePath}`;
       await FileSystem.deleteAsync(absUri, { idempotent: true });
 
-      await git.remove({ fs, dir, filepath: opts.filePath });
+      // git.remove can fail when the path moved upstream / was already
+      // removed in a fresh pull. Treat NotFoundError as a no-op and
+      // short-circuit; the file is already gone, deletion is complete.
+      try {
+        await git.remove({ fs, dir, filepath: opts.filePath });
+      } catch (removeError) {
+        const code = (removeError as { code?: string }).code;
+        if (code === 'NotFoundError' || code === 'ENOENT') {
+          return { success: true, filePath: opts.filePath };
+        }
+        throw removeError;
+      }
+
       await git.commit({
         fs,
         dir,
@@ -223,14 +278,35 @@ export class LocalGitWriter {
       });
 
       if (opts.push !== false) {
-        await git.push({
-          fs,
-          dir,
-          http: gitHttp,
-          ref: opts.branch,
-          remoteRef: opts.branch,
-          onAuth: tokenAuth(opts.token),
-        });
+        try {
+          await git.push({
+            fs,
+            dir,
+            http: gitHttp,
+            ref: opts.branch,
+            remoteRef: opts.branch,
+            onAuth: tokenAuth(opts.token),
+          });
+        } catch (pushError) {
+          const raw = pushError instanceof Error ? pushError.message : String(pushError);
+          if (!isPushRejected(raw)) throw pushError;
+          // Pull again and retry push exactly once. Anything still
+          // refusing means the upstream truly diverged and the user
+          // needs to reconcile manually — propagate.
+          await GitFsService.pullWithFastForward({
+            repoPath: opts.repoPath,
+            branch: opts.branch,
+            token: opts.token,
+          });
+          await git.push({
+            fs,
+            dir,
+            http: gitHttp,
+            ref: opts.branch,
+            remoteRef: opts.branch,
+            onAuth: tokenAuth(opts.token),
+          });
+        }
       }
 
       return { success: true, filePath: opts.filePath };

--- a/src/services/git/formatSyncError.ts
+++ b/src/services/git/formatSyncError.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared sanitizer for raw sync errors surfaced to the user. Both the
+ * isomorphic-git push path (LocalGitWriter) and the GitHub Contents-API
+ * path (Note/Todo/Canvas/Template sync services) leak wall-of-text errors
+ * with refs, ANSI codes, force-flag hints, etc. We map the common cases
+ * to one-line user-facing strings and strip jargon from anything that
+ * doesn't match a known matcher so the snackbar never shows raw stderr.
+ *
+ * Keep the raw text in `console.warn` at the call site — this helper is
+ * for the visible UI surface only.
+ */
+
+export type SyncOp = 'upsert' | 'delete';
+
+interface Matcher {
+  /** Case-insensitive substrings; any one matching wins. */
+  needles: string[];
+  message: string;
+}
+
+const MATCHERS: Matcher[] = [
+  {
+    needles: ['push rejected', 'not a simple fast-forward', 'non-fast-forward', 'one or more branches were not updated'],
+    message: 'Someone else changed this on GitHub. Pull and try again.',
+  },
+  {
+    needles: ['cannot lock ref'],
+    message: 'Branch is locked on GitHub. Check branch protection rules.',
+  },
+  {
+    needles: ['bad credentials', '401', 'not authorized'],
+    message: 'Sign in to GitHub again.',
+  },
+  {
+    needles: ['rate limit', '403'],
+    message: 'GitHub rate limit hit — try again in a few minutes.',
+  },
+  {
+    needles: ['409'],
+    message: 'This file changed on GitHub. Pull and try again.',
+  },
+  {
+    needles: ['422'],
+    message: 'GitHub rejected the change. Try again.',
+  },
+  {
+    needles: ['500', '502', '503', '504'],
+    message: 'GitHub is having trouble — will retry.',
+  },
+  {
+    needles: ['network', 'fetch', 'econn', 'timeout', 'offline'],
+    message: "No connection. Will retry when you're back online.",
+  },
+];
+
+function fallbackFor(op?: SyncOp): string {
+  if (op === 'delete') return "Couldn't delete from GitHub";
+  return 'Sync to GitHub failed';
+}
+
+/**
+ * Strips the noisy bits isomorphic-git / axios bake into raw error text
+ * before we run substring matching. Order matters: ANSI first, then
+ * structural (Error: prefix, ref names, "force: true" hint), then trim.
+ */
+function stripJargon(raw: string): string {
+  let out = raw;
+  // ANSI escape codes (e.g., \x1b[31m).
+  // eslint-disable-next-line no-control-regex
+  out = out.replace(/\x1b\[[0-9;]*m/g, '');
+  // Repeated "Error: " prefixes.
+  out = out.replace(/^(Error:\s*)+/i, '');
+  // Hint that surfaces in PushRejectedError text.
+  out = out.replace(/Use\s+["']?force:\s*true["']?\s*to\s+override\.?/gi, '');
+  // refs/heads/<branch> — rarely meaningful to users.
+  out = out.replace(/refs\/heads\/\S+/g, '');
+  // Stack-trace–looking parens with file paths, e.g. "(src/foo/bar.ts:12:34)".
+  out = out.replace(/\(\/?[^\s()]+\.[a-z]+:\d+:?\d*\)/gi, '');
+  return out.replace(/\s{2,}/g, ' ').trim();
+}
+
+export function formatSyncError(raw: string | undefined, op?: SyncOp): string {
+  if (!raw) return fallbackFor(op);
+  const cleaned = stripJargon(raw);
+  const haystack = cleaned.toLowerCase();
+  for (const matcher of MATCHERS) {
+    if (matcher.needles.some((n) => haystack.includes(n))) {
+      return matcher.message;
+    }
+  }
+  return fallbackFor(op);
+}

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -3,6 +3,7 @@ import { Canvas, CanvasCreateInput, CanvasUpdateInput, sortCanvasesByUpdated } f
 import { StorageService } from '../services/StorageService';
 import { GitHubService } from '../services/GitHubService';
 import { deleteCanvasFromGitHub } from '../services/CanvasGitHubSyncService';
+import { formatSyncError } from '../services/git/formatSyncError';
 
 interface CanvasState {
   canvases: Canvas[];
@@ -88,7 +89,8 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()((set, get) =
           accountId: canvas.accountId,
         });
         if (!remote.success) {
-          set({ error: remote.error || 'Failed to delete from GitHub' });
+          if (remote.error) console.warn('[CanvasStore] delete sync failed:', remote.error);
+          set({ error: formatSyncError(remote.error, 'delete') });
           return false;
         }
       }

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -4,7 +4,8 @@ import { Note, NoteCreateInput, NoteUpdateInput, sortNotesWithPinnedFirst, filte
 import { StorageService } from '../services/StorageService';
 import { deleteNoteFromGitHub } from '../services/NoteGitHubSyncService';
 import { GitHubService } from '../services/GitHubService';
-import { summarizePushError } from '../services/git/LocalGitWriter';
+import { formatSyncError } from '../services/git/formatSyncError';
+import { slugifyLocal, getExtensionForFormat } from '../components/editor/editorShared';
 
 interface NoteState {
   notes: Note[];
@@ -24,6 +25,14 @@ interface NoteActions {
   togglePin: (id: string) => Promise<boolean>;
   refreshNotes: () => Promise<void>;
   clearError: () => void;
+}
+
+function deriveDefaultNotePath(note: Note): string | null {
+  const title = (note.title ?? '').trim();
+  if (!title) return null;
+  const slug = slugifyLocal(title);
+  const ext = getExtensionForFormat(note.format);
+  return note.folderPath ? `${note.folderPath}/${slug}${ext}` : `notes/${slug}${ext}`;
 }
 
 export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
@@ -95,22 +104,33 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
       set({ error: null });
 
       const note = get().notes.find((n) => n.id === id);
-      if (note?.repo && note.filePath) {
+      if (note?.repo) {
         if (!GitHubService.isAuthenticated()) {
           set({ error: 'Sign in to GitHub to delete synced notes' });
           return false;
         }
-        const remote = await deleteNoteFromGitHub({
-          repo: note.repo,
-          branch: note.branch,
-          filePath: note.filePath,
-          title: note.title,
-          accountId: note.accountId,
-        });
-        if (!remote.success) {
-          if (remote.error) console.warn('[NoteStore] delete sync failed:', remote.error);
-          set({ error: summarizePushError(remote.error) });
-          return false;
+
+        // Recover from the case where the note synced but the response
+        // never landed (so `filePath` is unset locally) by deriving the
+        // canonical path from title + folder + format. The same shape is
+        // produced by `useNoteEditorDocument` when first uploading; if no
+        // such file exists upstream, deleteNoteFromGitHub treats sha-null
+        // as success and the row drops cleanly.
+        const filePath = note.filePath ?? deriveDefaultNotePath(note);
+
+        if (filePath) {
+          const remote = await deleteNoteFromGitHub({
+            repo: note.repo,
+            branch: note.branch,
+            filePath,
+            title: note.title,
+            accountId: note.accountId,
+          });
+          if (!remote.success) {
+            if (remote.error) console.warn('[NoteStore] delete sync failed:', remote.error);
+            set({ error: formatSyncError(remote.error, 'delete') });
+            return false;
+          }
         }
       }
 

--- a/src/stores/templateStore.ts
+++ b/src/stores/templateStore.ts
@@ -7,6 +7,7 @@ import {
   deleteTemplateFromGitHub,
 } from '../services/TemplateGitHubSyncService';
 import { generateId } from '../utils/ids';
+import { formatSyncError } from '../services/git/formatSyncError';
 
 interface TemplateState {
   customTemplates: NoteTemplate[];
@@ -54,7 +55,7 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
       if (result.success && result.filePath) {
         synced = { ...template, filePath: result.filePath };
       } else if (!result.success) {
-        console.warn(`[templateStore] Failed to sync template "${template.name}" to GitHub: ${result.error ?? 'unknown error'}`);
+        console.warn(`[templateStore] Failed to sync template "${template.name}" to GitHub: ${formatSyncError(result.error, 'upsert')}`);
       }
     }
 
@@ -80,7 +81,7 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
       if (result.success && result.filePath) {
         merged.filePath = result.filePath;
       } else if (!result.success) {
-        console.warn(`[templateStore] Failed to sync template "${merged.name}" to GitHub: ${result.error ?? 'unknown error'}`);
+        console.warn(`[templateStore] Failed to sync template "${merged.name}" to GitHub: ${formatSyncError(result.error, 'upsert')}`);
       }
     }
 
@@ -102,7 +103,7 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
         name: template.name,
       });
       if (!delResult.success) {
-        console.warn(`[templateStore] Failed to delete template "${template.name}" from GitHub: ${delResult.error ?? 'unknown error'}`);
+        console.warn(`[templateStore] Failed to delete template "${template.name}" from GitHub: ${formatSyncError(delResult.error, 'delete')}`);
       }
     }
 

--- a/src/stores/todoStore.ts
+++ b/src/stores/todoStore.ts
@@ -3,6 +3,7 @@ import { Todo, TodoCreateInput, TodoUpdateInput, reorderTodos } from '../models/
 import { StorageService } from '../services/StorageService';
 import { GitHubService } from '../services/GitHubService';
 import { deleteTodoFromGitHub } from '../services/TodoGitHubSyncService';
+import { formatSyncError } from '../services/git/formatSyncError';
 
 interface TodoState {
   todos: Todo[];
@@ -88,7 +89,8 @@ export const useTodoStore = create<TodoState & TodoActions>()((set, get) => ({
           text: todoToDelete!.text,
         });
         if (!remote.success) {
-          set({ error: remote.error || 'Failed to delete from GitHub' });
+          if (remote.error) console.warn('[TodoStore] delete sync failed:', remote.error);
+          set({ error: formatSyncError(remote.error, 'delete') });
           return false;
         }
       }


### PR DESCRIPTION
## Summary

- **Sanitizer (#568)**: extracted `summarizePushError` into a shared `formatSyncError(raw, op)` at `src/services/git/formatSyncError.ts`. Adds matchers for the current isomorphic-git messages (push rejected, cannot lock ref, 401/403/409/422/5xx, network/offline) and strips ANSI codes, "force: true" hints, `refs/heads/*`, and stack traces before matching. Wired into `noteStore`, `todoStore`, `canvasStore`, `templateStore`, and `TodoContext` so raw remote errors never leak into the snackbar.
- **Typed `getFileSha` (#567 fix A)**: returns `{ kind: 'found' | 'not-found' | 'error' }`. Delete sync helpers (`deleteNoteFromGitHub`, `deleteCanvasFromGitHub`, `deleteTodoFromGitHub`, `deleteTemplateFromGitHub`) now distinguish "remote already gone" (soft-success) from "couldn't reach GitHub" (hold the local row so the next pull doesn't re-import the upstream copy). Upsert/move call sites use a thin `getFileShaOrNull` shim to preserve their `string | null` shape.
- **`deleteFile` retry loop (#567 fix B)**: mirrors the 409 recovery in `updateFile` — refresh sha and retry up to 3 attempts, plus one network-error retry with 250ms / 1s backoff. 404 still soft-succeeds. Throws on terminal failure so callers can hold the local row.
- **Pull-before-delete (#567 fix C)**: `LocalGitWriter.deleteAndCommit` now fast-forwards before staging, so the delete commit lands on top of concurrent edits instead of getting rejected non-fast-forward. Push gets one auto-retry after a fresh pull on PushRejectedError. `git.remove`'s NotFoundError treats the file as already gone. Same push-retry pattern added to `writeAndCommit` (no pre-pull there; conservative).
- **Missing-filePath delete (#567 fix D, option 2)**: when a synced note has no local `filePath` (response was lost), derive the canonical upstream path from `slugify(title) + folderPath + extension` (the same shape `useNoteEditorDocument` uses on upload) and route through the typed sha lookup. Avoids stranding the local row.

## Closes

- Closes #567
- Closes #568

## Test plan

- [ ] **Clone-mode delete (Fix C)**: with two devices on the same branch, edit + push from device A while device B has a stale clone, then delete a note on device B. Pre-fix this PushRejectedError stranded the row; now the delete should land after the auto pull/retry.
- [ ] **Typed sha — missing file**: stub `getFileSha` to return `{ kind: 'not-found' }` (or simulate by deleting the upstream file out-of-band). Local delete should soft-succeed.
- [ ] **Typed sha — network error**: kill connectivity mid-delete. Local row must stay; snackbar shows "No connection. Will retry when you're back online." Pull should not re-import.
- [ ] **Delete 409 retry (Fix B)**: simulate a sha mismatch on `DELETE` (e.g., concurrent edit). After retry the delete should succeed without surfacing the raw 409 to the user.
- [ ] **Sanitizer**: trigger a raw `One or more branches were not updated: refs/heads/master: cannot lock ref ... Use "force: true" to override.` error path. Snackbar must read "Branch is locked on GitHub. Check branch protection rules." with no ref name, no "force: true" string, no ANSI bytes.
- [ ] **Missing-filePath note delete (Fix D)**: create a note where the sync upload completes but the filePath response is dropped (set the note's `filePath` to undefined manually). Delete should still purge upstream by deriving the path from title + folder + format.

## Verification run on this branch

- `yarn ts:check` — clean
- `yarn lint --quiet` — clean
- `yarn test --runInBand` — 876/876 passing

## Notes / scope

- Did not touch Fix E (queue-on-failure surface) or Fix F (Sync Status screen) from #567 — both depend on #565 which is out of scope per the task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)