### PR TITLE
fix(katex): render math correctly and stop dropping chars on multi-math lines (closes #670)

### DIFF
--- a/__tests__/components/KatexView.height.test.tsx
+++ b/__tests__/components/KatexView.height.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+
+let lastHandleMessage: ((event: any) => void) | null = null;
+
+jest.mock('react-native-webview', () => {
+  const { View } = require('react-native');
+  return {
+    WebView: (props: any) => {
+      lastHandleMessage = props.onMessage;
+      return <View testID="katex-view.webview" style={props.style} />;
+    },
+  };
+});
+
+import KatexView from '../../src/components/KatexView';
+
+const flatten = (style: any): any =>
+  Array.isArray(style)
+    ? Object.assign({}, ...style.flatMap((s) => [flatten(s)]))
+    : style ?? {};
+
+describe('KatexView internal height (issue #670)', () => {
+  beforeEach(() => {
+    lastHandleMessage = null;
+  });
+
+  test('container starts at 0 minHeight before WebView reports back', () => {
+    const { getByTestId } = render(
+      <KatexView expression="E = mc^2" displayMode="inline" isDark={false} />,
+    );
+    const container = getByTestId('katex-view.container');
+    expect(flatten(container.props.style).minHeight ?? 0).toBe(0);
+  });
+
+  test('container minHeight grows after WebView posts a height message', () => {
+    const { getByTestId } = render(
+      <KatexView expression="E = mc^2" displayMode="inline" isDark={false} />,
+    );
+
+    expect(lastHandleMessage).not.toBeNull();
+    act(() => lastHandleMessage!({ nativeEvent: { data: '42' } }));
+
+    const container = getByTestId('katex-view.container');
+    expect(flatten(container.props.style).minHeight).toBe(42);
+  });
+
+  test('subsequent height updates apply', () => {
+    const { getByTestId } = render(
+      <KatexView expression="x" displayMode="block" isDark={true} />,
+    );
+
+    act(() => lastHandleMessage!({ nativeEvent: { data: '20' } }));
+    act(() => lastHandleMessage!({ nativeEvent: { data: '80' } }));
+
+    const container = getByTestId('katex-view.container');
+    expect(flatten(container.props.style).minHeight).toBe(80);
+  });
+
+  test('still calls onHeightChange callback', () => {
+    const onHeightChange = jest.fn();
+    render(
+      <KatexView
+        expression="x"
+        displayMode="inline"
+        isDark={false}
+        onHeightChange={onHeightChange}
+      />,
+    );
+    act(() => lastHandleMessage!({ nativeEvent: { data: '24' } }));
+    expect(onHeightChange).toHaveBeenCalledWith(24);
+  });
+});

--- a/__tests__/utils/inlineTokens.test.ts
+++ b/__tests__/utils/inlineTokens.test.ts
@@ -1,0 +1,47 @@
+import { splitInlineTokens } from '../../src/utils/inlineTokens';
+
+describe('splitInlineTokens (issue #670)', () => {
+  test('returns single text node when no tokens present', () => {
+    const out = splitInlineTokens('plain text only');
+    expect(out).toEqual([{ type: 'text', value: 'plain text only' }]);
+  });
+
+  test('matches a single token surrounded by text', () => {
+    const out = splitInlineTokens('before GITNOTES_INLINE_MATH_TOKEN_0__ after');
+    expect(out).toEqual([
+      { type: 'text', value: 'before ' },
+      { type: 'token', value: 'GITNOTES_INLINE_MATH_TOKEN_0__' },
+      { type: 'text', value: ' after' },
+    ]);
+  });
+
+  test('matches MULTIPLE tokens on one line without dropping characters', () => {
+    const input =
+      'when GITNOTES_INLINE_MATH_TOKEN_0__, the equation GITNOTES_INLINE_MATH_TOKEN_1__ has solutions GITNOTES_INLINE_MATH_TOKEN_2__.';
+    const out = splitInlineTokens(input);
+
+    const tokens = out.filter((s) => s.type === 'token');
+    expect(tokens).toHaveLength(3);
+    expect(tokens[0].value).toBe('GITNOTES_INLINE_MATH_TOKEN_0__');
+    expect(tokens[1].value).toBe('GITNOTES_INLINE_MATH_TOKEN_1__');
+    expect(tokens[2].value).toBe('GITNOTES_INLINE_MATH_TOKEN_2__');
+
+    const reconstructed = out.map((s) => s.value).join('');
+    expect(reconstructed).toBe(input);
+  });
+
+  test('repeated calls do not leak state (regression for stateful global regex)', () => {
+    const input = 'a GITNOTES_INLINE_MATH_TOKEN_0__ b GITNOTES_INLINE_MATH_TOKEN_1__ c';
+    const first = splitInlineTokens(input);
+    const second = splitInlineTokens(input);
+    expect(second).toEqual(first);
+    expect(second.filter((s) => s.type === 'token')).toHaveLength(2);
+  });
+
+  test('also matches GITNOTES_WIKI_LINK_TOKEN tokens', () => {
+    const out = splitInlineTokens('see GITNOTES_WIKI_LINK_TOKEN_3__ for more');
+    const tokens = out.filter((s) => s.type === 'token');
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].value).toBe('GITNOTES_WIKI_LINK_TOKEN_3__');
+  });
+});

