### PR TITLE
refactor(ui): unify empty-state styling behind shared component

### DIFF
--- a/src/components/notes/NotesEmptyState.tsx
+++ b/src/components/notes/NotesEmptyState.tsx
@@ -1,45 +1,20 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
-import { useTheme } from '../../contexts/ThemeContext';
+
+import { EmptyState } from '../ui';
 
 interface NotesEmptyStateProps {
   isFiltered: boolean;
 }
 
 export function NotesEmptyState({ isFiltered }: NotesEmptyStateProps) {
-  const { colors } = useTheme();
   const { t } = useTranslation();
 
   return (
-    <View style={styles.container}>
-      <Ionicons name="document-text-outline" size={48} color={colors.textSecondary} />
-      <Text style={[styles.title, { color: colors.text }]}>
-        {isFiltered ? t('notes.noMatchingNotes') : t('notes.noNotesYet')}
-      </Text>
-      <Text style={[styles.subtext, { color: colors.textSecondary }]}>
-        {isFiltered ? t('notes.tryAdjusting') : t('notes.createFirst')}
-      </Text>
-    </View>
+    <EmptyState
+      icon="document-text-outline"
+      title={isFiltered ? t('notes.noMatchingNotes') : t('notes.noNotesYet')}
+      subtitle={isFiltered ? t('notes.tryAdjusting') : t('notes.createFirst')}
+    />
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingTop: 60,
-  },
-  title: {
-    fontSize: 17,
-    fontWeight: '600',
-    marginTop: 16,
-    marginBottom: 6,
-  },
-  subtext: {
-    fontSize: 14,
-    textAlign: 'center',
-  },
-});

--- a/src/components/templates/TemplatesEmptyState.tsx
+++ b/src/components/templates/TemplatesEmptyState.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
-import { View, Text } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
 
-import { useTheme } from '../../contexts/ThemeContext';
-import { styles } from './templateManagerStyles';
+import { EmptyState } from '../ui';
 
 export function TemplatesEmptyState() {
-  const { colors } = useTheme();
-
   return (
-    <View style={styles.empty}>
-      <Ionicons name="document-text-outline" size={42} color={colors.textSecondary} />
-      <Text style={[styles.emptyTitle, { color: colors.text }]}>No templates yet</Text>
-      <Text style={[styles.emptySub, { color: colors.textSecondary }]}>Create your first custom template to get started.</Text>
-    </View>
+    <EmptyState
+      icon="document-text-outline"
+      title="No templates yet"
+      subtitle="Create your first custom template to get started."
+    />
   );
 }

