### PR TITLE
fix(render): word-boundary strike/sub/super in renderer parser + indented headings (#659 #660)

### DIFF
--- a/__tests__/NeorgContentParser.indentedHeading.test.ts
+++ b/__tests__/NeorgContentParser.indentedHeading.test.ts
@@ -1,0 +1,42 @@
+import { NeorgContentParser } from '../src/services/NeorgContentParser';
+
+describe('NeorgContentParser indented headings (issue #659)', () => {
+  test('parses leading-whitespace *** as heading', () => {
+    const heading = NeorgContentParser.parseHeading('    *** Win-Back (Day 60+ inactive)');
+    expect(heading).not.toBeNull();
+    expect(heading!.level).toBe(3);
+    expect(heading!.text).toBe('Win-Back (Day 60+ inactive)');
+  });
+
+  test('parses tab-indented heading', () => {
+    const heading = NeorgContentParser.parseHeading('\t** Sub-section');
+    expect(heading).not.toBeNull();
+    expect(heading!.level).toBe(2);
+    expect(heading!.text).toBe('Sub-section');
+  });
+
+  test('indented heading + indented body produces two blocks (heading then paragraph)', () => {
+    const src = [
+      '    *** Win-Back (Day 60+ inactive)',
+      '        Three-email sequence. If no reply, soft-suppress for 90 days.',
+    ].join('\n');
+    const result = NeorgContentParser.parseContent(src);
+    const headings = result.blocks!.filter((b) => b.type === 'heading');
+    expect(headings).toHaveLength(1);
+    expect(headings[0].heading?.text).toBe('Win-Back (Day 60+ inactive)');
+
+    const paragraphs = result.blocks!.filter((b) => b.type === 'paragraph');
+    expect(paragraphs.length).toBeGreaterThanOrEqual(1);
+    expect(paragraphs[0].text).toContain('Three-email sequence');
+  });
+
+  test('zero-indent heading still works (no regression)', () => {
+    const heading = NeorgContentParser.parseHeading('*** Heading');
+    expect(heading?.level).toBe(3);
+    expect(heading?.text).toBe('Heading');
+  });
+
+  test('does not match a star inside a paragraph', () => {
+    expect(NeorgContentParser.parseHeading('paragraph with * inside')).toBeNull();
+  });
+});

--- a/__tests__/components/parseNeorgInlineSegments.test.ts
+++ b/__tests__/components/parseNeorgInlineSegments.test.ts
@@ -1,0 +1,70 @@
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+}));
+
+jest.mock('react-native-webview', () => ({
+  WebView: () => null,
+}));
+
+import { parseNeorgInlineSegments } from '../../src/components/StructuredRenderer';
+
+const segmentsOf = (input: string, type: string) =>
+  parseNeorgInlineSegments(input).filter((s) => s.type === type);
+
+describe('parseNeorgInlineSegments strike (issue #659/#660)', () => {
+  test.each([
+    'Win-Back (Day 60+ inactive)',
+    'Re-sending broadcasts to non-openers',
+    'time-to-value',
+    'time-to-first-value',
+    'side-by-side',
+    'Bottom-of-funnel',
+    'Self-hosted',
+    '2026-05-30',
+    'paid-influencer program in the lifestyle sense.',
+  ])('does NOT strike %p', (input) => {
+    expect(segmentsOf(input, 'strikethrough')).toEqual([]);
+  });
+
+  test('still strikes proper -gone- with whitespace boundaries', () => {
+    const out = segmentsOf('this is -gone- already', 'strikethrough');
+    expect(out).toHaveLength(1);
+    expect((out[0] as any).content).toBe('gone');
+  });
+
+  test('Three-email + Win-Back across newline does not chain a strike', () => {
+    const text = '*** Win-Back (Day 60+ inactive) Three-email sequence';
+    expect(segmentsOf(text, 'strikethrough')).toEqual([]);
+  });
+
+  test('multi-line paragraph with hyphenated tokens leaves them all alone', () => {
+    const text = [
+      'Compare onboarding flows side-by-side',
+      'time-to-value matters more than features.',
+      'Walk through each competitor signup; time-to-first-value should be < 90s.',
+    ].join('\n');
+    expect(segmentsOf(text, 'strikethrough')).toEqual([]);
+  });
+});
+
+describe('parseNeorgInlineSegments subscript (issue #660 comma-list bug)', () => {
+  test('does NOT subscript a comma-delimited clause inside a sentence', () => {
+    const text = 'one is bleeding share, one is picking fights on price, one is repositioning upmarket.';
+    expect(segmentsOf(text, 'subscript')).toEqual([]);
+  });
+
+  test('does NOT subscript a list of items separated by commas', () => {
+    const text = 'apple, banana, cherry, date.';
+    expect(segmentsOf(text, 'subscript')).toEqual([]);
+  });
+
+  test('still subscripts properly delimited ,sub, with whitespace boundaries', () => {
+    const out = segmentsOf('the index ,i, refers to row', 'subscript');
+    expect(out).toHaveLength(1);
+    expect((out[0] as any).content).toBe('i');
+  });
+});