--- a/src/components/KatexView.tsx
+++ b/src/components/KatexView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { WebViewMessageEvent } from 'react-native-webview';
 import { WebView } from 'react-native-webview';
@@ -60,6 +60,7 @@ return true;})();`;
 }
 
 export default function KatexView({ expression, displayMode, isDark, onHeightChange }: KatexViewProps) {
+  const [measuredHeight, setMeasuredHeight] = useState(0);
   const html = useMemo(() => buildHtml(isDark), [isDark]);
   const injectedJavaScript = useMemo(
     () => buildInjectedJavaScript(expression, displayMode === 'block'),
@@ -70,7 +71,8 @@ export default function KatexView({ expression, displayMode, isDark, onHeightCha
     (event: WebViewMessageEvent) => {
       const height = Number(event.nativeEvent.data);
 
-      if (Number.isFinite(height)) {
+      if (Number.isFinite(height) && height > 0) {
+        setMeasuredHeight(height);
         onHeightChange?.(height);
       }
     },
@@ -78,7 +80,7 @@ export default function KatexView({ expression, displayMode, isDark, onHeightCha
   );
 
   return (
-    <View style={styles.container}>
+    <View testID="katex-view.container" style={[styles.container, { minHeight: measuredHeight }]}>
       <WebView
         originWhitelist={['*']}
         source={{ html }}
@@ -90,7 +92,7 @@ export default function KatexView({ expression, displayMode, isDark, onHeightCha
         showsHorizontalScrollIndicator={false}
         automaticallyAdjustContentInsets={false}
         nestedScrollEnabled={false}
-        style={styles.webview}
+        style={[styles.webview, { minHeight: measuredHeight }]}
       />
     </View>
   );

--- a/src/utils/inlineTokens.ts
+++ b/src/utils/inlineTokens.ts
@@ -1,0 +1,29 @@
+export const INLINE_TOKEN_REGEX = /GITNOTES_(?:INLINE_MATH|WIKI_LINK)_TOKEN_\d+__/g;
+
+export type InlineSegment =
+  | { type: 'text'; value: string }
+  | { type: 'token'; value: string };
+
+export function splitInlineTokens(text: string): InlineSegment[] {
+  const segments: InlineSegment[] = [];
+  let cursor = 0;
+
+  for (const match of text.matchAll(INLINE_TOKEN_REGEX)) {
+    const start = match.index ?? 0;
+    if (start > cursor) {
+      segments.push({ type: 'text', value: text.slice(cursor, start) });
+    }
+    segments.push({ type: 'token', value: match[0] });
+    cursor = start + match[0].length;
+  }
+
+  if (cursor < text.length) {
+    segments.push({ type: 'text', value: text.slice(cursor) });
+  }
+
+  if (segments.length === 0) {
+    segments.push({ type: 'text', value: text });
+  }
+
+  return segments;
+}

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -22,6 +22,7 @@ import { classifyHref } from './linkClassifier';
 import { parseMath, type MathSegment } from './mathParser';
 import { parseTables, type TableSegment } from './tableParser';
 import { parseWikiLinks, type WikiLink } from './wikiLinksParser';
+import { splitInlineTokens } from './inlineTokens';
 
 const INLINE_MATH_TOKEN_PREFIX = 'GITNOTES_INLINE_MATH_TOKEN_';
 const WIKI_LINK_TOKEN_PREFIX = 'GITNOTES_WIKI_LINK_TOKEN_';
@@ -247,20 +248,20 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
 
   private renderInlineSegments(text: string, styles?: TextStyle): ReactNode[] {
     const nodes: ReactNode[] = [];
-    let cursor = 0;
-    let match: RegExpExecArray | null = INLINE_TOKEN_PATTERN.exec(text);
 
-    while (match !== null) {
-      const token = match[0];
-
-      if (match.index > cursor) {
-        nodes.push(
-          <Text key={this.getKey()} selectable style={styles}>
-            {text.slice(cursor, match.index)}
-          </Text>,
-        );
+    for (const segment of splitInlineTokens(text)) {
+      if (segment.type === 'text') {
+        if (segment.value.length > 0) {
+          nodes.push(
+            <Text key={this.getKey()} selectable style={styles}>
+              {segment.value}
+            </Text>,
+          );
+        }
+        continue;
       }
 
+      const token = segment.value;
       const mathSegment = this.inlineMathEmbeds.get(token);
       if (mathSegment) {
         nodes.push(
@@ -268,23 +269,13 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
             <KatexView expression={mathSegment.content} displayMode="inline" isDark={this.isDarkMode()} />
           </View>,
         );
+        continue;
       }
 
       const wikiLink = this.wikiLinkEmbeds.get(token);
       if (wikiLink) {
         nodes.push(this.link(wikiLink.displayText, wikiTargetToHref(wikiLink.target), styles));
       }
-
-      cursor = match.index + token.length;
-      match = INLINE_TOKEN_PATTERN.exec(text);
-    }
-
-    if (cursor < text.length) {
-      nodes.push(
-        <Text key={this.getKey()} selectable style={styles}>
-          {text.slice(cursor)}
-        </Text>,
-      );
     }
 
     return nodes.length > 0


### PR DESCRIPTION
Closes #670. Two distinct bugs that combined to produce the symptoms in the render-stress probe.

## 1. Multi-math line corruption + raw LaTeX leak

\`renderInlineSegments\` used the module-global \`INLINE_TOKEN_PATTERN\` (the regex literal carries \`g\` flag) and called \`.exec(text)\` *without* resetting \`lastIndex\` first. After the renderer processed any earlier paragraph, the regex's cursor was already mid-string, so on the next call the second/third math token on a single line either matched at the wrong offset or was skipped — producing the \`to → tn\` character drop and the leaked \`\$ax^2 + bx + c = 0\$\` LaTeX in the issue's "Mixed:" repro. (Compare to lines 438-439 in the same file which *did* reset lastIndex before exec.)

Replaced with a stateless \`splitInlineTokens\` helper (\`src/utils/inlineTokens.ts\`) that uses \`String.prototype.matchAll\`. The renderer now iterates pre-split segments, so there's no shared cursor between calls.

## 2. KaTeX renders blank

\`KatexView\`'s WebView had \`alignSelf: stretch\` but no parent or self height, and the \`onHeightChange\` callback was an *opt-in* prop the markdown renderer never wired up. So the WebView mounted at 0×0 — even when KaTeX successfully rendered the formula, there was no visible viewport.

\`KatexView\` now tracks the height the injected JS already reports back, in internal \`useState\`, and applies it as \`minHeight\` on both the container View and the WebView. Consumers that still want the height callback get it (we keep calling \`onHeightChange\` for them).

## Test plan
- [x] \`npx jest __tests__/utils/inlineTokens.test.ts\` — 5/5 pass: single token, multi-token reconstruction, repeated-call state-leak guard, wiki link tokens
- [x] \`npx jest __tests__/components/KatexView.height.test.tsx\` — 4/4 pass: starts at 0, grows on first message, applies subsequent updates, still calls onHeightChange
- [x] \`npx jest __tests__/utils\` — 28/28 pass across 4 suites (no regression in notePreview)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: open \`render-stress-probe.md\` from test-notes; verify single inline math renders, block math renders (no longer empty 80px gap), the "Mixed:" line shows three rendered formulas with no dropped chars or LaTeX leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)