### PR TITLE
feat(editor): pin markdown toolbar to bottom of note editor

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -49,6 +49,12 @@ interface MarkdownEditorProps {
    * that doesn't accept the focus action (#624).
    */
   inputTestID?: string;
+  /**
+   * Render the built-in MarkdownToolbar below the editor. Pass `false` when
+   * the toolbar is being hosted externally (e.g. NoteEditorForm pins it to
+   * the screen bottom so it doesn't scroll with the form).
+   */
+  showToolbar?: boolean;
 }
 
 /**
@@ -60,13 +66,22 @@ interface MarkdownEditorProps {
  */
 export interface MarkdownEditorHandle {
   focus: () => void;
+  /**
+   * Apply a markdown formatting action against the current selection. The
+   * built-in MarkdownToolbar already calls this internally; the imperative
+   * handle exists so a parent (e.g. NoteEditorForm) can host a sticky
+   * toolbar outside the editor's own layout.
+   */
+  applyFormat: (action: FormatAction) => void;
 }
 
-const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(function MarkdownEditor({ content, onContentChange, placeholder = 'Start writing...', initialMode, inputTestID }, ref) {
+const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(function MarkdownEditor({ content, onContentChange, placeholder = 'Start writing...', initialMode, inputTestID, showToolbar = true }, ref) {
   const { colors } = useTheme();
   const inputRef = useRef<TextInput>(null);
+  const handleFormatRef = useRef<(action: FormatAction) => void>(() => {});
   useImperativeHandle(ref, () => ({
     focus: () => inputRef.current?.focus(),
+    applyFormat: (action) => handleFormatRef.current(action),
   }), []);
   const { text, setText, undo, redo, canUndo, canRedo, reset } = useUndoRedo(content);
   const previousTextRef = useRef(text);
@@ -186,6 +201,8 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(fun
     if (result) setText(result.text);
   }, [cursor, text, setText]);
 
+  handleFormatRef.current = handleFormat;
+
   return (
     <View style={styles.container}>
       <View style={[styles.header, { borderBottomColor: colors.border }]}>
@@ -264,9 +281,11 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(fun
             }}
           />
 
-          <View testID="markdown-editor.toolbar-action.press">
-            <MarkdownToolbar onFormat={handleFormat} />
-          </View>
+          {showToolbar && (
+            <View testID="markdown-editor.toolbar-action.press">
+              <MarkdownToolbar onFormat={handleFormat} />
+            </View>
+          )}
         </>
       )}
     </View>

--- a/src/components/editor/NoteEditorForm.tsx
+++ b/src/components/editor/NoteEditorForm.tsx
@@ -8,6 +8,7 @@ import { HapticService } from '../../utils/haptics';
 import { canPersistNoteTags } from '../../utils/noteTagSupport';
 import GitContextPicker from '../GitContextPicker';
 import MarkdownEditor, { type MarkdownEditorHandle } from '../MarkdownEditor';
+import { MarkdownToolbar } from '../MarkdownToolbar';
 import TagInput from '../TagInput';
 import { FORMAT_OPTIONS } from './editorShared';
 
@@ -58,6 +59,7 @@ export function NoteEditorForm({
   const bodyRef = useRef<MarkdownEditorHandle>(null);
 
   return (
+    <View style={styles.container}>
     <ScrollView style={styles.scrollView} contentContainerStyle={styles.editorContent} keyboardShouldPersistTaps="handled">
       <View testID="note-editor-form.picker.repo" style={styles.gitContextContainer}>
         <GitContextPicker
@@ -172,14 +174,27 @@ export function NoteEditorForm({
         onContentChange={onContentChange}
         placeholder={placeholder}
         inputTestID="note-editor-form.input.content"
+        showToolbar={false}
       />
     </ScrollView>
+
+    <View
+      style={[styles.stickyToolbar, { backgroundColor: colors.surface, borderTopColor: colors.border }]}
+      testID="note-editor-form.toolbar.sticky"
+    >
+      <MarkdownToolbar onFormat={(action) => bodyRef.current?.applyFormat(action)} />
+    </View>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: { flex: 1 },
   scrollView: { flex: 1 },
   editorContent: { paddingBottom: 120 },
+  stickyToolbar: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
   gitContextContainer: {
     paddingHorizontal: 16,
     paddingTop: 12,


### PR DESCRIPTION
## Summary
The H1 / H2 / B / I / Link / list / Code / Quote / Tab toolbar previously rendered inside the MarkdownEditor below the TextInput, which sits inside NoteEditorForm's ScrollView. The toolbar scrolled with the form contents and was often off-screen when typing.

- Add an \`applyFormat\` method to MarkdownEditor's imperative handle so an external toolbar can drive formatting against the live selection without lifting cursor state out of the editor.
- Add a \`showToolbar\` prop (default \`true\`) that hides the built-in toolbar.
- In NoteEditorForm, wrap the ScrollView in a flex container and render a \`MarkdownToolbar\` as a sibling sticky bar. The screen's KeyboardAvoidingView already lifts the subtree, so the toolbar rides above the keyboard.

## Test plan
- [ ] Open a note → scroll the editor → toolbar stays pinned to the bottom of the screen, no longer scrolling away.
- [ ] Tap into the body → keyboard appears → toolbar rests directly above it.
- [ ] Tap H1 / H2 / B / I / Code → formatting is applied to the current selection or cursor position, same as before.
- [ ] Undo/redo via the top toolbar still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)