### PR TITLE
fix(editor): add crash guards around preview pipeline (#580)

### DIFF
--- a/src/components/editor/editorShared.ts
+++ b/src/components/editor/editorShared.ts
@@ -146,19 +146,23 @@ function stripTopMetadata(raw: string, format: NoteFormat): string {
 }
 
 export function getPreviewContent(content: string, noteFormat: NoteFormat): string {
-  if (noteFormat === 'pdf') return content.trim();
-  if (noteFormat === 'markdown') return stripTopMetadata(content, 'markdown');
+  try {
+    if (noteFormat === 'pdf') return content.trim();
+    if (noteFormat === 'markdown') return stripTopMetadata(content, 'markdown');
 
-  if (noteFormat === 'neorg') {
-    const stripped = stripTopMetadata(content, 'neorg');
-    const parsed = NeorgParser.parseDocument(stripped);
-    if (parsed.success && parsed.document) {
-      return parsed.document.content;
+    if (noteFormat === 'neorg') {
+      const stripped = stripTopMetadata(content, 'neorg');
+      const parsed = NeorgParser.parseDocument(stripped);
+      if (parsed.success && parsed.document) {
+        return parsed.document.content;
+      }
+      return stripped;
     }
-    return stripped;
-  }
 
-  return stripTopMetadata(content, 'org');
+    return stripTopMetadata(content, 'org');
+  } catch {
+    return typeof content === 'string' ? content : '';
+  }
 }
 
 export function getSpeakableContent(previewContent: string): string {

--- a/src/components/editor/useNoteEditorPreview.ts
+++ b/src/components/editor/useNoteEditorPreview.ts
@@ -89,11 +89,15 @@ export function useNoteEditorPreview({
   const pdfViewerUri = useMemo(() => resolvePdfUrl(previewContent), [previewContent, resolvePdfUrl]);
 
   const parsedStructuredContent = useMemo(() => {
-    if (noteFormat === 'markdown' || noteFormat === 'pdf') return null;
-    const parser = noteFormat === 'org' ? OrgContentParser : NeorgContentParser;
-    const parsed = parser.parseContent(previewContent);
-    if (!parsed.success || !parsed.blocks || parsed.blocks.length === 0) return null;
-    return parsed.blocks;
+    try {
+      if (noteFormat === 'markdown' || noteFormat === 'pdf') return null;
+      const parser = noteFormat === 'org' ? OrgContentParser : NeorgContentParser;
+      const parsed = parser.parseContent(previewContent);
+      if (!parsed.success || !parsed.blocks || parsed.blocks.length === 0) return null;
+      return parsed.blocks;
+    } catch {
+      return null;
+    }
   }, [noteFormat, previewContent]);
 
   const currentNotePath = useMemo(() => {

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -28,11 +28,20 @@ import { NotePreviewPane } from '../components/editor/NotePreviewPane';
 import { NoteViewer } from '../components/editor/NoteViewer';
 import { useNoteEditorDocument } from '../components/editor/useNoteEditorDocument';
 import { useNoteEditorPreview } from '../components/editor/useNoteEditorPreview';
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'NoteEditor'>;
 type NoteEditorRouteProp = RouteProp<RootStackParamList, 'NoteEditor'>;
 
 export default function NoteEditorScreen() {
+  return (
+    <ErrorBoundary>
+      <NoteEditorScreenInner />
+    </ErrorBoundary>
+  );
+}
+
+function NoteEditorScreenInner() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<NoteEditorRouteProp>();
   const { colors, isDark } = useTheme();


### PR DESCRIPTION
## Summary

Closes #580

- Wrap `getPreviewContent` in try-catch so unexpected parser input cannot crash the app during typing.
- Wrap `parsedStructuredContent` useMemo in try-catch for the same reason.
- Wrap the entire `NoteEditorScreen` in an `ErrorBoundary` so any unhandled render error shows a retry prompt instead of a hard crash.

## Context

Issue #580 reports crashes when typing in new notes and during edit, but lacks reproduction steps. The preview pipeline (parsers, renderer) runs on every content change via `useMemo` — any unhandled exception there crashes the entire screen.

## Changes

| File | Change |
|------|--------|
| `editorShared.ts` | `getPreviewContent` now catches and returns raw content on parser failure |
| `useNoteEditorPreview.ts` | `parsedStructuredContent` now catches and returns `null` on failure |
| `NoteEditorScreen.tsx` | Entire screen wrapped in `ErrorBoundary` with retry fallback |

## Behavior change

| Scenario | Before | After |
|----------|--------|-------|
| Parser throws on malformed neorg/org input | Hard crash | Preview shows raw content, app stays alive |
| Renderer constructor fails | Hard crash | ErrorBoundary shows retry button |
| Any unhandled render error in editor | Hard crash | ErrorBoundary catches, shows retry |

## Note

This is a defensive fix since the issue lacks repro steps. If a specific crash root cause is identified later, it should be fixed at the source. These guards ensure the app degrades gracefully in the meantime.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)