### PR TITLE
fix(ui): suppress LogBox notifications in non-dev builds

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,8 @@
 import './src/polyfills';
 import './src/i18n';
 import 'react-native-gesture-handler';
+import { LogBox } from 'react-native';
+if (!__DEV__) LogBox.ignoreAllLogs();
 import { configureReanimatedLogger, ReanimatedLogLevel } from 'react-native-reanimated';
 import React, { useState, useEffect, useCallback } from 'react';
 


### PR DESCRIPTION
## Summary
- Add `LogBox.ignoreAllLogs()` gated on `!__DEV__` at app entry point
- Prevents the "Open debugger to view warnings" toast from appearing to end-users

Closes #610