### PR TITLE
fix(chat): surface chat-storage init failures with inline retry (closes #655)

### DIFF
--- a/__tests__/ChatRepoPickerModal.error.test.tsx
+++ b/__tests__/ChatRepoPickerModal.error.test.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+
+const stableColors = {
+  background: '#fff',
+  surface: '#f4f4f4',
+  primary: '#2563eb',
+  text: '#111',
+  textSecondary: '#666',
+  border: '#ddd',
+  error: '#dc2626',
+  accent: '#8b5cf6',
+};
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: stableColors, isDark: false }),
+  useTokens: () => ({
+    colors: stableColors,
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 },
+    type: { xs: 12, sm: 14, md: 16, lg: 18, xl: 22 },
+    radii: { sm: 12, md: 18, lg: 24, pill: 999 },
+    style: 'flat',
+  }),
+}));
+
+const mockSetChatRepo = jest.fn(async () => undefined);
+
+jest.mock('../src/stores/repoStore', () => ({
+  useRepoStore: (selector: any) => {
+    const state = {
+      repositories: [
+        { name: 'owner/repo-a', path: 'owner/repo-a' },
+        { name: 'owner/repo-b', path: 'owner/repo-b' },
+      ],
+    };
+    return selector(state);
+  },
+}));
+
+jest.mock('../src/stores/aiStore', () => ({
+  useAIStore: (selector: any) => {
+    const state = { setChatRepo: mockSetChatRepo };
+    return selector(state);
+  },
+}));
+
+jest.mock('../src/components/SearchBar', () => {
+  const { View } = require('react-native');
+  return () => <View />;
+});
+
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: {
+    selection: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockInitializeChatStorage = jest.fn();
+jest.mock('../src/services/ChatStorageService', () => ({
+  initializeChatStorage: (...args: unknown[]) => mockInitializeChatStorage(...args),
+}));
+
+jest.mock('../src/components/ui', () => {
+  const { View, Text, Pressable, TextInput } = require('react-native');
+  return {
+    Modal: ({ visible, children }: any) => (visible ? <View>{children}</View> : null),
+    Button: ({ children, onPress, disabled, testID }: any) => (
+      <Pressable testID={testID} onPress={disabled ? undefined : onPress} disabled={disabled}>
+        <Text>{children}</Text>
+      </Pressable>
+    ),
+    Input: ({ value, onChangeText, testID, placeholder }: any) => (
+      <TextInput testID={testID} value={value} onChangeText={onChangeText} placeholder={placeholder} />
+    ),
+    Surface: ({ children }: any) => <View>{children}</View>,
+  };
+});
+
+import { ChatRepoPickerModal } from '../src/components/ai/ChatRepoPickerModal';
+
+describe('ChatRepoPickerModal init error recovery (issue #655)', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockInitializeChatStorage.mockReset();
+    mockSetChatRepo.mockClear();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('shows error row + keeps modal open when initializeChatStorage throws', async () => {
+    mockInitializeChatStorage.mockRejectedValueOnce(new Error('Network Error'));
+    const onSelected = jest.fn();
+    const onClose = jest.fn();
+
+    const { getAllByTestId, getByTestId, queryByTestId } = render(
+      <ChatRepoPickerModal visible onClose={onClose} onSelected={onSelected} />,
+    );
+
+    fireEvent.press(getAllByTestId('chat-repo-picker.button.select-repo')[0]);
+    await act(async () => {
+      fireEvent.press(getByTestId('chat-repo-picker.button.confirm'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('chat-repo-picker.text.error')).toBeTruthy();
+    });
+
+    expect(queryByTestId('chat-repo-picker.button.confirm')).toBeTruthy();
+    expect(onSelected).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    const errorText = getByTestId('chat-repo-picker.text.error');
+    expect(errorText.props.children).toMatch(/Network Error|couldn't|failed/i);
+  });
+
+  test('retry succeeds after first failure → onSelected fires', async () => {
+    mockInitializeChatStorage
+      .mockRejectedValueOnce(new Error('Network Error'))
+      .mockResolvedValueOnce(undefined);
+    const onSelected = jest.fn();
+
+    const { getAllByTestId, getByTestId, queryByTestId } = render(
+      <ChatRepoPickerModal visible onClose={() => {}} onSelected={onSelected} />,
+    );
+
+    fireEvent.press(getAllByTestId('chat-repo-picker.button.select-repo')[0]);
+    await act(async () => {
+      fireEvent.press(getByTestId('chat-repo-picker.button.confirm'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('chat-repo-picker.text.error')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('chat-repo-picker.button.confirm'));
+    });
+
+    await waitFor(() => {
+      expect(onSelected).toHaveBeenCalledTimes(1);
+    });
+    expect(queryByTestId('chat-repo-picker.text.error')).toBeNull();
+  });
+
+  test('changing branch clears the error', async () => {
+    mockInitializeChatStorage.mockRejectedValueOnce(new Error('Network Error'));
+
+    const { getAllByTestId, getByTestId, queryByTestId } = render(
+      <ChatRepoPickerModal visible onClose={() => {}} onSelected={() => {}} />,
+    );
+
+    fireEvent.press(getAllByTestId('chat-repo-picker.button.select-repo')[0]);
+    await act(async () => {
+      fireEvent.press(getByTestId('chat-repo-picker.button.confirm'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('chat-repo-picker.text.error')).toBeTruthy();
+    });
+
+    fireEvent.changeText(getByTestId('chat-repo-picker.input.branch'), 'develop');
+
+    expect(queryByTestId('chat-repo-picker.text.error')).toBeNull();
+  });
+});

--- a/src/components/ai/ChatRepoPickerModal.tsx
+++ b/src/components/ai/ChatRepoPickerModal.tsx
@@ -38,6 +38,7 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
   const [selectedRepoPath, setSelectedRepoPath] = useState<string | null>(null);
   const [branch, setBranch] = useState('main');
   const [isInitializing, setIsInitializing] = useState(false);
+  const [initError, setInitError] = useState<string | null>(null);
 
   const filteredRepos = useMemo(() => {
     if (!searchQuery.trim()) return repositories;
@@ -51,7 +52,13 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
 
   const handleSelectRepo = (path: string) => {
     setSelectedRepoPath(path);
+    setInitError(null);
     HapticService.selection();
+  };
+
+  const handleBranchChange = (next: string) => {
+    setBranch(next);
+    setInitError(null);
   };
 
   const handleConfirm = async () => {
@@ -64,6 +71,7 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
     const name = repo.path.split('/')[1] || repo.name;
 
     setIsInitializing(true);
+    setInitError(null);
     try {
       await setChatRepo(owner, name, branch);
       await ChatStorageService.initializeChatStorage(owner, name, branch);
@@ -72,6 +80,10 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
     } catch (error) {
       console.error('[ChatRepoPickerModal] Error initializing chat storage:', error);
       HapticService.error();
+      const detail = error instanceof Error ? error.message : 'Unknown error';
+      setInitError(
+        `Couldn't write to ${repo.path}/chats/. ${detail}. Check network and repository write access, then tap Retry.`,
+      );
     } finally {
       setIsInitializing(false);
     }
@@ -186,7 +198,7 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
                     <Input
                       testID="chat-repo-picker.input.branch"
                       value={branch}
-                      onChangeText={setBranch}
+                      onChangeText={handleBranchChange}
                       placeholder="main"
                       autoCapitalize="none"
                       autoCorrect={false}
@@ -207,13 +219,33 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
             },
           ]}
         >
+          {initError && (
+            <View
+              style={[
+                styles.errorRow,
+                { backgroundColor: colors.error + '1A', borderColor: colors.error },
+              ]}
+            >
+              <Ionicons name="alert-circle" size={18} color={colors.error} />
+              <Text
+                testID="chat-repo-picker.text.error"
+                style={[styles.errorText, { color: colors.error }]}
+              >
+                {initError}
+              </Text>
+            </View>
+          )}
           <Button
             testID="chat-repo-picker.button.confirm"
             variant="primary"
             onPress={handleConfirm}
             disabled={!selectedRepoPath || isInitializing}
           >
-            {isInitializing ? 'Initializing...' : 'Confirm Selection'}
+            {isInitializing
+              ? 'Initializing...'
+              : initError
+                ? 'Retry'
+                : 'Confirm Selection'}
           </Button>
         </View>
       </View>
@@ -292,6 +324,20 @@ const styles = StyleSheet.create({
     paddingTop: 12,
     paddingBottom: 4,
     borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  errorRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    padding: 10,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginBottom: 10,
+  },
+  errorText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
   },
   emptyState: {
     alignItems: 'center',


### PR DESCRIPTION
Closes #655.

## Summary
`ChatStorageService.initializeChatStorage` failures (Axios `Network Error` is the typical case after a sim rebuild) were swallowed into a `console.error` in `ChatRepoPickerModal`. The modal stayed open, the Confirm button re-enabled, and the user had no idea the call had failed — just a vibration from `HapticService.error()`.

This PR surfaces the failure inline:

- New `initError` state holds the human-readable message after a failed `initializeChatStorage`.
- An error row (red icon + body, `chat-repo-picker.text.error`) renders above the action button when set.
- The action button re-labels to **"Retry"** while `initError` is set; tapping it re-runs the same flow.
- Selecting a different repo OR editing the branch input clears the error so the affordance can't get stuck on stale state.

The error copy includes the failing repo path and the underlying error message, e.g.:
> Couldn't write to `owner/repo`/chats/. Network Error. Check network and repository write access, then tap Retry.

Pre-validating `repo:write` scope (the issue's "bonus" item) is intentionally out of scope here — would belong with a broader scope-check pass across the auth surface.

## Test plan
- [x] `npx jest __tests__/ChatRepoPickerModal.error.test.tsx` — **3/3 pass**:
  - Error row renders + modal stays open + `onSelected`/`onClose` not called when init throws
  - Retry succeeds → `onSelected` fires + error row disappears
  - Editing branch input clears the error
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: pick a repo on a flaky network (or with a token missing `repo:write`), confirm the modal stays open with the inline error + Retry button

🤖 Generated with [Claude Code](https://claude.com/claude-code)