### PR TITLE
fix(md): drop italic from inline math so backslashes stay readable

### DIFF
--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -295,8 +295,11 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
             style={[
               styles,
               {
+                // iOS system monospace italic skews `\` so far it becomes
+                // visually indistinguishable from `|`, scrambling LaTeX
+                // commands like `\neq` / `\frac` (issue #704). Plain
+                // monospace keeps the backslash glyph readable.
                 fontFamily: 'monospace',
-                fontStyle: 'italic',
                 color: this.deps.colors.text,
                 backgroundColor: (this.deps.colors.surfaceSecondary ?? '#f0f0f0') + 'AA',
                 paddingHorizontal: 3,


### PR DESCRIPTION
## Summary
- iOS system monospace italic skews `\` so far it becomes visually indistinguishable from `|`, scrambling LaTeX commands like `\neq` / `\frac` / `\sqrt` / `\pm`.
- Drop `fontStyle: 'italic'` from the inline math styled-Text branch added in PR #679. Plain monospace keeps the backslash glyph readable while still visually setting the math span apart from prose via the surface-tinted background.
- Inline parsing/substitution paths are unchanged: `mathSegment.content` already carried the literal backslash through to render — the regression was purely a glyph-rendering artifact of italic monospace on iOS.

Closes #704

## Test plan
- [ ] Build the app on iPhone 16 Pro iOS 26 sim.
- [ ] Open a note containing: `The set is $a \neq b$ and $\frac{1}{2}$ and $\sqrt{2}$ and $\pm 1$.`
- [ ] Verify each inline math span renders with a visible backslash (`\neq`, `\frac{1}{2}`, `\sqrt{2}`, `\pm 1`) — not `|neq` etc.
- [ ] Spot-check that block math `$$...$$` still renders via KaTeX/WebView unchanged.
- [ ] Spot-check that other inline math without backslashes (e.g. `$E = mc^2$`) still renders correctly with the surface-tinted background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)