### PR TITLE
fix(katex): markdown-safe inline tokens + inline width (closes #675)

### DIFF
--- a/__tests__/components/KatexView.height.test.tsx
+++ b/__tests__/components/KatexView.height.test.tsx
@@ -70,4 +70,43 @@ describe('KatexView internal height (issue #670)', () => {
     act(() => lastHandleMessage!({ nativeEvent: { data: '24' } }));
     expect(onHeightChange).toHaveBeenCalledWith(24);
   });
+
+  test('inline mode applies minWidth from {w,h} message (issue #675)', () => {
+    const { getByTestId } = render(
+      <KatexView expression="E = mc^2" displayMode="inline" isDark={false} />,
+    );
+
+    act(() =>
+      lastHandleMessage!({ nativeEvent: { data: JSON.stringify({ w: 64, h: 18 }) } }),
+    );
+
+    const container = getByTestId('katex-view.container');
+    const style = flatten(container.props.style);
+    expect(style.minHeight).toBe(18);
+    expect(style.minWidth).toBe(64);
+  });
+
+  test('block mode does NOT constrain minWidth (so the formula can stretch full-width)', () => {
+    const { getByTestId } = render(
+      <KatexView expression="x" displayMode="block" isDark={false} />,
+    );
+
+    act(() =>
+      lastHandleMessage!({ nativeEvent: { data: JSON.stringify({ w: 200, h: 80 }) } }),
+    );
+
+    const container = getByTestId('katex-view.container');
+    const style = flatten(container.props.style);
+    expect(style.minHeight).toBe(80);
+    expect(style.minWidth ?? 0).toBe(0);
+  });
+
+  test('parses legacy plain-number message format (back-compat)', () => {
+    const { getByTestId } = render(
+      <KatexView expression="x" displayMode="inline" isDark={false} />,
+    );
+    act(() => lastHandleMessage!({ nativeEvent: { data: '42' } }));
+    const container = getByTestId('katex-view.container');
+    expect(flatten(container.props.style).minHeight).toBe(42);
+  });
 });

--- a/__tests__/utils/inlineTokens.test.ts
+++ b/__tests__/utils/inlineTokens.test.ts
@@ -7,41 +7,41 @@ describe('splitInlineTokens (issue #670)', () => {
   });
 
   test('matches a single token surrounded by text', () => {
-    const out = splitInlineTokens('before GITNOTES_INLINE_MATH_TOKEN_0__ after');
+    const out = splitInlineTokens('before GITNOTESINLINEMATHTOKEN0 after');
     expect(out).toEqual([
       { type: 'text', value: 'before ' },
-      { type: 'token', value: 'GITNOTES_INLINE_MATH_TOKEN_0__' },
+      { type: 'token', value: 'GITNOTESINLINEMATHTOKEN0' },
       { type: 'text', value: ' after' },
     ]);
   });
 
   test('matches MULTIPLE tokens on one line without dropping characters', () => {
     const input =
-      'when GITNOTES_INLINE_MATH_TOKEN_0__, the equation GITNOTES_INLINE_MATH_TOKEN_1__ has solutions GITNOTES_INLINE_MATH_TOKEN_2__.';
+      'when GITNOTESINLINEMATHTOKEN0, the equation GITNOTESINLINEMATHTOKEN1 has solutions GITNOTESINLINEMATHTOKEN2.';
     const out = splitInlineTokens(input);
 
     const tokens = out.filter((s) => s.type === 'token');
     expect(tokens).toHaveLength(3);
-    expect(tokens[0].value).toBe('GITNOTES_INLINE_MATH_TOKEN_0__');
-    expect(tokens[1].value).toBe('GITNOTES_INLINE_MATH_TOKEN_1__');
-    expect(tokens[2].value).toBe('GITNOTES_INLINE_MATH_TOKEN_2__');
+    expect(tokens[0].value).toBe('GITNOTESINLINEMATHTOKEN0');
+    expect(tokens[1].value).toBe('GITNOTESINLINEMATHTOKEN1');
+    expect(tokens[2].value).toBe('GITNOTESINLINEMATHTOKEN2');
 
     const reconstructed = out.map((s) => s.value).join('');
     expect(reconstructed).toBe(input);
   });
 
   test('repeated calls do not leak state (regression for stateful global regex)', () => {
-    const input = 'a GITNOTES_INLINE_MATH_TOKEN_0__ b GITNOTES_INLINE_MATH_TOKEN_1__ c';
+    const input = 'a GITNOTESINLINEMATHTOKEN0 b GITNOTESINLINEMATHTOKEN1 c';
     const first = splitInlineTokens(input);
     const second = splitInlineTokens(input);
     expect(second).toEqual(first);
     expect(second.filter((s) => s.type === 'token')).toHaveLength(2);
   });
 
