### PR TITLE
feat(sync): foreground & online auto-pull mitigation (#563)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -31,6 +31,8 @@ import { StartupSyncGate } from './src/components/StartupSyncGate';
 import { GitHubActivityIndicator } from './src/components/GitHubActivityIndicator';
 import { bootstrapStorage } from './src/services/StorageBootstrap';
 import { useRenderStyleStore } from './src/stores/renderStyleStore';
+import { startForegroundWatcher } from './src/services/ForegroundSyncService';
+import { loadForegroundSyncConfig } from './src/hooks/useForegroundSyncSettings';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const queryClient = new QueryClient({
@@ -52,6 +54,14 @@ export default function App() {
     const completed = await OnboardingService.isOnboardingCompleted();
     setShowOnboarding(!completed);
     await NotificationService.requestPermissions();
+    // Foreground auto-pull (#563): subscribe AppState/NetInfo/interval after
+    // storage is hydrated so the first pull sees the persisted repo list.
+    try {
+      const cfg = await loadForegroundSyncConfig();
+      startForegroundWatcher(cfg);
+    } catch (error) {
+      console.warn('[App] foreground sync watcher start failed:', error);
+    }
   }, []);
 
   useEffect(() => {

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -17,6 +17,7 @@ import type { GitRepository } from '../../services/GitService';
 import type { TemplateRepoPreference } from '../../services/TemplateRepoPreferenceService';
 import type { AIProviderConfig } from '../../models/AIProvider';
 import { TIMEOUT_OPTIONS, type BiometricKind, type LockTimeout } from '../../contexts/BiometricLockContext';
+import { SYNC_INTERVAL_OPTIONS, type SyncIntervalSeconds } from '../../hooks/useForegroundSyncSettings';
 
 type ThemeColors = {
   background: string;
@@ -95,6 +96,10 @@ type SettingsContentProps = {
   onSetLockTimeout: (v: LockTimeout) => void;
   isBackgroundSyncEnabled: boolean;
   onToggleBackgroundSync: () => void;
+  syncFrequentlyEnabled: boolean;
+  syncIntervalSeconds: SyncIntervalSeconds;
+  onToggleSyncFrequently: (value: boolean) => void;
+  onSetSyncIntervalSeconds: (value: SyncIntervalSeconds) => void;
 };
 
 export function SettingsContent(props: SettingsContentProps) {
@@ -152,11 +157,18 @@ export function SettingsContent(props: SettingsContentProps) {
     onSetLockTimeout,
     isBackgroundSyncEnabled,
     onToggleBackgroundSync,
+    syncFrequentlyEnabled,
+    syncIntervalSeconds,
+    onToggleSyncFrequently,
+    onSetSyncIntervalSeconds,
   } = props;
   const { t } = useTranslation();
   const [languagePref, setLanguagePref] = useState<string>('system');
   const [showTimeoutPicker, setShowTimeoutPicker] = useState(false);
   const [showLanguagePicker, setShowLanguagePicker] = useState(false);
+  const [showIntervalPicker, setShowIntervalPicker] = useState(false);
+  const intervalLabel =
+    SYNC_INTERVAL_OPTIONS.find((opt) => opt.value === syncIntervalSeconds)?.label ?? 'Every minute';
 
   useEffect(() => {
     getLanguagePreference().then(setLanguagePref);
@@ -457,7 +469,48 @@ export function SettingsContent(props: SettingsContentProps) {
         </GroupRow>
       </Group>
 
-      <Group title="Sync" footer="Periodically sync notes in the background (every 15 min).">
+      <Group
+        title="Sync"
+        footer={
+          syncFrequentlyEnabled
+            ? 'Pulls every tracked repo when the app comes to the foreground, when network reconnects, and on the chosen interval.'
+            : 'Still pulls when the app comes to the foreground or network reconnects, but skips the periodic interval.'
+        }
+      >
+        <GroupRow
+          trailing={
+            <Toggle
+              testID="sync-frequently-toggle"
+              value={syncFrequentlyEnabled}
+              onValueChange={onToggleSyncFrequently}
+            />
+          }
+        >
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+            <Ionicons name="sync-outline" size={20} color={colors.text} />
+            <Text style={[styles.settingLabel, { color: colors.text }]}>Sync frequently (recommended for multi-device)</Text>
+          </View>
+        </GroupRow>
+        <GroupRow
+          testID="sync-interval-row"
+          onPress={syncFrequentlyEnabled ? () => setShowIntervalPicker(true) : undefined}
+          disabled={!syncFrequentlyEnabled}
+          trailing={
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+              <Text style={[styles.settingValue, { color: colors.textSecondary }]}>{intervalLabel}</Text>
+              <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
+            </View>
+          }
+        >
+          <Text
+            style={[
+              styles.settingLabel,
+              { color: syncFrequentlyEnabled ? colors.text : colors.textSecondary },
+            ]}
+          >
+            Sync interval
+          </Text>
+        </GroupRow>
         <GroupRow
           trailing={
             <Toggle
@@ -468,8 +521,8 @@ export function SettingsContent(props: SettingsContentProps) {
           }
         >
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-            <Ionicons name="sync-outline" size={20} color={colors.text} />
-            <Text style={[styles.settingLabel, { color: colors.text }]}>Background Sync</Text>
+            <Ionicons name="cloud-download-outline" size={20} color={colors.text} />
+            <Text style={[styles.settingLabel, { color: colors.text }]}>Background Sync (every 15 min)</Text>
           </View>
         </GroupRow>
       </Group>
@@ -562,6 +615,38 @@ export function SettingsContent(props: SettingsContentProps) {
               onPress={() => {
                 onSetLockTimeout(opt.value);
                 setShowTimeoutPicker(false);
+              }}
+              trailing={isActive ? <Ionicons name="checkmark" size={20} color={colors.primary} /> : null}
+            >
+              <Text style={{ color: isActive ? colors.primary : colors.text, fontSize: 16 }}>{opt.label}</Text>
+            </GroupRow>
+          );
+        })}
+      </Group>
+    </Modal>
+
+    <Modal
+      visible={showIntervalPicker}
+      onRequestClose={() => setShowIntervalPicker(false)}
+      bottomSheet
+      contentStyle={{ padding: 16, paddingBottom: 34 }}
+    >
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <Text style={{ color: colors.text, fontSize: 17, fontWeight: '600' }}>Sync interval</Text>
+        <TouchableOpacity onPress={() => setShowIntervalPicker(false)} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <Ionicons name="close" size={22} color={colors.textSecondary} />
+        </TouchableOpacity>
+      </View>
+      <Group>
+        {SYNC_INTERVAL_OPTIONS.map((opt) => {
+          const isActive = opt.value === syncIntervalSeconds;
+          return (
+            <GroupRow
+              key={opt.value}
+              testID={`sync-interval-option-${opt.value}`}
+              onPress={() => {
+                onSetSyncIntervalSeconds(opt.value);
+                setShowIntervalPicker(false);
               }}
               trailing={isActive ? <Ionicons name="checkmark" size={20} color={colors.primary} /> : null}
             >

--- a/src/hooks/useForegroundSyncSettings.ts
+++ b/src/hooks/useForegroundSyncSettings.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  startForegroundWatcher,
+  updateForegroundWatcherConfig,
+} from '../services/ForegroundSyncService';
+
+const ENABLED_KEY = '@gitnotes:sync_frequently_enabled';
+const INTERVAL_KEY = '@gitnotes:sync_interval_seconds';
+
+export const SYNC_INTERVAL_OPTIONS = [
+  { value: 30, label: 'Every 30 seconds' },
+  { value: 60, label: 'Every minute' },
+  { value: 300, label: 'Every 5 minutes' },
+  { value: 900, label: 'Every 15 minutes' },
+] as const;
+
+export type SyncIntervalSeconds = (typeof SYNC_INTERVAL_OPTIONS)[number]['value'];
+
+export const DEFAULT_SYNC_FREQUENTLY_ENABLED = true;
+export const DEFAULT_SYNC_INTERVAL_SECONDS: SyncIntervalSeconds = 60;
+
+const ALLOWED_INTERVALS = new Set<number>(SYNC_INTERVAL_OPTIONS.map((opt) => opt.value));
+
+function coerceInterval(raw: string | null): SyncIntervalSeconds {
+  if (!raw) return DEFAULT_SYNC_INTERVAL_SECONDS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_SYNC_INTERVAL_SECONDS;
+  if (!ALLOWED_INTERVALS.has(parsed)) return DEFAULT_SYNC_INTERVAL_SECONDS;
+  return parsed as SyncIntervalSeconds;
+}
+
+export async function loadForegroundSyncConfig(): Promise<{
+  syncFrequentlyEnabled: boolean;
+  syncIntervalSeconds: SyncIntervalSeconds;
+}> {
+  const [rawEnabled, rawInterval] = await Promise.all([
+    AsyncStorage.getItem(ENABLED_KEY),
+    AsyncStorage.getItem(INTERVAL_KEY),
+  ]);
+  // Default-on for the toggle: only `'false'` opts out. `null` (first launch)
+  // and any other value fall through to the default.
+  const enabled = rawEnabled === null ? DEFAULT_SYNC_FREQUENTLY_ENABLED : rawEnabled !== 'false';
+  return {
+    syncFrequentlyEnabled: enabled,
+    syncIntervalSeconds: coerceInterval(rawInterval),
+  };
+}
+
+export function useForegroundSyncSettings() {
+  const [syncFrequentlyEnabled, setSyncFrequentlyEnabledState] = useState<boolean>(
+    DEFAULT_SYNC_FREQUENTLY_ENABLED,
+  );
+  const [syncIntervalSeconds, setSyncIntervalSecondsState] = useState<SyncIntervalSeconds>(
+    DEFAULT_SYNC_INTERVAL_SECONDS,
+  );
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const cfg = await loadForegroundSyncConfig();
+      if (cancelled) return;
+      setSyncFrequentlyEnabledState(cfg.syncFrequentlyEnabled);
+      setSyncIntervalSecondsState(cfg.syncIntervalSeconds);
+      setHydrated(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setSyncFrequentlyEnabled = useCallback(
+    async (next: boolean) => {
+      setSyncFrequentlyEnabledState(next);
+      await AsyncStorage.setItem(ENABLED_KEY, String(next));
+      updateForegroundWatcherConfig({
+        syncFrequentlyEnabled: next,
+        syncIntervalSeconds,
+      });
+    },
+    [syncIntervalSeconds],
+  );
+
+  const setSyncIntervalSeconds = useCallback(
+    async (next: SyncIntervalSeconds) => {
+      setSyncIntervalSecondsState(next);
+      await AsyncStorage.setItem(INTERVAL_KEY, String(next));
+      updateForegroundWatcherConfig({
+        syncFrequentlyEnabled,
+        syncIntervalSeconds: next,
+      });
+    },
+    [syncFrequentlyEnabled],
+  );
+
+  return {
+    hydrated,
+    syncFrequentlyEnabled,
+    syncIntervalSeconds,
+    setSyncFrequentlyEnabled,
+    setSyncIntervalSeconds,
+  };
+}
+
+// Re-export for the App-level bootstrapper.
+export { startForegroundWatcher };

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -12,6 +12,7 @@ import { useCanvases } from '../contexts/CanvasContext';
 import { useTodos } from '../contexts/TodoContext';
 import { useBiometricLock } from '../contexts/BiometricLockContext';
 import { useBackgroundSync } from '../hooks/useBackgroundSync';
+import { useForegroundSyncSettings } from '../hooks/useForegroundSyncSettings';
 import type { RootStackParamList } from '../navigation/types';
 import { GitHubService, type GitHubRepository } from '../services/GitHubService';
 import { RepoFileSyncService } from '../services/RepoFileSyncService';
@@ -59,6 +60,12 @@ export default function SettingsScreen() {
     setLockTimeout,
   } = useBiometricLock();
   const { isEnabled: isBackgroundSyncEnabled, toggle: toggleBackgroundSync } = useBackgroundSync();
+  const {
+    syncFrequentlyEnabled,
+    syncIntervalSeconds,
+    setSyncFrequentlyEnabled,
+    setSyncIntervalSeconds,
+  } = useForegroundSyncSettings();
   const isAIEnabled = useAIStore((state) => state.isEnabled);
   const selectedModelId = useAIStore((state) => state.selectedModelId);
   const actionMode = useAIStore((state) => state.actionMode);
@@ -513,6 +520,10 @@ export default function SettingsScreen() {
         onSetLockTimeout={(v) => void setLockTimeout(v)}
         isBackgroundSyncEnabled={isBackgroundSyncEnabled}
         onToggleBackgroundSync={() => void toggleBackgroundSync()}
+        syncFrequentlyEnabled={syncFrequentlyEnabled}
+        syncIntervalSeconds={syncIntervalSeconds}
+        onToggleSyncFrequently={(value) => void setSyncFrequentlyEnabled(value)}
+        onSetSyncIntervalSeconds={(value) => void setSyncIntervalSeconds(value)}
       />
       <SettingsModals
         colors={colors}

--- a/src/services/ForegroundSyncService.ts
+++ b/src/services/ForegroundSyncService.ts
@@ -1,0 +1,189 @@
+import { AppState, type AppStateStatus, type NativeEventSubscription } from 'react-native';
+import NetInfo, { type NetInfoSubscription } from '@react-native-community/netinfo';
+import { GitHubService } from './GitHubService';
+import { StorageService } from './StorageService';
+import { pullAllFromRepos } from './RepoPullService';
+
+/**
+ * Foreground auto-pull driver: pulls every tracked repo when the app becomes
+ * active, when network transitions offline → online, and on a configurable
+ * interval while the app is in the foreground. This complements
+ * `BackgroundSyncService` (which runs at OS-scheduled intervals) and is the
+ * mitigation for issue #563 — multi-device users no longer have to pull-to-
+ * refresh every time they switch phones.
+ *
+ * All triggers funnel through `runPull()`, which:
+ *   - skips if no GitHub token / no repos
+ *   - skips if offline (`NetInfo.fetch()`)
+ *   - coalesces overlapping triggers via `inFlight` and a 2-second debounce
+ *     so that AppState→active and online→online firing together don't queue
+ *     two pulls back-to-back
+ */
+
+const COALESCE_WINDOW_MS = 2000;
+
+type Listener = () => void;
+
+let appStateSub: NativeEventSubscription | null = null;
+let netInfoUnsub: NetInfoSubscription | null = null;
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+let inFlight = false;
+let lastRunAt = 0;
+
+let currentIntervalSeconds = 0;
+let currentSyncFrequentlyEnabled = true;
+
+let lastNetReachable: boolean | null = null;
+let lastAppState: AppStateStatus = AppState.currentState;
+
+const listeners = new Set<Listener>();
+
+function notify(): void {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch (error) {
+      console.warn('[ForegroundSync] listener failed:', error);
+    }
+  }
+}
+
+async function shouldPull(): Promise<boolean> {
+  if (!GitHubService.isAuthenticated()) return false;
+  const repos = await StorageService.getSavedRepositories();
+  if (repos.length === 0) return false;
+  const net = await NetInfo.fetch();
+  const reachable = net.isInternetReachable ?? net.isConnected ?? false;
+  return reachable;
+}
+
+async function runPull(reason: string): Promise<void> {
+  if (inFlight) return;
+  if (Date.now() - lastRunAt < COALESCE_WINDOW_MS) return;
+  if (!(await shouldPull())) return;
+
+  inFlight = true;
+  lastRunAt = Date.now();
+  notify();
+  try {
+    await pullAllFromRepos();
+  } catch (error) {
+    console.warn(`[ForegroundSync] pull (${reason}) failed:`, error);
+  } finally {
+    inFlight = false;
+    lastRunAt = Date.now();
+    notify();
+  }
+}
+
+function restartInterval(): void {
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+  if (!currentSyncFrequentlyEnabled) return;
+  if (currentIntervalSeconds <= 0) return;
+  if (lastAppState !== 'active') return;
+
+  intervalHandle = setInterval(() => {
+    void runPull('interval');
+  }, currentIntervalSeconds * 1000);
+}
+
+function handleAppStateChange(state: AppStateStatus): void {
+  const wasInactive = lastAppState !== 'active';
+  lastAppState = state;
+  if (state === 'active') {
+    if (wasInactive) void runPull('appstate-active');
+    restartInterval();
+  } else if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+}
+
+function handleNetInfo(reachable: boolean): void {
+  const cameOnline = lastNetReachable === false && reachable === true;
+  lastNetReachable = reachable;
+  if (cameOnline) void runPull('online');
+}
+
+export interface ForegroundSyncConfig {
+  syncFrequentlyEnabled: boolean;
+  syncIntervalSeconds: number;
+}
+
+export function startForegroundWatcher(config: ForegroundSyncConfig): void {
+  currentSyncFrequentlyEnabled = config.syncFrequentlyEnabled;
+  currentIntervalSeconds = config.syncIntervalSeconds;
+
+  if (!appStateSub) {
+    appStateSub = AppState.addEventListener('change', handleAppStateChange);
+  }
+  if (!netInfoUnsub) {
+    netInfoUnsub = NetInfo.addEventListener((state) => {
+      const reachable = state.isInternetReachable ?? state.isConnected ?? false;
+      handleNetInfo(reachable);
+    });
+    // Seed the last-known reachability so the very first event isn't
+    // misread as "came online" (otherwise the watcher would pull every
+    // mount on a connected device).
+    NetInfo.fetch()
+      .then((state) => {
+        lastNetReachable = state.isInternetReachable ?? state.isConnected ?? false;
+      })
+      .catch(() => undefined);
+  }
+
+  restartInterval();
+}
+
+export function updateForegroundWatcherConfig(config: ForegroundSyncConfig): void {
+  currentSyncFrequentlyEnabled = config.syncFrequentlyEnabled;
+  currentIntervalSeconds = config.syncIntervalSeconds;
+  restartInterval();
+}
+
+export function stopForegroundWatcher(): void {
+  if (appStateSub) {
+    appStateSub.remove();
+    appStateSub = null;
+  }
+  if (netInfoUnsub) {
+    netInfoUnsub();
+    netInfoUnsub = null;
+  }
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+  lastNetReachable = null;
+  lastAppState = AppState.currentState;
+}
+
+export function isForegroundSyncInFlight(): boolean {
+  return inFlight;
+}
+
+export function subscribeForegroundSync(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// Test-only: manual trigger so unit tests don't have to fake AppState/NetInfo.
+export async function __runPullForTest(reason = 'test'): Promise<void> {
+  await runPull(reason);
+}
+
+// Test-only: reset internal state so each test starts fresh.
+export function __resetForegroundSyncForTest(): void {
+  stopForegroundWatcher();
+  inFlight = false;
+  lastRunAt = 0;
+  currentIntervalSeconds = 0;
+  currentSyncFrequentlyEnabled = true;
+  listeners.clear();
+}


### PR DESCRIPTION
## Summary

- New `ForegroundSyncService` subscribes to AppState, NetInfo, and a configurable interval. When the app comes back to the foreground, when network reconnects, or when the interval elapses, it pulls every tracked repo via `pullAllFromRepos()`.
- Triggers coalesce — overlapping requests are deduped by an in-flight guard and a 2s debounce, so AppState→active firing alongside online→online never queues two pulls back-to-back.
- Pull is gated: skipped when no GitHub token, no saved repos, or `NetInfo.fetch()` says we're offline. The very first NetInfo event after mount is seeded so a connected device doesn't get spuriously treated as "just came online."
- Wired into `App.tsx` after `bootstrapStorage()` so the first pull sees the persisted repo list.
- Settings adds a default-on **"Sync frequently (recommended for multi-device)"** toggle and a sync-interval picker (30 s / 1 min / 5 min / 15 min, default 1 min). Toggling off stops the periodic poll but leaves the cheap AppState/online triggers running. Interval row is greyed and non-tappable when the toggle is off. Persisted via AsyncStorage in the same style as `useBackgroundSync`.

## Refs #563 (partial)

This is **Part 1** of issue #563 — the cheap, low-risk mitigation. Multi-device users were hitting note overwrites because the app only pulled at OS-scheduled background-task intervals; foreground state changes never triggered a pull. This PR closes that gap.

## Deferred

Explicitly **not** in scope (separate follow-ups):

- Pull-before-write inside `LocalGitWriter.writeAndCommit` — overlaps with in-flight #567 + #568 PR which owns `LocalGitWriter.ts`.
- `ConflictResolverService` / 3-way merge.
- Conflict banner / Sync Status screen.
- Per-file resolver UI.
- Resume-after-quit persistence of pending pulls.
- JSON-structured resolvers for canvas / todo / template stores.

## Test plan

- [ ] Background → foreground triggers a pull (watch console for `[RepoPullService]` activity).
- [ ] Airplane mode on → off triggers a pull once network reachable becomes true.
- [ ] Toggle "Sync frequently" off → interval poll stops; AppState/online triggers still fire.
- [ ] Pick 30 s interval, leave foreground for >30 s, watch logs for the periodic pull.
- [ ] Pick 15 min interval → previous 30 s timer is cleared, 15 min timer is scheduled.
- [ ] Two rapid AppState transitions inside the 2 s window only run one pull.
- [ ] Existing 876 unit tests still pass (`yarn test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)