--- a/src/components/StructuredRenderer.tsx
+++ b/src/components/StructuredRenderer.tsx
@@ -104,14 +104,37 @@ const inlinePatterns: InlinePattern[] = [
   {
     regex: /-([^-\s][^-]*)-/g,
     handler: (m) => ({ type: 'strikethrough', content: m[1] }),
+    validate: (source, match) => {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      const prev = start > 0 ? source[start - 1] : '';
+      const next = end < source.length ? source[end] : '';
+      return (!prev || !WORD_CHAR_REGEX.test(prev)) && (!next || !WORD_CHAR_REGEX.test(next));
+    },
   },
   {
     regex: /\^([^^]+)\^/g,
     handler: (m) => ({ type: 'superscript', content: m[1] }),
+    validate: (source, match) => {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      const prev = start > 0 ? source[start - 1] : '';
+      const next = end < source.length ? source[end] : '';
+      return (!prev || !WORD_CHAR_REGEX.test(prev)) && (!next || !WORD_CHAR_REGEX.test(next));
+    },
   },
   {
     regex: /,([^,]+),/g,
     handler: (m) => ({ type: 'subscript', content: m[1] }),
+    validate: (source, match) => {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      const prev = start > 0 ? source[start - 1] : '';
+      const next = end < source.length ? source[end] : '';
+      const content = match[1];
+      if (/\s/.test(content)) return false;
+      return (!prev || !WORD_CHAR_REGEX.test(prev)) && (!next || !WORD_CHAR_REGEX.test(next));
+    },
   },
   { regex: /\+([^+\s][^+]*[^+\s]?)\+/g, handler: (m) => ({ type: 'org-strike', content: m[1] }) },
   { regex: /=([^=\s][^=]*[^=\s]?)=/g, handler: (m) => ({ type: 'verbatim', content: m[1] }) },

--- a/src/services/NeorgContentParser.ts
+++ b/src/services/NeorgContentParser.ts
@@ -343,12 +343,12 @@ export class NeorgContentParser {
   }
 
   static parseHeading(line: string): NeorgHeading | null {
-    const starMatch = line.match(/^(\*{1,7})\s+(.+)$/);
+    const starMatch = line.match(/^\s*(\*{1,7})\s+(.+)$/);
     if (starMatch) {
       return { level: starMatch[1].length, text: starMatch[2].trim() };
     }
 
-    const mdMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    const mdMatch = line.match(/^\s*(#{1,6})\s+(.+)$/);
     if (mdMatch) {
       return { level: mdMatch[1].length, text: mdMatch[2].trim() };
     }


### PR DESCRIPTION
Closes follow-up reports on #659 and #660.

## Why this was missed

There are TWO Neorg inline parsers in this repo:

| Parser | File | Used by |
|---|---|---|
| \`NeorgInlineParser\` | \`src/services/NeorgInlineParser.ts\` | tests, \`MarkdownPreviewContent\`, \`stripPreview\` |
| \`parseNeorgInlineSegments\` | inline in \`src/components/StructuredRenderer.tsx\` | the actual rendered viewer |

#662 fixed the first one (word-boundary strike). The viewer uses the **second**, which still had the unbounded regexes. After the user did \`expo start --clear\` + reinstall + cold launch they correctly noted the bug persisted in headings, paragraphs, and list bodies — those all flow through \`renderInline → parseNeorgInlineSegments\`, not through \`NeorgInlineParser\`.

## What this PR changes

### 1. parseNeorgInlineSegments — add word-boundary validate
Strikethrough (line 105), superscript (line 109), and subscript (line 113) now use the same \`validate\` shape that italic already had: rejected when the open delimiter is preceded by an alphanumeric or the close delimiter is followed by one. Subscript additionally rejects whitespace inside the content so a comma-clause like \`, one is picking fights on price,\` no longer matches.

### 2. parseHeading — allow leading whitespace
The seed file uses indented \`    *** Heading\`. The old regex \`/^(\*{1,7})\\s+(.+)$/\` required the asterisks at column 0, so the heading fell through to a paragraph. The paragraph then bundled the heading line with the following indented body line, the bold parser ate \`***\` down to a single \`*\`, and the strike parser ran across the join into the \`Three-email\` dash on the next line — exactly the symptom in the #659 follow-up. Heading regexes now allow \`^\\s*\`.

## Cases now passing

From the latest #659 / #660 follow-ups:
- \`Win-Back (Day 60+ inactive)\` — no strike
- \`Re-sending broadcasts to non-openers\` — no strike
- \`time-to-value\`, \`time-to-first-value\`, \`side-by-side\`, \`Bottom-of-funnel\`, \`Self-hosted\`, \`paid-influencer …\` — no strike
- \`2026-05-30\` — dashes preserved
- \`one is bleeding share, one is picking fights on price, one is repositioning upmarket.\` — no subscript on the comma-clause
- \`apple, banana, cherry, date.\` — no subscript
- \`    *** Win-Back (Day 60+ inactive)\` (4-space indent) — parses as level-3 heading with full text
- \`\\t** Sub-section\` — tab indent works

## Out of scope (separate follow-up)
- Literal \`-\` next to the bullet glyph: that \`- \` IS the rendered bullet (\`StructuredRenderer.tsx:460\`). Cosmetic — could swap to \`•\` later.

## Test plan
- [x] \`npx jest __tests__/components/parseNeorgInlineSegments.test.ts __tests__/NeorgContentParser.indentedHeading.test.ts\` — 20/20 pass
- [x] All neorg/org test suites — 167/167 pass across 11 suites (no regression)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: rebuild on iPhone sim with \`notes/email-marketing-playbook.norg\` + \`notes/competitor-analysis.org\` open; confirm \`Win-Back\`, \`time-to-value\`, \`side-by-side\`, \`2026-05-30\`, indented headings, and the comma-list paragraph all render plain

🤖 Generated with [Claude Code](https://claude.com/claude-code)