### PR TITLE
feat(lists): swipe-to-delete + bulk delete on Notes & Todos

### DIFF
--- a/src/components/list/BulkActionBar.tsx
+++ b/src/components/list/BulkActionBar.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { useTheme } from '../../contexts/ThemeContext';
+
+interface BulkActionBarProps {
+  count: number;
+  onCancel: () => void;
+  onDelete: () => void;
+  bottomOffset: number;
+  itemNoun: string;
+}
+
+export function BulkActionBar({
+  count,
+  onCancel,
+  onDelete,
+  bottomOffset,
+  itemNoun,
+}: BulkActionBarProps) {
+  const { colors } = useTheme();
+  if (count === 0) return null;
+
+  const noun = count === 1 ? itemNoun : `${itemNoun}s`;
+
+  return (
+    <View
+      testID="bulk-action-bar.container"
+      style={[
+        styles.bar,
+        {
+          backgroundColor: colors.surface,
+          borderColor: colors.border,
+          bottom: bottomOffset,
+        },
+      ]}
+    >
+      <TouchableOpacity
+        testID="bulk-action-bar.button.cancel"
+        style={styles.cancelBtn}
+        onPress={onCancel}
+        accessibilityLabel="Cancel selection"
+      >
+        <Ionicons name="close" size={18} color={colors.textSecondary} />
+      </TouchableOpacity>
+      <Text style={[styles.count, { color: colors.text }]} numberOfLines={1}>
+        {count} {noun} selected
+      </Text>
+      <TouchableOpacity
+        testID="bulk-action-bar.button.delete"
+        style={[styles.deleteBtn, { backgroundColor: colors.error }]}
+        onPress={onDelete}
+        accessibilityLabel={`Delete ${count} ${noun}`}
+      >
+        <Ionicons name="trash" size={16} color="#FFFFFF" />
+        <Text style={styles.deleteText}>Delete</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    position: 'absolute',
+    left: 12,
+    right: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    shadowColor: '#000',
+    shadowOpacity: 0.12,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
+  },
+  cancelBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  count: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  deleteBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 10,
+  },
+  deleteText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});
+
+export default BulkActionBar;

