### PR TITLE
fix(ai): silence console.error around generateText fallback

### DIFF
--- a/src/services/AIService.ts
+++ b/src/services/AIService.ts
@@ -228,7 +228,18 @@ async function* runGenerateTextFallback(
   tools: Record<string, Tool> | undefined,
   abortSignal: AbortSignal | undefined,
 ): AsyncGenerator<string> {
-  const result = await generateText({ model, messages, tools, abortSignal });
+  // `generateText` has no `onError` hook (unlike `streamText`), so when the
+  // SDK's parser-error path runs against an OpenRouter chunk shape it logs
+  // via `console.error` before re-throwing. In dev this surfaces as a
+  // RedBox / LogBox toast even though we recover successfully (#705). We
+  // throw the error away ourselves below, so silence the SDK's own log
+  // for the duration of this call.
+  const originalConsoleError = console.error;
+  console.error = () => {};
+  const result = await generateText({ model, messages, tools, abortSignal })
+    .finally(() => {
+      console.error = originalConsoleError;
+    });
   if (typeof result.text === 'string' && result.text.length > 0) {
     yield result.text;
   }


### PR DESCRIPTION
## Summary
- `generateText` has no `onError` hook (unlike `streamText`), so the SDK's parser-error path on OpenRouter chunk shapes logs via `console.error` before re-throwing — RedBox / LogBox catches it in dev even though we recover.
- Wrap the fallback `generateText` call with a temporary `console.error` no-op, restored via `.finally()` so the patch is scoped strictly to the SDK call's lifetime.
- Mirrors PR #703's intent (suppress only the SDK's noise, keep our humanised throw intact).

## Test plan
- [ ] Configure OpenRouter as openai-compatible provider against a free model that returns the non-OpenAI chunk shape (e.g. `gemini-2.0-flash-lite`).
- [ ] Send a message in the AI chat in dev.
- [ ] Confirm reply still arrives via the fallback.
- [ ] Confirm no `AI_APICallError: Failed to process successful response` RedBox.
- [ ] Confirm no follow-up yellow `Console Warning` LogBox.

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)