### PR TITLE
fix(e2e): long-press delete + accessibility labels for TodoCard (#582)

### DIFF
--- a/src/components/todos/TodoCard.tsx
+++ b/src/components/todos/TodoCard.tsx
@@ -50,6 +50,9 @@ function TodoCardImpl({
       <View testID="todo-card.button.press">
         <TouchableOpacity
           testID="todo-card-root.button.edit"
+          accessibilityLabel={`Todo: ${todo.text}`}
+          onLongPress={onDelete}
+          delayLongPress={500}
         style={[
           styles.todoItem,
           { backgroundColor: colors.surface, borderColor: isOverdue ? colors.error : colors.border },

--- a/src/components/todos/TodosSwipeActions.tsx
+++ b/src/components/todos/TodosSwipeActions.tsx
@@ -15,6 +15,8 @@ export function TodosSwipeActions({ onDelete }: TodosSwipeActionsProps) {
     <View style={styles.track}>
       <TouchableOpacity
         testID="todos-swipe.button.delete"
+        accessibilityLabel="Delete todo"
+        accessibilityRole="button"
         style={[styles.action, { backgroundColor: colors.error }]}
         onPress={onDelete}
         activeOpacity={0.85}


### PR DESCRIPTION
## Summary

Closes #582.

Maestro's `swipe direction: LEFT` doesn't reliably reveal the delete action on TodoCard's ReanimatedSwipeable nested in FlashList.

**Fix:**
- Add long-press (500ms) on todo body → triggers delete as alternative to swipe
- Add `accessibilityLabel="Delete todo"` and `accessibilityRole="button"` to delete swipe action for accessibility-driven test flows
- Add `accessibilityLabel` to todo card body

E2E flows can now use long-press instead of swipe to trigger delete.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)