### PR TITLE
fix(sync): SHA conflict guard + preserve filePath on save

### DIFF
--- a/src/components/editor/useNoteEditorDocument.ts
+++ b/src/components/editor/useNoteEditorDocument.ts
@@ -58,6 +58,7 @@ export function useNoteEditorDocument({
   const [repo, setRepo] = useState<string | undefined>(initialRepo);
   const [branch, setBranch] = useState<string | undefined>(initialBranch);
   const [commit, setCommit] = useState<string | undefined>();
+  const [existingFilePath, setExistingFilePath] = useState<string | undefined>();
   const [folderPath, setFolderPath] = useState<string | undefined>(initialFolderPath);
   const [, setGithub] = useState<NoteGitHubLink | undefined>();
   const [accountId, setAccountId] = useState<string | undefined>(activeAccountId ?? undefined);
@@ -152,6 +153,7 @@ export function useNoteEditorDocument({
     setRepo(existingNote.repo);
     setBranch(existingNote.branch);
     setCommit(existingNote.commit);
+    setExistingFilePath(existingNote.filePath);
     setFolderPath(existingNote.folderPath);
     setGithub(existingNote.github);
     setAccountId(existingNote.accountId ?? activeAccountId ?? undefined);
@@ -258,13 +260,14 @@ export function useNoteEditorDocument({
         const syncParams = {
           repo,
           branch,
-          filePath: folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : undefined,
+          filePath: existingFilePath ?? (folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : undefined),
           title: title.trim(),
           content: content.trim(),
           format: noteFormat,
           accountId,
           tags,
           color: existingForColor?.color ?? null,
+          knownSha: commit,
         };
 
         const syncResult = await syncNoteToGitHub(syncParams);

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -388,8 +388,9 @@ export async function syncNoteToGitHub(params: {
    * Contents-API path — every API call is its own round-trip.
    */
   push?: boolean;
+  knownSha?: string;
 }): Promise<NoteGitHubSyncResult> {
-  const { repo: repoPath, branch, filePath, title, content, format, accountId, tags = [], color, push } = params;
+  const { repo: repoPath, branch, filePath, title, content, format, accountId, tags = [], color, push, knownSha } = params;
   const tokenOverride = await resolveToken(accountId);
 
   if (!tokenOverride && !GitHubService.isAuthenticated()) {
@@ -421,7 +422,7 @@ export async function syncNoteToGitHub(params: {
     console.warn('[NoteGitHubSync] Image upload failed, syncing note without images:', error);
   }
 
-  const message = filePath ? `Update note: ${title}` : `Create note: ${title}`;
+  const message = knownSha || filePath ? `Update note: ${title}` : `Create note: ${title}`;
 
   // Clone-mode write path (#514). We deliberately use the same `targetPath`
   // and `finalContent` as the API path, so the on-disk markdown is byte-
@@ -448,6 +449,15 @@ export async function syncNoteToGitHub(params: {
   }
 
   try {
+    if (knownSha && filePath) {
+      const currentSha = await GitHubService.getFileShaOrNull(
+        repoInfo.owner, repoInfo.repo, targetPath, targetBranch, opts,
+      );
+      if (currentSha && currentSha !== knownSha) {
+        return { success: false, error: `Conflict: ${targetPath} was modified on GitHub since you last loaded it. Pull to get the latest version.` };
+      }
+    }
+
     const result = await GitHubService.updateFile(
       repoInfo.owner,
       repoInfo.repo,

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -34,6 +34,7 @@ export interface NoteUpsertParams {
   format?: NoteFormat;
   tags?: string[];
   color?: NoteColor | null;
+  knownSha?: string;
 }
 
 export interface NoteDeleteParams {


### PR DESCRIPTION
## Summary

Two bugs fixed:

1. **SHA conflict guard**: Added `knownSha` param to the sync pipeline. Before writing via Contents API, the note's stored SHA is compared against the current remote SHA. If they differ, the write is refused with a conflict error — no more silent overwrites.

2. **filePath preservation**: The editor now tracks the existing note's `filePath` and passes it through to `syncNoteToGitHub`. Previously, `filePath` was reconstructed from the title slug on every save, causing `Create note:` commit messages on updates and losing the original path.

Closes #615