### PR TITLE
fix(md): rewrite *italic* / **bold** to underscore form after inline code (closes #678)

### DIFF
--- a/__tests__/utils/normalizeAsteriskAfterCode.test.ts
+++ b/__tests__/utils/normalizeAsteriskAfterCode.test.ts
@@ -1,0 +1,53 @@
+import { normalizeAsteriskAfterCode } from '../../src/utils/normalizeAsteriskAfterCode';
+
+describe('normalizeAsteriskAfterCode (issue #678)', () => {
+  test('rewrites *italic* immediately after a code span to _italic_', () => {
+    expect(normalizeAsteriskAfterCode('child with `code` and *italic*')).toBe(
+      'child with `code` and _italic_',
+    );
+  });
+
+  test('rewrites **bold** immediately after a code span to __bold__', () => {
+    expect(normalizeAsteriskAfterCode('item with `multi word code` and **end bold**')).toBe(
+      'item with `multi word code` and __end bold__',
+    );
+  });
+
+  test('does not rewrite asterisks elsewhere on the line', () => {
+    expect(normalizeAsteriskAfterCode('start *italic* before any code')).toBe(
+      'start *italic* before any code',
+    );
+  });
+
+  test('does not rewrite **bold** that has no preceding code', () => {
+    expect(normalizeAsteriskAfterCode('plain **bold** no code')).toBe('plain **bold** no code');
+  });
+
+  test('handles multiple code spans on one line', () => {
+    expect(
+      normalizeAsteriskAfterCode('a `c1` and *one*, then `c2` and **two**'),
+    ).toBe('a `c1` and _one_, then `c2` and __two__');
+  });
+
+  test('preserves the code span content unchanged', () => {
+    expect(normalizeAsteriskAfterCode('see `*not italic*` and `code` *italic*')).toBe(
+      'see `*not italic*` and `code` _italic_',
+    );
+  });
+
+  test('does not eat asterisks across newlines', () => {
+    expect(
+      normalizeAsteriskAfterCode('line one with `code` and end\n*starts a line*'),
+    ).toBe('line one with `code` and end\n*starts a line*');
+  });
+
+  test('preserves triple-asterisk emphasis (***triple***)', () => {
+    expect(normalizeAsteriskAfterCode('with `code` then ***triple***')).toBe(
+      'with `code` then ***triple***',
+    );
+  });
+
+  test('returns input unchanged when no asterisks present', () => {
+    expect(normalizeAsteriskAfterCode('plain text only')).toBe('plain text only');
+  });
+});

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -17,6 +17,7 @@ import { TableRenderer } from '../components/TableRenderer';
 import { isCanvasLink, canvasIdFromLink } from '../models/Canvas';
 import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 import { parseFrontmatter } from './frontmatterParser';
+import { normalizeAsteriskAfterCode } from './normalizeAsteriskAfterCode';
 import { decodeHtmlEntities } from './htmlEntities';
 import { classifyHref } from './linkClassifier';
 import { parseMath, type MathSegment } from './mathParser';
@@ -165,7 +166,7 @@ function processMarkdown(markdown: string): ProcessedMarkdown {
       // ends up looking identical to a regular bullet list. Replacing the
       // brackets with ☐ / ☑ before parsing keeps a visible state marker
       // through the existing list_item path with no renderer override.
-      let segmentText = section.text
+      let segmentText = normalizeAsteriskAfterCode(section.text)
         .replace(/^(\s*[-*]\s+)\[ \]\s+/gm, '$1☐ ')
         .replace(/^(\s*[-*]\s+)\[x\]\s+/gim, '$1☑ ');
 

--- a/src/utils/normalizeAsteriskAfterCode.ts
+++ b/src/utils/normalizeAsteriskAfterCode.ts
@@ -1,0 +1,60 @@
+/**
+ * react-native-marked / marked has a quirk where `*italic*` or `**bold**`
+ * placed immediately after a closing inline-code backtick (inside a list
+ * item) renders raw — the asterisks are not interpreted as emphasis. The
+ * underscore form (`_italic_` / `__bold__`) does not have this problem.
+ *
+ * Rewrite asterisk emphasis to underscore emphasis in that specific
+ * position. The contents of the code span are left untouched (so an
+ * asterisk *inside* the backticks stays literal, as it should).
+ */
+export function normalizeAsteriskAfterCode(text: string): string {
+  if (!text.includes('`') || !text.includes('*')) return text;
+
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    lines[i] = rewriteLine(lines[i]);
+  }
+  return lines.join('\n');
+}
+
+function rewriteLine(line: string): string {
+  let out = '';
+  let cursor = 0;
+  let lastEmittedWasCode = false;
+
+  while (cursor < line.length) {
+    const tickStart = line.indexOf('`', cursor);
+    if (tickStart === -1) {
+      out += rewriteAfterCode(line.slice(cursor), lastEmittedWasCode);
+      break;
+    }
+
+    const tickEnd = line.indexOf('`', tickStart + 1);
+    if (tickEnd === -1) {
+      out += rewriteAfterCode(line.slice(cursor), lastEmittedWasCode);
+      break;
+    }
+
+    out += rewriteAfterCode(line.slice(cursor, tickStart), lastEmittedWasCode);
+    out += line.slice(tickStart, tickEnd + 1);
+    cursor = tickEnd + 1;
+    lastEmittedWasCode = true;
+  }
+
+  return out;
+}
+
+function rewriteAfterCode(segment: string, afterCode: boolean): string {
+  if (!afterCode) return segment;
+
+  let result = segment.replace(/(\s|^)\*\*([^*\n]+?)\*\*(?!\*)/g, (_match, lead, inner) => {
+    return `${lead}__${inner}__`;
+  });
+
+  result = result.replace(/(\s|^)\*([^*\n]+?)\*(?!\*)/g, (_match, lead, inner) => {
+    return `${lead}_${inner}_`;
+  });
+
+  return result;
+}


### PR DESCRIPTION
Closes #678.

## Summary
\`react-native-marked\` / underlying \`marked\` has a quirk where asterisk emphasis (\`*italic*\` / \`**bold**\`) placed **immediately after a closing inline-code backtick** in a list-item context renders raw — the asterisks survive into the rendered text and you see literal \`*italic*\`. The same emphasis written with underscores (\`_italic_\` / \`__bold__\`) does *not* exhibit this; nor does asterisk emphasis without a preceding code span.

This PR pre-processes each non-fenced markdown section before handing it to \`marked\`: when a closing backtick is followed (still on the same line) by \`*italic*\` or \`**bold**\`, the asterisks are swapped for underscores. The code-span contents themselves are left untouched, so an asterisk *inside* the backticks stays literal as it should.

## Test plan
- [x] \`npx jest __tests__/utils/normalizeAsteriskAfterCode.test.ts\` — 9/9: swap after single code, swap after multi-word code, no swap before any code, no swap with no code, multiple code spans on one line, code-span contents preserved, no swap across newlines, triple-asterisk left alone, no-op on plain text
- [x] \`npx jest __tests__/utils\` — 46/46 across 5 suites (no regression in notePreview / inlineTokens / etc.)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: open \`notes/render-probe2.md\` from test-notes; verify \`child with \`code\` and *italic*\` renders italic and \`item with \`multi word code\` and **end bold**\` renders bold

🤖 Generated with [Claude Code](https://claude.com/claude-code)