### PR TITLE
fix(ai): OpenRouter failure handling — real errors, generateText fallback, free-tier preflight

### DIFF
--- a/__tests__/ai/aiServiceErrors.test.ts
+++ b/__tests__/ai/aiServiceErrors.test.ts
@@ -1,0 +1,116 @@
+import {
+  extractErrorDetails,
+  humanizeStreamError,
+} from '../../src/services/ai/aiServiceErrors';
+
+const apiCallError = (overrides: Record<string, unknown> = {}) => {
+  const e: any = new Error(overrides.message as string ?? 'Provider returned error');
+  e.name = 'AI_APICallError';
+  Object.assign(e, overrides);
+  return e;
+};
+
+const retryError = (errors: unknown[], lastError?: unknown) => {
+  const e: any = new Error('Failed after 3 attempts. Last error: Provider returned error');
+  e.name = 'AI_RetryError';
+  if (errors) e.errors = errors;
+  if (lastError) e.lastError = lastError;
+  return e;
+};
+
+const emptyBodyError = (asCause = false) => {
+  if (asCause) {
+    const wrapper: any = new Error('upstream returned empty');
+    wrapper.cause = { name: 'AI_EmptyResponseBodyError' };
+    return wrapper;
+  }
+  const e: any = new Error('empty response body');
+  e.name = 'AI_EmptyResponseBodyError';
+  return e;
+};
+
+describe('extractErrorDetails', () => {
+  test('returns status 429 from AI_APICallError', () => {
+    const e = apiCallError({ statusCode: 429, responseBody: 'rate limited' });
+    const d = extractErrorDetails(e);
+    expect(d.status).toBe(429);
+    expect(d.body).toBe('rate limited');
+    expect(d.isRateLimit).toBe(true);
+    expect(d.isParserError).toBe(false);
+  });
+
+  test('walks AI_RetryError.errors[last] for inner status', () => {
+    const inner = apiCallError({ statusCode: 502, responseBody: 'bad gateway' });
+    const e = retryError([apiCallError({ statusCode: 502 }), apiCallError({ statusCode: 502 }), inner]);
+    const d = extractErrorDetails(e);
+    expect(d.status).toBe(502);
+    expect(d.body).toBe('bad gateway');
+  });
+
+  test('walks AI_RetryError.lastError when no errors array', () => {
+    const inner = apiCallError({ statusCode: 500, responseBody: 'oops' });
+    const e = retryError(undefined as any, inner);
+    const d = extractErrorDetails(e);
+    expect(d.status).toBe(500);
+    expect(d.body).toBe('oops');
+  });
+
+  test('isParserError true for AI_APICallError with successful HTTP status and non-empty body', () => {
+    const e = apiCallError({ statusCode: 200, responseBody: 'data: {...}\n\n' });
+    const d = extractErrorDetails(e);
+    expect(d.isParserError).toBe(true);
+    expect(d.isRateLimit).toBe(false);
+  });
+
+  test('isParserError false for HTTP error responses', () => {
+    const e = apiCallError({ statusCode: 500, responseBody: 'oops' });
+    expect(extractErrorDetails(e).isParserError).toBe(false);
+  });
+
+  test('isEmptyBody true for AI_EmptyResponseBodyError direct or via cause', () => {
+    expect(extractErrorDetails(emptyBodyError(false)).isEmptyBody).toBe(true);
+    expect(extractErrorDetails(emptyBodyError(true)).isEmptyBody).toBe(true);
+  });
+
+  test('handles unknown errors gracefully', () => {
+    const d = extractErrorDetails(new Error('whatever'));
+    expect(d.status).toBeUndefined();
+    expect(d.isRateLimit).toBe(false);
+    expect(d.isParserError).toBe(false);
+    expect(d.isEmptyBody).toBe(false);
+  });
+});
+
+describe('humanizeStreamError', () => {
+  test('rate limit returns HTTP 429 message with body snippet', () => {
+    const e = apiCallError({ statusCode: 429, responseBody: 'free tier exhausted' });
+    expect(humanizeStreamError(e)).toMatch(/HTTP 429.*rate limited.*free tier exhausted/);
+  });
+
+  test('5xx returns HTTP <code> message', () => {
+    const e = apiCallError({ statusCode: 503, responseBody: 'unavailable' });
+    expect(humanizeStreamError(e)).toMatch(/HTTP 503.*unavailable/);
+  });
+
+  test('parser error returns parser-specific copy', () => {
+    const e = apiCallError({ statusCode: 200, responseBody: 'data: {...}' });
+    expect(humanizeStreamError(e)).toMatch(/parse|parser/i);
+  });
+
+  test('empty body returns existing copy', () => {
+    expect(humanizeStreamError(emptyBodyError())).toMatch(/empty response/i);
+  });
+
+  test('truncates long body snippets', () => {
+    const longBody = 'x'.repeat(500);
+    const e = apiCallError({ statusCode: 500, responseBody: longBody });
+    const out = humanizeStreamError(e);
+    expect(out.length).toBeLessThan(400);
+  });
+
+  test('walks AI_RetryError to surface inner status', () => {
+    const inner = apiCallError({ statusCode: 429, responseBody: 'rl' });
+    const e = retryError([inner]);
+    expect(humanizeStreamError(e)).toMatch(/HTTP 429/);
+  });
+});

