### PR TITLE
fix(ai): detect parser errors by message when status is missing (closes #654)

### DIFF
--- a/__tests__/ai/aiServiceErrors.test.ts
+++ b/__tests__/ai/aiServiceErrors.test.ts
@@ -67,6 +67,38 @@ describe('extractErrorDetails', () => {
     expect(extractErrorDetails(e).isParserError).toBe(false);
   });
 
+  test('isParserError true for AI_APICallError with parser-class message and no status (issue #654)', () => {
+    const e = apiCallError({ message: 'Failed to process successful response' });
+    delete (e as any).statusCode;
+    delete (e as any).responseBody;
+    const d = extractErrorDetails(e);
+    expect(d.isParserError).toBe(true);
+    expect(d.isRateLimit).toBe(false);
+  });
+
+  test('isParserError true for AI_APICallError wrapped inside AI_RetryError with no status (issue #654)', () => {
+    const inner = apiCallError({ message: 'Failed to process successful response' });
+    delete (inner as any).statusCode;
+    const e = retryError([inner]);
+    expect(extractErrorDetails(e).isParserError).toBe(true);
+  });
+
+  test.each([
+    'Failed to process successful response',
+    'Failed to parse stream chunk',
+    'Failed to parse JSON response',
+    'invalid SSE chunk format',
+  ])('parser-class message detected: %s', (message) => {
+    const e = apiCallError({ message });
+    delete (e as any).statusCode;
+    expect(extractErrorDetails(e).isParserError).toBe(true);
+  });
+
+  test('non-AI_APICallError with parser-like message is NOT marked parser-error', () => {
+    const e = new Error('Failed to process successful response');
+    expect(extractErrorDetails(e).isParserError).toBe(false);
+  });
+
   test('isEmptyBody true for AI_EmptyResponseBodyError direct or via cause', () => {
     expect(extractErrorDetails(emptyBodyError(false)).isEmptyBody).toBe(true);
     expect(extractErrorDetails(emptyBodyError(true)).isEmptyBody).toBe(true);

--- a/__tests__/ai/streamChatResponse.test.ts
+++ b/__tests__/ai/streamChatResponse.test.ts
@@ -82,6 +82,24 @@ describe('streamChatResponse', () => {
     expect(mockGenerateText).toHaveBeenCalledTimes(1);
   });
 
+  test('falls back to generateText when stream throws status-less parser error (issue #654)', async () => {
+    mockStreamText.mockImplementationOnce(() => {
+      const err = apiCallError({ message: 'Failed to process successful response' });
+      delete (err as any).statusCode;
+      delete (err as any).responseBody;
+      return {
+        fullStream: (async function* () {
+          throw err;
+        })(),
+      };
+    });
+    mockGenerateText.mockResolvedValueOnce({ text: 'recovered via fallback', toolCalls: [] });
+
+    const out = await collect(streamChatResponse(fakeModel, []));
+    expect(out).toEqual(['recovered via fallback']);
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
+  });
+
   test('does NOT fall back on rate-limit error; surfaces HTTP 429', async () => {
     mockStreamText.mockImplementationOnce(() => {
       const stream = (async function* () {

--- a/src/services/ai/aiServiceErrors.ts
+++ b/src/services/ai/aiServiceErrors.ts
@@ -59,6 +59,16 @@ function readBody(e: unknown): string | undefined {
   return typeof b === 'string' ? b : undefined;
 }
 
+const PARSER_MESSAGE_PATTERN =
+  /failed to (process successful response|parse(?: \w+)? (?:stream|json|sse)?[^.]*)|invalid sse chunk|chunk format/i;
+
+function hasParserMessage(e: unknown): boolean {
+  const o = asObj(e);
+  if (!o) return false;
+  const msg = typeof o.message === 'string' ? o.message : '';
+  return PARSER_MESSAGE_PATTERN.test(msg);
+}
+
 export function extractErrorDetails(error: unknown): ErrorDetails {
   const inner = unwrapInner(error);
   const status = readStatus(inner);
@@ -66,8 +76,12 @@ export function extractErrorDetails(error: unknown): ErrorDetails {
   const isEmptyBody = isEmptyBodyError(error) || isEmptyBodyError(inner);
   const isRateLimit = status === 429;
   const isApi = isApiCallError(inner);
-  const isParserError =
+
+  const isStatusedParserError =
     isApi && typeof status === 'number' && status >= 200 && status < 300 && !isEmptyBody;
+  const isMessagedParserError =
+    isApi && typeof status !== 'number' && !isEmptyBody && hasParserMessage(inner);
+  const isParserError = isStatusedParserError || isMessagedParserError;
 
   return {
     status,


### PR DESCRIPTION
Closes #654. Follow-up to #653.

## Summary
The `generateText` fallback added in #653 only fires when `extractErrorDetails` flags `isParserError`, which required `AI_APICallError` to carry `statusCode` in 2xx. The actual error the SDK emits on free Gemma — `Failed to process successful response` — comes through as `AI_APICallError` with no `statusCode` / `responseBody`, so the fallback was skipped and the user saw the raw SDK string.

This PR widens the parser-error detection: when the inner `AI_APICallError` has no `statusCode`, match its message against a parser-class regex (`failed to process successful response` / `failed to parse … stream|json|sse` / `invalid sse chunk` / `chunk format`). Status-bearing detection still wins when both are available, so HTTP 4xx/5xx continue to surface as errors rather than triggering a fallback.

## Files
- `src/services/ai/aiServiceErrors.ts` — adds `hasParserMessage` + a `PARSER_MESSAGE_PATTERN` regex; `extractErrorDetails` now combines status-based and message-based detection.
- `__tests__/ai/aiServiceErrors.test.ts` — 6 new cases (status-less direct, status-less wrapped in `AI_RetryError`, four messages via `test.each`, negative case for non-`AI_APICallError`).
- `__tests__/ai/streamChatResponse.test.ts` — integration test confirming the `generateText` fallback fires for the status-less shape.

## Test plan
- [x] `npx jest __tests__/ai` — **112/112 pass across 10 suites** (was 104 before, +8 new tests)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: send a prompt to a free Gemma model on OpenRouter; verify the bubble renders fallback text instead of `Failed to stream chat response: Failed to process successful response`

🤖 Generated with [Claude Code](https://claude.com/claude-code)