### PR TITLE
feat(ai): provider eligibility gating + UI

### DIFF
--- a/__tests__/ai/providerAvailability.test.ts
+++ b/__tests__/ai/providerAvailability.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import type { AIProviderConfig } from '../../src/models/AIProvider';
+
+const mockState: {
+  os: 'ios' | 'android';
+  appleAvailable: boolean;
+  appleThrows: boolean;
+  modelId: string | null;
+} = {
+  os: 'ios',
+  appleAvailable: false,
+  appleThrows: false,
+  modelId: null,
+};
+
+jest.mock('react-native', () => ({
+  get Platform() {
+    return { OS: mockState.os, select: (m: Record<string, unknown>) => m[mockState.os] };
+  },
+}));
+
+jest.mock('@react-native-ai/apple', () => ({
+  AppleFoundationModels: {
+    isAvailable: () => {
+      if (mockState.appleThrows) throw new Error('native bridge unavailable');
+      return mockState.appleAvailable;
+    },
+  },
+}));
+
+jest.mock('expo-device', () => ({
+  get modelId() {
+    return mockState.modelId;
+  },
+}));
+
+const baseProvider = (overrides: Partial<AIProviderConfig>): AIProviderConfig => ({
+  id: 'apple-default',
+  type: 'apple',
+  name: 'Apple Intelligence',
+  isEnabled: true,
+  models: [],
+  addedAt: 0,
+  supportedPlatforms: ['ios'],
+  ...overrides,
+});
+
+function setMocks(opts: Partial<typeof mockState>) {
+  Object.assign(mockState, opts);
+}
+
+describe('resolveProviderAvailability', () => {
+  beforeEach(() => {
+    Object.assign(mockState, {
+      os: 'ios',
+      appleAvailable: false,
+      appleThrows: false,
+      modelId: null,
+    });
+    jest.resetModules();
+  });
+
+  test('marks ios-only provider as platform-mismatch on android', async () => {
+    setMocks({ os: 'android' });
+    const { resolveProviderAvailability } = require('../../src/services/ai/providerAvailability');
+    const result = await resolveProviderAvailability(baseProvider({ id: 'apple-platform-mismatch' }));
+    expect(result.kind).toBe('unavailable');
+    expect(result.reason.code).toBe('platform-mismatch');
+    expect(result.reason.supportedPlatforms).toEqual(['ios']);
+  });
+
+  test('marks A16-or-older iPhone as device-ineligible when native says unavailable', async () => {
+    setMocks({ os: 'ios', appleAvailable: false, modelId: 'iPhone15,3' }); // iPhone 14 Pro Max
+    const { resolveProviderAvailability } = require('../../src/services/ai/providerAvailability');
+    const result = await resolveProviderAvailability(baseProvider({ id: 'apple-iphone14' }));
+    expect(result.kind).toBe('unavailable');
+    expect(result.reason.code).toBe('device-ineligible');
+    expect(result.reason.message).toMatch(/iPhone 15 Pro/);
+  });
+
+  test('treats iPhone 15 Pro (iPhone16,1) as eligible when native reports available', async () => {
+    setMocks({ os: 'ios', appleAvailable: true, modelId: 'iPhone16,1' });
+    const { resolveProviderAvailability } = require('../../src/services/ai/providerAvailability');
+    const result = await resolveProviderAvailability(baseProvider({ id: 'apple-iphone15pro' }));
+    expect(result.kind).toBe('available');
+  });
+
+  test('eligible device but Apple Intelligence not active reports apple-intelligence-disabled', async () => {
+    setMocks({ os: 'ios', appleAvailable: false, modelId: 'iPhone17,3' }); // iPhone 16 family
+    const { resolveProviderAvailability } = require('../../src/services/ai/providerAvailability');
+    const result = await resolveProviderAvailability(baseProvider({ id: 'apple-iphone16-disabled' }));
+    expect(result.kind).toBe('unavailable');
+    expect(result.reason.code).toBe('apple-intelligence-disabled');
+  });
+
+  test('classifies non-Pro iPhone 15 (iPhone15,4) as device-ineligible', async () => {
+    setMocks({ os: 'ios', appleAvailable: false, modelId: 'iPhone15,4' });
+    const { resolveProviderAvailability } = require('../../src/services/ai/providerAvailability');
+    const result = await resolveProviderAvailability(baseProvider({ id: 'apple-iphone15-base' }));
+    expect(result.kind).toBe('unavailable');
+    expect(result.reason.code).toBe('device-ineligible');
+  });
+
+  test('non-apple provider always available regardless of platform', async () => {
+    setMocks({ os: 'android' });
+    const { resolveProviderAvailability } = require('../../src/services/ai/providerAvailability');
+    const result = await resolveProviderAvailability({
+      id: 'openai-default',
+      type: 'openai-compatible',
+      name: 'OpenAI',
+      isEnabled: true,
+      models: [],
+      addedAt: 0,
+    });
+    expect(result.kind).toBe('available');
+  });
+
+  test('caches result for identical provider id within TTL', async () => {
+    setMocks({ os: 'ios', appleAvailable: true, modelId: 'iPhone16,1' });
+    const { resolveProviderAvailability } = require('../../src/services/ai/providerAvailability');
+    const provider = baseProvider({ id: 'apple-cache-hit' });
+    const first = await resolveProviderAvailability(provider);
+    const second = await resolveProviderAvailability(provider);
+    expect(first).toBe(second);
+  });
+});