-  test('also matches GITNOTES_WIKI_LINK_TOKEN tokens', () => {
-    const out = splitInlineTokens('see GITNOTES_WIKI_LINK_TOKEN_3__ for more');
+  test('also matches GITNOTESWIKILINKTOKEN tokens', () => {
+    const out = splitInlineTokens('see GITNOTESWIKILINKTOKEN3 for more');
     const tokens = out.filter((s) => s.type === 'token');
     expect(tokens).toHaveLength(1);
-    expect(tokens[0].value).toBe('GITNOTES_WIKI_LINK_TOKEN_3__');
+    expect(tokens[0].value).toBe('GITNOTESWIKILINKTOKEN3');
   });
 });

--- a/__tests__/utils/inlineTokensSurvival.test.ts
+++ b/__tests__/utils/inlineTokensSurvival.test.ts
@@ -1,0 +1,45 @@
+import {
+  INLINE_MATH_TOKEN_PREFIX,
+  WIKI_LINK_TOKEN_PREFIX,
+  INLINE_TOKEN_REGEX,
+  splitInlineTokens,
+} from '../../src/utils/inlineTokens';
+
+const buildMathToken = (n: number) => `${INLINE_MATH_TOKEN_PREFIX}${n}`;
+const buildWikiToken = (n: number) => `${WIKI_LINK_TOKEN_PREFIX}${n}`;
+
+describe('inline tokens markdown-safety (issue #675)', () => {
+  test.each([
+    ['math token', buildMathToken(0)],
+    ['math token at index 999', buildMathToken(999)],
+    ['wiki token', buildWikiToken(3)],
+  ])('%s contains no markdown-active characters', (_label, token) => {
+    expect(token).not.toMatch(/[_*~`\[\]()<>$]/);
+  });
+
+  test('INLINE_TOKEN_REGEX matches the safe token format', () => {
+    expect(buildMathToken(0)).toMatch(INLINE_TOKEN_REGEX);
+    expect(buildMathToken(42)).toMatch(INLINE_TOKEN_REGEX);
+    expect(buildWikiToken(5)).toMatch(INLINE_TOKEN_REGEX);
+  });
+
+  test('three tokens on one line all match', () => {
+    const t0 = buildMathToken(0);
+    const t1 = buildMathToken(1);
+    const t2 = buildMathToken(2);
+    const text = `when ${t0}, the equation ${t1} has solutions ${t2}.`;
+    const tokens = splitInlineTokens(text).filter((s) => s.type === 'token');
+    expect(tokens.map((t) => t.value)).toEqual([t0, t1, t2]);
+  });
+
+  test('emphasis-style markdown patterns do not match the token regex', () => {
+    expect('an _italic_ word'.match(INLINE_TOKEN_REGEX)).toBeNull();
+    expect('a __bold__ word'.match(INLINE_TOKEN_REGEX)).toBeNull();
+  });
+
+  test('a doubly-underscored word would NOT survive marked italic/bold parsing — guard against regression', () => {
+    const wouldGetEatenByMarked = /_[A-Za-z0-9]+_/g;
+    expect(buildMathToken(0)).not.toMatch(wouldGetEatenByMarked);
+    expect(buildWikiToken(0)).not.toMatch(wouldGetEatenByMarked);
+  });
+});

--- a/src/components/KatexView.tsx
+++ b/src/components/KatexView.tsx
@@ -43,10 +43,10 @@ function buildHtml(isDark: boolean): string {
 function buildInjectedJavaScript(expression: string, displayMode: boolean): string {
   return `(function(){
 var container=document.getElementById('container');
-if(!container){window.ReactNativeWebView.postMessage('0');return true;}
+if(!container){window.ReactNativeWebView.postMessage('{"w":0,"h":0}');return true;}
 if(!window.katex||typeof window.katex.render!=="function"){
   container.textContent=${JSON.stringify(expression)};
-  window.ReactNativeWebView.postMessage(String(Math.ceil(container.offsetHeight||0)));
+  window.ReactNativeWebView.postMessage(JSON.stringify({w:Math.ceil(container.offsetWidth||0),h:Math.ceil(container.offsetHeight||0)}));
   return true;
 }
 try{
@@ -54,13 +54,33 @@ try{
 }catch(e){
   container.textContent=${JSON.stringify(expression)};
 }
-var height=Math.ceil(container.offsetHeight||document.body.scrollHeight||0);
-window.ReactNativeWebView.postMessage(String(height));
+var w=Math.ceil(container.offsetWidth||document.body.scrollWidth||0);
+var h=Math.ceil(container.offsetHeight||document.body.scrollHeight||0);
+window.ReactNativeWebView.postMessage(JSON.stringify({w:w,h:h}));
 return true;})();`;
 }
 
+function parseSize(data: string): { w: number; h: number } | null {
+  try {
+    const parsed = JSON.parse(data);
+    if (parsed && typeof parsed === 'object') {
+      const w = Number(parsed.w);
+      const h = Number(parsed.h);
+      if (Number.isFinite(w) && Number.isFinite(h)) return { w, h };
+    }
+    if (typeof parsed === 'number' && Number.isFinite(parsed)) {
+      return { w: 0, h: parsed };
+    }
+  } catch {
+    // not JSON; fall through to scalar
+  }
+  const legacy = Number(data);
+  if (Number.isFinite(legacy)) return { w: 0, h: legacy };
+  return null;
+}
+
 export default function KatexView({ expression, displayMode, isDark, onHeightChange }: KatexViewProps) {
-  const [measuredHeight, setMeasuredHeight] = useState(0);
+  const [size, setSize] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
   const html = useMemo(() => buildHtml(isDark), [isDark]);
   const injectedJavaScript = useMemo(
     () => buildInjectedJavaScript(expression, displayMode === 'block'),
@@ -69,18 +89,24 @@ export default function KatexView({ expression, displayMode, isDark, onHeightCha
 
   const handleMessage = useCallback(
     (event: WebViewMessageEvent) => {
-      const height = Number(event.nativeEvent.data);
-
-      if (Number.isFinite(height) && height > 0) {
-        setMeasuredHeight(height);
-        onHeightChange?.(height);
-      }
+      const next = parseSize(event.nativeEvent.data);
+      if (!next || next.h <= 0) return;
+      setSize(next);
+      onHeightChange?.(next.h);
     },
     [onHeightChange],
   );
 
+  const isInline = displayMode === 'inline';
+
   return (
-    <View testID="katex-view.container" style={[styles.container, { minHeight: measuredHeight }]}>
+    <View
+      testID="katex-view.container"
+      style={[
+        isInline ? styles.containerInline : styles.container,
+        { minHeight: size.h, minWidth: isInline ? size.w : 0 },
+      ]}
+    >
       <WebView
         originWhitelist={['*']}
         source={{ html }}
@@ -92,7 +118,10 @@ export default function KatexView({ expression, displayMode, isDark, onHeightCha
         showsHorizontalScrollIndicator={false}
         automaticallyAdjustContentInsets={false}
         nestedScrollEnabled={false}
-        style={[styles.webview, { minHeight: measuredHeight }]}
+        style={[
+          styles.webview,
+          { minHeight: size.h, minWidth: isInline ? size.w : 0 },
+        ]}
       />
     </View>
   );
@@ -101,6 +130,9 @@ export default function KatexView({ expression, displayMode, isDark, onHeightCha
 const styles = StyleSheet.create({
   container: {
     alignSelf: 'stretch',
+  },
+  containerInline: {
+    alignSelf: 'flex-start',
   },
   webview: {
     backgroundColor: 'transparent',

--- a/src/utils/inlineTokens.ts
+++ b/src/utils/inlineTokens.ts
@@ -1,4 +1,6 @@
-export const INLINE_TOKEN_REGEX = /GITNOTES_(?:INLINE_MATH|WIKI_LINK)_TOKEN_\d+__/g;
+export const INLINE_MATH_TOKEN_PREFIX = 'GITNOTESINLINEMATHTOKEN';
+export const WIKI_LINK_TOKEN_PREFIX = 'GITNOTESWIKILINKTOKEN';
+export const INLINE_TOKEN_REGEX = /GITNOTES(?:INLINEMATH|WIKILINK)TOKEN\d+/g;
 
 export type InlineSegment =
   | { type: 'text'; value: string }

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -22,11 +22,12 @@ import { classifyHref } from './linkClassifier';
 import { parseMath, type MathSegment } from './mathParser';
 import { parseTables, type TableSegment } from './tableParser';
 import { parseWikiLinks, type WikiLink } from './wikiLinksParser';
-import { splitInlineTokens } from './inlineTokens';
-
-const INLINE_MATH_TOKEN_PREFIX = 'GITNOTES_INLINE_MATH_TOKEN_';
-const WIKI_LINK_TOKEN_PREFIX = 'GITNOTES_WIKI_LINK_TOKEN_';
-const INLINE_TOKEN_PATTERN = /GITNOTES_(?:INLINE_MATH|WIKI_LINK)_TOKEN_\d+__/g;
+import {
+  splitInlineTokens,
+  INLINE_MATH_TOKEN_PREFIX,
+  WIKI_LINK_TOKEN_PREFIX,
+  INLINE_TOKEN_REGEX as INLINE_TOKEN_PATTERN,
+} from './inlineTokens';
 const BLOCK_MATH_COMPONENT = 'MarkdownMath';
 const TABLE_COMPONENT = 'MarkdownTable';
 
@@ -184,7 +185,7 @@ function processMarkdown(markdown: string): ProcessedMarkdown {
       const inlineMathOffset = inlineMath.length;
       const inlineMathEmbeds = parsedInlineMath.map((segment, index) => ({
         ...segment,
-        token: `${INLINE_MATH_TOKEN_PREFIX}${inlineMathOffset + index}__`,
+        token: `${INLINE_MATH_TOKEN_PREFIX}${inlineMathOffset + index}`,
       }));
       inlineMath.push(...inlineMathEmbeds);
       segmentText = replaceSegments(segmentText, parsedInlineMath, (_math, index) => inlineMathEmbeds[index]?.token ?? '');
@@ -192,7 +193,7 @@ function processMarkdown(markdown: string): ProcessedMarkdown {
       const wikiOffset = wikiLinks.length;
       const parsedWikiEmbeds = parseWikiLinks(segmentText).map((segment, index) => ({
         ...segment,
-        token: `${WIKI_LINK_TOKEN_PREFIX}${wikiOffset + index}__`,
+        token: `${WIKI_LINK_TOKEN_PREFIX}${wikiOffset + index}`,
       }));
       wikiLinks.push(...parsedWikiEmbeds);
       segmentText = replaceSegments(segmentText, parsedWikiEmbeds, (_link, index) => parsedWikiEmbeds[index]?.token ?? '');


### PR DESCRIPTION
Closes #675. Two distinct bugs that #674 didn't reach.

## 1. Underscore-laden tokens were chewed by marked emphasis

Tokens like \`GITNOTES_INLINE_MATH_TOKEN_0__\` look (to marked's italic/bold parser) like \`_0__\` — emphasis open, emphasis close, stray underscore. Marked happily reshapes them, so by the time the renderer's text method gets the string, the token is corrupted (\`GITNOTES_INLINE_MATH_TOKEN0_\` etc.). \`splitInlineTokens\` then misses it, the LaTeX leaks raw, and adjacent characters get dropped where the emphasis tried to span them — exactly the "to → tn" + raw \`\$ax^2 + bx + c = 0\$\` symptoms in #675.

Switched the placeholder format to all-caps, no-separator tokens with **no** markdown-active characters: \`GITNOTESINLINEMATHTOKEN0\`, \`GITNOTESWIKILINKTOKEN0\`. Moved \`INLINE_MATH_TOKEN_PREFIX\`, \`WIKI_LINK_TOKEN_PREFIX\`, and \`INLINE_TOKEN_REGEX\` into \`src/utils/inlineTokens.ts\` so there's one source of truth.

## 2. Inline KaTeX mounted at 0 width

The injected JS only posted height back. In a flex-row text container the WebView still mounted at 0 width because nothing told React Native how wide the rendered formula was. Block math worked because it stretched container-wide; single-pair inline math stayed invisible.

The injected JS now posts \`{w, h}\` JSON. KatexView tracks both in state; inline mode applies \`minWidth\`, block mode does not (so block formulas keep stretching). \`parseSize\` accepts the legacy plain-number format too — back-compat in case any cached bundle is still posting old data.

## Test plan
- [x] \`npx jest __tests__/utils/inlineTokensSurvival.test.ts\` — 7/7: token format has no markdown-active chars, regex matches, three-tokens-on-one-line split, emphasis-style markdown does NOT match the regex
- [x] \`npx jest __tests__/components/KatexView.height.test.tsx\` — 7/7: starts at 0, height update applies, multiple updates apply, onHeightChange still fires, **inline minWidth applies**, **block does not constrain minWidth**, legacy plain-number message parses
- [x] \`npx jest __tests__/utils\` — **44/44 across 5 suites** (no regression)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: open \`render-stress-probe.md\` from test-notes; verify single \`\$E = mc^2\$\` is now visible inline AND the three-math "Mixed:" line shows three rendered formulas with no leaked LaTeX or dropped characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)