### PR TITLE
fix(nav): deduplicate tab-bar testID (#584)

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -75,7 +75,7 @@ function TabletRail({ state, navigation }: BottomTabBarProps) {
           return (
             <TouchableOpacity
               key={route.key}
-              testID={`tab-bar.tab.press-${route.name}`}
+              testID={`tab-bar-nav.tab.press-${route.name}`}
               accessibilityRole="button"
               accessibilityState={isFocused ? { selected: true } : {}}
               accessibilityLabel={t(config.labelKey)}


### PR DESCRIPTION
## Summary

Closes #584.

Rename `TabNavigator.tsx` tab testID prefix from `tab-bar.tab.press-*` to `tab-bar-nav.tab.press-*` so it no longer collides with the `TabBar.tsx` component.

Maestro flows targeting the visible `TabBar` component remain unchanged (`tab-bar.tab.press-*`).

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)