### PR TITLE
fix(explore): optimistically remove deleted items from tree UI

### DIFF
--- a/src/components/repo/RepoTreeItem.tsx
+++ b/src/components/repo/RepoTreeItem.tsx
@@ -12,7 +12,7 @@ import { RepoTreeMoveDialog } from './RepoTreeMoveDialog';
 import { RepoTreeRenameDialog } from './RepoTreeRenameDialog';
 import { treeStyles } from './repoTreeStyles';
 
-export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, onRefresh }: TreeItemProps) {
+export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, onRefresh, onChildDeleted }: TreeItemProps) {
   const { colors } = useTheme();
   const [expanded, setExpanded] = useState(false);
   const [children, setChildren] = useState<TreeItemProps['node'][]>([]);
@@ -86,6 +86,10 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
     }
   }, [branch, isDir, onRefresh, owner, repo]);
 
+  const handleChildDeleted = useCallback((path: string) => {
+    setChildren((prev) => prev.filter((c) => c.path !== path));
+  }, []);
+
   const handleMove = useCallback(async (oldPath: string, newPath: string) => {
     setIsOperating(true);
     try {
@@ -131,6 +135,7 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
               }
             }
             HapticService.success();
+            onChildDeleted?.(node.path);
             onRefresh?.();
           } catch (error) {
             Alert.alert('Delete Failed', error instanceof Error ? error.message : 'Unknown error');
@@ -140,7 +145,7 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
         },
       },
     ]);
-  }, [branch, isDir, node, onRefresh, owner, repo]);
+  }, [branch, isDir, node, onRefresh, onChildDeleted, owner, repo]);
 
   const iconName = isDir ? (expanded ? 'folder-open' : 'folder') : getFileIcon(node.name);
   const iconColor = isDir ? '#FF9500' : colors.textSecondary;
@@ -201,9 +206,7 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
               level={level + 1}
               onFilePress={onFilePress}
               onRefresh={onRefresh}
-            />
-          ))
-        : null}
+              onChildDeleted={handleChildDeleted}
 
       <ContextMenu
         visible={showContextMenu}

--- a/src/components/repo/repoTreeShared.ts
+++ b/src/components/repo/repoTreeShared.ts
@@ -17,6 +17,7 @@ export interface TreeItemProps {
   level: number;
   onFilePress?: (node: TreeNode) => void;
   onRefresh?: () => void;
+  onChildDeleted?: (path: string) => void;
 }
 
 export type IoniconName = keyof typeof Ionicons.glyphMap;


### PR DESCRIPTION
## Summary
- Add `onChildDeleted` callback to `RepoTreeItem` that splices deleted nodes from parent's cached `children` state
- After successful delete, optimistically remove the entry instead of relying on root-only refresh

Closes #606