### PR TITLE
fix(a11y): use tab role for TabletRail navigation items

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -77,7 +77,7 @@ function TabletRail({ state, navigation }: BottomTabBarProps) {
             <TouchableOpacity
               key={route.key}
               testID={`tab-bar-nav.tab.press-${route.name}`}
-              accessibilityRole="button"
+              accessibilityRole="tab"
               accessibilityState={isFocused ? { selected: true } : {}}
               accessibilityLabel={t(config.labelKey)}
               style={[


### PR DESCRIPTION
## Summary
- Changes `accessibilityRole` from `"button"` to `"tab"` on iPad TabletRail navigation items
- VoiceOver now correctly announces tab role instead of generic button

Closes #634