### PR TITLE
fix(ui): replace hardcoded emojis with Ionicons

### DIFF
--- a/src/components/CanvasModal.tsx
+++ b/src/components/CanvasModal.tsx
@@ -60,16 +60,16 @@ interface DrawShape {
 type DrawElement = DrawStroke | DrawShape;
 
 const COLORS = ['#000000', '#FFFFFF', '#FF3B30', '#FF9500', '#FFCC00', '#34C759', '#007AFF', '#5856D6', '#AF52DE', '#FF2D55'];
-const TOOLS = [
+const TOOLS: { key: string; icon?: ToolIconName; label?: string }[] = [
   { key: 'pen', icon: 'pencil' as ToolIconName },
   { key: 'highlighter', icon: 'brush' as ToolIconName },
   { key: 'eraser', icon: 'backspace-outline' as ToolIconName },
-  { key: 'line', label: '╱' },
-  { key: 'arrow', label: '→' },
-  { key: 'rect', label: '□' },
-  { key: 'roundRect', label: '⬜' },
-  { key: 'ellipse', label: '○' },
-  { key: 'diamond', label: '◇' },
+  { key: 'line', icon: 'remove' as ToolIconName },
+  { key: 'arrow', icon: 'arrow-forward' as ToolIconName },
+  { key: 'rect', icon: 'square-outline' as ToolIconName },
+  { key: 'roundRect', icon: 'rectangle-outline' as ToolIconName },
+  { key: 'ellipse', icon: 'ellipse-outline' as ToolIconName },
+  { key: 'diamond', icon: 'diamond-outline' as ToolIconName },
 ];
 
 function uid(): string {

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -231,9 +231,15 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(fun
               onPress={() => setMode(m)}
               style={[styles.modeButton, mode === m && styles.modeButtonActive]}
             >
-              <Text style={[styles.modeButtonText, { color: mode === m ? colors.primary : colors.textSecondary }]}>
-                {m === 'markdown' ? 'MD' : m === 'checklist' ? '✓' : 'Raw'}
-              </Text>
+              <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                {m === 'checklist' ? (
+                  <Ionicons name="checkmark" size={14} color={mode === m ? colors.primary : colors.textSecondary} />
+                ) : (
+                  <Text style={[styles.modeButtonText, { color: mode === m ? colors.primary : colors.textSecondary }]}>
+                    {m === 'markdown' ? 'MD' : 'Raw'}
+                  </Text>
+                )}
+              </View>
             </TouchableOpacity>
           ))}
         </View>

--- a/src/components/ReorderableChecklist.tsx
+++ b/src/components/ReorderableChecklist.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -206,7 +207,7 @@ const ChecklistRow = memo(function ChecklistRow({
           },
         ]}
       >
-        {item.checked ? <Text style={styles.checkboxMark}>✓</Text> : null}
+        {item.checked ? <Ionicons name="checkmark" size={16} color="#fff" /> : null}
       </TouchableOpacity>
 
       <TextInput
@@ -240,7 +241,7 @@ const ChecklistRow = memo(function ChecklistRow({
         onPress={() => onDeleteItem(index)}
         style={{ paddingHorizontal: spacing[1], paddingVertical: spacing[2] }}
       >
-        <Text style={{ color: colors.textSecondary, fontSize: type.md }}>✕</Text>
+        <Ionicons name="close" size={18} color={colors.textSecondary} />
       </TouchableOpacity>
     </Animated.View>
   );

--- a/src/components/StructuredRenderer.tsx
+++ b/src/components/StructuredRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { View, Text, StyleSheet, Alert, Linking, ScrollView, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { NeorgContentBlock, NeorgHeading, NeorgListItem, NeorgChecklistItem, NeorgDefinitionItem } from '../models/NeorgContent';
 import { useTheme } from '../contexts/ThemeContext';
 import { useRenderStyle } from '../stores/renderStyleStore';
@@ -215,7 +216,8 @@ function DetailsBlock({ summary, content, colors }: { summary?: string; content:
   return (
     <View style={{ marginVertical: 8, borderRadius: 8, borderWidth: 1, borderColor: colors.border, overflow: 'hidden' }}>
       <TouchableOpacity onPress={() => setExpanded(e => !e)} style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 12, paddingVertical: 10, backgroundColor: colors.surfaceSecondary }}>
-        <Text style={{ fontSize: 14, fontWeight: '600', color: colors.primary }}>{expanded ? '▼' : '▶'} {summary || 'Details'}</Text>
+        <Ionicons name={expanded ? 'chevron-down' : 'chevron-forward'} size={14} color={colors.primary} />
+        <Text style={{ fontSize: 14, fontWeight: '600', color: colors.primary, marginLeft: 4 }}>{summary || 'Details'}</Text>
       </TouchableOpacity>
       {expanded && (
         <View style={{ padding: 12 }}>
@@ -397,17 +399,17 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
     );
   };
 
-  const taskStatusIcon = (status?: string): string => {
+  const taskStatusIconName = (status?: string): React.ComponentProps<typeof Ionicons>['name'] => {
     switch (status) {
-      case 'done': return '✓';
-      case 'important': return '!';
-      case 'uncertain': return '?';
-      case 'in-progress': return '◐';
-      case 'urgent': return '⏰';
-      case 'cancelled': return '✗';
-      case 'on-hold': return '⏸';
-      case 'recurring': return '↻';
-      default: return '○';
+      case 'done': return 'checkmark-circle';
+      case 'important': return 'alert-circle';
+      case 'uncertain': return 'help-circle';
+      case 'in-progress': return 'hourglass';
+      case 'urgent': return 'alarm';
+      case 'cancelled': return 'close-circle';
+      case 'on-hold': return 'pause-circle';
+      case 'recurring': return 'refresh';
+      default: return 'ellipse-outline';
     }
   };
 
@@ -447,16 +449,19 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
 
   const renderListItem = (item: NeorgListItem, blockIndex: number, itemIndex: number) => {
     const indent = item.indentLevel * 16;
-    let prefix = '- ';
-    if (item.type === 'ordered') {
-      prefix = `${itemIndex + 1}. `;
-    } else if (item.type === 'task') {
-      prefix = `${taskStatusIcon(item.status)} `;
-    }
     return (
-      <View key={`list-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent }]}> 
-        <Text selectable style={[styles.listText, { color: colors.text }]}>
-          {prefix}{renderInline(item.text)}
+      <View key={`list-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent, flexDirection: 'row', alignItems: 'flex-start' }]}>
+        {item.type === 'task' ? (
+          <View style={{ marginTop: 4, marginRight: 6 }}>
+            <Ionicons name={taskStatusIconName(item.status)} size={16} color={colors.text} />
+          </View>
+        ) : (
+          <Text selectable style={[styles.listText, { color: colors.text }]}>
+            {item.type === 'ordered' ? `${itemIndex + 1}. ` : '- '}
+          </Text>
+        )}
+        <Text selectable style={[styles.listText, { color: colors.text, flex: 1 }]}>
+          {renderInline(item.text)}
         </Text>
       </View>
     );
@@ -465,9 +470,12 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
   const renderChecklistItem = (item: NeorgChecklistItem, blockIndex: number, itemIndex: number) => {
     const indent = item.indentLevel * 16;
     return (
-      <View key={`check-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent }]}> 
-        <Text selectable style={[styles.listText, { color: colors.text }]}>
-          {item.checked ? '✓' : '○'} {renderInline(item.text)}
+      <View key={`check-${blockIndex}-${itemIndex}`} style={[styles.listItem, { marginLeft: indent, flexDirection: 'row', alignItems: 'flex-start' }]}> 
+        <View style={{ marginTop: 4, marginRight: 6 }}>
+          <Ionicons name={item.checked ? 'checkmark-circle' : 'ellipse-outline'} size={16} color={colors.text} />
+        </View>
+        <Text selectable style={[styles.listText, { color: colors.text, flex: 1 }]}>
+          {renderInline(item.text)}
         </Text>
       </View>
     );
@@ -572,11 +580,22 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
       case 'timestamp':
         return block.timestamp ? (
           <View key={`ts-${index}`} style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
+            <Ionicons 
+              name={
+                block.timestamp.type === 'scheduled' ? 'calendar' :
+                block.timestamp.type === 'deadline' ? 'alarm' :
+                block.timestamp.type === 'closed' ? 'checkmark-circle' :
+                block.timestamp.type === 'active' ? 'calendar-outline' : 'clipboard'
+              } 
+              size={14} 
+              color={colors.textSecondary} 
+              style={{ marginRight: 4 }}
+            />
             <Text selectable style={{ fontSize: 14, color: colors.textSecondary }}>
-              {block.timestamp.type === 'scheduled' ? '📅 SCHEDULED' :
-               block.timestamp.type === 'deadline' ? '⏰ DEADLINE' :
-               block.timestamp.type === 'closed' ? '✅ CLOSED' :
-               block.timestamp.type === 'active' ? '📆' : '📋'} {block.timestamp.date}
+              {block.timestamp.type === 'scheduled' ? 'SCHEDULED ' :
+               block.timestamp.type === 'deadline' ? 'DEADLINE ' :
+               block.timestamp.type === 'closed' ? 'CLOSED ' : ''}
+              {block.timestamp.date}
               {block.timestamp.time ? ` ${block.timestamp.time}` : ''}
             </Text>
           </View>
@@ -614,8 +633,11 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
       case 'image':
         return block.image ? (
           <View key={`img-${index}`} style={{ padding: 8, borderRadius: 4, marginVertical: 4, backgroundColor: colors.surfaceSecondary, alignItems: 'center' }}>
-            <Text selectable style={{ fontSize: 14, color: colors.text }}>📷 {block.image.path}</Text>
-            {block.image.caption ? <Text selectable style={{ fontSize: 12, color: colors.textSecondary }}>{block.image.caption}</Text> : null}
+            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+              <Ionicons name="camera" size={14} color={colors.text} style={{ marginRight: 6 }} />
+              <Text selectable style={{ fontSize: 14, color: colors.text }}>{block.image.path}</Text>
+            </View>
+            {block.image.caption ? <Text selectable style={{ fontSize: 12, color: colors.textSecondary, marginTop: 4 }}>{block.image.caption}</Text> : null}
           </View>
         ) : null;
       case 'math':

--- a/src/components/canvas/CanvasEditorContent.tsx
+++ b/src/components/canvas/CanvasEditorContent.tsx
@@ -53,16 +53,16 @@ type Point = { x: number; y: number };
 type ToolIconName = React.ComponentProps<typeof Ionicons>['name'];
 
 const COLORS = ['#000000', '#FFFFFF', '#FF3B30', '#FF9500', '#FFCC00', '#34C759', '#007AFF', '#5856D6', '#AF52DE', '#FF2D55'];
-const TOOLS = [
+const TOOLS: { key: string; icon?: ToolIconName; label?: string }[] = [
   { key: 'pen', icon: 'pencil' as ToolIconName },
   { key: 'highlighter', icon: 'brush' as ToolIconName },
   { key: 'eraser', icon: 'backspace-outline' as ToolIconName },
-  { key: 'line', label: '╱' },
-  { key: 'arrow', label: '→' },
-  { key: 'rect', label: '□' },
-  { key: 'roundRect', label: '⬜' },
-  { key: 'ellipse', label: '○' },
-  { key: 'diamond', label: '◇' },
+  { key: 'line', icon: 'remove' as ToolIconName },
+  { key: 'arrow', icon: 'arrow-forward' as ToolIconName },
+  { key: 'rect', icon: 'square-outline' as ToolIconName },
+  { key: 'roundRect', icon: 'rectangle-outline' as ToolIconName },
+  { key: 'ellipse', icon: 'ellipse-outline' as ToolIconName },
+  { key: 'diamond', icon: 'diamond-outline' as ToolIconName },
   { key: 'text', label: 'T' },
   { key: 'select', icon: 'hand-left-outline' as ToolIconName },
 ];

--- a/src/components/ui/ConflictBanner.tsx
+++ b/src/components/ui/ConflictBanner.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { useConflictStore } from '../../stores/conflictStore';
 
@@ -31,9 +32,12 @@ export function ConflictBanner() {
           { backgroundColor: `${WARNING}20`, borderColor: `${WARNING}33` },
         ]}
       >
-        <Text style={[styles.text, { color: WARNING_DARK }]}>
-          ⚠ {label} — Tap to resolve
-        </Text>
+        <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <Ionicons name="warning" size={16} color={WARNING_DARK} />
+          <Text style={[styles.text, { color: WARNING_DARK, marginLeft: 6 }]}>
+            {label} — Tap to resolve
+          </Text>
+        </View>
       </View>
     </TouchableOpacity>
   );


### PR DESCRIPTION
## Summary
- Replace all hardcoded emoji characters in UI rendering with proper Ionicon components from `@expo/vector-icons`
- Affects 6 files: ConflictBanner, MarkdownEditor, ReorderableChecklist, CanvasModal, CanvasEditorContent, StructuredRenderer
- Ensures consistent cross-platform icon rendering instead of relying on emoji font support

## Changes
| File | Replaced |
|------|----------|
| `ConflictBanner.tsx` | ⚠ → `warning` icon |
| `MarkdownEditor.tsx` | ✓ → `checkmark` icon |
| `ReorderableChecklist.tsx` | ✓ ✕ → `checkmark` / `close` icons |
| `CanvasModal.tsx` | → □ ⬜ ○ ◇ → `arrow-forward` / `square-outline` / `rectangle-outline` / `ellipse-outline` / `diamond-outline` |
| `CanvasEditorContent.tsx` | Same shape tool icons as CanvasModal |
| `StructuredRenderer.tsx` | ▼ ▶ ✓ ✗ ○ ◐ ⏰ ⏸ ↻ 📅 📷 ✅ 📆 → Ionicons |

## Test Plan
- [x] `npx tsc --noEmit` passes clean
- [ ] Visual check: ConflictBanner shows warning icon
- [ ] Visual check: Checklist mode selector shows checkmark icon
- [ ] Visual check: ReorderableChecklist check/close icons render
- [ ] Visual check: Canvas toolbar shape icons render correctly
- [ ] Visual check: StructuredRenderer task statuses show proper icons
- [ ] Visual check: Details toggle shows chevron icons