### PR TITLE
feat(ai): search bar in ModelSelector

### DIFF
--- a/__tests__/ModelSelector.search.test.tsx
+++ b/__tests__/ModelSelector.search.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+
+const stableColors = {
+  background: '#fff',
+  surface: '#f4f4f4',
+  primary: '#2563eb',
+  text: '#111',
+  textSecondary: '#666',
+  border: '#ddd',
+  error: '#dc2626',
+  accent: '#8b5cf6',
+};
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: stableColors, isDark: false }),
+  useTokens: () => ({
+    colors: stableColors,
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 },
+    type: { xs: 12, sm: 14, md: 16, lg: 18, xl: 22 },
+    radii: { sm: 12, md: 18, lg: 24, pill: 999 },
+    style: 'flat',
+  }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/components/ui', () => {
+  const React = require('react');
+  const { View, Text, Pressable } = require('react-native');
+  return {
+    Group: ({ title, children }: any) => (
+      <View testID={`group-${title}`}>
+        <Text>{title}</Text>
+        {children}
+      </View>
+    ),
+    GroupRow: ({ children, onPress, testID }: any) => (
+      <Pressable testID={testID} onPress={onPress}>
+        {children}
+      </Pressable>
+    ),
+  };
+});
+
+jest.mock('../src/services/AIService', () => ({
+  downloadModel: jest.fn(),
+  getModelStatus: jest.fn(async () => 'ready'),
+}));
+
+jest.mock('../src/services/ai/providerAvailability', () => ({
+  resolveProviderAvailability: jest.fn(async () => ({ kind: 'available' })),
+}));
+
+jest.mock('../src/services/ai/providerAvailabilityCopy', () => ({
+  describeAvailability: jest.fn(() => 'unavailable'),
+}));
+
+const mockProviders = [
+  {
+    id: 'openai',
+    type: 'openai-compatible',
+    name: 'OpenAI',
+    isEnabled: true,
+    addedAt: 0,
+    models: [
+      { id: 'm-gpt4o', name: 'gpt-4o', providerId: 'openai', providerType: 'openai-compatible', requiresDownload: false },
+      { id: 'm-gpt4o-mini', name: 'gpt-4o-mini', providerId: 'openai', providerType: 'openai-compatible', requiresDownload: false },
+    ],
+  },
+  {
+    id: 'openrouter',
+    type: 'openai-compatible',
+    name: 'OpenRouter',
+    isEnabled: true,
+    addedAt: 0,
+    models: [
+      { id: 'm-claude', name: 'anthropic/claude-3.5-sonnet', providerId: 'openrouter', providerType: 'openai-compatible', requiresDownload: false },
+      { id: 'm-llama', name: 'meta/llama-3.1-70b', providerId: 'openrouter', providerType: 'openai-compatible', requiresDownload: false },
+    ],
+  },
+];
+
+const mockAIStore = {
+  providers: mockProviders,
+  selectedModelId: null,
+  selectModel: jest.fn(),
+  updateProvider: jest.fn(),
+};
+
+jest.mock('../src/stores/aiStore', () => ({
+  useAIStore: (selector: any) => (selector ? selector(mockAIStore) : mockAIStore),
+}));
+
+import { ModelSelector } from '../src/components/ai/ModelSelector';
+
+describe('ModelSelector search', () => {
+  test('typing filters model rows; clear restores; empty state shows', async () => {
+    const { getByTestId, queryByTestId } = render(
+      <ModelSelector visible onClose={() => {}} />,
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId('model-selector.button.select-model-m-gpt4o')).toBeTruthy();
+      expect(queryByTestId('model-selector.button.select-model-m-claude')).toBeTruthy();
+    });
+
+    const search = getByTestId('model-selector.input.search');
+    fireEvent.changeText(search, 'mini');
+
+    await waitFor(() => {
+      expect(queryByTestId('model-selector.button.select-model-m-gpt4o-mini')).toBeTruthy();
+      expect(queryByTestId('model-selector.button.select-model-m-gpt4o')).toBeNull();
+      expect(queryByTestId('model-selector.button.select-model-m-claude')).toBeNull();
+    });
+
+    fireEvent.changeText(search, 'openrouter');
+    await waitFor(() => {
+      expect(queryByTestId('model-selector.button.select-model-m-claude')).toBeTruthy();
+      expect(queryByTestId('model-selector.button.select-model-m-llama')).toBeTruthy();
+      expect(queryByTestId('model-selector.button.select-model-m-gpt4o')).toBeNull();
+    });
+
+    fireEvent.changeText(search, 'xyzzy');
+    await waitFor(() => {
+      expect(getByTestId('model-selector.text.empty')).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('model-selector.button.clear-search'));
+    await waitFor(() => {
+      expect(queryByTestId('model-selector.text.empty')).toBeNull();
+      expect(queryByTestId('model-selector.button.select-model-m-gpt4o')).toBeTruthy();
+      expect(queryByTestId('model-selector.button.select-model-m-claude')).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/modelSelectorFilter.test.ts
+++ b/__tests__/modelSelectorFilter.test.ts
@@ -1,0 +1,71 @@
+import { filterProviders } from '../src/components/ai/modelSelectorFilter';
+import type { AIProviderConfig } from '../src/models/AIProvider';
+
+const makeProvider = (
+  id: string,
+  name: string,
+  modelNames: string[],
+): AIProviderConfig => ({
+  id,
+  type: 'openai-compatible',
+  name,
+  isEnabled: true,
+  addedAt: 0,
+  models: modelNames.map((mName, idx) => ({
+    id: `${id}-${idx}`,
+    name: mName,
+    providerId: id,
+    providerType: 'openai-compatible',
+    requiresDownload: false,
+  })),
+});
+
+const providers: AIProviderConfig[] = [
+  makeProvider('openai', 'OpenAI', ['gpt-4o', 'gpt-4o-mini', 'o1-preview']),
+  makeProvider('openrouter', 'OpenRouter', ['anthropic/claude-3.5-sonnet', 'meta/llama-3.1-70b']),
+  makeProvider('apple', 'Apple Intelligence', []),
+];
+
+describe('filterProviders', () => {
+  test('empty query returns providers unchanged', () => {
+    expect(filterProviders(providers, '')).toEqual(providers);
+  });
+
+  test('whitespace-only query returns providers unchanged', () => {
+    expect(filterProviders(providers, '   ')).toEqual(providers);
+  });
+
+  test('case-insensitive model-name match', () => {
+    const result = filterProviders(providers, 'GPT');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('openai');
+    expect(result[0].models.map((m) => m.name)).toEqual(['gpt-4o', 'gpt-4o-mini']);
+  });
+
+  test('provider-name match returns provider with all its models', () => {
+    const result = filterProviders(providers, 'openrouter');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('openrouter');
+    expect(result[0].models).toHaveLength(2);
+  });
+
+  test('partial model-name match within a provider returns only matching models', () => {
+    const result = filterProviders(providers, 'mini');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('openai');
+    expect(result[0].models.map((m) => m.name)).toEqual(['gpt-4o-mini']);
+  });
+
+  test('no match returns empty array', () => {
+    expect(filterProviders(providers, 'xyzzy-no-match')).toEqual([]);
+  });
+
+  test('provider with empty models array included only on provider-name match', () => {
+    const onName = filterProviders(providers, 'apple');
+    expect(onName).toHaveLength(1);
+    expect(onName[0].id).toBe('apple');
+
+    const offName = filterProviders(providers, 'gpt');
+    expect(offName.find((p) => p.id === 'apple')).toBeUndefined();
+  });
+});

--- a/docs/superpowers/specs/2026-05-09-model-selector-search-design.md
+++ b/docs/superpowers/specs/2026-05-09-model-selector-search-design.md
@@ -1,0 +1,73 @@
+# Model Selector Search — Design
+
+## Problem
+
+`ModelSelector` modal lists every model from every enabled provider, grouped by provider. With custom OpenAI-compatible providers (e.g. OpenRouter), a single provider can contribute hundreds of models discovered via `/v1/models`. Scrolling becomes the only way to find a model.
+
+## Goal
+
+Add a search bar to `ModelSelector` that filters the list by model name and provider name.
+
+## Non-goals
+
+- Sorting, favorites, recent-models, fuzzy matching.
+- Search inside `ProviderConfigModal` (separate concern).
+- Pagination or virtualization.
+
+## UI
+
+- Sticky `TextInput` placed below the modal header (`modalHeader`) and above the `ScrollView` (`modalBody`).
+- Placeholder: `Search models or providers`.
+- Trailing clear button (`×`) when query non-empty; tapping clears the query.
+- No autofocus (keyboard should not pop on modal open).
+- `autoCorrect={false}`, `autoCapitalize="none"`.
+- Always rendered (no count threshold) for predictability.
+
+## Filter logic
+
+Pure function `filterProviders(providers, query) → providers`.
+
+- Trim and lowercase `query`. Empty → return providers unchanged.
+- For each provider:
+  - If lowercased `provider.name` includes `q` → include the provider with all its models (typing "openrouter" reveals the whole group).
+  - Else filter `provider.models` by `model.name.toLowerCase().includes(q)`. Include the provider only if at least one model survives.
+- Provider order preserved. Model order preserved.
+
+The unavailable-provider branch (current lines 132–144 — provider rendered with an availability message instead of models) is treated like any other provider: shown only if its name matches the query. Its model list is empty so name-match is the only path.
+
+The platform filter (`supportedPlatforms`) and `isEnabled` filter run before search, unchanged.
+
+## Empty state
+
+When `query` is non-empty and the filtered list is empty, render a centered text inside the scroll area:
+
+> `No models match "<query>"`
+
+## Files
+
+- `src/components/ai/modelSelectorFilter.ts` — new pure function + types.
+- `src/components/ai/ModelSelector.tsx` — add `query` state, `TextInput`, call filter, render empty state.
+- `__tests__/modelSelectorFilter.test.ts` — unit tests for the filter.
+
+## Tests
+
+Unit tests for `filterProviders`:
+
+1. Empty query → returns input unchanged (same reference or deep equal).
+2. Case-insensitive model-name match (`"GPT"` matches `"gpt-4o"`).
+3. Provider-name match returns provider with all its models.
+4. Partial model-name match within a provider returns only matching models.
+5. No match → empty array.
+6. Whitespace-only query treated as empty.
+7. Provider with empty `models` array included only on provider-name match.
+
+## TestIDs
+
+- `model-selector.input.search` — the `TextInput`.
+- `model-selector.button.clear-search` — the clear button.
+- `model-selector.text.empty` — empty-state text.
+
+## Out of scope / risks
+
+- Performance: filtering a few hundred items per keystroke is fine in JS without debounce. If a provider ever exceeds ~5k models, revisit.
+- Persistence: query is not persisted across modal opens.

--- a/src/components/ai/ModelSelector.tsx
+++ b/src/components/ai/ModelSelector.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Modal,
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   ScrollView,
   StyleSheet,
@@ -18,6 +19,7 @@ import { downloadModel, getModelStatus } from '../../services/AIService';
 import { AIModelConfig, AIProviderConfig } from '../../models/AIProvider';
 import { resolveProviderAvailability, type Availability } from '../../services/ai/providerAvailability';
 import { describeAvailability } from '../../services/ai/providerAvailabilityCopy';
+import { filterProviders } from './modelSelectorFilter';
 
 interface ModelSelectorProps {
   visible: boolean;
@@ -38,6 +40,11 @@ export function ModelSelector({ visible, onClose }: ModelSelectorProps) {
   const [providerAvailability, setProviderAvailability] = useState<Record<string, Availability>>({});
   const [downloadProgress, setDownloadProgress] = useState<Record<string, number>>({});
   const [isDownloading, setIsDownloading] = useState<Record<string, boolean>>({});
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    if (!visible) setQuery('');
+  }, [visible]);
 
   const loadStatuses = useCallback(async () => {
     const newStatuses: Record<string, 'ready' | 'needs-download' | 'unavailable'> = {};
@@ -93,6 +100,19 @@ export function ModelSelector({ visible, onClose }: ModelSelectorProps) {
     }
   };
 
+  const visibleProviders = useMemo(() => {
+    const baseProviders = providers
+      .filter((p) => p.isEnabled)
+      .filter((p) => {
+        if (!p.supportedPlatforms || p.supportedPlatforms.length === 0) return true;
+        const os = Platform.OS as 'ios' | 'android';
+        return p.supportedPlatforms.includes(os);
+      });
+    return filterProviders(baseProviders, query);
+  }, [providers, query]);
+
+  const trimmedQuery = query.trim();
+
   const handleSelectModel = async (model: AIModelConfig) => {
     if (statuses[model.id] === 'unavailable') return;
     if (statuses[model.id] === 'needs-download') return;
@@ -112,17 +132,44 @@ export function ModelSelector({ visible, onClose }: ModelSelectorProps) {
             </TouchableOpacity>
           </View>
           
+          <View style={[styles.searchWrap, { borderBottomColor: colors.border }]}>
+            <Ionicons name="search" size={16} color={colors.textSecondary} />
+            <TextInput
+              testID="model-selector.input.search"
+              style={[styles.searchInput, { color: colors.text }]}
+              placeholder="Search models or providers"
+              placeholderTextColor={colors.textSecondary}
+              value={query}
+              onChangeText={setQuery}
+              autoCorrect={false}
+              autoCapitalize="none"
+              returnKeyType="search"
+            />
+            {query.length > 0 && (
+              <TouchableOpacity
+                testID="model-selector.button.clear-search"
+                onPress={() => setQuery('')}
+                hitSlop={8}
+              >
+                <Ionicons name="close-circle" size={18} color={colors.textSecondary} />
+              </TouchableOpacity>
+            )}
+          </View>
+
           <ScrollView
             style={styles.modalBody}
             contentContainerStyle={{ paddingBottom: spacing[8] }}
+            keyboardShouldPersistTaps="handled"
           >
-            {providers
-              .filter((p) => p.isEnabled)
-              .filter((p) => {
-                if (!p.supportedPlatforms || p.supportedPlatforms.length === 0) return true;
-                const os = Platform.OS as 'ios' | 'android';
-                return p.supportedPlatforms.includes(os);
-              })
+            {trimmedQuery !== '' && visibleProviders.length === 0 && (
+              <Text
+                testID="model-selector.text.empty"
+                style={[styles.emptyText, { color: colors.textSecondary }]}
+              >
+                No models match "{trimmedQuery}"
+              </Text>
+            )}
+            {visibleProviders
               .map((provider: AIProviderConfig) => {
                 const availability = providerAvailability[provider.id];
                 const providerUnavailable = availability && availability.kind === 'unavailable';
@@ -242,6 +289,24 @@ const styles = StyleSheet.create({
   },
   modalBody: {
     padding: 20,
+  },
+  searchWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    paddingVertical: 4,
+  },
+  emptyText: {
+    fontSize: 14,
+    textAlign: 'center',
+    paddingVertical: 24,
   },
   rowContent: {
     flexDirection: 'row',

--- a/src/components/ai/modelSelectorFilter.ts
+++ b/src/components/ai/modelSelectorFilter.ts
@@ -1,0 +1,24 @@
+import type { AIProviderConfig } from '../../models/AIProvider';
+
+export function filterProviders(
+  providers: AIProviderConfig[],
+  query: string,
+): AIProviderConfig[] {
+  const q = query.trim().toLowerCase();
+  if (q === '') return providers;
+
+  const result: AIProviderConfig[] = [];
+  for (const provider of providers) {
+    if (provider.name.toLowerCase().includes(q)) {
+      result.push(provider);
+      continue;
+    }
+    const matchedModels = provider.models.filter((m) =>
+      m.name.toLowerCase().includes(q),
+    );
+    if (matchedModels.length > 0) {
+      result.push({ ...provider, models: matchedModels });
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Adds a sticky search input to `ModelSelector` that filters models by model name or provider name.
- Provider-name match keeps the whole group; model-name match keeps only matching rows. Empty query → original behavior.
- Empty-state message when query yields no matches; clear (×) button resets the query.

Motivated by custom OpenAI-compatible providers (e.g. OpenRouter) which can contribute hundreds of models via `/v1/models` discovery.

Filter is a pure function (`src/components/ai/modelSelectorFilter.ts`) with 7 unit tests covering case-insensitivity, provider-vs-model match, empty/whitespace queries, and the empty-models edge case. Integration test on `ModelSelector` verifies typing filters rows, clear restores, and the empty state renders.

Spec: `docs/superpowers/specs/2026-05-09-model-selector-search-design.md`.

## Test plan
- [x] `npx jest __tests__/modelSelectorFilter.test.ts` — 7/7 pass
- [x] `npx jest __tests__/ModelSelector.search.test.tsx` — 1/1 pass
- [x] `npx jest --testPathPattern="ai|ModelSelector"` — 77/77 pass across 9 suites
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open ModelSelector with an OpenRouter-style provider, type partial model name, verify only matching rows visible; clear via × button; type unknown query, verify empty state
- [ ] Manual: type provider name (e.g. "openrouter"), verify entire provider group visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)