### PR TITLE
fix(editor): warn when opening folder picker with no repo selected

### DIFF
--- a/__tests__/components/NoteEditorFormFolderGuard.test.tsx
+++ b/__tests__/components/NoteEditorFormFolderGuard.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import { NoteEditorForm } from '../../src/components/editor/NoteEditorForm';
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f4f4f4',
+      surfaceSecondary: '#eee',
+      primary: '#2563eb',
+      text: '#111',
+      textSecondary: '#666',
+      border: '#ddd',
+      error: '#dc2626',
+    },
+    isDark: false,
+  }),
+}));
+
+jest.mock('../../src/utils/haptics', () => ({
+  HapticService: { light: jest.fn(), selection: jest.fn() },
+}));
+
+jest.mock('../../src/components/GitContextPicker', () => () => null);
+jest.mock('../../src/components/MarkdownEditor', () => () => null);
+jest.mock('../../src/components/TagInput', () => () => null);
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof NoteEditorForm>> = {}) {
+  return {
+    repo: undefined,
+    branch: undefined,
+    commit: undefined,
+    title: '',
+    folderPath: undefined,
+    noteFormat: 'markdown' as const,
+    tags: [],
+    canvasJsonRefs: [],
+    content: '',
+    placeholder: '',
+    onRepoChange: jest.fn(),
+    onBranchChange: jest.fn(),
+    onCommitChange: jest.fn(),
+    onTitleChange: jest.fn(),
+    onOpenFolderDialog: jest.fn(),
+    onNoteFormatChange: jest.fn(),
+    onTagsChange: jest.fn(),
+    onEditCanvasJson: jest.fn(),
+    onContentChange: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('NoteEditorForm folder selector guard', () => {
+  it('shows hint and blocks dialog when no repo selected', () => {
+    const onOpenFolderDialog = jest.fn();
+    const { getByTestId } = render(
+      <NoteEditorForm {...makeProps({ repo: undefined, onOpenFolderDialog })} />,
+    );
+
+    expect(getByTestId('note-editor-form.text.folder-no-repo-hint')).toBeTruthy();
+    fireEvent.press(getByTestId('note-editor-form.button.open-folder'));
+    expect(onOpenFolderDialog).not.toHaveBeenCalled();
+  });
+
+  it('opens dialog when repo is selected and hides hint', () => {
+    const onOpenFolderDialog = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <NoteEditorForm {...makeProps({ repo: 'owner/repo', onOpenFolderDialog })} />,
+    );
+
+    expect(queryByTestId('note-editor-form.text.folder-no-repo-hint')).toBeNull();
+    fireEvent.press(getByTestId('note-editor-form.button.open-folder'));
+    expect(onOpenFolderDialog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/editor/NoteEditorForm.tsx
+++ b/src/components/editor/NoteEditorForm.tsx
@@ -85,12 +85,19 @@ export function NoteEditorForm({
 
       <TouchableOpacity
         testID="note-editor-form.button.open-folder"
-        style={[styles.folderSelector, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
+        style={[
+          styles.folderSelector,
+          { backgroundColor: colors.surfaceSecondary, borderColor: colors.border },
+          !repo && styles.folderSelectorDisabled,
+        ]}
         onPress={() => {
+          if (!repo) return;
           HapticService.light();
           onOpenFolderDialog();
         }}
-        activeOpacity={0.7}
+        activeOpacity={repo ? 0.7 : 1}
+        disabled={!repo}
+        accessibilityState={{ disabled: !repo }}
       >
         <Ionicons name="folder-outline" size={18} color={folderPath ? colors.primary : colors.textSecondary} />
         <Text style={[styles.folderSelectorLabel, { color: colors.textSecondary }]}>Folder</Text>
@@ -99,6 +106,14 @@ export function NoteEditorForm({
         </Text>
         <Ionicons name="chevron-forward" size={16} color={colors.textSecondary} />
       </TouchableOpacity>
+      {!repo ? (
+        <Text
+          testID="note-editor-form.text.folder-no-repo-hint"
+          style={[styles.folderHint, { color: colors.textSecondary }]}
+        >
+          Select a repository before choosing a folder.
+        </Text>
+      ) : null}
 
       <View style={[styles.formatRow, { borderBottomColor: colors.border }]}> 
         <Ionicons name="document-outline" size={18} color={colors.textSecondary} />
@@ -190,6 +205,15 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 15,
     textAlign: 'right',
+  },
+  folderSelectorDisabled: {
+    opacity: 0.5,
+  },
+  folderHint: {
+    fontSize: 12,
+    marginHorizontal: 16,
+    marginTop: 4,
+    marginBottom: 4,
   },
   formatRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- Disable the folder picker button on `NoteEditorForm` when no repo is selected.
- Show inline hint *"Select a repository before choosing a folder."* below the disabled button.
- Folder dialog no longer opens via tap when `repo` is undefined — prevents an unscoped folder list during note creation.

## Why
Note creation needs repo context for folder paths. Previously tapping the folder selector with no repo opened the dialog with merged-but-unanchored folders, which is confusing and produced incorrect folderPath state.

## Test plan
- [x] `jest __tests__/components/NoteEditorFormFolderGuard.test.tsx` (new, 2 cases: blocked w/o repo, opens w/ repo)
- [x] `jest __tests__/screens/NoteEditorScreen.test.tsx` (existing, still green)
- [x] `tsc --noEmit` clean
- [ ] Manual: create new note, confirm folder button disabled + hint visible until repo picked, then enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)