### PR TITLE
fix(lists): use order-aware extraData token for FlashList re-layout on pin/sort

### DIFF
--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -120,6 +120,11 @@ export default function NotesListScreen() {
     return chips;
   }, [filters]);
 
+  const notesListToken = useMemo(
+    () => displayNotes.map((n) => `${n.id}:${n.isPinned ? 1 : 0}`).join('|'),
+    [displayNotes],
+  );
+
   const handleRemoveFilterChip = useCallback(
     (id: string) => {
       if (id === 'format') handleSelectFormat(null);
@@ -389,7 +394,7 @@ export default function NotesListScreen() {
         renderItem={renderNote}
         keyExtractor={(item) => item.id}
         key={viewMode}
-        extraData={displayNotes.length}
+        extraData={notesListToken}
         numColumns={1}
         contentContainerStyle={{ padding: 12, paddingTop: 4, paddingBottom: tabBarHeight + 16 }}
         refreshControl={

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -86,6 +86,11 @@ export default function TodoListScreen() {
     entityName: 'todo',
   });
 
+  const todosListToken = useMemo(
+    () => filteredTodos.map((t) => `${t.id}:${t.completed ? 1 : 0}`).join('|'),
+    [filteredTodos],
+  );
+
   const getSwipeableRef = useCallback((todoId: string) => {
     if (!swipeableRefs.current[todoId]) {
       swipeableRefs.current[todoId] = React.createRef<SwipeableMethods>();
@@ -422,7 +427,7 @@ export default function TodoListScreen() {
         data={filteredTodos}
         renderItem={renderTodoItem}
         keyExtractor={(item) => item.id}
-        extraData={filteredTodos.length}
+        extraData={todosListToken}
         contentContainerStyle={{ ...styles.listContent, paddingBottom: tabBarHeight + 16 }}
         ListEmptyComponent={<TodosEmptyState isFiltered={hasActiveFilters} />}
         showsVerticalScrollIndicator={false}


### PR DESCRIPTION
## Summary

- Replace `extraData={displayNotes.length}` / `extraData={filteredTodos.length}` with order-aware tokens that encode each item's `id` + `isPinned`/`completed` state
- FlashList now correctly recomputes item layouts when the list order changes (pin/unpin, sort toggle, mark-complete, hide-completed filter)

Closes #599