### PR TITLE
fix(ai): swallow streamText onError so dev RedBox doesn't fire on recovered failures

### DIFF
--- a/src/services/AIService.ts
+++ b/src/services/AIService.ts
@@ -252,7 +252,19 @@ export async function* streamChatResponse(
 
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      const result = streamText({ model, messages, tools, abortSignal });
+      // The default `onError` in `streamText` calls `console.error(error)`,
+      // which surfaces as a RedBox / LogBox toast in dev even when we
+      // recover via the generateText fallback below. Swallow it here so
+      // the only error the user sees is the humanised one we throw
+      // ourselves; the stream error still propagates via `part.type ===
+      // 'error'` so our recovery logic is unaffected.
+      const result = streamText({
+        model,
+        messages,
+        tools,
+        abortSignal,
+        onError: () => {},
+      });
 
       for await (const part of result.fullStream as AsyncIterable<any>) {
         if (part.type === 'text-delta' || part.type === 'text') {


### PR DESCRIPTION
The onError fix that was supposed to ship with #702 got missed because the PR was squash-merged before the second commit was pushed. Re-shipping it here.

## Symptom
After a chat send, the dev LogBox / RedBox surfaces:
\`\`\`
Console Error
AI_APICallError: Failed to process successful response

Call Stack
  console.level         setUpDeveloperTools.js:42:33
  <anonymous>           index.mjs:6428:18     ← ai SDK default onError
  TransformStream$argument_0.transform
  ...
\`\`\`

The trace ends at \`index.mjs:6428\` — exactly where \`streamText\` defaults \`onError\` to \`({error}) => console.error(error)\`. Even when \`runGenerateTextFallback\` (#697) successfully recovers and the user sees a normal assistant reply, the SDK still console.errors and the dev toast scares the user.

## Fix
Pass \`onError: () => {}\` to \`streamText\`. The stream error still propagates via \`part.type === 'error'\` so the parser-error detection / generateText fallback continue to work — only the dev console.error noise is silenced.

## Test plan
- [ ] iPad / iPhone sim, OpenRouter free model → \`Hi\` → no RedBox toast, response either streams or arrives via fallback.
- [ ] An actual fatal error (e.g. wrong API key) still surfaces — the humanised \`Failed to stream chat response: …\` message comes from our throw, not the SDK's console.error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)