### PR TITLE
feat(chat): show tool call bubbles as they stream

### DIFF
--- a/src/components/ai/ChatMessageBubble.tsx
+++ b/src/components/ai/ChatMessageBubble.tsx
@@ -155,8 +155,25 @@ function ChatMessageBubbleImpl({ message, isStreaming, onLongPress }: ChatMessag
             <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: message.toolCallResult ? spacing[1] : 0 }}>
               <Ionicons name="build-outline" size={16} color={textColor} style={{ marginRight: spacing[1] }} />
               <Text style={{ color: textColor, fontWeight: 'bold' }}>
-                {message.toolCallName}...
+                {message.toolCallName}{message.toolCallResult ? '' : '…'}
               </Text>
+              {!message.toolCallResult && isStreaming && (
+                <View style={{ flexDirection: 'row', marginLeft: spacing[2] }}>
+                  {[0, 1, 2].map((i) => (
+                    <View
+                      key={i}
+                      style={{
+                        width: 4,
+                        height: 4,
+                        borderRadius: 2,
+                        backgroundColor: textColor,
+                        opacity: dotStep === i + 1 || dotStep === 0 ? 0.9 : 0.3,
+                        marginRight: i < 2 ? 3 : 0,
+                      }}
+                    />
+                  ))}
+                </View>
+              )}
             </View>
             {noteToolResult ? (
               <Pressable

--- a/src/components/chat/useChatScreenController.ts
+++ b/src/components/chat/useChatScreenController.ts
@@ -46,6 +46,11 @@ export function useChatScreenController(threadId: string) {
   const truncateAfter = useChatStore((state) => state.truncateAfter);
 
   const toolArgsBufferRef = useRef<Record<string, string>>({});
+  // Maps each in-flight `toolCallId` to the chat message bubble we created
+  // when the tool call started streaming, so subsequent deltas + the final
+  // tool-call event can update the same bubble (rather than creating a
+  // second one once execution finishes).
+  const toolMessageIdsRef = useRef<Record<string, string>>({});
   const abortRef = useRef<AbortController | null>(null);
   const { t } = useTranslation();
 
@@ -167,7 +172,29 @@ export function useChatScreenController(threadId: string) {
         const toolCallId = toolEvent.toolCallId ?? generateId();
         const existingArgs = toolArgsBufferRef.current[toolCallId] ?? '';
         if (toolEvent.type === 'tool-call-streaming-start') {
+          // Pre-create the bubble so the user immediately sees
+          // "create_note…" appear; otherwise nothing renders until the
+          // model finishes streaming the args and the tool actually runs.
           toolArgsBufferRef.current[toolCallId] = existingArgs;
+          if (!toolMessageIdsRef.current[toolCallId] && toolEvent.toolName) {
+            const streamingMessageId = generateId();
+            toolMessageIdsRef.current[toolCallId] = streamingMessageId;
+            addMessage({
+              id: streamingMessageId,
+              role: 'assistant',
+              content: '',
+              timestamp: Date.now(),
+              toolCallId,
+              toolCallName: toolEvent.toolName,
+              toolCallArgs: {},
+            });
+            // Flush any pending assistant text so the new bubble lands
+            // after everything streamed so far, not mid-debounce.
+            if (pendingFlush) {
+              clearTimeout(pendingFlush);
+              flushAssistantText();
+            }
+          }
           continue;
         }
         if (toolEvent.type === 'tool-call-delta') {
@@ -177,11 +204,20 @@ export function useChatScreenController(threadId: string) {
         if (toolEvent.type === 'tool-result' || !toolEvent.toolName) continue;
 
         const args = parseToolArgs(toolEvent.input, toolArgsBufferRef.current[toolCallId]);
-        const toolMessageId = generateId();
+        // Re-use the streaming bubble if we already showed one, otherwise
+        // (older providers that skip the streaming start event) create
+        // the bubble here.
+        const toolMessageId = toolMessageIdsRef.current[toolCallId] ?? generateId();
+        if (!toolMessageIdsRef.current[toolCallId]) {
+          toolMessageIdsRef.current[toolCallId] = toolMessageId;
+          addMessage({ id: toolMessageId, role: 'assistant', content: '', timestamp: Date.now(), toolCallId, toolCallName: toolEvent.toolName, toolCallArgs: args });
+        } else {
+          updateMessage(toolMessageId, { toolCallArgs: args });
+        }
         handledToolCount += 1;
-        addMessage({ id: toolMessageId, role: 'assistant', content: '', timestamp: Date.now(), toolCallId, toolCallName: toolEvent.toolName, toolCallArgs: args });
         const result = await runToolCall(toolEvent.toolName, args, { messageId: toolMessageId });
         delete toolArgsBufferRef.current[toolCallId];
+        delete toolMessageIdsRef.current[toolCallId];
         if (result.requiresConfirmation) {
           pausedForConfirmation = true;
           break;


### PR DESCRIPTION
The previous flow buffered \`tool-call-streaming-start\` + \`tool-call-delta\` events silently and only created the bubble once the full final \`tool-call\` event arrived AND the tool execution returned. With slow free-tier models that read like several seconds of "nothing happening" — the user sees a stale placeholder and assumes the chat is stuck.

## Changes
- **Create the tool bubble at \`tool-call-streaming-start\`** so the user immediately sees the tool name appear ("create_note…"). The final \`tool-call\` event reuses the same bubble (via a \`toolCallId → messageId\` map) instead of adding a duplicate row.
- **Animated dots next to the tool name** while the bubble is still streaming (no \`toolCallResult\` yet). The same dot animation we already use for the assistant placeholder, just smaller.
- **Flush pending assistant text before adding the tool bubble** so the ordering reads text → tool → text rather than the tool jumping in front of half-rendered text.

## Test plan
- [ ] Ask the chat to create a note → "create_note…" with animated dots appears immediately, then converts to the "Open note: …" link once the tool returns.
- [ ] Models that skip the streaming-start event (some non-OpenAI compatible routes) still get a bubble at the final \`tool-call\` event — the lookup falls back to creating it.
- [ ] Streaming text before / after a tool call lands in the correct order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)