### PR TITLE
fix(canvas): hydrate editor title from stored canvas, not 'Untitled Canvas'

### DIFF
--- a/src/components/canvas/CanvasEditorContent.tsx
+++ b/src/components/canvas/CanvasEditorContent.tsx
@@ -252,8 +252,25 @@ export default function CanvasEditorContent() {
   const cw = canvasWidth ?? Dimensions.get('window').width;
   const [canvasSize, setCanvasSize] = useState<{ width: number; height: number } | null>(null);
 
-  const [title, setTitle] = useState(canvasTitle ?? 'Untitled Canvas');
   const existingCanvas = canvasId ? getCanvasById(canvasId) : undefined;
+  // Stored canvas title is source-of-truth when reopening. Falls back to the
+  // route-param title (used by the new-canvas size picker), then a default.
+  // Without this, the editor used to mount with 'Untitled Canvas' for any
+  // existing canvas and a Save would overwrite the real title (#713).
+  const [title, setTitle] = useState(
+    existingCanvas?.title || canvasTitle || 'Untitled Canvas',
+  );
+  // Deep-links / cold-launches into the editor may mount before the canvas
+  // store has finished loading. Hydrate once existingCanvas resolves, but
+  // never clobber a user edit in progress.
+  const titleHydratedRef = useRef(!!existingCanvas?.title || !canvasId);
+  useEffect(() => {
+    if (titleHydratedRef.current) return;
+    if (existingCanvas?.title) {
+      setTitle(existingCanvas.title);
+      titleHydratedRef.current = true;
+    }
+  }, [existingCanvas?.title]);
   const [elements, setElements] = useState<CanvasElement[]>(
     existingCanvas?.scene?.elements ?? DEFAULT_SCENE.elements,
   );


### PR DESCRIPTION
## Summary
- `CanvasEditor` mounted its title state as `canvasTitle ?? 'Untitled Canvas'`, ignoring the stored canvas — so reopening any saved canvas showed `Untitled Canvas` in the input, and the next Save overwrote the real title. Typing without clearing the placeholder produced concat artefacts like `Untitled Canvasmaestro canvas one` that then surfaced in the Canvases list.
- Source of truth is now `existingCanvas.title`, with `canvasTitle` (size-picker route param) only used for new canvases and `'Untitled Canvas'` as the last-resort fallback.
- Adds a one-shot hydration effect for the deep-link / cold-launch path where the canvas store finishes loading after the editor mounts; never clobbers a user edit in progress.

## Test plan
- [ ] From the Canvases tab, create a canvas with title `maestro canvas one`, save, reopen — editor title input shows `maestro canvas one` (not `Untitled Canvas`).
- [ ] Reopen, hit Save without editing — list still shows `maestro canvas one` (no overwrite).
- [ ] Tap `+`, type a name in the size picker, save the new canvas — title persists end-to-end.
- [ ] Tap `+`, leave the name blank, save — list shows `Untitled Canvas`, file is `canvases/untitled-canvas.json`.
- [ ] Open a canvas via deep link / cold launch (e.g. canvas link in a note) — title hydrates once the store loads.

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)