### PR TITLE
refactor(home): drop large hero tile from Recent feed

### DIFF
--- a/src/components/home/BentoRecent.tsx
+++ b/src/components/home/BentoRecent.tsx
@@ -13,32 +13,26 @@ interface Props {
  * Bento layout for the Home screen "Recent" feed.
  *
  * Phone (single column logical width):
- *   [        large        ]
- *   [ medium ] [ medium  ]
- *   [ medium ] [ medium  ]
+ *   [ medium ] [ medium ]
+ *   [ medium ] [ medium ]
  *   ...
  *
- * Every row after the hero uses the same `medium` tile size so the grid
- * reads as a single uniform block instead of an ad-hoc featured row +
- * smaller follow-ups.
+ * Uniform 2-column grid of medium tiles.
  */
 export function BentoRecent({ items, onOpen }: Props) {
   const { colors } = useTheme();
   if (items.length === 0) return null;
 
-  const [first, ...rest] = items;
-
-  const restRows: RecentItem[][] = [];
-  for (let i = 0; i < rest.length; i += 2) {
-    restRows.push(rest.slice(i, i + 2));
+  const rows: RecentItem[][] = [];
+  for (let i = 0; i < items.length; i += 2) {
+    rows.push(items.slice(i, i + 2));
   }
 
   return (
     <View testID="bento-recent.button.open" style={styles.section}>
       <Text style={[styles.heading, { color: colors.textSecondary }]}>Recent</Text>
       <View style={styles.column}>
-        <BentoTile item={first} size="large" onPress={() => onOpen(first)} />
-        {restRows.map((row, idx) => (
+        {rows.map((row, idx) => (
           <View key={`recent-row-${idx}`} style={styles.row}>
             {row.map((item) => (
               <View key={`${item.kind}-${item.data.id}`} style={styles.cell}>


### PR DESCRIPTION
## Summary
- Remove the featured large `BentoTile` at the top of the Home screen's Recent feed.
- Render all recent items in a uniform 2-column grid of medium tiles.
- Update the layout comment accordingly.

## Test plan
- [x] `yarn ts:check` passes
- [x] `npx jest --testPathPattern=home` passes (905/905)
- [ ] Manual: open Home, verify Recent section shows uniform 2-col tiles with no hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)