--- a/src/components/list/SwipeableListItem.tsx
+++ b/src/components/list/SwipeableListItem.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import ReanimatedSwipeable, {
+  SwipeableMethods,
+} from 'react-native-gesture-handler/ReanimatedSwipeable';
+
+import { useTheme } from '../../contexts/ThemeContext';
+import { HapticService } from '../../utils/haptics';
+
+interface SwipeableListItemProps {
+  itemId: string;
+  selected: boolean;
+  selectionMode: boolean;
+  onDelete: () => void;
+  onToggleSelect: () => void;
+  registerRef: (id: string) => React.RefObject<SwipeableMethods | null>;
+  onSwipeableWillOpen: (id: string) => void;
+  onSwipeableWillClose: (id: string) => void;
+  children: React.ReactNode;
+}
+
+const ACTION_WIDTH = 88;
+const SWIPE_THRESHOLD = 48;
+
+export function SwipeableListItem({
+  itemId,
+  selected,
+  selectionMode,
+  onDelete,
+  onToggleSelect,
+  registerRef,
+  onSwipeableWillOpen,
+  onSwipeableWillClose,
+  children,
+}: SwipeableListItemProps) {
+  const { colors } = useTheme();
+  const ref = registerRef(itemId);
+
+  const close = () => ref.current?.close();
+
+  const handleDelete = () => {
+    HapticService.medium();
+    close();
+    onDelete();
+  };
+
+  const handleSelectFromSwipe = () => {
+    HapticService.selection();
+    close();
+    onToggleSelect();
+  };
+
+  const renderRightActions = () => (
+    <View style={styles.actionRowRight}>
+      <TouchableOpacity
+        testID={`swipeable-list-item.button.delete-${itemId}`}
+        style={[styles.action, { backgroundColor: colors.error }]}
+        onPress={handleDelete}
+        accessibilityLabel="Delete"
+      >
+        <Ionicons name="trash" size={20} color="#FFFFFF" />
+        <Text style={styles.actionText}>Delete</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  const renderLeftActions = () => (
+    <View style={styles.actionRowLeft}>
+      <TouchableOpacity
+        testID={`swipeable-list-item.button.select-${itemId}`}
+        style={[styles.action, { backgroundColor: colors.primary }]}
+        onPress={handleSelectFromSwipe}
+        accessibilityLabel={selected ? 'Deselect' : 'Select'}
+      >
+        <Ionicons name={selected ? 'checkmark-circle' : 'ellipse-outline'} size={20} color="#FFFFFF" />
+        <Text style={styles.actionText}>{selected ? 'Deselect' : 'Select'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  const wrapped = (
+    <View
+      style={[
+        styles.itemWrap,
+        selected && {
+          backgroundColor: colors.primary + '14',
+          borderColor: colors.primary,
+        },
+      ]}
+    >
+      {selectionMode ? (
+        <TouchableOpacity
+          testID={`swipeable-list-item.button.toggle-${itemId}`}
+          activeOpacity={0.7}
+          onPress={() => {
+            HapticService.selection();
+            onToggleSelect();
+          }}
+        >
+          {children}
+        </TouchableOpacity>
+      ) : (
+        children
+      )}
+    </View>
+  );
+
+  return (
+    <ReanimatedSwipeable
+      ref={ref}
+      enabled={!selectionMode}
+      friction={2}
+      rightThreshold={SWIPE_THRESHOLD}
+      leftThreshold={SWIPE_THRESHOLD}
+      renderRightActions={renderRightActions}
+      renderLeftActions={renderLeftActions}
+      onSwipeableWillOpen={() => onSwipeableWillOpen(itemId)}
+      onSwipeableWillClose={() => onSwipeableWillClose(itemId)}
+    >
+      {wrapped}
+    </ReanimatedSwipeable>
+  );
+}
+
+const styles = StyleSheet.create({
+  itemWrap: {
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'transparent',
+  },
+  actionRowRight: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    justifyContent: 'flex-end',
+  },
+  actionRowLeft: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    justifyContent: 'flex-start',
+  },
+  action: {
+    width: ACTION_WIDTH,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 12,
+    marginVertical: 4,
+    marginHorizontal: 4,
+    gap: 4,
+  },
+  actionText: {
+    color: '#FFFFFF',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});
+
+export default SwipeableListItem;

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import { View, Text, StyleSheet, ActivityIndicator, RefreshControl, FlatList } from 'react-native';
+import { Alert, View, Text, StyleSheet, ActivityIndicator, RefreshControl, FlatList } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
@@ -32,6 +32,8 @@ import { NotesEmptyState } from '../components/notes/NotesEmptyState';
 import { NotesContextMenu } from '../components/notes/NotesContextMenu';
 import { useNotesListFilters } from '../components/notes/useNotesListFilters';
 import { useNotesListNoteActions } from '../components/notes/useNotesListNoteActions';
+import { SwipeableListItem } from '../components/list/SwipeableListItem';
+import { BulkActionBar } from '../components/list/BulkActionBar';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -72,6 +74,20 @@ export default function NotesListScreen() {
   const [longPressedNote, setLongPressedNote] = useState<Note | null>(null);
   const [colorPickerNote, setColorPickerNote] = useState<Note | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+
+  const selectionMode = selectedIds.size > 0;
+
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
 
   const closeOpenSwipeable = useCallback(() => {
     openSwipeableRef.current?.close();
@@ -177,6 +193,38 @@ export default function NotesListScreen() {
       openSwipeableRef.current = null;
     }
   }, []);
+
+  const handleBulkDelete = useCallback(() => {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+    Alert.alert(
+      `Delete ${ids.length} ${ids.length === 1 ? 'note' : 'notes'}?`,
+      'This cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            setIsDeleting(true);
+            try {
+              for (const id of ids) {
+                try {
+                  await deleteNote(id);
+                } catch (error) {
+                  void error;
+                }
+              }
+              HapticService.success();
+              clearSelection();
+            } finally {
+              setIsDeleting(false);
+            }
+          },
+        },
+      ],
+    );
+  }, [selectedIds, deleteNote, clearSelection]);
 
   useEffect(() => {
     if (authState.token) GitHubService.setToken(authState.token);
@@ -290,16 +338,27 @@ export default function NotesListScreen() {
 
   const renderNote = useCallback(
     ({ item, index }: { item: Note; index: number }) => (
-      <NotesListCard
-        note={item}
-        viewMode={viewMode}
-        onPress={handleNotePress}
-        onLongPress={handleNoteLongPress}
-        highlighted={hasActiveSearch && index === currentSearchMatchIndex}
-        isOffline={isConnected === false}
-        isCached={!!item.content?.trim()}
-        onTagPress={handleTagPress}
-      />
+      <SwipeableListItem
+        itemId={item.id}
+        selected={selectedIds.has(item.id)}
+        selectionMode={selectionMode}
+        onDelete={() => handleDeleteFromSwipe(item)}
+        onToggleSelect={() => toggleSelected(item.id)}
+        registerRef={getSwipeableRef}
+        onSwipeableWillOpen={handleSwipeableWillOpen}
+        onSwipeableWillClose={handleSwipeableWillClose}
+      >
+        <NotesListCard
+          note={item}
+          viewMode={viewMode}
+          onPress={handleNotePress}
+          onLongPress={handleNoteLongPress}
+          highlighted={hasActiveSearch && index === currentSearchMatchIndex}
+          isOffline={isConnected === false}
+          isCached={!!item.content?.trim()}
+          onTagPress={handleTagPress}
+        />
+      </SwipeableListItem>
     ),
     [
       currentSearchMatchIndex,
@@ -312,6 +371,9 @@ export default function NotesListScreen() {
       handleTagPress,
       hasActiveSearch,
       isConnected,
+      selectedIds,
+      selectionMode,
+      toggleSelected,
       viewMode,
     ],
   );
@@ -438,6 +500,13 @@ export default function NotesListScreen() {
         onClose={() => setColorPickerNote(null)}
         selected={colorPickerNote?.color ?? null}
         onSelect={(color) => handleColorSelect(colorPickerNote, color)}
+      />
+      <BulkActionBar
+        count={selectedIds.size}
+        itemNoun="note"
+        bottomOffset={tabBarHeight + 12}
+        onCancel={clearSelection}
+        onDelete={handleBulkDelete}
       />
       <ScreenHeader title="Notes" />
     </SafeAreaView>

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -26,6 +26,8 @@ import { TodoCard } from '../components/todos/TodoCard';
 import { TodosEmptyState } from '../components/todos/TodosEmptyState';
 import { TodosListHeader } from '../components/todos/TodosListHeader';
 import { TodoEditorModal } from '../components/todos/TodoEditorModal';
+import { SwipeableListItem } from '../components/list/SwipeableListItem';
+import { BulkActionBar } from '../components/list/BulkActionBar';
 
 export default function TodoListScreen() {
   const { colors, isDark } = useTheme();
@@ -56,6 +58,20 @@ export default function TodoListScreen() {
   const swipeableRefs = useRef<Record<string, React.RefObject<SwipeableMethods | null>>>({});
   const openSwipeableRef = useRef<SwipeableMethods | null>(null);
   const filter = useEntityFilter<Todo>(todos);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+
+  const selectionMode = selectedIds.size > 0;
+
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
 
   const todosAfterEntityFilters = useMemo(() => {
     const baseTodos = filter.applyFilters(todos);
@@ -109,6 +125,34 @@ export default function TodoListScreen() {
       openSwipeableRef.current = null;
     }
   }, []);
+
+  const handleBulkDelete = useCallback(() => {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+    Alert.alert(
+      `Delete ${ids.length} ${ids.length === 1 ? 'todo' : 'todos'}?`,
+      'This cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            for (const id of ids) {
+              try {
+                await deleteTodo(id);
+                delete swipeableRefs.current[id];
+              } catch (error) {
+                void error;
+              }
+            }
+            HapticService.success();
+            clearSelection();
+          },
+        },
+      ],
+    );
+  }, [selectedIds, deleteTodo, clearSelection]);
 
   const resetForm = useCallback(() => {
     setTodoText('');
@@ -334,7 +378,18 @@ export default function TodoListScreen() {
 
   const renderTodoItem = useCallback(
     ({ item }: { item: Todo }) => (
-      <TodoCard todo={item} onPress={openEditModal} onToggle={handleToggleTodo} />
+      <SwipeableListItem
+        itemId={item.id}
+        selected={selectedIds.has(item.id)}
+        selectionMode={selectionMode}
+        onDelete={() => handleDeleteTodo(item.id)}
+        onToggleSelect={() => toggleSelected(item.id)}
+        registerRef={getSwipeableRef}
+        onSwipeableWillOpen={handleSwipeableWillOpen}
+        onSwipeableWillClose={handleSwipeableWillClose}
+      >
+        <TodoCard todo={item} onPress={openEditModal} onToggle={handleToggleTodo} />
+      </SwipeableListItem>
     ),
     [
       getSwipeableRef,
@@ -343,6 +398,9 @@ export default function TodoListScreen() {
       handleSwipeableWillOpen,
       handleToggleTodo,
       openEditModal,
+      selectedIds,
+      selectionMode,
+      toggleSelected,
     ],
   );
 
@@ -470,6 +528,14 @@ export default function TodoListScreen() {
         onRepoChange={setTodoRepo}
         onBranchChange={setTodoBranch}
         onSubmit={editingTodo ? handleUpdateTodo : handleAddTodo}
+      />
+
+      <BulkActionBar
+        count={selectedIds.size}
+        itemNoun="todo"
+        bottomOffset={tabBarHeight + 12}
+        onCancel={clearSelection}
+        onDelete={handleBulkDelete}
       />
 
       <ScreenHeader


### PR DESCRIPTION
## Summary
- New shared **SwipeableListItem** wraps each row in Notes and Todos. Slide left exposes red **Delete** (uses the existing single-item confirm Alert). Slide right exposes blue **Select**, toggling the row into a multi-select set.
- New shared **BulkActionBar** floats above the tab bar whenever ≥1 row is selected: count + Cancel + Delete (confirm Alert before iterating deletes).
- In selection mode, taps toggle selection instead of opening rows, and swipe gestures are disabled so gesture grammar stays unambiguous.
- Reuses each screen's existing swipeable-ref bookkeeping so opening one swipeable still auto-closes the previous.

## Why
User asked for slide-left-to-delete (with alert) and slide-right-to-select for bulk delete on both Notes and Todos. The screens had ref scaffolding but the swipeable wrapper itself was never mounted — this finally connects it.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Full jest suite: same 14 failures as origin/main (`flash-list` testID, KaTeX, etc — pre-existing, unrelated)
- [ ] Manual on iOS: swipe left a note → delete confirm. Swipe right a note → enters selection mode, bar appears. Select a few → bulk delete confirm. Cancel clears.
- [ ] Manual on iOS for Todos: same flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)