### PR TITLE
fix(a11y): un-fold canvas size picker overlay (closes #649)

### DIFF
--- a/__tests__/canvas-size-picker-a11y.test.tsx
+++ b/__tests__/canvas-size-picker-a11y.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+const stableColors = {
+  background: '#fff',
+  surface: '#f4f4f4',
+  primary: '#2563eb',
+  text: '#111',
+  textSecondary: '#666',
+  border: '#ddd',
+  error: '#dc2626',
+  accent: '#8b5cf6',
+};
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: any) => children,
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+  useFocusEffect: (cb: any) => {
+    const React = require('react');
+    React.useEffect(() => {
+      const cleanup = cb();
+      return cleanup;
+    }, []);
+  },
+}));
+
+jest.mock('@react-navigation/native-stack', () => ({}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: stableColors, isDark: false }),
+}));
+
+jest.mock('../src/contexts/CanvasContext', () => ({
+  useCanvases: () => ({
+    canvases: [],
+    filteredCanvases: [],
+    searchQuery: '',
+    setSearchQuery: jest.fn(),
+    deleteCanvas: jest.fn(),
+    refreshCanvases: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({ repositories: [] }),
+}));
+
+jest.mock('../src/hooks/useEntityFilter', () => ({
+  useEntityFilter: () => ({
+    applyFilters: (xs: any) => xs,
+    activeCount: 0,
+    filters: {},
+    setFilter: jest.fn(),
+    clearFilters: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/components/SearchBar', () => {
+  const { View } = require('react-native');
+  return () => <View />;
+});
+
+jest.mock('../src/components/EntityFilterModal', () => {
+  const { View } = require('react-native');
+  return { EntityFilterModal: () => <View /> };
+});
+
+jest.mock('../src/components/ActiveFilterStrip', () => {
+  const { View } = require('react-native');
+  return { ActiveFilterStrip: () => <View /> };
+});
+
+jest.mock('../src/components/ui', () => {
+  const { View, Text, Pressable } = require('react-native');
+  return {
+    ScreenHeader: ({ title, actions }: any) => (
+      <View>
+        <Text>{title}</Text>
+        {actions}
+      </View>
+    ),
+    IconButton: ({ children, onPress, testID, accessibilityLabel }: any) => (
+      <Pressable testID={testID} accessibilityLabel={accessibilityLabel} onPress={onPress}>
+        {children}
+      </Pressable>
+    ),
+    useScreenHeaderHeight: () => 60,
+  };
+});
+
+import CanvasListScreen from '../src/screens/CanvasListScreen';
+
+describe('canvas size picker a11y (issue #649)', () => {
+  test('overlay TouchableOpacity exposes accessible={false} so child rows surface in a11y tree', () => {
+    const { getByTestId } = render(<CanvasListScreen />);
+    fireEvent.press(getByTestId('canvas-list.icon-button.new-canvas'));
+
+    const overlay = getByTestId('canvas-list.overlay.size-picker');
+    expect(overlay.props.accessible).toBe(false);
+  });
+
+  test('every preset row remains individually queryable by testID', () => {
+    const { getByTestId } = render(<CanvasListScreen />);
+    fireEvent.press(getByTestId('canvas-list.icon-button.new-canvas'));
+
+    expect(getByTestId('canvas-list.button.pick-size-phone')).toBeTruthy();
+    expect(getByTestId('canvas-list.button.pick-size-tablet')).toBeTruthy();
+    expect(getByTestId('canvas-list.button.pick-size-landscape')).toBeTruthy();
+    expect(getByTestId('canvas-list.button.pick-size-square')).toBeTruthy();
+    expect(getByTestId('canvas-list.button.pick-size-a4')).toBeTruthy();
+  });
+});

--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -210,8 +210,10 @@ export default function CanvasListScreen() {
         onRequestClose={() => setShowSizePicker(false)}
       >
         <TouchableOpacity
+          testID="canvas-list.overlay.size-picker"
           style={styles.sizeOverlay}
           activeOpacity={1}
+          accessible={false}
           onPress={() => setShowSizePicker(false)}
         >
           <View style={[styles.sizeModal, { backgroundColor: colors.surface }]} onStartShouldSetResponder={() => true}>


### PR DESCRIPTION
## Summary
- Adds `accessible={false}` (plus a `testID`) to the tap-to-dismiss overlay that wraps the size-picker modal in `CanvasListScreen.tsx`.
- iOS RN collapses children's accessibility info under a focusable parent — the per-row `testID`s added in #648 were not surfacing in `maestro hierarchy` or to VoiceOver. Setting `accessible={false}` on the overlay restores per-row a11y nodes.

Closes #649. Follows up on #648.

## Test plan
- [x] `npx jest __tests__/canvas-size-picker-a11y.test.tsx` — 2/2 pass: regression test asserts `overlay.props.accessible === false` and that all five preset rows are individually queryable by `testID`
- [x] `npx tsc --noEmit` — clean
- [ ] Manual / Maestro: open the size picker on iPhone, run `maestro hierarchy`, verify each preset row appears as a distinct node (not folded into one `accessibilityText` blob)

🤖 Generated with [Claude Code](https://claude.com/claude-code)