### PR TITLE
fix(a11y): add per-row accessibility to canvas size picker

### DIFF
--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -230,7 +230,10 @@ export default function CanvasListScreen() {
             {CANVAS_PRESETS.map((preset) => (
               <TouchableOpacity
                 key={preset.label}
-                testID="canvas-list.button.pick-size"
+                testID={`canvas-list.button.pick-size-${preset.label.toLowerCase()}`}
+                accessible
+                accessibilityRole="button"
+                accessibilityLabel={`${preset.label}, ${preset.desc}`}
                 style={[styles.sizeOption, { borderColor: colors.border }]}
                 onPress={() => handlePickSize(preset.w, preset.h)}
                 activeOpacity={0.7}


### PR DESCRIPTION
## Summary
- Adds `accessible`, `accessibilityRole="button"`, `accessibilityLabel`, and unique `testID` to each canvas size picker row (Phone, Tablet, Landscape, Square, A4)
- Fixes VoiceOver collapsing all rows into a single a11y group

Closes #633