### PR TITLE
feat(git): LFS pointer download + binary readability (#570)

### DIFF
--- a/__tests__/parseLfsPointer.test.ts
+++ b/__tests__/parseLfsPointer.test.ts
@@ -1,0 +1,74 @@
+import { parseLfsPointer } from '../src/services/git/lfs';
+
+describe('parseLfsPointer', () => {
+  const VALID = `version https://git-lfs.github.com/spec/v1
+oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+size 12345
+`;
+
+  test('parses a valid pointer', () => {
+    const ptr = parseLfsPointer(VALID);
+    expect(ptr).toEqual({
+      oid: '4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393',
+      size: 12345,
+    });
+  });
+
+  test('parses a valid pointer from a Uint8Array', () => {
+    const bytes = new Uint8Array(VALID.length);
+    for (let i = 0; i < VALID.length; i++) bytes[i] = VALID.charCodeAt(i);
+    expect(parseLfsPointer(bytes)).toEqual({
+      oid: '4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393',
+      size: 12345,
+    });
+  });
+
+  test('rejects non-pointer text', () => {
+    expect(parseLfsPointer('# Hello\nThis is a regular markdown file.')).toBeNull();
+  });
+
+  test('rejects pointer with bad oid format', () => {
+    const bad = `version https://git-lfs.github.com/spec/v1
+oid sha256:not_hex
+size 100
+`;
+    expect(parseLfsPointer(bad)).toBeNull();
+  });
+
+  test('rejects pointer with missing version line', () => {
+    const bad = `oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+size 100
+`;
+    expect(parseLfsPointer(bad)).toBeNull();
+  });
+
+  test('rejects pointer with negative size', () => {
+    const bad = `version https://git-lfs.github.com/spec/v1
+oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+size -1
+`;
+    // -1 has '-' which fails the SIZE_REGEX pattern (\d+ only)
+    expect(parseLfsPointer(bad)).toBeNull();
+  });
+
+  test('rejects oversize input (> 2KiB) cheaply', () => {
+    const big = VALID + 'x'.repeat(3000);
+    expect(parseLfsPointer(big)).toBeNull();
+  });
+
+  test('rejects binary-looking input (bytes > 0x7f)', () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic
+    expect(parseLfsPointer(bytes)).toBeNull();
+  });
+
+  test('handles size=0 LFS pointer', () => {
+    const zero = `version https://git-lfs.github.com/spec/v1
+oid sha256:0000000000000000000000000000000000000000000000000000000000000000
+size 0
+`;
+    expect(parseLfsPointer(zero)).toEqual({
+      oid: '0000000000000000000000000000000000000000000000000000000000000000',
+      size: 0,
+    });
+  });
+});

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -73,6 +73,9 @@ type SettingsContentProps = {
   onRemoveRepo: (repo: GitRepository) => void;
   onEnableCloneMode: (repo: GitRepository) => void;
   onDisableCloneMode: (repo: GitRepository) => void;
+  lfsPending: Record<string, { count: number; bytes: number }>;
+  lfsDownloadingRepo: string | null;
+  onDownloadLfsObjects: (repo: GitRepository) => void;
   onOpenTemplatesRepoPicker: () => void;
   onSyncExistingTemplates: () => void;
   onClearTemplatesRepo: () => void;
@@ -96,6 +99,13 @@ type SettingsContentProps = {
   isBackgroundSyncEnabled: boolean;
   onToggleBackgroundSync: () => void;
 };
+
+function formatLfsBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
 
 export function SettingsContent(props: SettingsContentProps) {
   const {
@@ -130,6 +140,9 @@ export function SettingsContent(props: SettingsContentProps) {
     onRemoveRepo,
     onEnableCloneMode,
     onDisableCloneMode,
+    lfsPending,
+    lfsDownloadingRepo,
+    onDownloadLfsObjects,
     onOpenTemplatesRepoPicker,
     onSyncExistingTemplates,
     onClearTemplatesRepo,
@@ -387,30 +400,60 @@ export function SettingsContent(props: SettingsContentProps) {
             const mode = syncModes[repo.path] ?? 'api';
             const isClone = mode === 'clone';
             const isCloning = cloningRepo === repo.path;
+            const lfs = lfsPending[repo.path];
+            const isDownloadingLfs = lfsDownloadingRepo === repo.path;
             return (
-              <GroupRow
-                key={repo.id}
-                testID={`sync-engine-row-${repo.path}`}
-                leading={<Ionicons name={isClone ? 'cloud-done-outline' : 'cloud-outline'} size={18} color={isClone ? colors.primary : colors.textSecondary} />}
-                trailing={
-                  isCloning ? (
-                    <ActivityIndicator size="small" color={colors.primary} />
-                  ) : isClone ? (
-                    <TouchableOpacity testID={`sync-engine-disable-${repo.path}`} onPress={() => onDisableCloneMode(repo)} style={{ padding: 4 }}>
-                      <Text style={[styles.settingLabel, { color: colors.error }]}>Use API</Text>
-                    </TouchableOpacity>
-                  ) : (
-                    <TouchableOpacity testID={`sync-engine-enable-${repo.path}`} onPress={() => onEnableCloneMode(repo)} style={{ padding: 4 }}>
-                      <Text style={[styles.settingLabel, { color: colors.primary }]}>Clone</Text>
-                    </TouchableOpacity>
-                  )
-                }
-              >
-                <Text style={[styles.repoName, { color: colors.text }]} numberOfLines={1}>{repo.name}</Text>
-                <Text style={[styles.repoPath, { color: colors.textSecondary }]} numberOfLines={1}>
-                  {isClone ? 'Clone (local working tree)' : 'GitHub API (per-file)'}
-                </Text>
-              </GroupRow>
+              <React.Fragment key={repo.id}>
+                <GroupRow
+                  testID={`sync-engine-row-${repo.path}`}
+                  leading={<Ionicons name={isClone ? 'cloud-done-outline' : 'cloud-outline'} size={18} color={isClone ? colors.primary : colors.textSecondary} />}
+                  trailing={
+                    isCloning ? (
+                      <ActivityIndicator size="small" color={colors.primary} />
+                    ) : isClone ? (
+                      <TouchableOpacity testID={`sync-engine-disable-${repo.path}`} onPress={() => onDisableCloneMode(repo)} style={{ padding: 4 }}>
+                        <Text style={[styles.settingLabel, { color: colors.error }]}>Use API</Text>
+                      </TouchableOpacity>
+                    ) : (
+                      <TouchableOpacity testID={`sync-engine-enable-${repo.path}`} onPress={() => onEnableCloneMode(repo)} style={{ padding: 4 }}>
+                        <Text style={[styles.settingLabel, { color: colors.primary }]}>Clone</Text>
+                      </TouchableOpacity>
+                    )
+                  }
+                >
+                  <Text style={[styles.repoName, { color: colors.text }]} numberOfLines={1}>{repo.name}</Text>
+                  <Text style={[styles.repoPath, { color: colors.textSecondary }]} numberOfLines={1}>
+                    {isClone ? 'Clone (local working tree)' : 'GitHub API (per-file)'}
+                  </Text>
+                </GroupRow>
+                {isClone && lfs && lfs.count > 0 ? (
+                  <GroupRow
+                    testID={`lfs-pending-row-${repo.path}`}
+                    leading={<Ionicons name="document-attach-outline" size={18} color={colors.accent} />}
+                    trailing={
+                      isDownloadingLfs ? (
+                        <ActivityIndicator size="small" color={colors.primary} />
+                      ) : (
+                        <TouchableOpacity
+                          testID={`lfs-download-${repo.path}`}
+                          onPress={() => onDownloadLfsObjects(repo)}
+                          style={{ padding: 4 }}
+                          disabled={!!lfsDownloadingRepo}
+                        >
+                          <Text style={[styles.settingLabel, { color: colors.primary }]}>Download</Text>
+                        </TouchableOpacity>
+                      )
+                    }
+                  >
+                    <Text style={[styles.repoName, { color: colors.text }]} numberOfLines={1}>
+                      {lfs.count} LFS file{lfs.count === 1 ? '' : 's'} not downloaded
+                    </Text>
+                    <Text style={[styles.repoPath, { color: colors.textSecondary }]} numberOfLines={1}>
+                      {formatLfsBytes(lfs.bytes)} pending
+                    </Text>
+                  </GroupRow>
+                ) : null}
+              </React.Fragment>
             );
           })}
         </Group>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -21,6 +21,7 @@ import { syncTemplateToGitHub } from '../services/TemplateGitHubSyncService';
 import { SyncEngineService, type SyncEngineMode } from '../services/SyncEngineService';
 import { GitFsService } from '../services/git/GitFsService';
 import { CloneMigrationService } from '../services/git/CloneMigrationService';
+import { LfsService } from '../services/git/lfs';
 import { AuthService } from '../services/AuthService';
 import { OnboardingService } from '../services/OnboardingService';
 import { HapticService } from '../utils/haptics';
@@ -92,6 +93,8 @@ export default function SettingsScreen() {
   const [cloneProgress, setCloneProgress] = useState<CloneProgress | null>(null);
   const cloneAbortedRef = useRef(false);
   const [isSyncingExistingTemplates, setIsSyncingExistingTemplates] = useState(false);
+  const [lfsPending, setLfsPending] = useState<Record<string, { count: number; bytes: number }>>({});
+  const [lfsDownloadingRepo, setLfsDownloadingRepo] = useState<string | null>(null);
 
   useEffect(() => {
     TemplateRepoPreferenceService.get().then(setTemplatesRepoPref);
@@ -110,6 +113,27 @@ export default function SettingsScreen() {
       cancelled = true;
     };
   }, [repositories]);
+
+  const refreshLfsPending = useCallback(async (repoPaths: string[]) => {
+    const next: Record<string, { count: number; bytes: number }> = {};
+    for (const path of repoPaths) {
+      const items = await LfsService.listPending(path);
+      if (items.length > 0) {
+        const bytes = items.reduce((acc, item) => acc + item.pointer.size, 0);
+        next[path] = { count: items.length, bytes };
+      }
+    }
+    setLfsPending(next);
+  }, []);
+
+  useEffect(() => {
+    const cloned = Object.entries(syncModes).filter(([, mode]) => mode === 'clone').map(([path]) => path);
+    if (cloned.length === 0) {
+      setLfsPending({});
+      return;
+    }
+    void refreshLfsPending(cloned);
+  }, [syncModes, refreshLfsPending]);
 
   const handlePasteToken = useCallback(async () => {
     try {
@@ -185,6 +209,7 @@ export default function SettingsScreen() {
       }
       await SyncEngineService.setMode(repo.path, 'clone');
       setSyncModes((prev) => ({ ...prev, [repo.path]: 'clone' }));
+      void refreshLfsPending([repo.path]);
       HapticService.success();
       Alert.alert('Clone mode enabled', `${repo.name} now syncs through a local working tree.\n\nPush any offline edits up to this clone now?`, [
         { text: 'Skip', style: 'cancel' },
@@ -221,7 +246,7 @@ export default function SettingsScreen() {
       setCloningRepo(null);
       setCloneProgress(null);
     }
-  }, []);
+  }, [refreshLfsPending]);
 
   const handleCancelClone = useCallback(() => {
     cloneAbortedRef.current = true;
@@ -230,6 +255,48 @@ export default function SettingsScreen() {
     // Updating the modal copy gives immediate feedback while that unwinds.
     setCloneProgress((prev) => (prev ? { ...prev, phase: 'Cancelling…' } : prev));
   }, []);
+
+  const handleDownloadLfsObjects = useCallback(async (repo: GitRepository) => {
+    const token = (await AuthService.getToken()) ?? undefined;
+    if (!token) {
+      Alert.alert('GitHub required', 'Connect a GitHub account before downloading LFS objects.');
+      return;
+    }
+    setLfsDownloadingRepo(repo.path);
+    try {
+      const items = await LfsService.listPending(repo.path);
+      const workingTreeUri = GitFsService.workingTreeUri({ repoPath: repo.path });
+      const root = workingTreeUri.endsWith('/') ? workingTreeUri : `${workingTreeUri}/`;
+      let succeeded = 0;
+      const failures: { path: string; error: string }[] = [];
+      for (const item of items) {
+        try {
+          await LfsService.downloadObject({
+            repoPath: repo.path,
+            filePath: item.path,
+            fileUri: `${root}${item.path}`,
+            accessToken: token,
+          });
+          succeeded++;
+        } catch (e) {
+          failures.push({ path: item.path, error: e instanceof Error ? e.message : String(e) });
+        }
+      }
+      await refreshLfsPending([repo.path]);
+      if (failures.length === 0) {
+        HapticService.success();
+        Alert.alert('LFS downloads complete', `Downloaded ${succeeded} file(s) for ${repo.name}.`);
+      } else {
+        HapticService.error();
+        Alert.alert(
+          'Some LFS downloads failed',
+          `Downloaded ${succeeded} file(s); ${failures.length} failed.\n\n${failures[0].error}`,
+        );
+      }
+    } finally {
+      setLfsDownloadingRepo(null);
+    }
+  }, [refreshLfsPending]);
 
   const handleDisableCloneMode = useCallback((repo: GitRepository) => {
     Alert.alert('Switch to API mode?', `This will remove the local clone of ${repo.name} and revert to the GitHub Contents API.`, [
@@ -484,6 +551,9 @@ export default function SettingsScreen() {
         onRemoveRepo={handleRemoveRepo}
         onEnableCloneMode={(repo) => void handleEnableCloneMode(repo)}
         onDisableCloneMode={handleDisableCloneMode}
+        lfsPending={lfsPending}
+        lfsDownloadingRepo={lfsDownloadingRepo}
+        onDownloadLfsObjects={(repo) => void handleDownloadLfsObjects(repo)}
         onOpenTemplatesRepoPicker={() => setShowTemplatesRepoPicker(true)}
         onSyncExistingTemplates={() => void handleSyncExistingTemplates()}
         onClearTemplatesRepo={() => void handleClearTemplatesRepo()}

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -3,6 +3,7 @@ import git, { TREE } from 'isomorphic-git';
 import { parseRepoPath } from '../../utils/gitPathParser';
 import { makeGitFs } from './gitFs';
 import { gitHttp } from './gitHttp';
+import { LfsService } from './lfs';
 
 const CLONES_SUBDIR = 'GitNotes/';
 
@@ -107,6 +108,16 @@ export class GitFsService {
         ? (event) => opts.onProgress!(event.phase, event.loaded, event.total ?? null)
         : undefined,
     });
+
+    // isomorphic-git has no smudge filter pipeline, so any LFS-tracked
+    // binaries land on disk as ~130-byte pointer text files. Scan now and
+    // remember them so the UI can surface a "Download" affordance and the
+    // user isn't left wondering why their PDF won't open.
+    try {
+      await LfsService.scanRepo(opts.repoPath, GitFsService.workingTreeUri({ repoPath: opts.repoPath }));
+    } catch {
+      // best-effort; pointer detection failure shouldn't fail the clone.
+    }
   }
 
   /** Fetch updates for the cloned repo. Caller must have run `clone` first. */
@@ -166,6 +177,11 @@ export class GitFsService {
         singleBranch: true,
         onAuth: ensureToken(opts.token),
       });
+      try {
+        await LfsService.scanRepo(opts.repoPath, GitFsService.workingTreeUri({ repoPath: opts.repoPath }));
+      } catch {
+        // best-effort
+      }
       return { ok: true };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -254,6 +270,7 @@ export class GitFsService {
     const fsRoot = clonesRoot();
     const dir = `${fsRoot}${info.owner}/${info.repo}`;
     await FileSystem.deleteAsync(dir, { idempotent: true });
+    await LfsService.clearRepo(opts.repoPath).catch(() => undefined);
   }
 
   /** Absolute on-disk URI of a repo's working tree. */

--- a/src/services/git/gitFs.ts
+++ b/src/services/git/gitFs.ts
@@ -101,8 +101,19 @@ export function makeGitFs(root: string): PromiseFsClient {
       if (typeof data === 'string') {
         const encoding = typeof opts === 'string' ? opts : opts?.encoding;
         if (encoding && encoding !== 'utf8') {
-          // Caller passed a non-utf8 encoding for a string body — treat it as
-          // an explicit binary signal and fall through to base64 path.
+          // Caller declared a non-utf8 encoding (e.g. 'base64') for a string
+          // body — write through expo-file-system's matching encoding rather
+          // than the default utf8 path so binary survives the round-trip.
+          if (encoding === 'base64') {
+            await FileSystem.writeAsStringAsync(uri, data, {
+              encoding: FileSystem.EncodingType.Base64,
+            });
+            return;
+          }
+          throw new FsError(
+            'EINVAL',
+            `writeFile encoding '${encoding}' not supported for '${filepath}'`,
+          );
         }
         await FileSystem.writeAsStringAsync(uri, data);
       } else {

--- a/src/services/git/lfs.ts
+++ b/src/services/git/lfs.ts
@@ -1,0 +1,363 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as FileSystem from 'expo-file-system/legacy';
+import { parseRepoPath } from '../../utils/gitPathParser';
+
+/**
+ * Git LFS pointer parser + on-demand object download.
+ *
+ * Pointer file spec (https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md):
+ *
+ *   version https://git-lfs.github.com/spec/v1
+ *   oid sha256:<64 hex chars>
+ *   size <integer bytes>
+ *
+ * Lines are LF-terminated, the file ends with LF, and ASCII only. Real
+ * pointers are tiny (~130 bytes); a >2 KiB file masquerading as one is
+ * almost certainly a regular text file and we skip it cheaply.
+ */
+const POINTER_MAX_BYTES = 2048;
+const POINTER_VERSION = 'https://git-lfs.github.com/spec/v1';
+const OID_REGEX = /^oid sha256:([0-9a-f]{64})$/;
+const SIZE_REGEX = /^size (\d+)$/;
+
+export interface LfsPointer {
+  oid: string;
+  size: number;
+}
+
+const STORAGE_KEY_PREFIX = '@gitnotes:lfs_pending:';
+const storageKey = (repoKey: string) => `${STORAGE_KEY_PREFIX}${repoKey}`;
+
+/**
+ * Parse a buffer (string or Uint8Array) as an LFS pointer file.
+ * Returns `{ oid, size }` on success, `null` otherwise — non-pointer files
+ * (binaries, regular text, anything missing the spec lines) are silently
+ * rejected so callers can use this as a cheap classifier.
+ */
+export function parseLfsPointer(buffer: string | Uint8Array): LfsPointer | null {
+  let text: string;
+  if (typeof buffer === 'string') {
+    if (buffer.length > POINTER_MAX_BYTES) return null;
+    text = buffer;
+  } else {
+    if (buffer.byteLength > POINTER_MAX_BYTES) return null;
+    // Pointers are pure ASCII; charCode-per-byte avoids depending on a
+    // TextDecoder polyfill in the RN runtime.
+    let acc = '';
+    for (let i = 0; i < buffer.length; i++) {
+      const b = buffer[i];
+      if (b > 0x7f) return null;
+      acc += String.fromCharCode(b);
+    }
+    text = acc;
+  }
+  if (!text.startsWith('version ')) return null;
+  const lines = text.split('\n').filter((line) => line.length > 0);
+  if (lines.length < 3) return null;
+  if (lines[0] !== `version ${POINTER_VERSION}`) return null;
+
+  let oid: string | null = null;
+  let size: number | null = null;
+  for (let i = 1; i < lines.length; i++) {
+    const oidMatch = lines[i].match(OID_REGEX);
+    if (oidMatch) {
+      oid = oidMatch[1];
+      continue;
+    }
+    const sizeMatch = lines[i].match(SIZE_REGEX);
+    if (sizeMatch) {
+      size = Number(sizeMatch[1]);
+      continue;
+    }
+  }
+  if (!oid || size === null || !Number.isFinite(size) || size < 0) return null;
+  return { oid, size };
+}
+
+interface ScanOpts {
+  /** Working-tree URI from `GitFsService.workingTreeUri` (no trailing slash). */
+  workingTreeUri: string;
+  /** Maximum bytes to read while sniffing a candidate file. Defaults to 2 KiB. */
+  maxFileBytes?: number;
+}
+
+/**
+ * Walk the working tree and collect every file that parses as an LFS
+ * pointer. Skips `.git`. Sized cap on what we read keeps the scan cheap on
+ * repos with large working trees.
+ */
+async function scanForPointers(opts: ScanOpts): Promise<Map<string, LfsPointer>> {
+  const root = opts.workingTreeUri.endsWith('/')
+    ? opts.workingTreeUri
+    : `${opts.workingTreeUri}/`;
+  const max = opts.maxFileBytes ?? POINTER_MAX_BYTES;
+  const out = new Map<string, LfsPointer>();
+
+  async function walk(dirUri: string, relPath: string): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await FileSystem.readDirectoryAsync(dirUri);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      if (name === '.git') continue;
+      const childUri = `${dirUri}${name}`;
+      const childRel = relPath ? `${relPath}/${name}` : name;
+      let info;
+      try {
+        info = await FileSystem.getInfoAsync(childUri);
+      } catch {
+        continue;
+      }
+      if (!info.exists) continue;
+      if (info.isDirectory) {
+        await walk(`${childUri}/`, childRel);
+        continue;
+      }
+      if ((info.size ?? 0) > max) continue;
+      let text: string;
+      try {
+        text = await FileSystem.readAsStringAsync(childUri);
+      } catch {
+        continue;
+      }
+      const pointer = parseLfsPointer(text);
+      if (pointer) out.set(childRel, pointer);
+    }
+  }
+
+  await walk(root, '');
+  return out;
+}
+
+interface DownloadOpts {
+  owner: string;
+  repo: string;
+  oid: string;
+  size: number;
+  accessToken: string;
+}
+
+interface BatchObject {
+  oid: string;
+  size: number;
+  actions?: {
+    download?: {
+      href: string;
+      header?: Record<string, string>;
+    };
+  };
+  error?: { code: number; message: string };
+}
+
+interface BatchResponse {
+  objects: BatchObject[];
+}
+
+/**
+ * GitHub LFS batch endpoint — request a signed download URL for a single
+ * object. The endpoint requires the application/vnd.git-lfs+json content
+ * type and accepts PAT auth via Authorization: token <pat>.
+ */
+async function requestBatchDownload(opts: DownloadOpts): Promise<BatchObject> {
+  const url = `https://github.com/${opts.owner}/${opts.repo}.git/info/lfs/objects/batch`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/vnd.git-lfs+json',
+      Accept: 'application/vnd.git-lfs+json',
+      Authorization: `token ${opts.accessToken}`,
+    },
+    body: JSON.stringify({
+      operation: 'download',
+      transfers: ['basic'],
+      objects: [{ oid: opts.oid, size: opts.size }],
+    }),
+  });
+  if (res.status === 403) {
+    throw new Error('LFS access denied — check your PAT permissions.');
+  }
+  if (!res.ok) {
+    throw new Error(`LFS batch request failed (${res.status}).`);
+  }
+  const data = (await res.json()) as BatchResponse;
+  const obj = data.objects?.[0];
+  if (!obj) throw new Error('LFS batch response missing object.');
+  if (obj.error) {
+    if (obj.error.code === 403) throw new Error('LFS access denied — check your PAT permissions.');
+    throw new Error(`LFS object error: ${obj.error.message}`);
+  }
+  return obj;
+}
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let bin = '';
+  // Chunk the conversion so a multi-MB binary doesn't blow the JS string
+  // arg-list limit on String.fromCharCode.
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + CHUNK)));
+  }
+  return globalThis.btoa(bin);
+}
+
+/**
+ * Service for tracking + resolving LFS pointer files left on disk by
+ * isomorphic-git (which has no smudge-filter pipeline). State persists
+ * across launches via AsyncStorage so a relaunch still knows which files
+ * are placeholders.
+ */
+export class LfsService {
+  private static cache = new Map<string, Map<string, LfsPointer>>();
+
+  private static repoKey(owner: string, repo: string): string {
+    return `${owner}/${repo}`;
+  }
+
+  private static async load(repoKey: string): Promise<Map<string, LfsPointer>> {
+    const cached = LfsService.cache.get(repoKey);
+    if (cached) return cached;
+    try {
+      const raw = await AsyncStorage.getItem(storageKey(repoKey));
+      if (raw) {
+        const parsed = JSON.parse(raw) as Record<string, LfsPointer>;
+        const map = new Map(Object.entries(parsed));
+        LfsService.cache.set(repoKey, map);
+        return map;
+      }
+    } catch {
+      // fall through to empty
+    }
+    const empty = new Map<string, LfsPointer>();
+    LfsService.cache.set(repoKey, empty);
+    return empty;
+  }
+
+  private static async persist(repoKey: string): Promise<void> {
+    const map = LfsService.cache.get(repoKey);
+    if (!map || map.size === 0) {
+      await AsyncStorage.removeItem(storageKey(repoKey)).catch(() => undefined);
+      return;
+    }
+    const obj: Record<string, LfsPointer> = {};
+    for (const [path, ptr] of map) obj[path] = ptr;
+    await AsyncStorage.setItem(storageKey(repoKey), JSON.stringify(obj));
+  }
+
+  /**
+   * Walk the working tree, parse every small file, and remember any LFS
+   * pointers we find. Call after `git.checkout` completes (or whenever the
+   * working tree may have been rewritten with placeholders).
+   */
+  static async scanRepo(
+    repoPath: string,
+    workingTreeUri: string,
+  ): Promise<Map<string, LfsPointer>> {
+    const info = parseRepoPath(repoPath);
+    if (!info) return new Map();
+    const repoKey = LfsService.repoKey(info.owner, info.repo);
+    const found = await scanForPointers({ workingTreeUri });
+    LfsService.cache.set(repoKey, found);
+    await LfsService.persist(repoKey);
+    return found;
+  }
+
+  /** Whether this file path is currently a known LFS placeholder. */
+  static async isPending(repoPath: string, filePath: string): Promise<boolean> {
+    const info = parseRepoPath(repoPath);
+    if (!info) return false;
+    const map = await LfsService.load(LfsService.repoKey(info.owner, info.repo));
+    return map.has(filePath);
+  }
+
+  /** Get pointer metadata (oid + size) for a known placeholder. */
+  static async getPointer(repoPath: string, filePath: string): Promise<LfsPointer | null> {
+    const info = parseRepoPath(repoPath);
+    if (!info) return null;
+    const map = await LfsService.load(LfsService.repoKey(info.owner, info.repo));
+    return map.get(filePath) ?? null;
+  }
+
+  /** Snapshot of all pending pointer paths for a repo. */
+  static async listPending(repoPath: string): Promise<{ path: string; pointer: LfsPointer }[]> {
+    const info = parseRepoPath(repoPath);
+    if (!info) return [];
+    const map = await LfsService.load(LfsService.repoKey(info.owner, info.repo));
+    return Array.from(map, ([path, pointer]) => ({ path, pointer }));
+  }
+
+  /** Drop all tracked pointers for a repo (e.g. after `removeRepo`). */
+  static async clearRepo(repoPath: string): Promise<void> {
+    const info = parseRepoPath(repoPath);
+    if (!info) return;
+    const repoKey = LfsService.repoKey(info.owner, info.repo);
+    LfsService.cache.delete(repoKey);
+    await AsyncStorage.removeItem(storageKey(repoKey)).catch(() => undefined);
+  }
+
+  /**
+   * Resolve a single LFS object: hit the batch endpoint, fetch the signed
+   * URL, write the binary back to disk over the pointer, and remove the
+   * path from the pending map. Caller passes the absolute on-disk URI of
+   * the working-tree file (use `GitFsService.workingTreeUri` + path).
+   */
+  static async downloadObject(opts: {
+    repoPath: string;
+    filePath: string;
+    fileUri: string;
+    accessToken: string;
+  }): Promise<void> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) throw new Error(`Invalid repo path: ${opts.repoPath}`);
+    const repoKey = LfsService.repoKey(info.owner, info.repo);
+    const map = await LfsService.load(repoKey);
+    const pointer = map.get(opts.filePath);
+    if (!pointer) {
+      // Already resolved on a prior tap — nothing to do.
+      return;
+    }
+
+    let batchObj: BatchObject;
+    try {
+      batchObj = await requestBatchDownload({
+        owner: info.owner,
+        repo: info.repo,
+        oid: pointer.oid,
+        size: pointer.size,
+        accessToken: opts.accessToken,
+      });
+    } catch (e) {
+      if (e instanceof Error) throw e;
+      throw new Error("Couldn't download LFS file — try again.");
+    }
+
+    const action = batchObj.actions?.download;
+    if (!action?.href) {
+      throw new Error('LFS server did not return a download URL.');
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(action.href, {
+        method: 'GET',
+        headers: action.header ?? {},
+      });
+    } catch {
+      throw new Error("Couldn't download LFS file — try again.");
+    }
+    if (!res.ok) {
+      throw new Error(`Couldn't download LFS file (${res.status}).`);
+    }
+
+    const ab = await res.arrayBuffer();
+    const b64 = arrayBufferToBase64(ab);
+    await FileSystem.writeAsStringAsync(opts.fileUri, b64, {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+
+    map.delete(opts.filePath);
+    await LfsService.persist(repoKey);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `parseLfsPointer` + `LfsService` so LFS-tracked binaries don't sit on disk as 130-byte placeholder text after a clone (isomorphic-git has no smudge filter).
- Scan working tree after `git.clone` and after a successful `pullWithFastForward`, persist pending pointers per repo via AsyncStorage, drop them on `removeRepo`.
- Resolve on demand through GitHub's LFS batch endpoint (`https://github.com/<o>/<r>.git/info/lfs/objects/batch`) with PAT auth; write the binary back to disk via base64 over the pointer.
- Settings → Sync engine group now shows "N LFS files not downloaded — Download" under each clone-mode repo when pointers are pending. Spinner during download; success/failure alert.
- Map 403 → "LFS access denied — check your PAT permissions"; network failures → "Couldn't download LFS file — try again."
- Fix the misleading fall-through comment in `gitFs.writeFile`: now actually routes a non-utf8 declared encoding (`base64`) through `writeAsStringAsync({ encoding: Base64 })` instead of silently writing UTF-8.
- Add 9 `parseLfsPointer` unit tests.

## Closes #570

## Deferred (intentionally out of scope)

- **Phase A (debug "Inspect cloned repo" UI)** — pure diagnostic surface, only useful with a device in hand; not worth the surface area in this PR.
- **Phase E (atomic temp-file writes)** — broader hardening; deferred as a follow-up.
- **Phase D (commit `ios/GitNots/Info.plist` keys)** — `ios/` is fully `.gitignore`d in this repo (no tracked files under it); the iOS native project regenerates from `app.json` via `expo prebuild`. `app.json` already declares `UIFileSharingEnabled` + `LSSupportsOpeningDocumentsInPlace`, so there is no committed plist to amend. Deferred until the repo decides to track the native project.
- **Per-file viewer-side tap-to-download badge** — current trigger is the bulk "Download" action in Settings → Sync engine. A per-file badge in the file viewer is a follow-up; the service API + parser + persisted state are in place so wiring it later is mechanical.

## Test plan

- [ ] Clone an LFS-backed repo (e.g. one with a tracked PDF/PNG); verify the new "N LFS files not downloaded — N MB pending" row appears under that repo in Settings → Sync engine.
- [ ] Tap "Download"; spinner shows, completes; row disappears; opening the file in Files.app shows the real binary, not the pointer text.
- [ ] Clone a non-LFS repo; verify no LFS row is shown and pull/clone behaviour is unchanged.
- [ ] Disable clone mode for a repo and re-enable it; verify pending state is cleared and re-detected respectively.
- [ ] With an invalid/limited PAT, tap Download; verify the alert reads "LFS access denied — check your PAT permissions."
- [ ] `yarn ts:check` passes.
- [ ] `__tests__/parseLfsPointer.test.ts` (9 cases) passes.

## Notes

- LFS pointer detection cap of 2 KiB keeps the post-clone scan cheap; a >2 KiB file masquerading as a pointer is almost always a regular text file.
- AsyncStorage key shape: `@gitnotes:lfs_pending:<owner>/<repo>` → `Record<filePath, { oid, size }>`.