--- a/__tests__/ai/openrouterPreflight.test.ts
+++ b/__tests__/ai/openrouterPreflight.test.ts
@@ -1,0 +1,91 @@
+import {
+  isOpenRouterBaseURL,
+  checkOpenRouterKey,
+} from '../../src/services/ai/openrouterPreflight';
+
+describe('isOpenRouterBaseURL', () => {
+  test.each([
+    'https://openrouter.ai/api/v1',
+    'https://openrouter.ai/api/v1/',
+    'https://OpenRouter.AI/api/v1',
+    'https://openrouter.ai/api',
+    'https://openrouter.ai/',
+  ])('matches %s', (url) => {
+    expect(isOpenRouterBaseURL(url)).toBe(true);
+  });
+
+  test.each([
+    'https://api.openai.com/v1',
+    'https://anthropic.openrouter.fake.com/v1',
+    'https://example.com/openrouter.ai',
+    '',
+  ])('rejects %s', (url) => {
+    expect(isOpenRouterBaseURL(url)).toBe(false);
+  });
+});
+
+describe('checkOpenRouterKey', () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  test('returns null for non-OpenRouter URL', async () => {
+    const result = await checkOpenRouterKey('https://api.openai.com/v1', 'sk-x');
+    expect(result).toBeNull();
+  });
+
+  test('parses /auth/key response on success', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: { is_free_tier: true, limit: 50, usage: 12 },
+      }),
+    })) as any;
+
+    const result = await checkOpenRouterKey('https://openrouter.ai/api/v1', 'sk-or-x');
+    expect(result).toEqual({ isFreeTier: true, limit: 50, usage: 12 });
+  });
+
+  test('handles paid tier (is_free_tier false)', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: { is_free_tier: false, limit: null, usage: 100 } }),
+    })) as any;
+
+    const result = await checkOpenRouterKey('https://openrouter.ai/api/v1', 'sk-or-x');
+    expect(result).toEqual({ isFreeTier: false, limit: null, usage: 100 });
+  });
+
+  test('returns null when fetch throws', async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error('network down');
+    }) as any;
+
+    const result = await checkOpenRouterKey('https://openrouter.ai/api/v1', 'sk-or-x');
+    expect(result).toBeNull();
+  });
+
+  test('returns null when response is not ok', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    })) as any;
+
+    const result = await checkOpenRouterKey('https://openrouter.ai/api/v1', 'sk-or-x');
+    expect(result).toBeNull();
+  });
+
+  test('handles trailing slash in baseURL', async () => {
+    const fetchMock = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: { is_free_tier: true, limit: 50, usage: 0 } }),
+    })) as any;
+    global.fetch = fetchMock;
+
+    await checkOpenRouterKey('https://openrouter.ai/api/v1/', 'sk-or-x');
+    const calledUrl = (fetchMock.mock.calls[0][0] as string);
+    expect(calledUrl).toBe('https://openrouter.ai/api/v1/auth/key');
+  });
+});

