### PR TITLE
fix(deeplink): show 404 when note id from deep link doesn't exist locally (closes #669)

### DIFF
--- a/__tests__/components/useNoteEditorDocument.notFound.test.ts
+++ b/__tests__/components/useNoteEditorDocument.notFound.test.ts
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-native';
+
+jest.mock('expo-image-picker', () => ({}));
+
+jest.mock('../../src/services/GitService', () => ({
+  GitService: {
+    commit: jest.fn(),
+    push: jest.fn(),
+    getRepositoryFolders: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('../../src/services/NoteGitHubSyncService', () => ({
+  syncNoteToGitHub: jest.fn(),
+}));
+
+jest.mock('../../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: { enqueue: jest.fn() },
+}));
+
+jest.mock('../../src/utils/haptics', () => ({
+  HapticService: { selection: jest.fn(), success: jest.fn(), error: jest.fn() },
+}));
+
+import { useNoteEditorDocument } from '../../src/components/editor/useNoteEditorDocument';
+
+const baseParams = {
+  initialFormat: 'markdown' as const,
+  activeAccountId: null,
+  repositories: [],
+  folders: [],
+  createNote: jest.fn(),
+  updateNote: jest.fn(),
+  navigation: { navigate: jest.fn(), goBack: jest.fn(), setOptions: jest.fn() } as any,
+};
+
+describe('useNoteEditorDocument notFound (issue #669)', () => {
+  test('notFound true when noteId provided but getNoteById returns undefined', () => {
+    const { result } = renderHook(() =>
+      useNoteEditorDocument({
+        ...baseParams,
+        noteId: 'bogus-id-xyz',
+        getNoteById: () => undefined,
+      }),
+    );
+    expect(result.current.notFound).toBe(true);
+  });
+
+  test('notFound false when noteId provided and note exists', () => {
+    const fakeNote = {
+      id: 'real-id',
+      title: 'Hello',
+      content: 'world',
+      filePath: 'notes/hello.md',
+      folderPath: undefined,
+      format: 'markdown' as const,
+      repo: 'owner/repo',
+      branch: 'main',
+      commit: 'abc',
+      github: undefined,
+      accountId: undefined,
+      tags: [],
+      attachments: [],
+      createdAt: 0,
+      updatedAt: 0,
+    } as any;
+
+    const { result } = renderHook(() =>
+      useNoteEditorDocument({
+        ...baseParams,
+        noteId: 'real-id',
+        getNoteById: (id) => (id === 'real-id' ? fakeNote : undefined),
+      }),
+    );
+    expect(result.current.notFound).toBe(false);
+  });
+
+  test('notFound false when no noteId provided (creating a new note)', () => {
+    const { result } = renderHook(() =>
+      useNoteEditorDocument({
+        ...baseParams,
+        noteId: undefined,
+        getNoteById: () => undefined,
+      }),
+    );
+    expect(result.current.notFound).toBe(false);
+  });
+});

--- a/src/components/editor/useNoteEditorDocument.ts
+++ b/src/components/editor/useNoteEditorDocument.ts
@@ -70,6 +70,7 @@ export function useNoteEditorDocument({
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [repoFolders, setRepoFolders] = useState<Folder[]>([]);
   const [canvasEditJsonUri, setCanvasEditJsonUri] = useState<string | undefined>(undefined);
+  const [notFound, setNotFound] = useState(false);
 
   const allFolders = useMemo(() => {
     const merged = new Map<string, Folder>();
@@ -144,9 +145,16 @@ export function useNoteEditorDocument({
   }, [repo, branch]);
 
   useEffect(() => {
-    if (!noteId) return;
+    if (!noteId) {
+      setNotFound(false);
+      return;
+    }
     const existingNote = getNoteByIdRef.current(noteId);
-    if (!existingNote) return;
+    if (!existingNote) {
+      setNotFound(true);
+      return;
+    }
+    setNotFound(false);
 
     setTitle(existingNote.title);
     setContent(existingNote.content);
@@ -470,6 +478,7 @@ export function useNoteEditorDocument({
     attachments,
     isSaving,
     isEditing,
+    notFound,
     canUndo,
     canRedo,
     repoFolders,

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, Text, Pressable, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native';
 
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -95,6 +95,31 @@ function NoteEditorScreenInner() {
     initialAnchor,
   });
   const isPdfNote = document.noteFormat === 'pdf';
+
+  // ── NOT FOUND (deep link to a noteId that isn't on this device) ──
+  if (document.notFound) {
+    return (
+      <SafeAreaView
+        testID="note-editor.view.not-found"
+        style={[styles.notFoundContainer, { backgroundColor: colors.background }]}
+        edges={['top', 'bottom']}
+      >
+        <Text style={[styles.notFoundTitle, { color: colors.text }]}>Note not found</Text>
+        <Text style={[styles.notFoundBody, { color: colors.textSecondary }]}>
+          {noteId
+            ? `No note with id "${noteId}" exists on this device.`
+            : 'This note isn’t on this device.'}
+        </Text>
+        <Pressable
+          testID="note-editor.button.back-to-notes"
+          onPress={() => navigation.navigate('MainTabs', { screen: 'NotesTab' })}
+          style={[styles.notFoundButton, { backgroundColor: colors.primary }]}
+        >
+          <Text style={styles.notFoundButtonText}>Back to Notes</Text>
+        </Pressable>
+      </SafeAreaView>
+    );
+  }
 
   // ── PREVIEW MODE ──────────────────────────────────────────────
   if (!document.isEditing) {
@@ -290,5 +315,31 @@ const styles = StyleSheet.create({
   },
   sideBySidePreview: {
     flex: 1,
+  },
+  notFoundContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  notFoundTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  notFoundBody: {
+    fontSize: 15,
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  notFoundButton: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 999,
+  },
+  notFoundButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '600',
   },
 });


### PR DESCRIPTION
Closes #669.

## Summary
\`gitnotes://note/<bogus-id>\` opened the NoteViewer with an empty record. \`useNoteEditorDocument\` silently \`return\`-ed when \`getNoteById(noteId)\` missed, so the screen kept rendering as if the lookup had succeeded — blank header, empty body, the \"No content — tap the pencil\" placeholder, and an Edit button that would create a *phantom* note bound to the missing id.

## What this PR does
- Adds a \`notFound\` flag to \`useNoteEditorDocument\`. The flag flips \`true\` when \`noteId\` is provided but \`getNoteById\` returns \`undefined\`, and stays \`false\` when no \`noteId\` is provided (creating a new note) or when the lookup succeeds.
- \`NoteEditorScreen\` now branches on \`document.notFound\` *before* the preview/editor code paths and renders a \"Note not found\" view with the offending id and a \"Back to Notes\" button (navigates to \`MainTabs/NotesTab\`).
- The phantom-write path is closed: the editor is never mounted so \`createNote\` can't fire on a deep-link-injected id.

## Test plan
- [x] \`npx jest __tests__/components/useNoteEditorDocument.notFound.test.ts\` — 3/3 pass: bogus id flips notFound true; valid id keeps it false; missing id (create-new flow) keeps it false
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: \`xcrun simctl openurl <UDID> \"gitnotes://note/non-existent-xyz\"\` → confirm \"Note not found\" view + Back button works; then re-open a real note id and confirm normal viewer/editor flow still works

## Out of scope
- Toast / inline 404 \"on the screen the user was on\" (the issue listed it as an alternative). The current screen-level 404 is the simplest path inside the existing route registration; a toast would need a global toast surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)