### PR TITLE
fix(e2e): add returnKeyType=done to TodoEditorModal title input (#583)

### DIFF
--- a/src/components/todos/TodoEditorModal.tsx
+++ b/src/components/todos/TodoEditorModal.tsx
@@ -105,6 +105,7 @@ export function TodoEditorModal({
               onChangeText={onChangeText}
               placeholder="What needs to be done?"
               placeholderTextColor={colors.textSecondary}
+              returnKeyType="done"
               autoFocus
             />
 


### PR DESCRIPTION
## Summary

Closes #583.

Add `returnKeyType="done"` to the title TextInput in TodoEditorModal. Maestro's `hideKeyboard` can now dismiss via the Done key on iOS.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)