--- a/src/components/ai/ModelSelector.tsx
+++ b/src/components/ai/ModelSelector.tsx
@@ -10,11 +10,14 @@ import {
   Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
 import { useTheme, useTokens } from '../../contexts/ThemeContext';
 import { Group, GroupRow } from '../ui';
 import { useAIStore } from '../../stores/aiStore';
 import { downloadModel, getModelStatus } from '../../services/AIService';
 import { AIModelConfig, AIProviderConfig } from '../../models/AIProvider';
+import { resolveProviderAvailability, type Availability } from '../../services/ai/providerAvailability';
+import { describeAvailability } from '../../services/ai/providerAvailabilityCopy';
 
 interface ModelSelectorProps {
   visible: boolean;
@@ -24,20 +27,28 @@ interface ModelSelectorProps {
 export function ModelSelector({ visible, onClose }: ModelSelectorProps) {
   const { colors } = useTheme();
   const { spacing, type } = useTokens();
-  
+  const { t } = useTranslation();
+
   const providers = useAIStore((state) => state.providers);
   const selectedModelId = useAIStore((state) => state.selectedModelId);
   const selectModel = useAIStore((state) => state.selectModel);
   const updateProvider = useAIStore((state) => state.updateProvider);
-  
+
   const [statuses, setStatuses] = useState<Record<string, 'ready' | 'needs-download' | 'unavailable'>>({});
+  const [providerAvailability, setProviderAvailability] = useState<Record<string, Availability>>({});
   const [downloadProgress, setDownloadProgress] = useState<Record<string, number>>({});
   const [isDownloading, setIsDownloading] = useState<Record<string, boolean>>({});
 
   const loadStatuses = useCallback(async () => {
     const newStatuses: Record<string, 'ready' | 'needs-download' | 'unavailable'> = {};
+    const newAvailability: Record<string, Availability> = {};
     for (const provider of providers) {
       if (!provider.isEnabled) continue;
+      try {
+        newAvailability[provider.id] = await resolveProviderAvailability(provider);
+      } catch {
+        newAvailability[provider.id] = { kind: 'available' };
+      }
       for (const model of provider.models) {
         try {
           const status = await getModelStatus(model);
@@ -48,6 +59,7 @@ export function ModelSelector({ visible, onClose }: ModelSelectorProps) {
       }
     }
     setStatuses(newStatuses);
+    setProviderAvailability(newAvailability);
   }, [providers]);
 
   useEffect(() => {
@@ -114,7 +126,12 @@ export function ModelSelector({ visible, onClose }: ModelSelectorProps) {
                     const isSelected = selectedModelId === model.id;
                     const isUnavailable = status === 'unavailable';
                     const needsDownload = status === 'needs-download';
-                    
+                    const availability = providerAvailability[provider.id];
+                    const unavailableReason =
+                      availability && availability.kind === 'unavailable'
+                        ? describeAvailability(t, availability.reason)
+                        : null;
+
                     return (
                       <GroupRow
                         key={model.id}
@@ -132,7 +149,7 @@ export function ModelSelector({ visible, onClose }: ModelSelectorProps) {
                             </Text>
                             {isUnavailable && (
                               <Text style={[styles.modelDesc, { color: colors.textSecondary }]}>
-                                Not available on this device
+                                {unavailableReason ?? t('ai.availability.unknown')}
                               </Text>
                             )}
                             {needsDownload && !downloading && (

--- a/src/components/chat/useChatScreenController.ts
+++ b/src/components/chat/useChatScreenController.ts
@@ -10,6 +10,9 @@ import { buildSystemPrompt } from '../../services/ai/systemPrompt';
 import { checkContextBudget } from '../../services/ai/modelLimits';
 import { buildContextString } from '../../services/ContextService';
 import { STREAM_RENDER_FLUSH_MS } from '../../services/ai/config';
+import { ProviderUnavailableError } from '../../services/ai/providerAvailability';
+import { describeAvailability } from '../../services/ai/providerAvailabilityCopy';
+import { useTranslation } from 'react-i18next';
 import { useAIStore } from '../../stores/aiStore';
 import { useChatStore } from '../../stores/chatStore';
 import { useNoteStore } from '../../stores/noteStore';
@@ -44,6 +47,7 @@ export function useChatScreenController(threadId: string) {
 
   const toolArgsBufferRef = useRef<Record<string, string>>({});
   const abortRef = useRef<AbortController | null>(null);
+  const { t } = useTranslation();
 
   const [attachedContexts, setAttachedContexts] = useState<AIContextItem[]>([]);
   const [isContextPickerVisible, setIsContextPickerVisible] = useState(false);
@@ -198,14 +202,20 @@ export function useChatScreenController(threadId: string) {
       const aborted = (error as Error)?.name === 'AbortError' || abortController.signal.aborted;
       if (aborted) updateMessage(assistantMessageId, { content: assistantText || 'Stopped.' });
       else {
-        setLocalError(error instanceof Error ? error.message : 'Failed to send message.');
-        updateMessage(assistantMessageId, { content: assistantText || 'Something went wrong while streaming this response.' });
+        const message =
+          error instanceof ProviderUnavailableError
+            ? describeAvailability(t, error.reason)
+            : error instanceof Error
+              ? error.message
+              : 'Failed to send message.';
+        setLocalError(message);
+        updateMessage(assistantMessageId, { content: assistantText || message });
       }
     } finally {
       if (abortRef.current === abortController) abortRef.current = null;
       setStreaming(false);
     }
-  }, [addMessage, clearError, getSelectedModelConfig, noteCount, renameThread, runToolCall, saveActiveThread, setStreaming, todoCount, updateMessage]);
+  }, [addMessage, clearError, getSelectedModelConfig, noteCount, renameThread, runToolCall, saveActiveThread, setStreaming, t, todoCount, updateMessage]);
 
   const stopStreaming = useCallback(() => abortRef.current?.abort(), []);
 

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -18,6 +18,8 @@ import type { TemplateRepoPreference } from '../../services/TemplateRepoPreferen
 import type { AIProviderConfig } from '../../models/AIProvider';
 import { TIMEOUT_OPTIONS, type BiometricKind, type LockTimeout } from '../../contexts/BiometricLockContext';
 import { SYNC_INTERVAL_OPTIONS, type SyncIntervalSeconds } from '../../hooks/useForegroundSyncSettings';
+import { useProvidersAvailability } from '../../hooks/useProviderAvailability';
+import { describeAvailability } from '../../services/ai/providerAvailabilityCopy';
 
 type ThemeColors = {
   background: string;
@@ -180,6 +182,7 @@ export function SettingsContent(props: SettingsContentProps) {
   const [showTimeoutPicker, setShowTimeoutPicker] = useState(false);
   const [showLanguagePicker, setShowLanguagePicker] = useState(false);
   const [showIntervalPicker, setShowIntervalPicker] = useState(false);
+  const providerAvailability = useProvidersAvailability(providers);
   const intervalLabel =
     SYNC_INTERVAL_OPTIONS.find((opt) => opt.value === syncIntervalSeconds)?.label ?? 'Every minute';
 
@@ -613,11 +616,38 @@ export function SettingsContent(props: SettingsContentProps) {
           </Group>
 
           <Group title={t('settings.providers')}>
-            {providers.map((provider) => (
-              <GroupRow key={provider.id} onPress={() => onProviderPress(provider)} trailing={<Text style={[styles.settingValue, { color: colors.textSecondary }]}>{provider.isEnabled ? 'Enabled' : 'Disabled'}</Text>}>
-                <Text style={[styles.settingLabel, { color: colors.text }]}>{provider.name}</Text>
-              </GroupRow>
-            ))}
+            {providers.map((provider) => {
+              const availability = providerAvailability[provider.id];
+              const isUnavailable = availability?.kind === 'unavailable';
+              const reasonText = isUnavailable
+                ? describeAvailability(t, availability.reason)
+                : null;
+              return (
+                <GroupRow
+                  key={provider.id}
+                  onPress={() => onProviderPress(provider)}
+                  trailing={
+                    <Text style={[styles.settingValue, { color: colors.textSecondary }]}>
+                      {isUnavailable
+                        ? t('settings.unavailable')
+                        : provider.isEnabled
+                          ? 'Enabled'
+                          : 'Disabled'}
+                    </Text>
+                  }
+                  style={isUnavailable ? { opacity: 0.5 } : undefined}
+                >
+                  <View>
+                    <Text style={[styles.settingLabel, { color: colors.text }]}>{provider.name}</Text>
+                    {reasonText ? (
+                      <Text style={[styles.settingValue, { color: colors.textSecondary, marginTop: 2 }]}>
+                        {reasonText}
+                      </Text>
+                    ) : null}
+                  </View>
+                </GroupRow>
+              );
+            })}
             <GroupRow onPress={onAddProvider}>
               <Text style={[styles.settingLabel, { color: colors.primary }]}>Add Provider</Text>
             </GroupRow>

--- a/src/hooks/useProviderAvailability.ts
+++ b/src/hooks/useProviderAvailability.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import type { AIProviderConfig } from '../models/AIProvider';
+import {
+  Availability,
+  resolveProviderAvailability,
+} from '../services/ai/providerAvailability';
+
+const PENDING: Availability = { kind: 'available' };
+
+export function useProviderAvailability(provider: AIProviderConfig | null | undefined): Availability {
+  const [availability, setAvailability] = useState<Availability>(PENDING);
+
+  useEffect(() => {
+    if (!provider) {
+      setAvailability(PENDING);
+      return;
+    }
+
+    let cancelled = false;
+    resolveProviderAvailability(provider)
+      .then((result) => {
+        if (!cancelled) setAvailability(result);
+      })
+      .catch(() => {
+        if (!cancelled) setAvailability(PENDING);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [provider]);
+
+  return availability;
+}
+
+export function useProvidersAvailability(
+  providers: AIProviderConfig[]
+): Record<string, Availability> {
+  const [map, setMap] = useState<Record<string, Availability>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const entries = await Promise.all(
+        providers.map(async (provider) => {
+          try {
+            const result = await resolveProviderAvailability(provider);
+            return [provider.id, result] as const;
+          } catch {
+            return [provider.id, PENDING] as const;
+          }
+        })
+      );
+      if (cancelled) return;
+      const next: Record<string, Availability> = {};
+      for (const [id, value] of entries) next[id] = value;
+      setMap(next);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [providers]);
+
+  return map;
+}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -133,9 +133,19 @@
     "addProvider": "Anbieter hinzufügen",
     "enabled": "Aktiviert",
     "disabled": "Deaktiviert",
+    "unavailable": "Nicht verfügbar",
     "auto": "Automatisch",
     "confirm": "Bestätigen",
     "notSet": "Nicht festgelegt"
+  },
+  "ai": {
+    "availability": {
+      "iosOnly": "Nur iOS — auf Android nicht verfügbar",
+      "androidOnly": "Nur Android — auf iOS nicht verfügbar",
+      "appleIntelligenceDisabled": "Apple Intelligence in Einstellungen aktivieren",
+      "appleIntelligenceDownloading": "Apple Intelligence wird geladen — bitte gleich erneut versuchen",
+      "unknown": "Auf diesem Gerät nicht verfügbar"
+    }
   },
   "chat": {
     "askAI": "KI fragen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -133,9 +133,19 @@
     "addProvider": "Add Provider",
     "enabled": "Enabled",
     "disabled": "Disabled",
+    "unavailable": "Unavailable",
     "auto": "Auto",
     "confirm": "Confirm",
     "notSet": "Not set"
+  },
+  "ai": {
+    "availability": {
+      "iosOnly": "iOS only — not available on Android",
+      "androidOnly": "Android only — not available on iOS",
+      "appleIntelligenceDisabled": "Enable Apple Intelligence in Settings",
+      "appleIntelligenceDownloading": "Apple Intelligence is downloading — try again shortly",
+      "unknown": "Not available on this device"
+    }
   },
   "chat": {
     "askAI": "Ask AI",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -133,9 +133,19 @@
     "addProvider": "Añadir proveedor",
     "enabled": "Habilitado",
     "disabled": "Deshabilitado",
+    "unavailable": "No disponible",
     "auto": "Auto",
     "confirm": "Confirmar",
     "notSet": "No configurado"
+  },
+  "ai": {
+    "availability": {
+      "iosOnly": "Solo iOS — no disponible en Android",
+      "androidOnly": "Solo Android — no disponible en iOS",
+      "appleIntelligenceDisabled": "Activa Apple Intelligence en Ajustes",
+      "appleIntelligenceDownloading": "Apple Intelligence se está descargando — inténtalo en breve",
+      "unknown": "No disponible en este dispositivo"
+    }
   },
   "chat": {
     "askAI": "Preguntar a IA",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -133,9 +133,19 @@
     "addProvider": "Ajouter un fournisseur",
     "enabled": "Activé",
     "disabled": "Désactivé",
+    "unavailable": "Indisponible",
     "auto": "Auto",
     "confirm": "Confirmer",
     "notSet": "Non défini"
+  },
+  "ai": {
+    "availability": {
+      "iosOnly": "iOS uniquement — non disponible sur Android",
+      "androidOnly": "Android uniquement — non disponible sur iOS",
+      "appleIntelligenceDisabled": "Activez Apple Intelligence dans Réglages",
+      "appleIntelligenceDownloading": "Apple Intelligence est en cours de téléchargement — réessayez sous peu",
+      "unknown": "Non disponible sur cet appareil"
+    }
   },
   "chat": {
     "askAI": "Demander à l'IA",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -133,9 +133,19 @@
     "addProvider": "プロバイダーを追加",
     "enabled": "有効",
     "disabled": "無効",
+    "unavailable": "利用不可",
     "auto": "自動",
     "confirm": "確認",
     "notSet": "未設定"
+  },
+  "ai": {
+    "availability": {
+      "iosOnly": "iOS のみ — Android では利用できません",
+      "androidOnly": "Android のみ — iOS では利用できません",
+      "appleIntelligenceDisabled": "設定で Apple Intelligence を有効にしてください",
+      "appleIntelligenceDownloading": "Apple Intelligence をダウンロード中です — しばらくしてから再度お試しください",
+      "unknown": "このデバイスでは利用できません"
+    }
   },
   "chat": {
     "askAI": "AIに質問",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -133,9 +133,19 @@
     "addProvider": "공급자 추가",
     "enabled": "활성화됨",
     "disabled": "비활성화됨",
+    "unavailable": "사용할 수 없음",
     "auto": "자동",
     "confirm": "확인",
     "notSet": "설정되지 않음"
+  },
+  "ai": {
+    "availability": {
+      "iosOnly": "iOS 전용 — Android에서는 사용할 수 없습니다",
+      "androidOnly": "Android 전용 — iOS에서는 사용할 수 없습니다",
+      "appleIntelligenceDisabled": "설정에서 Apple Intelligence를 활성화하세요",
+      "appleIntelligenceDownloading": "Apple Intelligence를 다운로드 중입니다 — 잠시 후 다시 시도해 주세요",
+      "unknown": "이 기기에서 사용할 수 없습니다"
+    }
   },
   "chat": {
     "askAI": "AI에게 묻기",

--- a/src/models/AIProvider.ts
+++ b/src/models/AIProvider.ts
@@ -1,5 +1,7 @@
 export type AIProviderType = 'apple' | 'llama' | 'openai-compatible';
 
+export type ProviderPlatform = 'ios' | 'android';
+
 export interface AIModelConfig {
   id: string;
   name: string;
@@ -19,6 +21,11 @@ export interface AIProviderConfig {
   isEnabled: boolean;
   models: AIModelConfig[];
   addedAt: number;
+  /**
+   * Platforms this provider is compatible with. `undefined` means cross-platform.
+   * Apple Intelligence is iOS-only; future Android-only providers may set `['android']`.
+   */
+  supportedPlatforms?: ProviderPlatform[];
 }
 
 export type AIActionMode = 'auto' | 'confirm';

--- a/src/services/AIService.ts
+++ b/src/services/AIService.ts
@@ -4,6 +4,10 @@ import { Platform } from 'react-native';
 import type { AIModelConfig, AIProviderConfig } from '../models/AIProvider';
 import { chatTools } from './ai/tools';
 import { buildQuirkedFetch } from './ai/providerQuirks';
+import {
+  ProviderUnavailableError,
+  resolveProviderAvailability,
+} from './ai/providerAvailability';
 
 type OnDeviceAvailability = {
   apple: boolean;
@@ -89,6 +93,23 @@ export async function initializeModel(
           throw new Error('Apple Intelligence is only available on iOS');
         }
 
+        // Probe device eligibility before touching the bridge so the call
+        // doesn't hang silently on devices like iPhone 14 Pro that are
+        // permanently ineligible for Apple Intelligence (A16 Bionic).
+        const probeProvider: AIProviderConfig = providerConfig ?? {
+          id: modelConfig.providerId,
+          type: 'apple',
+          name: 'Apple Intelligence',
+          isEnabled: true,
+          models: [modelConfig],
+          addedAt: 0,
+          supportedPlatforms: ['ios'],
+        };
+        const availability = await resolveProviderAvailability(probeProvider);
+        if (availability.kind === 'unavailable') {
+          throw new ProviderUnavailableError(availability.reason, probeProvider.name);
+        }
+
         const { createAppleProvider } = await import('@react-native-ai/apple');
         const provider = createAppleProvider({ availableTools: chatTools });
 
@@ -125,6 +146,11 @@ export async function initializeModel(
         throw new Error(`Unsupported AI model type: ${(modelConfig as AIModelConfig).providerType}`);
     }
   } catch (error) {
+    // Preserve typed eligibility errors so the UI can surface the specific reason
+    // (otherwise the bridge call would just hang on ineligible iPhones like the 14 Pro).
+    if (error instanceof ProviderUnavailableError) {
+      throw error;
+    }
     const message = error instanceof Error ? error.message : 'Unknown model initialization error';
     throw new Error(`Failed to initialize model \"${modelConfig.name}\": ${message}`);
   }
@@ -341,7 +367,17 @@ export async function downloadModel(
 export async function getModelStatus(modelConfig: AIModelConfig): Promise<ModelStatus> {
   try {
     if (modelConfig.providerType === 'apple') {
-      return Platform.OS === 'ios' ? 'ready' : 'unavailable';
+      const probeProvider: AIProviderConfig = {
+        id: modelConfig.providerId,
+        type: 'apple',
+        name: 'Apple Intelligence',
+        isEnabled: true,
+        models: [modelConfig],
+        addedAt: 0,
+        supportedPlatforms: ['ios'],
+      };
+      const availability = await resolveProviderAvailability(probeProvider);
+      return availability.kind === 'available' ? 'ready' : 'unavailable';
     }
 
     if (modelConfig.providerType === 'llama') {

--- a/src/services/ai/providerAvailability.ts
+++ b/src/services/ai/providerAvailability.ts
@@ -1,0 +1,143 @@
+import { Platform } from 'react-native';
+import type { AIProviderConfig, ProviderPlatform } from '../../models/AIProvider';
+
+export type AvailabilityReason =
+  | { code: 'platform-mismatch'; supportedPlatforms: ProviderPlatform[] }
+  | { code: 'device-ineligible'; message: string }
+  | { code: 'apple-intelligence-disabled' }
+  | { code: 'apple-intelligence-downloading' }
+  | { code: 'unknown'; message: string };
+
+export type Availability =
+  | { kind: 'available' }
+  | { kind: 'unavailable'; reason: AvailabilityReason };
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { value: Availability; expiresAt: number }>();
+
+export function clearProviderAvailabilityCache(): void {
+  cache.clear();
+}
+
+function currentPlatform(): ProviderPlatform | null {
+  if (Platform.OS === 'ios') return 'ios';
+  if (Platform.OS === 'android') return 'android';
+  return null;
+}
+
+// Apple Intelligence requires A17 Pro / M-series silicon.
+// First eligible iPhone is iPhone 15 Pro (iPhone16,1 / iPhone16,2). All iPhone 17,x
+// (iPhone 16 family) are eligible; older identifiers are not.
+function isAppleIntelligenceEligibleModel(modelId: string | null | undefined): boolean {
+  if (!modelId) return true; // simulator returns null modelId — assume eligible there
+  const match = modelId.match(/^iPhone(\d+),(\d+)$/);
+  if (!match) {
+    // iPad / Mac: iPad14,8+ and any Mac with Apple silicon are eligible.
+    // For now, assume non-iPhone Apple devices are eligible (best-effort).
+    return true;
+  }
+  const major = parseInt(match[1], 10);
+  // iPhone16,x = iPhone 15 / 15 Plus / 15 Pro / 15 Pro Max.
+  // Only the Pro variants (16,1 and 16,2) are eligible.
+  if (major === 16) {
+    const minor = parseInt(match[2], 10);
+    return minor === 1 || minor === 2;
+  }
+  // iPhone17,x and newer are all A18+/Pro chips, all eligible.
+  return major >= 17;
+}
+
+async function probeApple(): Promise<Availability> {
+  if (Platform.OS !== 'ios') {
+    return {
+      kind: 'unavailable',
+      reason: { code: 'platform-mismatch', supportedPlatforms: ['ios'] },
+    };
+  }
+
+  let nativeAvailable = false;
+  let nativeError: unknown = null;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const apple = require('@react-native-ai/apple') as typeof import('@react-native-ai/apple');
+    nativeAvailable = apple.AppleFoundationModels.isAvailable();
+  } catch (error) {
+    nativeError = error;
+  }
+
+  if (nativeAvailable) {
+    return { kind: 'available' };
+  }
+
+  // Native says unavailable. Disambiguate by checking the device model.
+  let modelId: string | null | undefined = null;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Device = require('expo-device') as typeof import('expo-device');
+    modelId = Device.modelId ?? null;
+  } catch {
+    // expo-device unavailable — fall through to generic unknown
+  }
+
+  if (!isAppleIntelligenceEligibleModel(modelId)) {
+    return {
+      kind: 'unavailable',
+      reason: {
+        code: 'device-ineligible',
+        message: 'Requires iPhone 15 Pro or newer',
+      },
+    };
+  }
+
+  // Device is capable but the model isn't ready — most likely the user hasn't
+  // enabled Apple Intelligence in Settings (or it's still downloading; we can't
+  // currently tell those apart from JS).
+  if (nativeError) {
+    const message = nativeError instanceof Error ? nativeError.message : String(nativeError);
+    return { kind: 'unavailable', reason: { code: 'unknown', message } };
+  }
+
+  return { kind: 'unavailable', reason: { code: 'apple-intelligence-disabled' } };
+}
+
+export async function resolveProviderAvailability(
+  provider: AIProviderConfig
+): Promise<Availability> {
+  const cached = cache.get(provider.id);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
+  let value: Availability;
+
+  const supported = provider.supportedPlatforms;
+  if (supported && supported.length > 0) {
+    const platform = currentPlatform();
+    if (!platform || !supported.includes(platform)) {
+      value = {
+        kind: 'unavailable',
+        reason: { code: 'platform-mismatch', supportedPlatforms: supported },
+      };
+      cache.set(provider.id, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+      return value;
+    }
+  }
+
+  if (provider.type === 'apple') {
+    value = await probeApple();
+  } else {
+    value = { kind: 'available' };
+  }
+
+  cache.set(provider.id, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  return value;
+}
+
+export class ProviderUnavailableError extends Error {
+  readonly reason: AvailabilityReason;
+  constructor(reason: AvailabilityReason, providerName: string) {
+    super(`Provider "${providerName}" is unavailable: ${reason.code}`);
+    this.name = 'ProviderUnavailableError';
+    this.reason = reason;
+  }
+}

--- a/src/services/ai/providerAvailabilityCopy.ts
+++ b/src/services/ai/providerAvailabilityCopy.ts
@@ -1,0 +1,25 @@
+import type { TFunction } from 'i18next';
+import type { AvailabilityReason } from './providerAvailability';
+
+export function describeAvailability(t: TFunction, reason: AvailabilityReason): string {
+  switch (reason.code) {
+    case 'platform-mismatch': {
+      if (reason.supportedPlatforms.includes('ios') && !reason.supportedPlatforms.includes('android')) {
+        return t('ai.availability.iosOnly');
+      }
+      if (reason.supportedPlatforms.includes('android') && !reason.supportedPlatforms.includes('ios')) {
+        return t('ai.availability.androidOnly');
+      }
+      return t('ai.availability.unknown');
+    }
+    case 'device-ineligible':
+      return reason.message;
+    case 'apple-intelligence-disabled':
+      return t('ai.availability.appleIntelligenceDisabled');
+    case 'apple-intelligence-downloading':
+      return t('ai.availability.appleIntelligenceDownloading');
+    case 'unknown':
+    default:
+      return t('ai.availability.unknown');
+  }
+}

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -3,6 +3,7 @@ import * as SecureStore from 'expo-secure-store';
 import { create } from 'zustand';
 import { AIActionMode, AIModelConfig, AIProviderConfig, AISettings } from '../models/AIProvider';
 import { setChatRepoAccount } from '../services/ChatStorageService';
+import { resolveProviderAvailability } from '../services/ai/providerAvailability';
 
 const AI_SETTINGS_STORAGE_KEY = 'ai-settings';
 const AI_PROVIDER_KEY_PREFIX = 'ai-provider-key-';
@@ -42,6 +43,7 @@ const createDefaultProviders = (): AIProviderConfig[] => [
     name: 'Apple Intelligence',
     isEnabled: true,
     addedAt: 0,
+    supportedPlatforms: ['ios'],
     models: [
       {
         id: 'apple-foundation',
@@ -105,6 +107,9 @@ const mergeProviders = (storedProviders?: AIProviderConfig[]): AIProviderConfig[
       ...defaultProvider,
       ...storedProvider,
       models: storedProvider.models?.length ? storedProvider.models : defaultProvider.models,
+      // Always re-derive platform support from the default config so old persisted
+      // entries inherit new gating rules (the Apple provider is iOS-only).
+      supportedPlatforms: defaultProvider.supportedPlatforms,
     };
   });
 
@@ -122,6 +127,48 @@ const hydrateProviderApiKeys = async (providers: AIProviderConfig[]): Promise<AI
       return apiKey ? { ...provider, apiKey } : provider;
     })
   );
+
+/**
+ * If the persisted selection points at a provider that is no longer available
+ * on this device (e.g. user moved from an iPhone 15 Pro to a 14 Pro), pick the
+ * first model from a still-available enabled provider instead. Only runs at
+ * cold start so we don't yank the model out from under an active session.
+ */
+const resolveSelectedModelOnStartup = async (
+  selectedModelId: string | null,
+  providers: AIProviderConfig[]
+): Promise<string | null> => {
+  if (!selectedModelId) return null;
+
+  const owningProvider = providers.find(
+    (p) => p.isEnabled && p.models.some((m) => m.id === selectedModelId)
+  );
+
+  if (owningProvider) {
+    try {
+      const availability = await resolveProviderAvailability(owningProvider);
+      if (availability.kind === 'available') {
+        return selectedModelId;
+      }
+    } catch {
+      // fall through to fallback
+    }
+  }
+
+  for (const provider of providers) {
+    if (!provider.isEnabled || provider.models.length === 0) continue;
+    try {
+      const availability = await resolveProviderAvailability(provider);
+      if (availability.kind === 'available') {
+        return provider.models[0].id;
+      }
+    } catch {
+      // try next
+    }
+  }
+
+  return null;
+};
 
 export const useAIStore = create<AIState & AIActions>()((set, get) => ({
   ...createDefaultSettings(),
@@ -280,7 +327,11 @@ export const useAIStore = create<AIState & AIActions>()((set, get) => ({
       if (!savedSettingsRaw) {
         const defaultSettings = createDefaultSettings();
         const providers = await hydrateProviderApiKeys(defaultSettings.providers);
-        set({ ...defaultSettings, providers, isLoading: false, error: null });
+        const selectedModelId = await resolveSelectedModelOnStartup(
+          defaultSettings.selectedModelId,
+          providers
+        );
+        set({ ...defaultSettings, providers, selectedModelId, isLoading: false, error: null });
         return;
       }
 
@@ -296,10 +347,15 @@ export const useAIStore = create<AIState & AIActions>()((set, get) => ({
       };
 
       const providers = await hydrateProviderApiKeys(mergedSettings.providers);
+      const selectedModelId = await resolveSelectedModelOnStartup(
+        mergedSettings.selectedModelId,
+        providers
+      );
 
       set({
         ...mergedSettings,
         providers,
+        selectedModelId,
         isLoading: false,
         error: null,
       });


### PR DESCRIPTION
## Summary
- Add a runtime probe so Apple Intelligence is dimmed with a clear reason instead of hanging the bridge on ineligible iPhones (iPhone 14 Pro and older).
- Introduce a typed `supportedPlatforms` field on providers; the default Apple provider is iOS-only, future Android-only providers can declare `['android']`.
- Surface the specific reason ("Requires iPhone 15 Pro or newer", "Enable Apple Intelligence in Settings", "iOS only — not available on Android", etc.) in Settings → Providers and the Model Selector, in en/de/es/fr/ja/ko.
- AIService now throws `ProviderUnavailableError` before touching the bridge for unavailable providers; the chat controller surfaces the reason instead of spinning forever.
- aiStore cold-start fallback: if the persisted selection points at a provider that is no longer available on this device, switch to the first enabled-and-available provider.

## Why
A user reported that Apple Foundation Models works on the iOS simulator but "just loads" on iPhone 14 Pro / iOS 26.3.1. Root cause: iPhone 14 Pro (A16 Bionic, 6 GB RAM) is permanently ineligible for Apple Intelligence — Apple gates Foundation Models to A17 Pro+ (iPhone 15 Pro / 16 family). The framework returns `.unavailable(.deviceNotEligible)`. The bridge had no availability check, so it tried to call the model and the promise never settled.

## What's new
- `AIProviderConfig.supportedPlatforms?: ('ios' | 'android')[]`; `apple-default` declares `['ios']`. `mergeProviders` always re-derives this from the default config so older persisted state inherits the gating rule.
- `src/services/ai/providerAvailability.ts`: `resolveProviderAvailability(provider): Promise<Availability>` with a 30s in-process cache and a `ProviderUnavailableError` class.
- Apple probe path: query `AppleFoundationModels.isAvailable()`; if `false`, disambiguate using `expo-device.modelId` — `iPhone16,1`/`iPhone16,2` (iPhone 15 Pro / Pro Max) and any `iPhone17+` count as eligible. Anything older → `device-ineligible: "Requires iPhone 15 Pro or newer"`. Eligible-but-disabled → `apple-intelligence-disabled`. Bridge throws → `unknown` with message.
- Hooks `useProviderAvailability(provider)` and `useProvidersAvailability(providers)`.
- Settings provider rows: dimmed (`opacity: 0.5`), reason subtitle under provider name, trailing label "Unavailable".
- ModelSelector reuses the same resolver and replaces the generic "Not available on this device" copy with the specific reason via `describeAvailability(t, reason)`.
- AIService.initializeModel + getModelStatus call `resolveProviderAvailability` for Apple before invoking the bridge, throwing `ProviderUnavailableError` (preserved through the existing catch).
- useChatScreenController catches `ProviderUnavailableError` and shows the localized reason instead of the raw error string.
- aiStore.loadSettings runs `resolveSelectedModelOnStartup` once at hydration so a persisted Apple selection on an iPhone 14 Pro falls back to the first available enabled provider.
- Locale keys (`ai.availability.*` + `settings.unavailable`) added in en/de/es/fr/ja/ko.

### Probe approach (notable design choice)
`@react-native-ai/apple` only exposes a single boolean (`AppleFoundationModels.isAvailable()`) — it can't distinguish "device ineligible" from "Apple Intelligence disabled in Settings" from "model still downloading". I disambiguate from JS by reading `expo-device.modelId` (already a project dep) and checking against the known Apple Intelligence eligibility list. This is best-effort but covers the reported regression. We cannot currently detect "downloading" specifically; that branch is plumbed through but not produced by the probe yet.

`require()` is used inside the probe rather than dynamic `import()` — `babel-preset-expo` doesn't transform dynamic import for the Jest pipeline, so the test suite would otherwise blow up.

## Test plan
- [x] `yarn ts:check` — clean
- [x] `yarn lint --quiet` — clean
- [x] `yarn test --runInBand` — 117 suites / 892 tests pass (incl. the previously-flaky swipe-delete + save-loading-indicator)
- [x] New tests in `__tests__/ai/providerAvailability.test.ts` cover: platform-mismatch on Android, A16 iPhone (iPhone15,3) → device-ineligible, iPhone 15 Pro (iPhone16,1) → available, eligible-but-disabled (iPhone17,3) → apple-intelligence-disabled, base iPhone 15 (iPhone15,4) → device-ineligible, non-Apple provider always available, and 30s caching.
- [ ] Manual: Apple FM row dimmed on Android with "iOS only" badge.
- [ ] Manual: on iPhone 14 Pro shows "Requires iPhone 15 Pro or newer".
- [ ] Manual: ModelSelector shows the specific reason instead of generic copy.
- [ ] Manual: tapping send when Apple FM unavailable surfaces an error toast/snackbar instead of spinner.
- [ ] Manual: cold-start with an unavailable selected provider auto-falls-back.

## Out of scope
- Real A17 Pro device test — I don't have one. The eligibility list is derived from public Apple Intelligence requirements; if Apple ships eligibility on additional A17/M-series identifiers, extend `isAppleIntelligenceEligibleModel`.
- Detecting "Apple Intelligence is downloading" specifically — the framework doesn't expose that state through the bridge. The reason code is plumbed through for future use.
- Extending eligibility to iPad / Mac identifiers — non-iPhone Apple devices are currently treated as eligible (best-effort) since the reported issue is iPhone-specific.