### PR TITLE
fix(table): explicit cell text color so dark mode is readable (closes #687)

### DIFF
--- a/__tests__/TableRenderer.test.tsx
+++ b/__tests__/TableRenderer.test.tsx
@@ -97,4 +97,38 @@ describe('TableRenderer', () => {
     const scrollView = getByTestId('table-scroll-view');
     expect(scrollView.props.horizontal).toBe(true);
   });
+
+  describe('dark-mode text color (issue #687)', () => {
+    const flatten = (style: any): any =>
+      Array.isArray(style)
+        ? Object.assign({}, ...style.flatMap((s: any) => [flatten(s)]))
+        : style ?? {};
+
+    it('cell text color is light in dark mode', () => {
+      const { getAllByTestId } = render(
+        <TableRenderer headers={headers} aligns={aligns} rows={rows} isDark={true} />,
+      );
+      const cells = [...getAllByTestId('table-cell'), ...getAllByTestId('table-header-cell')];
+      cells.forEach((cell) => {
+        const color = flatten(cell.props.style).color;
+        expect(color).toBeDefined();
+        // light text color means high luminance — accept any non-black hex
+        expect(color).not.toBe('#000');
+        expect(color).not.toBe('#000000');
+      });
+    });
+
+    it('cell text color is dark in light mode', () => {
+      const { getAllByTestId } = render(
+        <TableRenderer headers={headers} aligns={aligns} rows={rows} isDark={false} />,
+      );
+      const cells = [...getAllByTestId('table-cell'), ...getAllByTestId('table-header-cell')];
+      cells.forEach((cell) => {
+        const color = flatten(cell.props.style).color;
+        expect(color).toBeDefined();
+        expect(color).not.toBe('#FFF');
+        expect(color).not.toBe('#FFFFFF');
+      });
+    });
+  });
 });

--- a/src/components/TableRenderer.tsx
+++ b/src/components/TableRenderer.tsx
@@ -12,6 +12,8 @@ interface TableRendererProps {
 
 const LIGHT_BORDER = '#D8D8D8';
 const DARK_BORDER = '#262626';
+const LIGHT_TEXT = '#111827';
+const DARK_TEXT = '#F3F4F6';
 const MIN_COL_WIDTH = 80;
 const MAX_COL_WIDTH = 220;
 const CELL_HORIZONTAL_PADDING = 16;
@@ -38,6 +40,7 @@ function computeColumnWidths(headers: string[], rows: string[][]): number[] {
 
 export function TableRenderer({ headers, aligns, rows, isDark }: TableRendererProps) {
   const borderColor = isDark ? DARK_BORDER : LIGHT_BORDER;
+  const textColor = isDark ? DARK_TEXT : LIGHT_TEXT;
   const colWidths = useMemo(() => computeColumnWidths(headers, rows), [headers, rows]);
 
   return (
@@ -53,7 +56,7 @@ export function TableRenderer({ headers, aligns, rows, isDark }: TableRendererPr
               testID="table-header-cell"
               style={[
                 styles.headerCell,
-                { borderColor, width: colWidths[colIdx], textAlign: aligns[colIdx] ?? 'left' },
+                { borderColor, color: textColor, width: colWidths[colIdx], textAlign: aligns[colIdx] ?? 'left' },
               ]}
             >
               {header}
@@ -69,7 +72,7 @@ export function TableRenderer({ headers, aligns, rows, isDark }: TableRendererPr
                 testID="table-cell"
                 style={[
                   styles.cell,
-                  { borderColor, width: colWidths[colIdx], textAlign: aligns[colIdx] ?? 'left' },
+                  { borderColor, color: textColor, width: colWidths[colIdx], textAlign: aligns[colIdx] ?? 'left' },
                 ]}
               >
                 {row[colIdx] ?? ''}


### PR DESCRIPTION
Closes #687.

## Summary
\`TableRenderer\` derived \`borderColor\` from \`isDark\` but never set a text color, so cells fell through to the platform default (\`#000\` on iOS). In dark mode the table rendered as black-on-near-black — only the cell borders were readable.

This PR also derives \`textColor\` from \`isDark\` (\`#F3F4F6\` dark / \`#111827\` light) and applies it to both header and body cells. The .org and .norg table paths already had themed text via \`StructuredRenderer\`; this brings the .md table renderer in line.

## Test plan
- [x] \`npx jest __tests__/TableRenderer.test.tsx\` — **10/10 pass** (8 existing + 2 new): dark mode cells use a non-black color, light mode cells use a non-white color
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: open \`render-stress-probe.md\` in dark mode, scroll to **Tables**; confirm \`Lang / Year / Note\` headers and the data rows are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)