### PR TITLE
fix(settings): reset opposite picker state before opening repo picker modal

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -560,7 +560,7 @@ export default function SettingsScreen() {
         lfsPending={lfsPending}
         lfsDownloadingRepo={lfsDownloadingRepo}
         onDownloadLfsObjects={(repo) => void handleDownloadLfsObjects(repo)}
-        onOpenTemplatesRepoPicker={() => setShowTemplatesRepoPicker(true)}
+        onOpenTemplatesRepoPicker={() => { setShowChatRepoPicker(false); setShowTemplatesRepoPicker(true); }}
         onSyncExistingTemplates={() => void handleSyncExistingTemplates()}
         onClearTemplatesRepo={() => void handleClearTemplatesRepo()}
         onOpenRenderStyleSettings={() => navigation.navigate('RenderStyleSettings')}
@@ -570,7 +570,7 @@ export default function SettingsScreen() {
         onToggleAI={() => { void toggleAI(); }}
         onOpenModelSelector={() => setShowModelSelector(true)}
         onToggleActionMode={() => { void setActionMode(actionMode === 'auto' ? 'confirm' : 'auto'); }}
-        onOpenChatRepoPicker={() => setShowChatRepoPicker(true)}
+        onOpenChatRepoPicker={() => { setShowTemplatesRepoPicker(false); setShowChatRepoPicker(true); }}
         onProviderPress={(provider) => {
           if (provider.type === 'openai-compatible') {
             setEditingProvider(provider);


### PR DESCRIPTION
## Summary
- Ensures `showChatRepoPicker` is reset before opening templates picker, and vice versa
- Prevents RN transparent Modal overlap bug that made templates picker inert after closing chat-repo picker

Closes #642