### PR TITLE
fix(canvas): mark shape path builders as worklets

### DIFF
--- a/src/components/canvas/CanvasEditorContent.tsx
+++ b/src/components/canvas/CanvasEditorContent.tsx
@@ -91,6 +91,7 @@ function buildStrokePath(points: Point[]): SkPath | null {
 }
 
 function buildArrowPath(x1: number, y1: number, x2: number, y2: number, sw: number): SkPath {
+  'worklet';
   const p = Skia.Path.Make();
   p.moveTo(x1, y1);
   p.lineTo(x2, y2);
@@ -104,6 +105,7 @@ function buildArrowPath(x1: number, y1: number, x2: number, y2: number, sw: numb
 }
 
 function buildDiamondPath(x1: number, y1: number, x2: number, y2: number): SkPath {
+  'worklet';
   const cx = (x1 + x2) / 2;
   const cy = (y1 + y2) / 2;
   const p = Skia.Path.Make();
@@ -116,6 +118,7 @@ function buildDiamondPath(x1: number, y1: number, x2: number, y2: number): SkPat
 }
 
 function buildLinePath(x1: number, y1: number, x2: number, y2: number): SkPath {
+  'worklet';
   const p = Skia.Path.Make();
   p.moveTo(x1, y1);
   p.lineTo(x2, y2);


### PR DESCRIPTION
## Symptom
Drawing a shape on iPhone surfaced:
\`\`\`
[Worklets] Tried to synchronously call a non-worklet function \`buildDiamondPath\` on the UI thread.
CanvasEditorContent.tsx (454:29)
\`\`\`

## Cause
\`buildArrowPath\`, \`buildDiamondPath\`, and \`buildLinePath\` are called from two places in \`CanvasEditorContent.tsx\`:

- JS render — static Skia \`<Path>\` children for already-committed shapes.
- UI thread — \`useDerivedValue(...)\` blocks (\`activeArrowPath\`, \`activeDiamondPath\`, \`activeLinePath\`) that recompute the in-flight shape every frame as the user drags.

Reanimated requires functions invoked synchronously from a worklet to either be workletized or marshalled via \`runOnJS\`. The path builders weren't — Reanimated bailed.

## Fix
Add the \`'worklet'\` directive to all three builders. The Reanimated babel plugin then ships a UI-thread copy alongside the JS-thread version, so both call sites work. The neighbouring \`hexToRgba\` helper already does this for the same reason.

## Test plan
- [ ] iPhone sim, open a canvas → draw an arrow / diamond / line → no RedBox, shapes track the finger smoothly.
- [ ] Existing shapes from previous sessions still render after reopening the canvas (JS-thread render path still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)