### PR TITLE
feat(neorg): comprehensive .norg rendering improvements

### DIFF
--- a/src/components/StructuredRenderer.tsx
+++ b/src/components/StructuredRenderer.tsx
@@ -1,10 +1,12 @@
-import React, { useMemo } from 'react';
-import { View, Text, StyleSheet, Alert, Linking, ScrollView } from 'react-native';
+import React, { useMemo, useState } from 'react';
+import { View, Text, StyleSheet, Alert, Linking, ScrollView, TouchableOpacity } from 'react-native';
 import { NeorgContentBlock, NeorgHeading, NeorgListItem, NeorgChecklistItem, NeorgDefinitionItem } from '../models/NeorgContent';
 import { useTheme } from '../contexts/ThemeContext';
 import { useRenderStyle } from '../stores/renderStyleStore';
 import type { RenderFormat } from '../types/RenderStyle';
 import { classifyHref } from '../utils/linkClassifier';
+import CodeBlock from './CodeBlock';
+import KatexView from './KatexView';
 
 interface StructuredRendererProps {
   blocks: NeorgContentBlock[];
@@ -25,6 +27,7 @@ type InlineSegment =
   | { type: 'superscript'; content: string }
   | { type: 'subscript'; content: string }
   | { type: 'verbatim'; content: string }
+  | { type: 'spoiler'; content: string }
   | { type: 'org-code'; content: string }
   | { type: 'org-strike'; content: string }
   | { type: 'footnote-ref'; label: string; content: string }
@@ -112,6 +115,7 @@ const inlinePatterns: InlinePattern[] = [
   { regex: /\+([^+\s][^+]*[^+\s]?)\+/g, handler: (m) => ({ type: 'org-strike', content: m[1] }) },
   { regex: /=([^=\s][^=]*[^=\s]?)=/g, handler: (m) => ({ type: 'verbatim', content: m[1] }) },
   { regex: /~([^~\s][^~]*[^~\s]?)~/g, handler: (m) => ({ type: 'org-code', content: m[1] }) },
+  { regex: /!([^!\s][^!]*[^!\s]?)!/g, handler: (m) => ({ type: 'spoiler', content: m[1] }) },
 ];
 
 function findOuterDelimitedMatch(text: string, delimiter: '*' | '/'): { length: number; segment: InlineSegment } | null {
@@ -206,8 +210,24 @@ export function createMemoizedNeorgInlineParser(
   };
 }
 
+function DetailsBlock({ summary, content, colors }: { summary?: string; content: string; colors: any }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <View style={{ marginVertical: 8, borderRadius: 8, borderWidth: 1, borderColor: colors.border, overflow: 'hidden' }}>
+      <TouchableOpacity onPress={() => setExpanded(e => !e)} style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 12, paddingVertical: 10, backgroundColor: colors.surfaceSecondary }}>
+        <Text style={{ fontSize: 14, fontWeight: '600', color: colors.primary }}>{expanded ? '▼' : '▶'} {summary || 'Details'}</Text>
+      </TouchableOpacity>
+      {expanded && (
+        <View style={{ padding: 12 }}>
+          <Text selectable style={{ fontSize: 14, lineHeight: 20, color: colors.text }}>{content}</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
 export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNote, currentNotePath, headingPositions, scrollRef }: StructuredRendererProps) {
-  const { colors } = useTheme();
+  const { colors, isDark } = useTheme();
   const overrides = useRenderStyle(format);
 
   const headingColorFor = (level: number): string => {
@@ -356,6 +376,19 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
               );
             case 'footnote-ref':
               return <Text key={k} selectable style={{ fontSize: 11, lineHeight: 14, color: linkColor }}>{seg.label}</Text>;
+            case 'spoiler': {
+              const SpoilerWrap = ({ children }: { children: React.ReactNode }) => {
+                const [revealed, setRevealed] = useState(false);
+                return (
+                  <TouchableOpacity onPress={() => setRevealed(r => !r)} activeOpacity={0.7}>
+                    <Text selectable style={revealed ? styles.spoilerRevealed : [styles.spoilerHidden, { backgroundColor: colors.text }]}>
+                      {revealed ? children : '████'}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              };
+              return <SpoilerWrap key={k}>{seg.content}</SpoilerWrap>;
+            }
             default:
               return 'content' in seg ? <Text key={k} selectable>{seg.content}</Text> : null;
           }
@@ -463,11 +496,8 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
   );
 
   const renderCodeBlock = (code: { language?: string; content: string }, blockIndex: number) => (
-    <View key={`code-${blockIndex}`} style={[styles.codeBlock, { backgroundColor: codeBg }]}>
-      {code.language && (
-        <Text selectable style={[styles.codeLanguage, { color: colors.textSecondary }]}>{code.language}</Text>
-      )}
-      <Text selectable style={[styles.codeContent, { color: codeText }]}>{code.content}</Text>
+    <View key={`code-${blockIndex}`}>
+      <CodeBlock code={code.content} language={code.language} isDark={isDark} />
     </View>
   );
 
