### PR TITLE
fix(org): route .org inline rendering through OrgInlineParser (closes #681)

### DIFF
--- a/__tests__/components/parseOrgInlineSegments.test.ts
+++ b/__tests__/components/parseOrgInlineSegments.test.ts
@@ -1,0 +1,42 @@
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('expo-clipboard', () => ({ setStringAsync: jest.fn() }));
+jest.mock('react-native-webview', () => ({ WebView: () => null }));
+
+import { parseOrgInlineSegments } from '../../src/components/StructuredRenderer';
+
+const ofType = (input: string, type: string) =>
+  parseOrgInlineSegments(input).filter((s) => s.type === type);
+
+describe('parseOrgInlineSegments (issue #681)', () => {
+  test('does NOT match a comma-delimited clause as subscript', () => {
+    const text = 'one is bleeding share, one is picking fights on price, one is repositioning upmarket.';
+    expect(ofType(text, 'subscript')).toEqual([]);
+  });
+
+  test('does NOT strike on hyphenated tokens via dash-strike', () => {
+    expect(ofType('time-to-value', 'strikethrough')).toEqual([]);
+    expect(ofType('time-to-value', 'org-strike')).toEqual([]);
+  });
+
+  test('parses *Strength:* / *Weakness:* / *Pricing:* on one paragraph as separate bold spans', () => {
+    const text = '*Strength:* Cheap, fast, big community. *Weakness:* Reliability dips, support is volunteer-led. *Pricing:* $19/seat/mo, generous free tier.';
+    const bolds = ofType(text, 'bold').map((s: any) => s.content);
+    expect(bolds).toEqual(['Strength:', 'Weakness:', 'Pricing:']);
+  });
+
+  test('still parses org-strike with +text+', () => {
+    const out = ofType('this is +cancelled+ text', 'org-strike');
+    expect(out).toHaveLength(1);
+    expect((out[0] as any).content).toBe('cancelled');
+  });
+
+  test('still parses italic with /text/ at proper boundaries', () => {
+    const out = ofType('an /italic/ word', 'italic');
+    expect(out).toHaveLength(1);
+    expect((out[0] as any).content).toBe('italic');
+  });
+
+  test('does NOT italicise a slash mid-word', () => {
+    expect(ofType('time/space tradeoff', 'italic')).toEqual([]);
+  });
+});

--- a/src/components/StructuredRenderer.tsx
+++ b/src/components/StructuredRenderer.tsx
@@ -8,6 +8,7 @@ import type { RenderFormat } from '../types/RenderStyle';
 import { classifyHref } from '../utils/linkClassifier';
 import CodeBlock from './CodeBlock';
 import KatexView from './KatexView';
+import { OrgInlineParser } from '../services/OrgInlineParser';
 
 interface StructuredRendererProps {
   blocks: NeorgContentBlock[];
@@ -220,6 +221,45 @@ export function parseNeorgInlineSegments(text: string): InlineSegment[] {
   return segments;
 }
 
+export function parseOrgInlineSegments(text: string): InlineSegment[] {
+  const parsed = OrgInlineParser.parseInline(text);
+  const out: InlineSegment[] = [];
+  for (const seg of parsed.segments) {
+    if (seg.type === 'text') {
+      if (seg.text) out.push({ type: 'text', content: seg.text });
+      continue;
+    }
+    const m = seg.markup;
+    if (!m) continue;
+    switch (m.type) {
+      case 'bold':
+        out.push({ type: 'bold', content: m.content });
+        break;
+      case 'italic':
+        out.push({ type: 'italic', content: m.content });
+        break;
+      case 'underline':
+        out.push({ type: 'underline', content: m.content });
+        break;
+      case 'org-strike':
+        out.push({ type: 'org-strike', content: m.content });
+        break;
+      case 'verbatim':
+        out.push({ type: 'verbatim', content: m.content });
+        break;
+      case 'org-code':
+        out.push({ type: 'org-code', content: m.content });
+        break;
+      case 'link':
+        out.push({ type: 'link', label: m.content, target: m.content });
+        break;
+      default:
+        out.push({ type: 'text', content: m.content });
+    }
+  }
+  return out;
+}
+
 export function createMemoizedNeorgInlineParser(
   parser: (text: string) => InlineSegment[] = parseNeorgInlineSegments,
 ): (text: string) => InlineSegment[] {
@@ -336,7 +376,13 @@ export default function StructuredRenderer({ blocks, format = 'neorg', onOpenNot
     }
   };
 
-  const parseInline = useMemo(() => createMemoizedNeorgInlineParser(), []);
+  const parseInline = useMemo(
+    () =>
+      createMemoizedNeorgInlineParser(
+        format === 'org' ? parseOrgInlineSegments : parseNeorgInlineSegments,
+      ),
+    [format],
+  );
 
   const segKey = (seg: InlineSegment, i: number): string =>
     `${i}-${seg.type}-${'content' in seg ? seg.content : 'name' in seg ? seg.name : seg.type}`;


### PR DESCRIPTION
Closes #681.

## Summary
The viewer was using \`parseNeorgInlineSegments\` for both \`.norg\` and \`.org\` files. Norg's inline rules don't fit Org:

- Norg's \`,sub,\` subscript matched a comma-delimited clause in prose (\"share, one is picking fights on price,\"). The overlap filter then suppressed the smaller \`*Pricing:*\` bold contained inside that range, leaving raw \`*\` glyphs and a giant unintended bold sweep — exactly the symptom reported in #681.
- Norg's \`-strike-\` matched hyphenated tokens, and \`*bold*\` had no PRE/POST word-boundary check, so any \`*\` next to alphanumeric chars could anchor a span.

\`OrgInlineParser\` already exists in the codebase with the proper Org markup set (\`*\` bold, \`/\` italic, \`_\` underline, \`+\` strike, \`=\` verbatim, \`~\` code) and PRE/POST checks. It just wasn't wired up.

This PR adds a small adapter \`parseOrgInlineSegments\` (converts \`OrgInlineParser\`'s output to the renderer's \`InlineSegment\` shape) and dispatches on \`format === 'org'\` inside the memoized parser factory in \`StructuredRenderer\`. \`.norg\` keeps the existing parser unchanged.

## Test plan
- [x] \`npx jest __tests__/components/parseOrgInlineSegments.test.ts\` — 6/6: comma-delimited clause not subscripted, hyphen tokens not struck, three \`*X:*\` bolds parsed independently, \`+text+\` still strikes, \`/italic/\` at boundaries, mid-word slash not italicised
- [x] \`npx tsc --noEmit\` — clean
- [x] No regression in adjacent tests (39/39 across other component suites)
- [ ] Manual: open \`notes/competitor-analysis.org\` from test-notes; verify the Pulse / Forge stat-block lines (\`*Strength:*\` / \`*Weakness:*\` / \`*Pricing:*\`) each render as separate bolded labels with prose flowing normally between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)