### PR TITLE
fix(sync): add 5 MB size guard to prevent data corruption

### DIFF
--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -392,6 +392,11 @@ export async function syncNoteToGitHub(params: {
   const { repo: repoPath, branch, filePath, title, content, format, accountId, tags = [], color, push } = params;
   const tokenOverride = await resolveToken(accountId);
 
+  const MAX_FILE_SIZE = 5 * 1024 * 1024;
+  if (content.length > MAX_FILE_SIZE) {
+    return { success: false, error: `Refusing to write file exceeding 5 MB (${Math.round(content.length / 1024 / 1024)} MB) — possible data corruption` };
+  }
+
   if (!tokenOverride && !GitHubService.isAuthenticated()) {
     return { success: false, error: 'GitHub not authenticated' };
   }

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -159,6 +159,11 @@ export class LocalGitWriter {
     const info = parseRepoPath(opts.repoPath);
     if (!info) return { success: false, error: `Invalid repo path: ${opts.repoPath}` };
 
+    const MAX_FILE_SIZE = 5 * 1024 * 1024;
+    if (opts.content.length > MAX_FILE_SIZE) {
+      return { success: false, error: `Refusing to write file exceeding 5 MB (${Math.round(opts.content.length / 1024 / 1024)} MB) — possible data corruption` };
+    }
+
     const dir = repoDirVirtual(info.owner, info.repo);
     const fs = makeRepoFs();
     const fsRoot = clonesRoot();


### PR DESCRIPTION
## Summary
- Add 5 MB content size guard to `LocalGitWriter.writeAndCommit` and `NoteGitHubSyncService.syncNoteToGitHub`
- Prevents catastrophic file growth from content duplication bugs (defense-in-depth)

Closes #609