### PR TITLE
fix(ai): treat any status-less AI_APICallError as parser error (closes #685)

### DIFF
--- a/__tests__/ai/aiServiceErrors.test.ts
+++ b/__tests__/ai/aiServiceErrors.test.ts
@@ -146,3 +146,29 @@ describe('humanizeStreamError', () => {
     expect(humanizeStreamError(e)).toMatch(/HTTP 429/);
   });
 });
+
+describe('parser-error detection on bare AI_APICallError (issue #685)', () => {
+  test('AI_APICallError with no statusCode and generic message is treated as parser error', () => {
+    const e = apiCallError({ message: 'Provider returned error' });
+    delete (e as any).statusCode;
+    delete (e as any).responseBody;
+    const d = extractErrorDetails(e);
+    expect(d.isParserError).toBe(true);
+  });
+
+  test('AI_RetryError wrapping an AI_APICallError without statusCode is treated as parser error', () => {
+    const inner = apiCallError({ message: 'Provider returned error' });
+    delete (inner as any).statusCode;
+    const e = retryError([inner]);
+    expect(extractErrorDetails(e).isParserError).toBe(true);
+  });
+
+  test('AI_APICallError with explicit non-success statusCode is NOT marked parser', () => {
+    const e = apiCallError({ statusCode: 500, responseBody: 'oops' });
+    expect(extractErrorDetails(e).isParserError).toBe(false);
+  });
+
+  test('non-AI_APICallError without status is NOT marked parser', () => {
+    expect(extractErrorDetails(new Error('boom')).isParserError).toBe(false);
+  });
+});

--- a/src/services/ai/aiServiceErrors.ts
+++ b/src/services/ai/aiServiceErrors.ts
@@ -59,16 +59,6 @@ function readBody(e: unknown): string | undefined {
   return typeof b === 'string' ? b : undefined;
 }
 
-const PARSER_MESSAGE_PATTERN =
-  /failed to (process successful response|parse(?: \w+)? (?:stream|json|sse)?[^.]*)|invalid sse chunk|chunk format/i;
-
-function hasParserMessage(e: unknown): boolean {
-  const o = asObj(e);
-  if (!o) return false;
-  const msg = typeof o.message === 'string' ? o.message : '';
-  return PARSER_MESSAGE_PATTERN.test(msg);
-}
-
 export function extractErrorDetails(error: unknown): ErrorDetails {
   const inner = unwrapInner(error);
   const status = readStatus(inner);
@@ -79,9 +69,9 @@ export function extractErrorDetails(error: unknown): ErrorDetails {
 
   const isStatusedParserError =
     isApi && typeof status === 'number' && status >= 200 && status < 300 && !isEmptyBody;
-  const isMessagedParserError =
-    isApi && typeof status !== 'number' && !isEmptyBody && hasParserMessage(inner);
-  const isParserError = isStatusedParserError || isMessagedParserError;
+  const isStatuslessParserError =
+    isApi && typeof status !== 'number' && !isEmptyBody;
+  const isParserError = isStatusedParserError || isStatuslessParserError;
 
   return {
     status,


### PR DESCRIPTION
Closes #685.

## Why the earlier fix didn't catch this case
#654 widened parser-error detection to message-based matching when \`AI_APICallError\` had no \`statusCode\`, but only for a narrow regex (\"failed to process successful response\" / \"failed to parse … stream\" / \"invalid sse chunk\" / \"chunk format\"). The Vercel AI SDK retries internally before throwing, and after retry the wrapped \`AI_APICallError\` carries the generic message \"Provider returned error\" — which doesn't match the regex. So \`isParserError\` stayed false, the \`generateText\` fallback in \`streamChatResponse\` never fired, and the user saw the raw SDK error.

## What this PR changes
Widened the rule: **any** \`AI_APICallError\` with no \`statusCode\` is treated as parser-class. Status-bearing errors (4xx/5xx) still take the dedicated HTTP paths so rate-limits and server errors continue to surface as HTTP error messages instead of triggering a fallback.

The previous \`hasParserMessage\` helper + regex are no longer needed and are removed.

## Test plan
- [x] \`npx jest __tests__/ai/aiServiceErrors.test.ts\` — 24/24 pass: bare \`AI_APICallError\` without status is parser; same wrapped in \`AI_RetryError\`; HTTP 500 stays non-parser; non-\`AI_APICallError\` without status stays non-parser
- [x] \`npx jest __tests__/ai\` — 116/116 across 10 suites (no regression in streamChatResponse fallback paths or providerQuirks)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: configure an OpenRouter provider with a free-tier key, pick \`Gemma 4 26B (free)\` or any other \`(free)\` model, send any prompt; verify the assistant bubble fills via the \`generateText\` fallback instead of showing \"Failed to stream chat response\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)