### PR TITLE
fix(ai): preserve AI_APICallError so OpenRouter parser-error fallback fires

### DIFF
--- a/src/services/AIService.ts
+++ b/src/services/AIService.ts
@@ -258,9 +258,16 @@ export async function* streamChatResponse(
         }
 
         if (part.type === 'error') {
+          // Preserve the original error shape (e.g. AI_APICallError with
+          // statusCode) so the outer catch's extractErrorDetails can
+          // recognise parser failures and route to the generateText
+          // fallback. Wrapping in `new Error(message)` previously stripped
+          // the error name, so the parser-error branch never fired for
+          // stream-emitted errors (#691).
           const err = part.error;
-          const message = err instanceof Error ? err.message : typeof err === 'string' ? err : 'Stream error';
-          throw new Error(message);
+          if (err instanceof Error) throw err;
+          if (typeof err === 'string') throw new Error(err);
+          throw new Error('Stream error');
         }
 
         const toolEvent = serializeToolEvent(part);

--- a/src/services/ai/aiServiceErrors.ts
+++ b/src/services/ai/aiServiceErrors.ts
@@ -33,6 +33,23 @@ function isEmptyBodyError(e: unknown): boolean {
   return false;
 }
 
+/**
+ * The AI SDK throws `APICallError("Failed to process successful response")`
+ * when a 2xx response body can't be parsed (e.g. OpenRouter free-tier
+ * upstreams returning non-OpenAI chunks). The error message survives even
+ * when the error has been re-wrapped by intermediate layers, so we check
+ * it directly as a fallback to the structural `name === 'AI_APICallError'`
+ * check.
+ */
+function hasParserErrorMessage(e: unknown): boolean {
+  const o = asObj(e);
+  if (!o) return false;
+  if (typeof o.message === 'string' && /failed to process successful response/i.test(o.message)) return true;
+  const cause = asObj(o.cause);
+  if (cause?.message && typeof cause.message === 'string' && /failed to process successful response/i.test(cause.message)) return true;
+  return false;
+}
+
 function unwrapInner(e: unknown): unknown {
   if (!isRetryError(e)) return e;
   const o = asObj(e);
@@ -71,7 +88,9 @@ export function extractErrorDetails(error: unknown): ErrorDetails {
     isApi && typeof status === 'number' && status >= 200 && status < 300 && !isEmptyBody;
   const isStatuslessParserError =
     isApi && typeof status !== 'number' && !isEmptyBody;
-  const isParserError = isStatusedParserError || isStatuslessParserError;
+  const isMessageParserError =
+    !isEmptyBody && (hasParserErrorMessage(error) || hasParserErrorMessage(inner));
+  const isParserError = isStatusedParserError || isStatuslessParserError || isMessageParserError;
 
   return {
     status,


### PR DESCRIPTION
## Summary
#686 already routed \`AI_APICallError\` parser failures to a non-streaming \`generateText\` fallback, but two gaps kept the OpenRouter free-tier reproducer in #691 from benefiting:

1. The error part emitted from \`streamText().fullStream\` was re-thrown as a generic \`new Error(message)\`, dropping \`name === 'AI_APICallError'\` and \`statusCode\`. The outer catch's \`extractErrorDetails\` then saw a plain \`Error\`, \`isParserError\` was false, and the fallback never ran. Rethrow the original error instead.
2. Layers above can re-wrap the AI SDK error so the structural \`name === 'AI_APICallError'\` check stops matching, but the message \`"Failed to process successful response"\` survives. Detect that message as a parser-error signal too so the fallback fires regardless of how many wrappers sit on top.

Closes #691

## Test plan
- [ ] iPad sim, OpenRouter free-tier provider, free model (e.g. Gemma 4 26B free). Send \`Hi\` → response streams via the non-streaming fallback instead of failing with \`AI_APICallError: Failed to process successful response\`.
- [ ] Other providers (Apple Intelligence, paid OpenRouter, Z.AI) still stream as before — fallback only fires when the streaming parser actually fails.
- [ ] Provider responses with empty body still surface the empty-body message (not silently swallowed by the parser-error branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)