### PR TITLE
fix(md): theme-aware text color in table cells

### DIFF
--- a/src/components/TableRenderer.tsx
+++ b/src/components/TableRenderer.tsx
@@ -12,6 +12,8 @@ interface TableRendererProps {
 
 const LIGHT_BORDER = '#D8D8D8';
 const DARK_BORDER = '#262626';
+const LIGHT_TEXT = '#111827';
+const DARK_TEXT = '#F3F4F6';
 const MIN_COL_WIDTH = 80;
 const MAX_COL_WIDTH = 220;
 const CELL_HORIZONTAL_PADDING = 16;
@@ -38,6 +40,7 @@ function computeColumnWidths(headers: string[], rows: string[][]): number[] {
 
 export function TableRenderer({ headers, aligns, rows, isDark }: TableRendererProps) {
   const borderColor = isDark ? DARK_BORDER : LIGHT_BORDER;
+  const textColor = isDark ? DARK_TEXT : LIGHT_TEXT;
   const colWidths = useMemo(() => computeColumnWidths(headers, rows), [headers, rows]);
 
   return (
@@ -53,7 +56,7 @@ export function TableRenderer({ headers, aligns, rows, isDark }: TableRendererPr
               testID="table-header-cell"
               style={[
                 styles.headerCell,
-                { borderColor, width: colWidths[colIdx], textAlign: aligns[colIdx] ?? 'left' },
+                { borderColor, color: textColor, width: colWidths[colIdx], textAlign: aligns[colIdx] ?? 'left' },
               ]}
             >
               {header}
@@ -69,7 +72,7 @@ export function TableRenderer({ headers, aligns, rows, isDark }: TableRendererPr
                 testID="table-cell"
                 style={[
                   styles.cell,
-                  { borderColor, width: colWidths[colIdx], textAlign: aligns[colIdx] ?? 'left' },
+                  { borderColor, color: textColor, width: colWidths[colIdx], textAlign: aligns[colIdx] ?? 'left' },
                 ]}
               >
                 {row[colIdx] ?? ''}


### PR DESCRIPTION
## Summary
- `TableRenderer.tsx` now resolves a theme-aware text color alongside `borderColor` and applies it to both `headerCell` and `cell` `<Text>` styles.
- Light: `#111827`, dark: `#F3F4F6`. Previously cells inherited the iOS default (`#000`), invisible against the dark background.

Closes #687

## Test plan
- [ ] Open a `.md` note with a markdown table in dark mode → cell text legible.
- [ ] Light mode → cell text still legible / unchanged contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)