### PR TITLE
fix(org): hide property drawers + decouple heading chips from heading text (partial #660)

### DIFF
--- a/__tests__/components/StructuredRenderer.org.test.tsx
+++ b/__tests__/components/StructuredRenderer.org.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+const stableColors = {
+  background: '#fff',
+  surface: '#f4f4f4',
+  surfaceSecondary: '#f0f0f0',
+  primary: '#2563eb',
+  text: '#111',
+  textSecondary: '#666',
+  border: '#ddd',
+  error: '#dc2626',
+  accent: '#8b5cf6',
+};
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+}));
+
+jest.mock('../../src/components/CodeBlock', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View /> };
+});
+
+jest.mock('../../src/components/KatexView', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View /> };
+});
+
+jest.mock('react-native-webview', () => ({
+  WebView: () => null,
+}));
+
+jest.mock('../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: stableColors, isDark: false }),
+  useTokens: () => ({
+    colors: stableColors,
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 },
+    type: { xs: 12, sm: 14, md: 16, lg: 18, xl: 22 },
+    radii: { sm: 12, md: 18, lg: 24, pill: 999 },
+    style: 'flat',
+  }),
+}));
+
+jest.mock('../../src/stores/renderStyleStore', () => ({
+  useRenderStyle: () => ({}),
+}));
+
+import StructuredRenderer from '../../src/components/StructuredRenderer';
+import type { NeorgContentBlock } from '../../src/models/NeorgContent';
+
+function renderBlocks(blocks: NeorgContentBlock[], format: 'neorg' | 'org' = 'org') {
+  return render(<StructuredRenderer blocks={blocks} format={format} />);
+}
+
+describe('StructuredRenderer org behaviours (issue #660)', () => {
+  test('PROPERTIES drawer is hidden from rendered output', () => {
+    const { queryByText } = renderBlocks([
+      {
+        type: 'drawer',
+        drawer: {
+          name: 'PROPERTIES',
+          properties: { CATEGORY: 'Research', REVIEWED: '2026-05-08' },
+        },
+      },
+    ]);
+    expect(queryByText(':PROPERTIES:')).toBeNull();
+    expect(queryByText(/CATEGORY/)).toBeNull();
+    expect(queryByText(/Research/)).toBeNull();
+    expect(queryByText(/REVIEWED/)).toBeNull();
+  });
+
+  test('LOGBOOK drawer also hidden', () => {
+    const { queryByText } = renderBlocks([
+      {
+        type: 'drawer',
+        drawer: {
+          name: 'LOGBOOK',
+          properties: { LINE_1: 'CLOCK: [2026-01-01]' },
+        },
+      },
+    ]);
+    expect(queryByText(':LOGBOOK:')).toBeNull();
+    expect(queryByText(/CLOCK/)).toBeNull();
+  });
+
+  test('drawer surrounded by other blocks does not interrupt them', () => {
+    const { getByText, queryByText } = renderBlocks([
+      { type: 'paragraph', text: 'Before drawer' },
+      {
+        type: 'drawer',
+        drawer: { name: 'PROPERTIES', properties: { K: 'V' } },
+      },
+      { type: 'paragraph', text: 'After drawer' },
+    ]);
+    expect(getByText('Before drawer')).toBeTruthy();
+    expect(getByText('After drawer')).toBeTruthy();
+    expect(queryByText(':PROPERTIES:')).toBeNull();
+  });
+
+  test('heading with TODO + priority + long text renders all three (no clipping/truncation)', () => {
+    const { getByText } = renderBlocks([
+      {
+        type: 'heading',
+        heading: {
+          level: 3,
+          text: 'Compare onboarding flows',
+          todoState: 'TODO',
+          priority: 'A',
+        },
+      },
+    ]);
+    expect(getByText('TODO')).toBeTruthy();
+    expect(getByText('#A')).toBeTruthy();
+    expect(getByText('Compare onboarding flows')).toBeTruthy();
+  });
+});

