### PR TITLE
fix(notes-list): strip fenced code blocks + LaTeX math from preview (closes #671)

### DIFF
--- a/__tests__/utils/notePreview.test.ts
+++ b/__tests__/utils/notePreview.test.ts
@@ -101,3 +101,67 @@ describe('stripPreview (issue #661)', () => {
     });
   });
 });
+
+describe('stripPreview fenced code + math (issue #671)', () => {
+  test('strips a fenced code block entirely', () => {
+    const src = [
+      'Heading',
+      'Inline works.',
+      '```javascript',
+      "console.log('hello')",
+      'const x = 1;',
+      '```',
+      'After fence.',
+    ].join('\n');
+    const out = stripPreview(src, 'markdown');
+    expect(out).not.toMatch(/```/);
+    expect(out).not.toMatch(/console\.log/);
+    expect(out).not.toMatch(/const x = 1/);
+    expect(out).toMatch(/Heading/);
+    expect(out).toMatch(/After fence/);
+  });
+
+  test('strips multiple fenced blocks', () => {
+    const src = [
+      'A',
+      '```',
+      'first block',
+      '```',
+      'B',
+      '```py',
+      'second',
+      '```',
+      'C',
+    ].join('\n');
+    const out = stripPreview(src, 'markdown');
+    expect(out).toBe('A B C');
+  });
+
+  test('strips inline $math$', () => {
+    expect(stripPreview('Inline: $E = mc^2$ in a sentence.', 'markdown')).toBe(
+      'Inline: in a sentence.',
+    );
+  });
+
+  test('strips $$block math$$', () => {
+    const src = ['before', '$$', 'a + b = c', '$$', 'after'].join('\n');
+    const out = stripPreview(src, 'markdown');
+    expect(out).toMatch(/before/);
+    expect(out).toMatch(/after/);
+    expect(out).not.toMatch(/a \+ b/);
+    expect(out).not.toMatch(/\$/);
+  });
+
+  test('strips multiple inline math segments on one line', () => {
+    const src = 'when $a \\neq 0$, the equation $ax^2 + bx + c = 0$ has solutions.';
+    const out = stripPreview(src, 'markdown');
+    expect(out).toBe('when , the equation has solutions.');
+  });
+
+  test('does not gobble across paragraphs when $ is unbalanced', () => {
+    const src = 'a $ orphan dollar\nnext line ok';
+    const out = stripPreview(src, 'markdown');
+    expect(out).toMatch(/orphan/);
+    expect(out).toMatch(/next line ok/);
+  });
+});

--- a/src/utils/notePreview.ts
+++ b/src/utils/notePreview.ts
@@ -30,6 +30,16 @@ function stripOrgDrawers(text: string): string {
   );
 }
 
+function stripFencedCode(text: string): string {
+  return text.replace(/^[ \t]*```[^\n]*\n[\s\S]*?^[ \t]*```[ \t]*$\n?/gim, '');
+}
+
+function stripMath(text: string): string {
+  return text
+    .replace(/\$\$[\s\S]*?\$\$/g, '')
+    .replace(/\$([^$\n]+)\$/g, '');
+}
+
 function stripCheckboxes(text: string): string {
   return text
     .replace(/^[ \t]*[-*+][ \t]*\[[ xX-]\][ \t]*/gm, '')
@@ -67,6 +77,8 @@ export function stripPreview(content: string, noteFormat?: NoteFormat): string {
     text = stripOrgDrawers(text);
   }
 
+  text = stripFencedCode(text);
+  text = stripMath(text);
   text = stripCheckboxes(text);
   text = stripInlineMarkup(text);
 


### PR DESCRIPTION
Closes #671. Follow-up to #664.

## Summary
The note-list card preview helper (\`src/utils/notePreview.ts\`) covered \`#\` headings, \`[ ]\` checkboxes, org property drawers, slash italic, etc. — but missed two patterns the new \`render-stress-probe.md\` exposed:

1. **Triple-backtick fenced code blocks**: opening fence, body, closing fence all leaked into the preview as literal text.
2. **LaTeX math segments**: \`\$E = mc^2\$\` and \`\$\$...\$\$\` showed up with the dollar signs intact.

## What this PR does
- New \`stripFencedCode\`: drops the whole block from the opening \`\`\`\`\` (with optional language tag) through the closing \`\`\`\`\`. Multiple blocks in one note all get dropped.
- New \`stripMath\`: drops \`\$\$...\$\$\` block math first (greedy across newlines), then inline \`\$...\$\` math that doesn't cross a newline so an unbalanced \`\$\` in prose can't gobble the rest of the buffer.

Existing rules (front-matter, neorg \`@document.meta\`, org \`#+\` headers, drawers, asterisks/slashes/links, etc.) are preserved.

## Test plan
- [x] \`npx jest __tests__/utils/notePreview.test.ts\` — **21/21 pass** (was 15; +6 covering single fence, multiple fences, inline math, block math, multiple inline math on one line, unbalanced \`\$\`)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: open Notes list with \`render-stress-probe.md\` from the test-notes seed; verify the card preview shows neither \`\`\`\`\` runs nor \`\$\`-wrapped math

🤖 Generated with [Claude Code](https://claude.com/claude-code)