### PR TITLE
fix(ai): context picker — header pad, labeled tabs, plural count

### DIFF
--- a/src/components/ai/ContextPickerModal.tsx
+++ b/src/components/ai/ContextPickerModal.tsx
@@ -13,7 +13,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { FlatList } from 'react-native';
 
-import { Surface, ScreenHeader, Button, Input } from '../ui';
+import { Surface, ScreenHeader, Button, Input, useScreenHeaderHeight } from '../ui';
 import { useTokens } from '../../contexts/ThemeContext';
 import { AIContextItem } from '../../models/AIProvider';
 import { GitHubService } from '../../services/GitHubService';
@@ -47,6 +47,7 @@ export default function ContextPickerModal({
   initialSelected = [],
 }: ContextPickerModalProps) {
   const { colors, spacing, type, radii } = useTokens();
+  const headerHeight = useScreenHeaderHeight({ subtitle: true });
 
   const [activeTab, setActiveTab] = useState<TabType>('repo');
   const [selectedItems, setSelectedItems] = useState<AIContextItem[]>([]);
@@ -475,16 +476,16 @@ export default function ContextPickerModal({
       onRequestClose={onClose}
     >
       <View style={[styles.container, { backgroundColor: colors.bg }]}>
-        <SafeAreaView style={styles.safeArea}>
+        <SafeAreaView style={styles.safeArea} edges={['bottom']}>
           <ScreenHeader
             title="Select Context"
-            subtitle={`${selectedItems.length} items selected`}
+            subtitle={`${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`}
             onBack={onClose}
             actions={
-              <Button 
+              <Button
                 testID="context-picker.button.confirm"
-                variant="primary" 
-                
+                variant="primary"
+
                 onPress={handleConfirm}
                 disabled={selectedItems.length === 0}
               >
@@ -493,7 +494,7 @@ export default function ContextPickerModal({
             }
           />
 
-          <View style={[styles.tabBar, { backgroundColor: colors.surfaceSecondary, borderRadius: radii.lg, padding: spacing[1], marginHorizontal: spacing[4], marginBottom: spacing[2] }]}>
+          <View style={[styles.tabBar, { backgroundColor: colors.surfaceSecondary, borderRadius: radii.lg, padding: spacing[1], marginTop: headerHeight, marginHorizontal: spacing[4], marginBottom: spacing[2] }]}>
             {TABS.map(tab => {
               const isActive = activeTab === tab.key;
               return (
@@ -506,12 +507,24 @@ export default function ContextPickerModal({
                     isActive && { backgroundColor: colors.surface }
                   ]}
                   onPress={() => setActiveTab(tab.key)}
+                  accessibilityLabel={tab.label}
                 >
-                  <Ionicons 
-                    name={(isActive ? tab.icon.replace('-outline', '') : tab.icon) as keyof typeof Ionicons.glyphMap} 
-                    size={20} 
-                    color={isActive ? colors.text : colors.textSecondary} 
+                  <Ionicons
+                    name={(isActive ? tab.icon.replace('-outline', '') : tab.icon) as keyof typeof Ionicons.glyphMap}
+                    size={18}
+                    color={isActive ? colors.text : colors.textSecondary}
                   />
+                  <Text
+                    numberOfLines={1}
+                    style={{
+                      marginLeft: 6,
+                      fontSize: type.sm,
+                      fontWeight: isActive ? '600' : '500',
+                      color: isActive ? colors.text : colors.textSecondary,
+                    }}
+                  >
+                    {tab.label}
+                  </Text>
                 </TouchableOpacity>
               );
             })}
@@ -556,9 +569,11 @@ const styles = StyleSheet.create({
   },
   tabItem: {
     flex: 1,
+    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    paddingVertical: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 4,
   },
   contentContainer: {
     flex: 1,


### PR DESCRIPTION
## Summary
- iPad-visible bug: the floating `ScreenHeader` is `position: absolute` and expects callers to apply `paddingTop: useScreenHeaderHeight(...)` to the first child below. The Select Context sheet didn't, so the tab bar and the first repo row scrolled behind the header. Now offsets the tab bar by the header height and drops the SafeAreaView's top edge (header handles its own top inset).
- Showed tab labels next to the icons (`Files`, `Folders`, `Repo`, `Notes`, `Todos`). Previously icons-only made the picker feel like it only supported repo-level selection — the file/folder tabs were already wired up but undiscoverable.
- Pluralized subtitle: `1 item selected` / `N items selected`.

Closes #692

## Test plan
- [ ] iPad Pro 13" sim — open AI → New Chat → tap context (paperclip / `+`) → first repo row visible below the header, scroll keeps repos out from under the bar.
- [ ] All five tab labels render legibly on iPad and iPhone (no truncation).
- [ ] Select 0 items → subtitle `0 items selected`. Select 1 → `1 item selected`. Select 2 → `2 items selected`.
- [ ] Switching to Files / Folders tabs reveals per-file / per-folder selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)