### PR TITLE
feat: block note/todo/journal creation until a repo is configured

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -9,6 +9,8 @@ import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useNotes } from '../contexts/NoteContext';
 import { useCanvases } from '../contexts/CanvasContext';
+import { useRepos } from '../contexts/RepoContext';
+import { requireRepo } from '../utils/requireRepo';
 import { NoteFormat } from '../models/Note';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { HapticService } from '../utils/haptics';
@@ -40,6 +42,10 @@ export default function HomeScreen() {
   const { colors } = useTheme();
   const { notes } = useNotes();
   const { canvases } = useCanvases();
+  const { repositories } = useRepos();
+  const openSettings = useCallback(() => {
+    navigation.getParent()?.navigate('SettingsTab' as never);
+  }, [navigation]);
   const { isTablet } = useResponsive();
   const headerHeight = useScreenHeaderHeight({ subtitle: true });
   const tabBarHeight = useTabBarHeight();
@@ -60,13 +66,16 @@ export default function HomeScreen() {
 
   const handleCreateNote = useCallback(() => {
     HapticService.medium();
+    if (!requireRepo(repositories.length > 0, { kind: 'note', onOpenSettings: openSettings })) {
+      return;
+    }
     if (rememberFormat && defaultFormat) {
       navigation.navigate('NoteEditor', { format: defaultFormat });
       return;
     }
     setPickerRemember(false);
     setShowFormatPicker(true);
-  }, [navigation, rememberFormat, defaultFormat]);
+  }, [navigation, rememberFormat, defaultFormat, repositories.length, openSettings]);
 
   const handleSelectFormat = useCallback(async (format: EditableNoteFormat) => {
     setShowFormatPicker(false);
@@ -88,19 +97,26 @@ export default function HomeScreen() {
 
   const handleOpenTemplates = useCallback(() => {
     HapticService.medium();
+    if (!requireRepo(repositories.length > 0, { kind: 'template', onOpenSettings: openSettings })) {
+      return;
+    }
     setShowTemplateSelector(true);
-  }, []);
+  }, [repositories.length, openSettings]);
 
   const handleOpenTodaysJournal = useCallback(() => {
     HapticService.medium();
     const today = new Date();
     const existing = findJournalEntry(notes, today);
     if (existing) {
+      // Existing journal entry — let the user open it even with no repo.
       navigation.navigate('NoteEditor', { noteId: existing.id });
       return;
     }
+    if (!requireRepo(repositories.length > 0, { kind: 'journal', onOpenSettings: openSettings })) {
+      return;
+    }
     navigation.navigate('NoteEditor', buildJournalEditorParams(today));
-  }, [navigation, notes]);
+  }, [navigation, notes, repositories.length, openSettings]);
 
   const todaysJournalTitle = journalNoteTitle(new Date());
   const hasTodaysJournal = notes.some((n) => n.title === todaysJournalTitle);

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -19,6 +19,7 @@ import ColorPicker from '../components/ColorPicker';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import { ConflictBanner } from '../components/ui/ConflictBanner';
 import { IconButton, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
+import { requireRepo } from '../utils/requireRepo';
 import { HapticService } from '../utils/haptics';
 import { useNetworkStatus } from '../hooks/useNetworkStatus';
 import { GitHubActivityIndicator } from '../components/GitHubActivityIndicator';
@@ -547,6 +548,12 @@ export default function NotesListScreen() {
               testID="notes-list.icon-button.add"
               onPress={() => {
                 HapticService.medium();
+                if (!requireRepo(repositories.length > 0, {
+                  kind: 'note',
+                  onOpenSettings: () => navigation.getParent()?.navigate('SettingsTab' as never),
+                })) {
+                  return;
+                }
                 navigation.navigate('NoteEditor', {});
               }}
               accessibilityLabel="Add note"

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -3,7 +3,9 @@ import { View, StyleSheet, Alert, Platform, RefreshControl } from 'react-native'
 import { FlatList } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
 
+import { requireRepo } from '../utils/requireRepo';
 import { useTodos } from '../contexts/TodoContext';
 import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
@@ -32,6 +34,7 @@ export default function TodoListScreen() {
   const { colors, isDark } = useTheme();
   const headerHeight = useScreenHeaderHeight();
   const tabBarHeight = useTabBarHeight();
+  const navigation = useNavigation();
   const { todos, createTodo, updateTodo, toggleTodo, refreshTodos } = useTodos();
   const deleteTodo = useTodoStore((state) => state.deleteTodo);
   const { activeAccountId } = useAuth();
@@ -509,7 +512,20 @@ export default function TodoListScreen() {
                 color={filter.activeCount > 0 ? colors.accent : colors.textSecondary}
               />
             </IconButton>
-            <IconButton size="sm" testID="todo-list.icon-button.add" onPress={() => setShowAddModal(true)} accessibilityLabel="Add todo">
+            <IconButton
+              size="sm"
+              testID="todo-list.icon-button.add"
+              onPress={() => {
+                if (!requireRepo(repositories.length > 0, {
+                  kind: 'todo',
+                  onOpenSettings: () => navigation.getParent()?.navigate('SettingsTab' as never),
+                })) {
+                  return;
+                }
+                setShowAddModal(true);
+              }}
+              accessibilityLabel="Add todo"
+            >
               <Ionicons name="add" size={20} color={colors.accent} />
             </IconButton>
           </>

--- a/src/utils/requireRepo.ts
+++ b/src/utils/requireRepo.ts
@@ -1,0 +1,37 @@
+import { Alert } from 'react-native';
+
+/**
+ * Guard for "create" entry points (new note, new todo, new journal,
+ * pick template, …). Without at least one configured repository there's
+ * nowhere for the created item to land, so we surface an Alert that
+ * points users to Settings instead of letting them produce orphaned
+ * data.
+ *
+ * Returns `true` when the caller should proceed; otherwise the Alert
+ * is already showing and the caller should bail.
+ */
+export function requireRepo(
+  hasRepo: boolean,
+  options: { kind: 'note' | 'todo' | 'journal' | 'template'; onOpenSettings?: () => void },
+): boolean {
+  if (hasRepo) return true;
+
+  const noun =
+    options.kind === 'note' ? 'note'
+    : options.kind === 'todo' ? 'todo'
+    : options.kind === 'journal' ? 'journal entry'
+    : 'template';
+
+  Alert.alert(
+    'Add a repository first',
+    `You need to connect at least one GitHub repository before creating a ${noun}.`,
+    options.onOpenSettings
+      ? [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Open Settings', onPress: options.onOpenSettings },
+        ]
+      : [{ text: 'OK' }],
+  );
+
+  return false;
+}


### PR DESCRIPTION
## Summary
Without at least one configured repository there's nowhere for a new note / todo / journal entry / template-derived note to land — users were producing orphaned items that couldn't sync. Add a shared \`requireRepo()\` guard that surfaces an Alert pointing at Settings, and wire it through every create entry point:

- \`NotesListScreen\` — "+" header action.
- \`TodoListScreen\` — "+" header action.
- \`HomeScreen\` — Create New Note, Today's Journal (new entry only), From Template heroes.

Opening an *existing* journal entry still works without a repo so users aren't locked out of past data.

## Test plan
- [ ] Remove all repos in Settings → Notes / Todos tabs → tap "+" → Alert appears with "Open Settings" deep-link.
- [ ] Home → tap Create New Note / New Journal Entry / From Template with no repos → same Alert.
- [ ] With a repo configured → all entry points work as before.
- [ ] With a repo configured, then later remove the repo while a journal entry exists → tapping "Today's Journal" still opens that existing entry; tapping again on a *new* date prompts to add a repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)