### PR TITLE
fix(norg): recognize nested list markers '--', '~~~', etc. (closes #680)

### DIFF
--- a/__tests__/NeorgContentParser.nestedMarkers.test.ts
+++ b/__tests__/NeorgContentParser.nestedMarkers.test.ts
@@ -1,0 +1,55 @@
+import { NeorgContentParser } from '../src/services/NeorgContentParser';
+
+describe('NeorgContentParser nested list markers (issue #680)', () => {
+  test.each([
+    ['- level one', 1, 'unordered', 'level one'],
+    ['-- level two', 2, 'unordered', 'level two'],
+    ['--- level three', 3, 'unordered', 'level three'],
+    ['---- level four', 4, 'unordered', 'level four'],
+    ['~ ordered one', 1, 'ordered', 'ordered one'],
+    ['~~~ ordered three', 3, 'ordered', 'ordered three'],
+  ])('%p parses to %s nested', (input, expectedLevel, expectedType, expectedText) => {
+    const item = NeorgContentParser.parseListItem(input);
+    expect(item).not.toBeNull();
+    expect(item!.type).toBe(expectedType);
+    expect(item!.text).toBe(expectedText);
+    expect(item!.indentLevel).toBe(expectedLevel - 1);
+  });
+
+  test('-- ( ) task is recognized as a nested task', () => {
+    const item = NeorgContentParser.parseListItem('-- ( ) nested task');
+    expect(item).not.toBeNull();
+    expect(item!.type).toBe('task');
+    expect(item!.status).toBe('todo');
+    expect(item!.text).toBe('nested task');
+    expect(item!.indentLevel).toBe(1);
+  });
+
+  test('parseContent emits separate list items for -- block', () => {
+    const src = [
+      '- Pillar: "Deploy previews: a guide for product teams"',
+      '- Supporting:',
+      '-- "Deploy previews vs staging environments"',
+      '-- "How to set up deploy previews for monorepos"',
+      '-- "When deploy previews break (and how to fix them)"',
+    ].join('\n');
+    const result = NeorgContentParser.parseContent(src);
+    const lists = result.blocks!.filter((b) => b.type === 'list');
+    const items = lists.flatMap((b) => b.listItems ?? []);
+    expect(items).toHaveLength(5);
+    expect(items[2].indentLevel).toBe(1);
+    expect(items[3].indentLevel).toBe(1);
+    expect(items[4].indentLevel).toBe(1);
+
+    const paragraphs = result.blocks!.filter((b) => b.type === 'paragraph');
+    expect(paragraphs).toHaveLength(0);
+  });
+
+  test('preserves leading-whitespace indent on -- (combined with marker depth)', () => {
+    const item = NeorgContentParser.parseListItem('    -- two spaces twice');
+    expect(item).not.toBeNull();
+    expect(item!.type).toBe('unordered');
+    expect(item!.text).toBe('two spaces twice');
+    expect(item!.indentLevel).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/services/NeorgContentParser.ts
+++ b/src/services/NeorgContentParser.ts
@@ -422,33 +422,39 @@ export class NeorgContentParser {
     const indentLevel = this.getIndentLevel(spaces, indentWidth);
     const content = indentMatch[2];
 
-    const dashTaskMatch = content.match(/^\-\s+\(([ x!?~u\-_+])\)\s+(.+)$/);
+    const dashTaskMatch = content.match(/^(-+)\s+\(([ x!?~u\-_+])\)\s+(.+)$/);
     if (dashTaskMatch) {
       const statusMap: Record<string, 'todo' | 'done' | 'important' | 'uncertain' | 'in-progress' | 'urgent' | 'cancelled' | 'on-hold' | 'recurring'> = {
         ' ': 'todo', 'x': 'done', '!': 'important', '?': 'uncertain',
         '~': 'in-progress', 'u': 'urgent', '-': 'cancelled', '_': 'on-hold', '+': 'recurring',
       };
+      const markerDepth = dashTaskMatch[1].length;
       return {
         type: 'task',
-        text: dashTaskMatch[2].trim(),
-        status: statusMap[dashTaskMatch[1]] || 'todo',
-        indentLevel,
+        text: dashTaskMatch[3].trim(),
+        status: statusMap[dashTaskMatch[2]] || 'todo',
+        indentLevel: indentLevel + (markerDepth - 1),
       };
     }
 
-    const unorderedMatch = content.match(/^\-\s+(.+)$/);
+    const unorderedMatch = content.match(/^(-+)\s+(.+)$/);
     if (unorderedMatch) {
-      return { type: 'unordered', text: unorderedMatch[1].trim(), indentLevel };
+      const markerDepth = unorderedMatch[1].length;
+      return {
+        type: 'unordered',
+        text: unorderedMatch[2].trim(),
+        indentLevel: indentLevel + (markerDepth - 1),
+      };
     }
 
-    const norgOrdered = content.match(/^~\s+(.+)$/);
+    const norgOrdered = content.match(/^(~+)\s+(.+)$/);
     if (norgOrdered) {
-      return { type: 'ordered', text: norgOrdered[1].trim(), indentLevel };
-    }
-
-    const counterMatch = content.match(/^~~\s+(.+)$/);
-    if (counterMatch) {
-      return { type: 'ordered', text: counterMatch[1].trim(), indentLevel };
+      const markerDepth = norgOrdered[1].length;
+      return {
+        type: 'ordered',
+        text: norgOrdered[2].trim(),
+        indentLevel: indentLevel + (markerDepth - 1),
+      };
     }
 
     const numericMatch = content.match(/^(\d+)[.)]\s+(.+)$/);


### PR DESCRIPTION
Closes #680.

## Summary
\`parseListItem\`'s regexes were anchored to a single \`-\` or \`~\`, so Neorg's nested-list syntax (\`--\` lvl 2, \`---\` lvl 3, \`~~~\` lvl 3 ordered, etc.) wasn't recognised. Lines beginning with \`--\` fell through to paragraph aggregation; consecutive nested items collapsed into one run-on paragraph in the viewer.

This PR widens the unordered, ordered, and dash-task patterns to \`(-+)\` / \`(~+)\` and adds \`(markerDepth - 1)\` to \`indentLevel\` so each extra marker character bumps the visual nesting one level. The dash-task variant (\`- ( ) text\`) also accepts repeated dashes, so \`-- ( ) nested task\` is now a nested checkbox.

## Test plan
- [x] \`npx jest __tests__/NeorgContentParser.nestedMarkers.test.ts\` — 9/9 pass: \`-\` / \`--\` / \`---\` / \`----\` levels, ordered \`~~~\`, \`-- ( ) task\`, the seed-file repro produces 5 list items + 0 paragraphs, leading-whitespace + marker-depth combine
- [x] \`npx jest __tests__/NeorgContentParser*.test.ts\` — 58/58 across all parser suites (no regression on existing single-marker / task-after-dash / H3 tests)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: open \`notes/seo-keyword-strategy.norg\` from test-notes; verify the four \`--\` items under "Supporting:" render as nested bullets indented one level

🤖 Generated with [Claude Code](https://claude.com/claude-code)