--- a/__tests__/ai/streamChatResponse.test.ts
+++ b/__tests__/ai/streamChatResponse.test.ts
@@ -1,0 +1,155 @@
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+const mockStreamText = jest.fn();
+const mockGenerateText = jest.fn();
+
+jest.mock('ai', () => ({
+  streamText: (...args: unknown[]) => mockStreamText(...args),
+  generateText: (...args: unknown[]) => mockGenerateText(...args),
+  tool: (def: unknown) => def,
+}));
+
+import { streamChatResponse } from '../../src/services/AIService';
+
+const apiCallError = (overrides: Record<string, unknown> = {}) => {
+  const e: any = new Error((overrides.message as string) ?? 'Provider returned error');
+  e.name = 'AI_APICallError';
+  Object.assign(e, overrides);
+  return e;
+};
+
+const emptyBodyError = () => {
+  const e: any = new Error('empty response body');
+  e.name = 'AI_EmptyResponseBodyError';
+  return e;
+};
+
+const fakeStream = (parts: any[]) => ({
+  fullStream: (async function* () {
+    for (const p of parts) yield p;
+  })(),
+});
+
+const collect = async (gen: AsyncGenerator<string>) => {
+  const out: string[] = [];
+  for await (const chunk of gen) out.push(chunk);
+  return out;
+};
+
+const collectError = async (gen: AsyncGenerator<string>): Promise<Error> => {
+  try {
+    for await (const _ of gen) void _;
+  } catch (e) {
+    return e as Error;
+  }
+  throw new Error('expected stream to throw');
+};
+
+const fakeModel = {} as any;
+
+describe('streamChatResponse', () => {
+  beforeEach(() => {
+    mockStreamText.mockReset();
+    mockGenerateText.mockReset();
+  });
+
+  test('yields text-delta chunks from the stream', async () => {
+    mockStreamText.mockReturnValueOnce(
+      fakeStream([
+        { type: 'text-delta', text: 'hello ' },
+        { type: 'text-delta', text: 'world' },
+      ]),
+    );
+
+    const out = await collect(streamChatResponse(fakeModel, []));
+    expect(out.join('')).toBe('hello world');
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  test('falls back to generateText when stream throws parser-class error before any yield', async () => {
+    mockStreamText.mockImplementationOnce(() => {
+      const stream = (async function* () {
+        throw apiCallError({ statusCode: 200, responseBody: 'data: {...}' });
+      })();
+      return { fullStream: stream };
+    });
+    mockGenerateText.mockResolvedValueOnce({ text: 'fallback text', toolCalls: [] });
+
+    const out = await collect(streamChatResponse(fakeModel, []));
+    expect(out).toEqual(['fallback text']);
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
+  });
+
+  test('does NOT fall back on rate-limit error; surfaces HTTP 429', async () => {
+    mockStreamText.mockImplementationOnce(() => {
+      const stream = (async function* () {
+        throw apiCallError({ statusCode: 429, responseBody: 'rate limited' });
+      })();
+      return { fullStream: stream };
+    });
+
+    const err = await collectError(streamChatResponse(fakeModel, []));
+    expect(err.message).toMatch(/HTTP 429/);
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  test('surfaces HTTP 5xx without fallback', async () => {
+    mockStreamText.mockImplementationOnce(() => {
+      const stream = (async function* () {
+        throw apiCallError({ statusCode: 503, responseBody: 'unavailable' });
+      })();
+      return { fullStream: stream };
+    });
+
+    const err = await collectError(streamChatResponse(fakeModel, []));
+    expect(err.message).toMatch(/HTTP 503/);
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  test('retries once on empty body, then falls back to generateText if still failing', async () => {
+    mockStreamText
+      .mockImplementationOnce(() => ({
+        fullStream: (async function* () {
+          throw emptyBodyError();
+        })(),
+      }))
+      .mockImplementationOnce(() => ({
+        fullStream: (async function* () {
+          throw apiCallError({ statusCode: 200, responseBody: 'data: {...}' });
+        })(),
+      }));
+    mockGenerateText.mockResolvedValueOnce({ text: 'recovered', toolCalls: [] });
+
+    const out = await collect(streamChatResponse(fakeModel, []));
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    expect(out).toEqual(['recovered']);
+  });
+
+  test('fallback failure surfaces original (humanized) stream error', async () => {
+    mockStreamText.mockImplementationOnce(() => ({
+      fullStream: (async function* () {
+        throw apiCallError({ statusCode: 200, responseBody: 'data: {...}' });
+      })(),
+    }));
+    mockGenerateText.mockRejectedValueOnce(new Error('fallback boom'));
+
+    const err = await collectError(streamChatResponse(fakeModel, []));
+    expect(err.message).toMatch(/parse|parser/i);
+    expect(err.message).not.toMatch(/fallback boom/);
+  });
+
+  test('does NOT fall back if any chunk was already yielded', async () => {
+    mockStreamText.mockImplementationOnce(() => ({
+      fullStream: (async function* () {
+        yield { type: 'text-delta', text: 'partial' };
+        throw apiCallError({ statusCode: 200, responseBody: '...' });
+      })(),
+    }));
+
+    const err = await collectError(streamChatResponse(fakeModel, []));
+    expect(err.message).toMatch(/parse|parser/i);
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+});

--- a/docs/superpowers/specs/2026-05-10-openrouter-failures-design.md
+++ b/docs/superpowers/specs/2026-05-10-openrouter-failures-design.md
@@ -1,0 +1,72 @@
+# OpenRouter Failure Handling — Design
+
+## Problem (issue #651)
+
+Two distinct failures when using OpenRouter free-tier models in chat:
+
+1. `AI_RetryError`: "Failed after 3 attempts. Last error: Provider returned error" — masks the real HTTP status (429/5xx). Free tier rate-limits at 50 req/day, 20 req/min per IP; user sees only "Provider returned error".
+2. `AI_APICallError`: "Failed to process successful response" — some OpenRouter free providers (e.g. inclusionAI Ring-1T) emit SSE chunks the AI SDK's parser rejects. Stream returns 200 OK but no `text-delta` events.
+
+## Goals
+
+1. **Surface real error details** — propagate HTTP status + body snippet so users see "HTTP 429 (rate limited)" instead of "Provider returned error".
+2. **Pre-flight free-tier warning** — when adding/saving an OpenRouter provider, hit `/v1/auth/key` and warn if the key is on the free tier.
+3. **Fallback to `generateText`** — when `streamText` throws a parser-class error before any chunk yielded, retry once via `generateText`. Surface result as a single yield. If fallback also fails, surface the original (improved) error.
+
+## Non-goals
+
+- Retry policy changes (still 1 retry for transient empty-body).
+- New UI surface for daily-quota status.
+- Mid-stream recovery (only pre-yield fallback).
+
+## Module layout
+
+- `src/services/ai/aiServiceErrors.ts` (new)
+  - `extractErrorDetails(error: unknown): { status?: number; body?: string; isRateLimit: boolean; isParserError: boolean; isEmptyBody: boolean; underlying: unknown }`
+  - `humanizeStreamError(error: unknown): string`
+  - Walks `AI_RetryError.errors` / `AI_RetryError.lastError`, recognises `AI_APICallError` (`statusCode`, `responseBody`, `url`), `AI_EmptyResponseBodyError`.
+- `src/services/ai/openrouterPreflight.ts` (new)
+  - `isOpenRouterBaseURL(baseURL: string): boolean` — true when host endsWith `openrouter.ai`.
+  - `checkOpenRouterKey(baseURL, apiKey): Promise<{ isFreeTier: boolean; limit: number | null; usage: number | null } | null>` — null when not OpenRouter or call fails.
+- `src/services/AIService.ts`
+  - Replace inline `humanizeStreamError` and `isEmptyResponseError` with imports from `aiServiceErrors`.
+  - In `streamChatResponse`, after the empty-body retry block, attempt one `generateText` fallback when `!yielded` and `isParserError` (or `isEmptyBody` after retry already consumed). On fallback success, yield `result.text` and serialize each `toolCall`. On fallback failure, throw original humanized error.
+- `src/components/ai/ProviderConfigModal.tsx`
+  - In the existing "Test connection" path (which already hits `/v1/models`), additionally call `checkOpenRouterKey`. If `isFreeTier`, append a warning to the success Alert: "OpenRouter free tier — daily limit of N req/day. Streaming may fail when exhausted."
+
+## Test plan
+
+Unit tests (`__tests__/ai/aiServiceErrors.test.ts`):
+
+1. `extractErrorDetails` returns status 429 from an `AI_APICallError` with `statusCode: 429`.
+2. Walks `AI_RetryError.errors[last].statusCode` to find inner status.
+3. Walks `AI_RetryError.lastError` when no `errors` array.
+4. `isRateLimit` true when status is 429.
+5. `isParserError` true for `AI_APICallError` with `statusCode` 200 + non-empty body, false for HTTP errors.
+6. `isEmptyBody` true for `AI_EmptyResponseBodyError` (direct or via `cause`).
+7. `humanizeStreamError` formats: `"HTTP 429 (rate limited): <body snippet ≤200 chars>"` for rate-limit; `"HTTP 5xx: ..."` for server errors; `"The provider returned a successful response the SDK could not parse."` for parser errors; existing empty-body copy preserved.
+
+Unit tests (`__tests__/ai/openrouterPreflight.test.ts`):
+
+1. `isOpenRouterBaseURL` matches `https://openrouter.ai/api/v1`, `https://openrouter.ai/api/v1/`, mixed case, ignores trailing slash.
+2. `isOpenRouterBaseURL` false for `https://api.openai.com`, `https://anthropic.openrouter.fake.com`.
+3. `checkOpenRouterKey` returns `null` for non-OpenRouter URL.
+4. `checkOpenRouterKey` returns `{ isFreeTier: true, limit: 50, usage: 12 }` for a stubbed `/v1/auth/key` response.
+5. `checkOpenRouterKey` returns `null` if fetch fails (never throws).
+
+Integration test (`__tests__/ai/streamChatResponse.test.ts`):
+
+Mock the `ai` module (`streamText` + `generateText`).
+
+1. Stream yields text chunks → consumer receives them, no fallback.
+2. Stream throws `AI_APICallError` with `statusCode: 200` (parser error), `generateText` returns `"hello world"` → consumer receives `"hello world"`.
+3. Stream throws `AI_APICallError` with `statusCode: 429` → consumer sees thrown error containing `"429"`.
+4. Stream throws `AI_EmptyResponseBodyError` → first retry; on second failure with parser shape, fallback runs.
+5. Fallback `generateText` itself throws → consumer sees original (humanized) stream error, not fallback error.
+
+## Risks / tradeoffs
+
+- Fallback doubles the upstream-call cost on parser failures. Mitigated by only triggering when `!yielded` and parser-class error, not on rate-limit.
+- `generateText` fallback drops streaming UX (single yield, no progressive render) — acceptable; the alternative is a hard error.
+- `checkOpenRouterKey` adds one extra HTTP call to the test-connection flow — fast, ignored on failure.
+- Tools: fallback passes `tools` through and serializes any `toolCalls` from `result.toolCalls` using existing `serializeToolEvent` shape; if upstream omits tool calls, behaviour matches direct streaming.

--- a/src/components/ai/ProviderConfigModal.tsx
+++ b/src/components/ai/ProviderConfigModal.tsx
@@ -19,6 +19,7 @@ import { useTokens } from '../../contexts/ThemeContext';
 import { Group, GroupRow } from '../ui';
 import { AIProviderConfig, AIModelConfig } from '../../models/AIProvider';
 import { useAIStore } from '../../stores/aiStore';
+import { checkOpenRouterKey, isOpenRouterBaseURL } from '../../services/ai/openrouterPreflight';
 
 interface ProviderConfigModalProps {
   visible: boolean;
@@ -79,9 +80,22 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
           providerType: 'openai-compatible',
           requiresDownload: false,
         }));
-        
+
         setTestedModels(discoveredModels);
-        Alert.alert('Success', `Connected and discovered ${discoveredModels.length} models.`);
+
+        let warning = '';
+        if (isOpenRouterBaseURL(baseURL.trim()) && apiKey.trim()) {
+          const keyInfo = await checkOpenRouterKey(baseURL.trim(), apiKey.trim());
+          if (keyInfo?.isFreeTier) {
+            const limitText = keyInfo.limit != null
+              ? `${keyInfo.limit} req/day`
+              : 'a daily request limit';
+            const usageText = keyInfo.usage != null ? ` (${keyInfo.usage} used)` : '';
+            warning = `\n\nThis API key is on the OpenRouter free tier — ${limitText}${usageText}. Streaming will fail when the daily quota is exhausted.`;
+          }
+        }
+
+        Alert.alert('Success', `Connected and discovered ${discoveredModels.length} models.${warning}`);
       } else {
         throw new Error('Unexpected response format. Expected an array of models.');
       }

--- a/src/services/AIService.ts
+++ b/src/services/AIService.ts
@@ -8,6 +8,10 @@ import {
   ProviderUnavailableError,
   resolveProviderAvailability,
 } from './ai/providerAvailability';
+import {
+  extractErrorDetails,
+  humanizeStreamError,
+} from './ai/aiServiceErrors';
 
 type OnDeviceAvailability = {
   apple: boolean;
@@ -211,20 +215,23 @@ function serializeToolEvent(part: unknown): string | null {
   }
 }
 
-function isEmptyResponseError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false;
-  const e = error as { name?: string; message?: string; cause?: { name?: string } };
-  if (e.name === 'AI_EmptyResponseBodyError') return true;
-  if (e.cause?.name === 'AI_EmptyResponseBodyError') return true;
-  return /empty response body/i.test(e.message ?? '');
-}
-
-function humanizeStreamError(error: unknown): string {
-  if (isEmptyResponseError(error)) {
-    return 'The AI provider returned an empty response. This is often caused by high load on the provider, an invalid model name, or a tools-incompatible request. Please try again, or pick a different model.';
+async function* runGenerateTextFallback(
+  model: LanguageModel,
+  messages: ModelMessage[],
+  tools: Record<string, Tool> | undefined,
+  abortSignal: AbortSignal | undefined,
+): AsyncGenerator<string> {
+  const result = await generateText({ model, messages, tools, abortSignal });
+  if (typeof result.text === 'string' && result.text.length > 0) {
+    yield result.text;
   }
-  const message = error instanceof Error ? error.message : 'Unknown streaming error';
-  return `Failed to stream chat response: ${message}`;
+  const toolCalls = (result as { toolCalls?: unknown[] }).toolCalls;
+  if (Array.isArray(toolCalls)) {
+    for (const call of toolCalls) {
+      const event = serializeToolEvent({ ...(call as object), type: 'tool-call' });
+      if (event) yield event;
+    }
+  }
 }
 
 export async function* streamChatResponse(
@@ -233,15 +240,12 @@ export async function* streamChatResponse(
   tools?: Record<string, Tool>,
   abortSignal?: AbortSignal,
 ): AsyncGenerator<string> {
+  let yielded = false;
+  let lastEmptyBodyError: unknown = null;
+
   for (let attempt = 0; attempt < 2; attempt++) {
-    let yielded = false;
     try {
-      const result = streamText({
-        model,
-        messages,
-        tools,
-        abortSignal,
-      });
+      const result = streamText({ model, messages, tools, abortSignal });
 
       for await (const part of result.fullStream as AsyncIterable<any>) {
         if (part.type === 'text-delta' || part.type === 'text') {
@@ -267,14 +271,32 @@ export async function* streamChatResponse(
       }
       return;
     } catch (error) {
-      // Retry once for transient empty-body responses, but only when no
-      // partial output has been emitted yet (otherwise we'd duplicate content).
-      if (!yielded && attempt === 0 && isEmptyResponseError(error)) {
+      const details = extractErrorDetails(error);
+
+      if (!yielded && attempt === 0 && details.isEmptyBody) {
+        lastEmptyBodyError = error;
         await new Promise((r) => setTimeout(r, 500));
         continue;
       }
+
+      if (!yielded && (details.isParserError || details.isEmptyBody)) {
+        try {
+          for await (const chunk of runGenerateTextFallback(model, messages, tools, abortSignal)) {
+            yielded = true;
+            yield chunk;
+          }
+          return;
+        } catch {
+          throw new Error(humanizeStreamError(error));
+        }
+      }
+
       throw new Error(humanizeStreamError(error));
     }
+  }
+
+  if (!yielded && lastEmptyBodyError) {
+    throw new Error(humanizeStreamError(lastEmptyBodyError));
   }
 }
 

--- a/src/services/ai/aiServiceErrors.ts
+++ b/src/services/ai/aiServiceErrors.ts
@@ -1,0 +1,117 @@
+export interface ErrorDetails {
+  status?: number;
+  body?: string;
+  isRateLimit: boolean;
+  isParserError: boolean;
+  isEmptyBody: boolean;
+  underlying: unknown;
+}
+
+const BODY_SNIPPET_MAX = 200;
+
+function asObj(x: unknown): Record<string, unknown> | null {
+  return x && typeof x === 'object' ? (x as Record<string, unknown>) : null;
+}
+
+function isApiCallError(e: unknown): boolean {
+  const o = asObj(e);
+  return o?.name === 'AI_APICallError';
+}
+
+function isRetryError(e: unknown): boolean {
+  const o = asObj(e);
+  return o?.name === 'AI_RetryError';
+}
+
+function isEmptyBodyError(e: unknown): boolean {
+  const o = asObj(e);
+  if (!o) return false;
+  if (o.name === 'AI_EmptyResponseBodyError') return true;
+  const cause = asObj(o.cause);
+  if (cause?.name === 'AI_EmptyResponseBodyError') return true;
+  if (typeof o.message === 'string' && /empty response body/i.test(o.message)) return true;
+  return false;
+}
+
+function unwrapInner(e: unknown): unknown {
+  if (!isRetryError(e)) return e;
+  const o = asObj(e);
+  if (!o) return e;
+  const errs = o.errors;
+  if (Array.isArray(errs) && errs.length > 0) {
+    return errs[errs.length - 1];
+  }
+  if (o.lastError !== undefined) return o.lastError;
+  return e;
+}
+
+function readStatus(e: unknown): number | undefined {
+  const o = asObj(e);
+  if (!o) return undefined;
+  const s = o.statusCode;
+  return typeof s === 'number' ? s : undefined;
+}
+
+function readBody(e: unknown): string | undefined {
+  const o = asObj(e);
+  if (!o) return undefined;
+  const b = o.responseBody;
+  return typeof b === 'string' ? b : undefined;
+}
+
+export function extractErrorDetails(error: unknown): ErrorDetails {
+  const inner = unwrapInner(error);
+  const status = readStatus(inner);
+  const body = readBody(inner);
+  const isEmptyBody = isEmptyBodyError(error) || isEmptyBodyError(inner);
+  const isRateLimit = status === 429;
+  const isApi = isApiCallError(inner);
+  const isParserError =
+    isApi && typeof status === 'number' && status >= 200 && status < 300 && !isEmptyBody;
+
+  return {
+    status,
+    body,
+    isRateLimit,
+    isParserError,
+    isEmptyBody,
+    underlying: inner,
+  };
+}
+
+function snippet(s?: string): string {
+  if (!s) return '';
+  const trimmed = s.trim();
+  if (trimmed.length <= BODY_SNIPPET_MAX) return trimmed;
+  return trimmed.slice(0, BODY_SNIPPET_MAX) + '…';
+}
+
+export function humanizeStreamError(error: unknown): string {
+  const d = extractErrorDetails(error);
+
+  if (d.isEmptyBody) {
+    return 'The AI provider returned an empty response. This is often caused by high load on the provider, an invalid model name, or a tools-incompatible request. Please try again, or pick a different model.';
+  }
+
+  if (d.isParserError) {
+    const body = snippet(d.body);
+    const tail = body ? ` Response snippet: ${body}` : '';
+    return `The provider returned a successful response the SDK could not parse.${tail}`;
+  }
+
+  if (typeof d.status === 'number') {
+    const body = snippet(d.body);
+    const tail = body ? `: ${body}` : '';
+    if (d.isRateLimit) {
+      return `HTTP 429 (rate limited)${tail}`;
+    }
+    return `HTTP ${d.status}${tail}`;
+  }
+
+  const message = error instanceof Error ? error.message : 'Unknown streaming error';
+  return `Failed to stream chat response: ${message}`;
+}
+
+export function isEmptyBody(error: unknown): boolean {
+  return extractErrorDetails(error).isEmptyBody;
+}

--- a/src/services/ai/openrouterPreflight.ts
+++ b/src/services/ai/openrouterPreflight.ts
@@ -1,0 +1,43 @@
+export interface OpenRouterKeyInfo {
+  isFreeTier: boolean;
+  limit: number | null;
+  usage: number | null;
+}
+
+export function isOpenRouterBaseURL(baseURL: string): boolean {
+  if (!baseURL) return false;
+  try {
+    const u = new URL(baseURL);
+    return u.hostname.toLowerCase() === 'openrouter.ai';
+  } catch {
+    return false;
+  }
+}
+
+export async function checkOpenRouterKey(
+  baseURL: string,
+  apiKey: string,
+): Promise<OpenRouterKeyInfo | null> {
+  if (!isOpenRouterBaseURL(baseURL)) return null;
+
+  const url = baseURL.endsWith('/') ? `${baseURL}auth/key` : `${baseURL}/auth/key`;
+
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    const data = (json as any)?.data;
+    if (!data || typeof data !== 'object') return null;
+
+    return {
+      isFreeTier: Boolean(data.is_free_tier),
+      limit: typeof data.limit === 'number' ? data.limit : null,
+      usage: typeof data.usage === 'number' ? data.usage : null,
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #651.

## Summary
Three independent fixes for the failure modes observed with OpenRouter free-tier models:

1. **Surface real HTTP status + body** — `humanizeStreamError` now walks `AI_RetryError` → inner `AI_APICallError` to produce messages like `HTTP 429 (rate limited): <body snippet>` or `HTTP 503: <body snippet>` instead of the opaque `Provider returned error`. Body snippets are trimmed to ≤200 chars.
2. **`generateText` fallback for parser-class errors** — when `streamText` throws an `AI_APICallError` with `statusCode` in 2xx (i.e. the upstream call succeeded but the SDK couldn't parse the SSE chunks — the inclusionAI Ring-1T symptom), `streamChatResponse` retries once via `generateText` and yields the resulting text plus serialized `toolCalls`. The fallback only fires when no chunk has been yielded yet, so rate-limit / 5xx / mid-stream errors are unaffected.
3. **OpenRouter free-tier preflight** — when the user runs "Test Connection" against an `openrouter.ai` host, the modal also hits `/v1/auth/key` and appends a warning to the success Alert when `is_free_tier` is true (showing the daily limit + usage).

## Module layout
- `src/services/ai/aiServiceErrors.ts` (new) — `extractErrorDetails`, `humanizeStreamError`. Recognises `AI_RetryError`, `AI_APICallError`, `AI_EmptyResponseBodyError`.
- `src/services/ai/openrouterPreflight.ts` (new) — `isOpenRouterBaseURL`, `checkOpenRouterKey`. Returns `null` (never throws) on non-OpenRouter URL or fetch failure.
- `src/services/AIService.ts` — `streamChatResponse` restructured to use the new helpers and the fallback path. Behaviour for healthy streams is unchanged.
- `src/components/ai/ProviderConfigModal.tsx` — preflight wired into `handleTestConnection`.

## Test plan
- [x] `npx jest __tests__/ai` — **104/104 pass across 10 suites**, including:
  - `aiServiceErrors.test.ts` — 13 tests covering error walking + humanization
  - `openrouterPreflight.test.ts` — 15 tests covering URL match + `/auth/key` parsing + failure handling
  - `streamChatResponse.test.ts` — 7 tests covering happy path, parser-error fallback, 429 / 5xx pass-through, empty-body retry → fallback chain, fallback failure surfaces original error, no-fallback-after-yield safety
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: add an OpenRouter provider with a free-tier key, verify the test-connection alert includes the free-tier warning
- [ ] Manual: send a message with a rate-limited free model, verify the bubble shows `HTTP 429 (rate limited): ...`
- [ ] Manual: send a message with `inclusionAI Ring-1T (free)`, verify the response renders (via fallback) instead of failing with `Failed to process successful response`

🤖 Generated with [Claude Code](https://claude.com/claude-code)