@@ -590,13 +620,16 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
         ) : null;
       case 'math':
         return block.math ? (
-          <View key={`math-${index}`} style={[styles.codeBlock, { backgroundColor: codeBg }]}>
-            <Text selectable style={{ fontSize: 12, fontWeight: '600', color: colors.textSecondary, marginBottom: 4 }}>MATH</Text>
-            <Text selectable style={{ fontFamily: 'monospace', fontSize: 14, color: codeText }}>{block.math.content}</Text>
+          <View key={`math-${index}`} style={{ marginVertical: 8 }}>
+            <KatexView expression={block.math.content} displayMode="block" isDark={isDark} />
           </View>
         ) : null;
       case 'comment':
         return null;
+      case 'details':
+        return block.details ? (
+          <DetailsBlock key={`details-${index}`} summary={block.details.summary} content={block.details.content} colors={colors} />
+        ) : null;
       default:
         return null;
     }
@@ -643,6 +676,19 @@ const styles = StyleSheet.create({
   subscript: {
     fontSize: 11,
     lineHeight: 14,
+  },
+  spoilerHidden: {
+    fontSize: 14,
+    lineHeight: 20,
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    overflow: 'hidden',
+  },
+  spoilerRevealed: {
+    fontSize: 14,
+    lineHeight: 20,
+    backgroundColor: 'transparent',
   },
   link: {
     textDecorationLine: 'underline',

--- a/src/models/NeorgContent.ts
+++ b/src/models/NeorgContent.ts
@@ -62,7 +62,7 @@ export interface NeorgTableRow {
 }
 
 export interface NeorgContentBlock {
-  type: 'heading' | 'list' | 'paragraph' | 'code' | 'checklist' | 'table' | 'quote' | 'divider' | 'definition' | 'footnote' | 'timestamp' | 'drawer' | 'image' | 'math' | 'fixed-width' | 'comment';
+  type: 'heading' | 'list' | 'paragraph' | 'code' | 'checklist' | 'table' | 'quote' | 'divider' | 'definition' | 'footnote' | 'timestamp' | 'drawer' | 'image' | 'math' | 'fixed-width' | 'comment' | 'details';
   heading?: NeorgHeading;
   listItems?: NeorgListItem[];
   checklistItems?: NeorgChecklistItem[];
@@ -79,6 +79,10 @@ export interface NeorgContentBlock {
   drawer?: NeorgDrawer;
   image?: NeorgImage;
   math?: NeorgMath;
+  details?: {
+    summary?: string;
+    content: string;
+  };
 }
 
 export interface NeorgContentParseResult {

--- a/src/services/NeorgContentParser.ts
+++ b/src/services/NeorgContentParser.ts
@@ -10,7 +10,7 @@ export class NeorgContentParser {
       const lines = content.split('\n');
       const blocks: NeorgContentBlock[] = [];
       let currentList: NeorgListItem[] | null = null;
-      let currentCodeBlock: { language?: string; lines: string[] } | null = null;
+      let currentCodeBlock: { language?: string; lines: string[]; blockType?: string } | null = null;
       let currentChecklist: NeorgChecklistItem[] | null = null;
       let currentTableRows: NeorgTableRow[] | null = null;
       let currentDefinitions: NeorgDefinitionItem[] | null = null;
@@ -93,7 +93,18 @@ export class NeorgContentParser {
           continue;
         }
 
-        if (trimmed === '=' && currentCodeBlock) {
+        const atBlockMatch = trimmed.match(/^@(code|raw|embed|math)(?:\s+(\w+))?\s*$/);
+        if (atBlockMatch && !currentCodeBlock) {
+          flushAll();
+          currentCodeBlock = {
+            language: atBlockMatch[1] === 'code' ? (atBlockMatch[2] || undefined) : undefined,
+            blockType: atBlockMatch[1] as 'code' | 'raw' | 'embed' | 'math',
+            lines: [],
+          };
+          continue;
+        }
+
+        if ((trimmed === '=' || trimmed === '@end') && currentCodeBlock) {
           this.finalizeCodeBlock(currentCodeBlock, blocks);
           currentCodeBlock = null;
           continue;
@@ -120,6 +131,13 @@ export class NeorgContentParser {
         }
 
         if (trimmed === '---') {
+          flushAll();
+          continue;
+        }
+
+        if (/^={3,}\s*$/.test(trimmed)) {
+          flushAll();
+          blocks.push({ type: 'divider' });
           continue;
         }
 
@@ -145,10 +163,11 @@ export class NeorgContentParser {
           continue;
         }
 
-        const rangedTagMatch = trimmed.match(/^\|([A-Za-z][\w-]*)\b.*$/);
+        const rangedTagMatch = trimmed.match(/^\|([A-Za-z][\w-]*)\b(.*)$/);
         if (rangedTagMatch && !/^\|.+\|\s*$/.test(trimmed)) {
           flushAll();
           const tagName = rangedTagMatch[1].toLowerCase();
+          const tagParams = rangedTagMatch[2]?.trim() || '';
           const collected: string[] = [];
           for (let j = i + 1; j < lines.length; j++) {
             if (/^\|end\s*$/.test(lines[j].trim())) {
@@ -166,6 +185,17 @@ export class NeorgContentParser {
             blocks.push({
               type: 'code',
               code: { content: collected.join('\n') },
+            });
+            continue;
+          }
+
+          if (tagName === 'details') {
+            blocks.push({
+              type: 'details',
+              details: {
+                summary: tagParams || undefined,
+                content: collected.join('\n').trim(),
+              },
             });
             continue;
           }
@@ -366,8 +396,9 @@ export class NeorgContentParser {
     const trimmed = line.trim();
 
     if (!trimmed) return false;
-    if (trimmed === '---' || trimmed === '=') return true;
+    if (trimmed === '---' || trimmed === '=' || trimmed === '@end') return true;
     if (/^=(code|raw|embed)(?:\.(\w+))?\s*$/.test(trimmed)) return true;
+    if (/^@(code|raw|embed|math)(?:\s+\w+)?\s*$/.test(trimmed)) return true;
     if (/^```(\w*)$/.test(line)) return true;
     if (/^\.(quote|aside)\s*$/.test(trimmed) || /^\.end\s*$/.test(trimmed)) return true;
     if (/^\|end\s*$/.test(trimmed)) return true;
@@ -460,10 +491,18 @@ export class NeorgContentParser {
     return null;
   }
 
-  static finalizeCodeBlock(codeBlock: { language?: string; lines: string[] }, blocks: NeorgContentBlock[]): void {
+  static finalizeCodeBlock(codeBlock: { language?: string; lines: string[]; blockType?: string }, blocks: NeorgContentBlock[]): void {
+    const content = codeBlock.lines.join('\n');
+    if (codeBlock.blockType === 'math') {
+      blocks.push({
+        type: 'math',
+        math: { content, inline: false },
+      });
+      return;
+    }
     blocks.push({
       type: 'code',
-      code: { language: codeBlock.language, content: codeBlock.lines.join('\n') },
+      code: { language: codeBlock.language, content },
     });
   }
 


### PR DESCRIPTION
## Summary

- **@code/@end syntax**: Support Neorg-standard `@code lang ... @end` alongside existing `=code.lang ... =` for backward compatibility
- **Syntax highlighting**: Wire existing `CodeBlock.tsx` component into `StructuredRenderer` for token-based code highlighting (9 languages)
- **Spoiler markup**: Parse and render `!spoiler!` inline markup with tap-to-reveal interaction
- **Collapsible details**: Parse `|details` ranged tags with summary text, render as expandable/collapsible sections
- **Math block wiring**: Wire `KatexView` component for `@math` block rendering (KatexView stub fix tracked separately in #592)
- **Root reversion**: `===` (3+ equals) now renders as a divider
- **@raw/@embed blocks**: Parsed via new `atBlockMatch` alongside @code/@math

## Remaining work (follow-up PRs)

- [ ] Fix KatexView stub with real KaTeX bundle (#592)
- [ ] Verify/complete Issue #423 audit fixes (B1-B7)
- [ ] Pipe modifier `*| text |*` and link modifier `W:*h*:y`
- [ ] Image rendering with `expo-image`
- [ ] Nested inline markup depth improvements

## Test plan

- [x] `yarn ts:check` passes (0 errors)
- [x] `yarn test` — 40/40 NeorgContentParser tests pass, pre-existing failures unrelated
- [x] Backward compatible: existing `=code.lang ... =` syntax still works
- [ ] Manual QA: create .norg note with all markup types and verify rendering

Refs: #592, #423