### PR TITLE
fix(ai-settings): move provider modal actions out of scroll area

### DIFF
--- a/src/components/ai/ProviderConfigModal.tsx
+++ b/src/components/ai/ProviderConfigModal.tsx
@@ -28,8 +28,8 @@ interface ProviderConfigModalProps {
 }
 
 export function ProviderConfigModal({ visible, onClose, provider }: ProviderConfigModalProps) {
-  const { colors, style: uiStyle } = useTheme();
-  const { spacing, type } = useTokens();
+  const { colors } = useTheme();
+  const { spacing } = useTokens();
   
   const [name, setName] = useState('');
   const [baseURL, setBaseURL] = useState('');

--- a/src/components/ai/ProviderConfigModal.tsx
+++ b/src/components/ai/ProviderConfigModal.tsx
@@ -209,7 +209,7 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
           <ScrollView
             style={styles.modalBody}
             keyboardShouldPersistTaps="handled"
-            contentContainerStyle={{ paddingBottom: spacing[8] }}
+            contentContainerStyle={{ paddingBottom: spacing[6] }}
           >
             <Group title="Provider Details">
               <GroupRow>
@@ -276,42 +276,47 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
                 </GroupRow>
               )}
             </Group>
-
-            <View style={[styles.actionsContainer, { marginTop: spacing[6], gap: spacing[3] }]}>
-              {!isBuiltIn && (
-                <TouchableOpacity
-                  testID="provider-config-modal.button.test-connection"
-                  style={[styles.actionBtn, { backgroundColor: colors.surface, borderColor: colors.border, borderWidth: 1 }]}
-                  onPress={handleTestConnection}
-                  disabled={isTesting}
-                >
-                  {isTesting ? (
-                    <ActivityIndicator size="small" color={colors.primary} />
-                  ) : (
-                    <Text style={[styles.actionBtnText, { color: colors.primary }]}>Test Connection</Text>
-                  )}
-                </TouchableOpacity>
-              )}
-
-              <TouchableOpacity
-                testID="provider-config-modal.button.save"
-                style={[styles.actionBtn, { backgroundColor: colors.primary }]}
-                onPress={handleSave}
-              >
-                <Text style={[styles.actionBtnText, { color: '#FFF' }]}>Save Provider</Text>
-              </TouchableOpacity>
-
-              {provider && provider.type !== 'apple' && provider.type !== 'llama' && (
-                <TouchableOpacity
-                  testID="provider-config.button.delete"
-                  style={[styles.actionBtn, { backgroundColor: 'transparent', marginTop: spacing[2] }]}
-                  onPress={handleDelete}
-                >
-                  <Text style={[styles.actionBtnText, { color: '#FF3B30' }]}>Delete Provider</Text>
-                </TouchableOpacity>
-              )}
-            </View>
           </ScrollView>
+
+          <View
+            style={[
+              styles.actionsContainer,
+              { gap: spacing[3], borderTopColor: colors.border, paddingHorizontal: 20, paddingTop: spacing[4] },
+            ]}
+          >
+            {!isBuiltIn && (
+              <TouchableOpacity
+                testID="provider-config-modal.button.test-connection"
+                style={[styles.actionBtn, { backgroundColor: colors.surface, borderColor: colors.border, borderWidth: 1 }]}
+                onPress={handleTestConnection}
+                disabled={isTesting}
+              >
+                {isTesting ? (
+                  <ActivityIndicator size="small" color={colors.primary} />
+                ) : (
+                  <Text style={[styles.actionBtnText, { color: colors.primary }]}>Test Connection</Text>
+                )}
+              </TouchableOpacity>
+            )}
+
+            <TouchableOpacity
+              testID="provider-config-modal.button.save"
+              style={[styles.actionBtn, { backgroundColor: colors.primary }]}
+              onPress={handleSave}
+            >
+              <Text style={[styles.actionBtnText, { color: '#FFF' }]}>Save Provider</Text>
+            </TouchableOpacity>
+
+            {provider && provider.type !== 'apple' && provider.type !== 'llama' && (
+              <TouchableOpacity
+                testID="provider-config.button.delete"
+                style={[styles.actionBtn, { backgroundColor: 'transparent', marginTop: spacing[2] }]}
+                onPress={handleDelete}
+              >
+                <Text style={[styles.actionBtnText, { color: '#FF3B30' }]}>Delete Provider</Text>
+              </TouchableOpacity>
+            )}
+          </View>
         </View>
       </KeyboardAvoidingView>
     </Modal>
@@ -359,6 +364,7 @@ const styles = StyleSheet.create({
   },
   actionsContainer: {
     paddingBottom: 40,
+    borderTopWidth: StyleSheet.hairlineWidth,
   },
   actionBtn: {
     paddingVertical: 14,


### PR DESCRIPTION
## Summary
- `ProviderConfigModal` had its Save/Test/Delete buttons inside the same `ScrollView` as the form inputs. With `keyboardShouldPersistTaps="handled"`, tapping the apparent empty area below the API Key input actually landed on the Save button hit slot, so the keyboard dismissed AND a half-filled provider got persisted.
- Lift the action buttons into a fixed footer below the `ScrollView` (same shape as `TemplateEditorModal`), so dismiss-taps inside the scroll area fall on real empty space and only dismiss the keyboard.
- Added a hairline top border on the footer for visual separation; replaced the now-redundant in-scroll bottom padding.

Closes #707

## Test plan
- [ ] Settings -> AI -> Add Provider
- [ ] Tap Base URL, type any URL
- [ ] Tap empty space below API Key (without pressing Test Connection)
- [ ] Confirm: keyboard dismisses, modal stays open, no provider saved
- [ ] Tap Save Provider deliberately -> provider saves and modal closes
- [ ] Tap Test Connection -> still works
- [ ] Edit existing provider -> Delete Provider still appears and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)