### PR TITLE
fix(sync): prevent resurrection and silent overwrite in API mode (#589 #588)

### DIFF
--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -625,7 +625,7 @@ class GitHubServiceClass {
     content: string,
     message: string,
     branch: string = 'main',
-    opts?: TokenOpts,
+    opts?: TokenOpts & { expectExists?: boolean },
   ): Promise<GitHubFileCommit | null> {
     const encodedPath = path.split('/').map(encodeURIComponent).join('/');
     const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
@@ -639,16 +639,16 @@ class GitHubServiceClass {
 
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
-        // Cache-first sha lookup (#565 phase C). The legacy
-        // `getFileShaOrNull` GET is now skipped on every write after the
-        // first one in this process — drain becomes 1 PUT per item
-        // instead of 1 GET + 1 PUT.
         let sha: string | null = this.shaCache.get(cacheKey) ?? null;
         if (!sha) {
           sha = await this.getFileShaOrNull(owner, repo, path, branch, opts);
           if (sha) this.shaCache.set(cacheKey, sha);
         }
         if (!sha) {
+          if (opts?.expectExists) {
+            console.warn(`[GitHubService] Remote file deleted, aborting update to prevent resurrection: ${path}`);
+            return null;
+          }
           const created = await this.createFile(owner, repo, path, content, message, branch, opts);
           const createdSha = created?.content?.sha;
           if (createdSha) this.shaCache.set(cacheKey, createdSha);
@@ -661,17 +661,21 @@ class GitHubServiceClass {
           { message, content: base64Content, sha, branch },
           opts,
         )) as GitHubFileCommit | null;
-        // Cache the freshly-issued sha so the next write doesn't have
-        // to round-trip for it.
         const newSha = response?.content?.sha;
         if (newSha) this.shaCache.set(cacheKey, newSha);
         return response;
       } catch (error) {
         const status = (error as { status?: number })?.status;
         if (status === 409 && attempt < 2) {
-          // Sha drifted upstream — drop the stale cache entry so the
-          // next iteration falls back to a fresh GET.
           this.shaCache.delete(cacheKey);
+          try {
+            const upstreamContent = await this.getFileContent(owner, repo, path, branch);
+            if (upstreamContent !== null && upstreamContent !== content) {
+              console.warn(`[GitHubService] Aborting update: upstream content diverged for ${path}`);
+              return null;
+            }
+          } catch {
+          }
           continue;
         }
         if (status === 422) {

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -455,7 +455,7 @@ export async function syncNoteToGitHub(params: {
       finalContent,
       message,
       targetBranch,
-      opts,
+      { ...opts, expectExists: !!filePath },
     );
 
     if (result) {


### PR DESCRIPTION
## Summary

Closes #589. Closes #588.

Two P1 data-integrity bugs in `GitHubService.updateFile`:

**#589 — Resurrection**: When a file is deleted remotely and the user saves locally, `updateFile` sees null sha → falls through to `createFile` → file reappears on GitHub, silently undoing the deletion.

**Fix**: Add `expectExists` option. When set and sha is null, abort instead of recreating. `syncNoteToGitHub` passes `expectExists: !!filePath` so previously-synced notes won't resurrect.

**#588 — Silent overwrite**: On 409 sha conflict, `updateFile` re-fetches sha and retries with same content, wiping any concurrent remote edit.

**Fix**: On 409, fetch upstream content before retrying. If upstream diverged from our write content, abort and return null instead of overwriting.

## Behavior change

| Scenario | Before | After |
|----------|--------|-------|
| Note deleted remotely, user saves locally | File resurrected on GitHub | Update aborted, note stays local-only |
| Concurrent edit on another device during save | Remote edit silently overwritten | Update aborted, no data loss |
| New note (no filePath) — sha null | Creates file on GitHub | Unchanged — still creates |
| 409 but upstream content unchanged | Retries successfully | Unchanged — still retries |

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)