### PR TITLE
fix(todos): keep TodoEditorModal buttons visible above keyboard

### DIFF
--- a/src/components/todos/TodoEditorModal.tsx
+++ b/src/components/todos/TodoEditorModal.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, TextInput, ScrollView, Modal } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, TextInput, ScrollView, Modal, KeyboardAvoidingView, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import DateTimePicker from '@react-native/datetimepicker';
 import { format } from 'date-fns';
@@ -85,8 +85,11 @@ export function TodoEditorModal({
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <View style={styles.modalOverlay}>
-        <View style={[styles.modalContent, { backgroundColor: colors.surface }]}> 
+      <KeyboardAvoidingView
+        style={styles.modalOverlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
           <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}> 
             <Text style={[styles.modalTitle, { color: colors.text }]}>
               {editingTodo ? 'Edit Todo' : 'New Todo'}
@@ -316,7 +319,7 @@ export function TodoEditorModal({
             </TouchableOpacity>
           </View>
         </View>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary
- Wrap `TodoEditorModal` content in `KeyboardAvoidingView` with `behavior="padding"` on iOS so the Add/Update/Cancel/X controls in the modal footer are pushed above the on-screen keyboard.
- Mirrors the existing pattern in `ProviderConfigModal` (and other sheet-style modals in the app) — KAV becomes the overlay; the sheet sits inside it.

## Test plan
- [ ] On iPhone (or iOS Simulator), open the Todos screen and tap the add (+) button.
- [ ] Tap into the "Todo Text" or "Notes" field so the keyboard appears.
- [ ] Confirm the Cancel / Add buttons and the close (X) icon remain visible above the keyboard and are tappable.
- [ ] Repeat in Edit mode (tap an existing todo) and confirm Update / Cancel are reachable with the keyboard up.
- [ ] Sanity check Android — modal still renders correctly (KAV is a no-op there).

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)