### PR TITLE
fix(ai): static-import openai-compatible (Openrouter init crash)

### DIFF
--- a/src/services/AIService.ts
+++ b/src/services/AIService.ts
@@ -1,6 +1,7 @@
 import { generateText, streamText } from 'ai';
 import type { LanguageModel, ModelMessage, Tool } from 'ai';
 import { Platform } from 'react-native';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { AIModelConfig, AIProviderConfig } from '../models/AIProvider';
 import { chatTools } from './ai/tools';
 import { buildQuirkedFetch } from './ai/providerQuirks';
@@ -67,7 +68,13 @@ async function buildProviderInstance(providerConfig: AIProviderConfig): Promise<
           throw new Error(`Provider \"${providerConfig.name}\" is missing an API key`);
         }
 
-        const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible');
+        // Static import (not `await import(...)`). Expo's `async-require`
+        // path went through the web HMR helper on iPad and threw
+        // `Cannot read property 'reload' of undefined` (it tried
+        // `window.location.reload`), surfacing in the chat panel as
+        // "Failed to build provider 'Openrouter'". A static import bypasses
+        // the dynamic loader and ships @ai-sdk/openai-compatible directly
+        // in the main bundle.
         const quirkedFetch = buildQuirkedFetch(providerConfig.baseURL);
 
         return createOpenAICompatible({


### PR DESCRIPTION
## Symptom
iPad, OpenRouter provider, MiniMax M2.5 (free) — sending \`Hi\` produced:

\`\`\`
Failed to initialize model "MiniMax: MiniMax M2.5 (free)":
Failed to build provider "Openrouter": Cannot read property 'reload' of undefined
\`\`\`

Same trace for every OpenAI-compatible provider — happened before any network call.

## Root cause
\`buildProviderInstance\` used a dynamic \`await import('@ai-sdk/openai-compatible')\`. That goes through Expo's async-require helper. On native it should call \`DevSettings.reload(...)\` from \`hmrUtils.native.ts\`, but the web helper (\`window.location.reload()\`) was being executed instead. RN's globalThis polyfills \`window\` but \`window.location\` is undefined → \`undefined.reload\` → the error above. \`buildProviderInstance\`'s catch rewraps it as \`Failed to build provider …\`.

## Fix
Static \`import { createOpenAICompatible } from '@ai-sdk/openai-compatible'\` so the module is in the main bundle and the async loader is never invoked. The Apple / Llama branches keep their dynamic imports — they own native modules that shouldn't ship to users who don't need them.

## Test plan
- [ ] iPad, OpenRouter free model → \`Hi\` returns a response (or, for upstream stream failures, falls through #697's generateText fallback).
- [ ] OpenAI / Z.AI / other compatible providers still work as before.
- [ ] Apple Intelligence and Llama providers unaffected (still dynamic-imported).
- [ ] Cold start time and bundle size unchanged in a meaningful way (the package is small JS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)