### PR TITLE
fix(editor): break infinite re-render loop in raw mode

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -99,10 +99,11 @@ export default function MarkdownEditor({ content, onContentChange, placeholder =
   }, [onContentChange, text]);
 
   useEffect(() => {
-    if (content !== text) {
+    if (content !== previousTextRef.current && content !== text) {
+      previousTextRef.current = content;
       reset(content);
     }
-  }, [content, reset]);
+  }, [content, reset, text]);
 
   const handleSearch = useCallback((query: string) => {
     setSearchQuery(query);


### PR DESCRIPTION
## Summary

- Fix `Maximum update depth exceeded` crash when typing in raw mode
- The second `useEffect` (sync-from-parent) now checks against `previousTextRef` in addition to local `text`, so it only resets when the parent sends a genuinely new value (e.g. a different note loaded) rather than the echo of a value we just emitted

Closes #593