### PR TITLE
fix(chat): surface 'No response received' as a retryable error

### DIFF
--- a/src/components/chat/useChatScreenController.ts
+++ b/src/components/chat/useChatScreenController.ts
@@ -190,9 +190,25 @@ export function useChatScreenController(threadId: string) {
 
       if (pendingFlush) clearTimeout(pendingFlush);
 
-      if (abortController.signal.aborted) updateMessage(assistantMessageId, { content: assistantText || 'Stopped.' });
-      else if (!assistantText.trim() && !pausedForConfirmation) updateMessage(assistantMessageId, { content: handledToolCount > 0 ? 'Done.' : 'No response received.' });
-      else updateMessage(assistantMessageId, { content: assistantText });
+      if (abortController.signal.aborted) {
+        updateMessage(assistantMessageId, { content: assistantText || 'Stopped.' });
+      } else if (!assistantText.trim() && !pausedForConfirmation) {
+        // Stream finished with no text. If the model invoked tools the
+        // tool bubbles carry the actual output — keep this bubble as
+        // "Done." Otherwise the model really did return nothing
+        // (free-tier OpenRouter routes occasionally do this on the first
+        // try). Surface it as a retryable error so the toast's Retry
+        // button appears instead of leaving the user staring at a
+        // dead-end "No response received." bubble.
+        if (handledToolCount > 0) {
+          updateMessage(assistantMessageId, { content: 'Done.' });
+        } else {
+          updateMessage(assistantMessageId, { content: 'No response received. Tap Retry to try again.' });
+          setLocalError('The model returned an empty response.');
+        }
+      } else {
+        updateMessage(assistantMessageId, { content: assistantText });
+      }
 
       await saveActiveThread();
 


### PR DESCRIPTION
## Symptom
On iPad, after a successful first turn, the next prompt ("Build me a note on python async") returned an empty stream and the chat showed:

\`\`\`
No response received.
\`\`\`

…with no retry button. Free-tier OpenRouter routes (MiniMax M2.5) occasionally return no choices on the first try; from the user's perspective the chat is dead.

## Fix
When the stream finishes with no text content AND no tool calls (i.e. \`handledToolCount === 0\` and not an abort or pending confirmation):

- Update the bubble copy to \`No response received. Tap Retry to try again.\`
- \`setLocalError(...)\` so the existing toast + Retry button surfaces.

Behaviour when tools fired is unchanged — those bubbles already carry the real output and we keep the existing \`Done.\` summary.

## Test plan
- [ ] Trigger an empty response (or wait for an OpenRouter free model to do it) → bubble copy nudges the user to retry, toast shows Retry. Tap → same prompt re-sends.
- [ ] A normal text response is still rendered as before.
- [ ] A tool-only response (no text) still shows \`Done.\` without an error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)