### PR TITLE
test(norg/org): regression coverage for #659 + #660 strikethrough cases

### DIFF
--- a/__tests__/services/NeorgInlineParser.severity659.test.ts
+++ b/__tests__/services/NeorgInlineParser.severity659.test.ts
@@ -1,0 +1,33 @@
+import { NeorgInlineParser } from '../../src/services/NeorgInlineParser';
+
+const strikes = (input: string) =>
+  NeorgInlineParser.parseInline(input)
+    .segments.filter((s) => s.type === 'markup' && s.markup?.type === 'strikethrough')
+    .map((s) => s.markup!.content);
+
+describe('NeorgInlineParser severity #659 examples', () => {
+  test('paid-influencer in long sentence stays unstruck', () => {
+    const out = strikes('This is a paid-influencer program in the lifestyle sense.');
+    expect(out).toEqual([]);
+  });
+
+  test('two italic-with-dash sentences do not chain a strike between them', () => {
+    const out = strikes(
+      "This is /not/ a paid-influencer program in the lifestyle sense.\n" +
+      "It's a /creator/-partnership effort with builders our audience already trusts.",
+    );
+    expect(out).toEqual([]);
+  });
+
+  test('follow-for-follow keeps both hyphens', () => {
+    expect(strikes('follow-for-follow')).toEqual([]);
+  });
+
+  test('engagement-bait or AI-spam keeps both hyphens', () => {
+    expect(strikes('engagement-bait or AI-spam')).toEqual([]);
+  });
+
+  test('/creator/-partnership construction yields no strike', () => {
+    expect(strikes('It is a /creator/-partnership.')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds regression coverage for the strikethrough cases surfaced in the #659 + #660 follow-up comments — both viewers share \`NeorgInlineParser\` via \`StructuredRenderer\`, so the word-boundary fix shipped in #662 covers both.

## Cases covered
**#659 severity:** \`paid-influencer\`, \`/not/\` + \`/creator/-partnership\`, \`follow-for-follow\`, \`engagement-bait or AI-spam\`, \`/creator/-partnership\`
**#660 follow-up:** \`time-to-value\`, \`time-to-first-value\`, \`side-by-side\`, \`Bottom-of-funnel\`, \`Self-hosted\`, \`paid-influencer\` in a long sentence, multi-line paragraph with several hyphenated tokens

All 12 inputs already pass under the current regex; the tests just lock them in so a future regex change doesn't silently bring the bug back.

Confirms that \`StructuredRenderer\` is the single render path for both formats — \`MarkdownBody\` only handles \`.md\` (\`NotePreviewPane.tsx:120-123\`), so an \`OrgInlineParser\` change is *not* needed for the rendered viewer.

## Test plan
- [x] \`npx jest __tests__/services/NeorgInlineParser.severity659.test.ts __tests__/services/strike.cross-format.test.ts\` — 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)