--- a/src/components/todos/TodosEmptyState.tsx
+++ b/src/components/todos/TodosEmptyState.tsx
@@ -1,46 +1,20 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 
-import { useTheme } from '../../contexts/ThemeContext';
+import { EmptyState } from '../ui';
 
 interface TodosEmptyStateProps {
   isFiltered: boolean;
 }
 
 export function TodosEmptyState({ isFiltered }: TodosEmptyStateProps) {
-  const { colors } = useTheme();
   const { t } = useTranslation();
 
   return (
-    <View style={styles.container}>
-      <Ionicons name="checkbox-outline" size={64} color={colors.textSecondary} />
-      <Text style={[styles.title, { color: colors.text }]}>
-        {isFiltered ? t('todos.noMatchingTodos') : t('todos.noTodosYet')}
-      </Text>
-      <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-        {isFiltered ? t('notes.tryAdjusting') : t('todos.addFirst')}
-      </Text>
-    </View>
+    <EmptyState
+      icon="checkbox-outline"
+      title={isFiltered ? t('todos.noMatchingTodos') : t('todos.noTodosYet')}
+      subtitle={isFiltered ? t('notes.tryAdjusting') : t('todos.addFirst')}
+    />
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingTop: 64,
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: '600',
-    marginTop: 16,
-  },
-  subtitle: {
-    fontSize: 14,
-    marginTop: 8,
-    textAlign: 'center',
-  },
-});

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { useTheme } from '../../contexts/ThemeContext';
+
+export interface EmptyStateProps {
+  icon: keyof typeof Ionicons.glyphMap;
+  title: string;
+  subtitle?: string;
+  /** Overrides the default `colors.textSecondary` icon color. */
+  iconColor?: string;
+  /** Optional testID to make the empty state targetable in tests. */
+  testID?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Shared empty-state block for list screens.
+ *
+ * Before this component, every list screen (notes, todos, templates, chat
+ * threads, explore, …) rolled its own combination of icon size, font
+ * weight, and spacing. The result looked subtly different on every tab.
+ * Centralise the typography here so the empty messages match.
+ */
+export function EmptyState({ icon, title, subtitle, iconColor, testID, style }: EmptyStateProps) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={[styles.container, style]} testID={testID}>
+      <Ionicons name={icon} size={48} color={iconColor ?? colors.textSecondary} />
+      <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
+      {subtitle ? (
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>{subtitle}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 60,
+    paddingHorizontal: 24,
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '600',
+    marginTop: 16,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    marginTop: 6,
+    textAlign: 'center',
+  },
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -19,3 +19,5 @@ export type { ModalProps } from './Modal';
 export { TabBar, useTabBarHeight, TAB_BAR_BASE_HEIGHT } from './TabBar';
 export { ScreenHeader, useScreenHeaderHeight, SCREEN_HEADER_BASE_HEIGHT, SCREEN_HEADER_SUBTITLE_HEIGHT } from './ScreenHeader';
 export type { ScreenHeaderProps } from './ScreenHeader';
+export { EmptyState } from './EmptyState';
+export type { EmptyStateProps } from './EmptyState';

--- a/src/screens/ChatThreadListScreen.tsx
+++ b/src/screens/ChatThreadListScreen.tsx
@@ -14,7 +14,7 @@ import { githubActivity } from '../stores/githubActivityStore';
 import { useTokens } from '../contexts/ThemeContext';
 import { RootStackParamList } from '../navigation/types';
 import { ChatThreadSummary } from '../models/Chat';
-import { ScreenHeader, Card, Button, useScreenHeaderHeight } from '../components/ui';
+import { ScreenHeader, Card, Button, EmptyState, useScreenHeaderHeight } from '../components/ui';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -200,12 +200,12 @@ export default function ChatThreadListScreen() {
     }
 
     return (
-      <View style={styles.centerContainer}>
-        <Ionicons name="sparkles" size={48} color={colors.primary} style={styles.emptyIcon} />
-        <Text style={[styles.emptyText, { color: colors.textSecondary, fontSize: type.md }]}>
-          Start your first AI chat
-        </Text>
-      </View>
+      <EmptyState
+        icon="sparkles"
+        iconColor={colors.primary}
+        title="Start your first AI chat"
+        subtitle="Tap New Chat above to send your first prompt."
+      />
     );
   };
 

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -20,7 +20,7 @@ import { HapticService } from '../utils/haptics';
 import { parseRepoPath } from '../utils/gitPathParser';
 import RepoFileTree, { TreeNode } from '../components/RepoFileTree';
 import { RootStackParamList } from '../navigation/types';
-import { ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
+import { EmptyState, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import SearchBar from '../components/SearchBar';
 
@@ -148,15 +148,11 @@ export default function ExploreScreen() {
             <Text style={[s.loadingText, { color: colors.textSecondary }]}>Loading repos…</Text>
           </View>
         ) : filteredRepos.length === 0 ? (
-          <View style={s.emptyContainer}>
-            <Ionicons name="git-branch-outline" size={48} color={colors.textSecondary} />
-            <Text style={[s.emptyTitle, { color: colors.text }]}>
-              {repos.length === 0 ? 'No repositories' : 'No matches'}
-            </Text>
-            <Text style={[s.emptySubtext, { color: colors.textSecondary }]}>
-              {repos.length === 0 ? 'Add a repo in Settings to get started' : 'Try a different search'}
-            </Text>
-          </View>
+          <EmptyState
+            icon="git-branch-outline"
+            title={repos.length === 0 ? 'No repositories' : 'No matches'}
+            subtitle={repos.length === 0 ? 'Add a repo in Settings to get started' : 'Try a different search'}
+          />
         ) : (
           <FlatList
             data={filteredRepos}


### PR DESCRIPTION
## Summary
Every list screen rolled its own empty-state block with subtly different icon sizes, font weights, and spacing, so "No notes yet" / "No todos yet" / "No repositories" each looked a little different.

Introduce a shared \`<EmptyState>\` in \`components/ui\`:
- icon size 48, color \`textSecondary\` (overridable for accent icons like chat sparkles)
- title fontSize 17 / weight 600 / colors.text / marginTop 16
- subtitle fontSize 14 / colors.textSecondary / marginTop 6 / centered

Route through it:
- \`NotesEmptyState\`, \`TodosEmptyState\`, \`TemplatesEmptyState\`
- \`ChatThreadListScreen\` empty state (keeps its primary-tinted sparkles icon via \`iconColor\`)
- \`ExploreScreen\` empty state

## Test plan
- [ ] Notes / Todos / Templates / Chat / Explore empty states render with matching typography.
- [ ] Chat empty state's sparkles icon stays primary-tinted.
- [ ] Translation strings still resolve (notes / todos still call \`t(...)\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)