### PR TITLE
fix(tabbar): box-none on BlurView so taps fall through transparent pill areas (closes #667)

### DIFF
--- a/__tests__/components/TabBar.pointerEvents.test.tsx
+++ b/__tests__/components/TabBar.pointerEvents.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+const stableColors = {
+  background: '#fff',
+  surface: '#f4f4f4',
+  surfaceSecondary: '#f0f0f0',
+  primary: '#2563eb',
+  text: '#111',
+  textSecondary: '#666',
+  border: '#ddd',
+  error: '#dc2626',
+  accent: '#8b5cf6',
+};
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 16, left: 0, right: 0 }),
+}));
+
+jest.mock('../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: stableColors, isDark: false, style: 'neumorphic' }),
+  useTokens: () => ({
+    colors: stableColors,
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 },
+    type: { xs: 12, sm: 14, md: 16, lg: 18, xl: 22 },
+    radii: { sm: 12, md: 18, lg: 24, pill: 999 },
+    style: 'neumorphic',
+  }),
+}));
+
+jest.mock('../../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({ isTablet: false }),
+}));
+
+jest.mock('../../src/components/ui/Surface', () => {
+  const { View } = require('react-native');
+  return { Surface: ({ children, style }: any) => <View style={style}>{children}</View> };
+});
+
+import { TabBar } from '../../src/components/ui/TabBar';
+
+const fakeNavigationProps = {
+  state: {
+    index: 1,
+    routes: [
+      { key: 'home', name: 'HomeTab' },
+      { key: 'notes', name: 'NotesTab' },
+      { key: 'explore', name: 'ExploreTab' },
+      { key: 'todos', name: 'TodosTab' },
+      { key: 'settings', name: 'SettingsTab' },
+    ],
+    routeNames: ['HomeTab', 'NotesTab', 'ExploreTab', 'TodosTab', 'SettingsTab'],
+  } as any,
+  navigation: {
+    emit: jest.fn(() => ({ defaultPrevented: false })),
+    navigate: jest.fn(),
+  } as any,
+  descriptors: {} as any,
+  insets: { top: 0, bottom: 16, left: 0, right: 0 } as any,
+};
+
+describe('TabBar pointer-event hit-zone (issue #667)', () => {
+  test('outer overlay View has pointerEvents="box-none"', () => {
+    const { UNSAFE_root } = render(<TabBar {...fakeNavigationProps} />);
+    const outerView = UNSAFE_root.findAll(
+      (node) => node.type === 'View' && node.props.pointerEvents === 'box-none',
+    );
+    expect(outerView.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('BlurView wrapper has pointerEvents="box-none" so taps fall through transparent pill areas', () => {
+    const { UNSAFE_root } = render(<TabBar {...fakeNavigationProps} />);
+    const allBoxNone = UNSAFE_root.findAll(
+      (node: any) => node.props && node.props.pointerEvents === 'box-none',
+    );
+    // Without the fix the count is 2 (outer overlay + RNTL container).
+    // After the fix the BlurView wrapper also carries box-none → count is 3+.
+    expect(allBoxNone.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/components/ui/TabBar.tsx
+++ b/src/components/ui/TabBar.tsx
@@ -62,6 +62,7 @@ export function TabBar({ state, navigation }: BottomTabBarProps) {
       <BlurView
         intensity={Platform.OS === 'ios' ? 60 : 30}
         tint={isDark ? 'dark' : 'light'}
+        pointerEvents="box-none"
         style={{
           flexDirection: 'row',
           alignItems: 'center',


### PR DESCRIPTION
Closes #667.

## Summary
The floating tab bar uses an absolute overlay View with \`pointerEvents=\"box-none\"\` so that empty space outside the pill lets touches through. The BlurView pill inside, however, had no pointer-events override, so its full rectangular hitbox (including the transparent corners between icons) intercepted any tap that landed on a list card visible underneath. The tap never reached the card; iOS routed it to the nearest \`Pressable\` (the Explore tab icon, in the user's repro).

Fix is one prop: \`pointerEvents=\"box-none\"\` on the BlurView. Touches over the transparent areas fall through to the underlying ScrollView/FlatList; the per-icon \`Pressable\` children inherit \`pointerEvents=\"auto\"\` and still catch their own taps.

## Test plan
- [x] \`npx jest __tests__/components/TabBar.pointerEvents.test.tsx\` — 2/2 pass: outer overlay carries \`box-none\`, BlurView wrapper now also does (count of \`box-none\` containers in the rendered tree goes from 2 to 3+)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: scroll a note to the bottom of the visible list so it's overlapped by the floating tab bar; tap it; verify it opens the note rather than activating the Explore tab. Also tap each tab icon to confirm normal tab navigation still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)