--- a/src/components/StructuredRenderer.tsx
+++ b/src/components/StructuredRenderer.tsx
@@ -416,17 +416,23 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
   const renderHeading = (heading: NeorgHeading, blockIndex: number) => {
     const fontSize = 32 - (heading.level - 1) * 4;
     const fontWeight = headingWeightFor(heading.level);
+    const hasChips = format === 'org' && (heading.todoState || heading.priority);
+    const hasTags = format === 'org' && heading.tags && heading.tags.length > 0;
     return (
-      <View key={`heading-${blockIndex}`} style={{ flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', marginTop: heading.level === 1 ? 16 : 12, marginBottom: 8 }}>
-        {format === 'org' && heading.todoState && (
-          <Text style={[styles.todoBadge, { backgroundColor: todoColor(heading.todoState) + '20', color: todoColor(heading.todoState) }]}>
-            {heading.todoState}
-          </Text>
-        )}
-        {format === 'org' && heading.priority && (
-          <Text style={[styles.priorityBadge, { backgroundColor: priorityColor(heading.priority) + '30', color: priorityColor(heading.priority) }]}>
-            #{heading.priority}
-          </Text>
+      <View key={`heading-${blockIndex}`} style={{ marginTop: heading.level === 1 ? 16 : 12, marginBottom: 8 }}>
+        {hasChips && (
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', marginBottom: 4 }}>
+            {heading.todoState && (
+              <Text style={[styles.todoBadge, { backgroundColor: todoColor(heading.todoState) + '20', color: todoColor(heading.todoState) }]}>
+                {heading.todoState}
+              </Text>
+            )}
+            {heading.priority && (
+              <Text style={[styles.priorityBadge, { backgroundColor: priorityColor(heading.priority) + '30', color: priorityColor(heading.priority) }]}>
+                #{heading.priority}
+              </Text>
+            )}
+          </View>
         )}
         <Text
           selectable
@@ -438,11 +444,15 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
         >
           {renderInline(heading.text)}
         </Text>
-        {format === 'org' && heading.tags && heading.tags.map((tag, ti) => (
-          <Text key={`tag-${ti}`} style={[styles.tagChip, { backgroundColor: colors.primary + '15', color: colors.primary }]}>
-            {tag}
-          </Text>
-        ))}
+        {hasTags && (
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', marginTop: 4 }}>
+            {heading.tags!.map((tag, ti) => (
+              <Text key={`tag-${ti}`} style={[styles.tagChip, { backgroundColor: colors.primary + '15', color: colors.primary }]}>
+                {tag}
+              </Text>
+            ))}
+          </View>
+        )}
       </View>
     );
   };
@@ -612,18 +622,7 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
           </View>
         ) : null;
       case 'drawer':
-        return block.drawer ? (
-          <View key={`dr-${index}`} style={{ padding: 8, borderRadius: 4, marginVertical: 4, backgroundColor: colors.surfaceSecondary, opacity: 0.7 }}>
-            <Text selectable style={{ fontSize: 12, fontWeight: '600', color: colors.textSecondary, marginBottom: 4 }}>
-              :{block.drawer.name}:
-            </Text>
-            {Object.entries(block.drawer.properties).map(([key, value]) => (
-              <Text key={key} selectable style={{ fontSize: 12, fontFamily: 'monospace', color: colors.textSecondary }}>
-                :{key}: {value}
-              </Text>
-            ))}
-          </View>
-        ) : null;
+        return null;
       case 'fixed-width':
         return block.text ? (
           <Text key={`fw-${index}`} selectable style={{ fontFamily: 'monospace', fontSize: 14, paddingVertical: 2, color: colors.text }}>


### PR DESCRIPTION
Partial fix for #660. Addresses the org-specific items; the strikethrough + bullet items are shared with the .norg renderer and tracked by #662.

## Summary

### 1. Drawers no longer leak into rendered output
\`\`\`org
:PROPERTIES:
:CATEGORY: Research
:REVIEWED: 2026-05-08
:END:
\`\`\`
…was being rendered as a faint inline block at the top of the body. Org property/log drawers are metadata. The renderer now returns \`null\` for the \`drawer\` case (matching Emacs default), so they don't surface in the body.

### 2. Heading + TODO + priority + tags split into rows
The header row used a single \`flexDirection: row\` container with \`flexWrap: wrap\`. When a TODO chip + priority chip were present, the heading Text wrapped under them — with no \`flexShrink\` it could clip the trailing characters on narrow screens (the \"final \`s\` off the right edge\" symptom in the issue).

Now structured as three rows inside the heading container:
- chip row (TODO + priority) — only when present
- heading text row — full container width, free to wrap normally
- tag row — only when present

Each wraps independently; the heading is no longer competing with chip width for room on its own line.

## Out of scope (covered elsewhere)
- Strikethrough eats hyphens (#660 item 2): same renderer as .norg → fixed in #662.
- Literal dash next to bullet glyph (#660 item 3): shared with .norg → tracked by remaining #659 work.

## Test plan
- [x] \`npx jest __tests__/components/StructuredRenderer.org.test.tsx\` — 4/4 pass: PROPERTIES drawer hidden, LOGBOOK drawer hidden, drawer between paragraphs leaves them intact, heading with TODO + priority + long text renders all parts
- [x] \`npx jest __tests__/services/OrgContentParser.test.ts __tests__/services/OrgInlineParser.test.ts\` — 53/53 pass (no regression in parser layer)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: open \`notes/competitor-analysis.org\` from \`vidwadeseram/test-notes\` on iPhone sim; verify the two property drawers vanish and \`*** TODO [#A] Compare onboarding flows\` shows TODO/#A on one row above the (uncliped) heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)