### PR TITLE
fix(canvas): keep tab bar visible on Canvases list screen

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -11,7 +11,6 @@ import ChatScreen from '../screens/ChatScreen';
 import ChatThreadListScreen from '../screens/ChatThreadListScreen';
 import NoteEditorScreen from '../screens/NoteEditorScreen';
 import CanvasEditorScreen from '../screens/CanvasEditorScreen';
-import CanvasListScreen from '../screens/CanvasListScreen';
 import PdfViewerScreen from '../screens/PdfViewerScreen';
 import FileViewerScreen from '../screens/FileViewerScreen';
 import ImageViewerScreen from '../screens/ImageViewerScreen';
@@ -45,11 +44,11 @@ const linking: LinkingOptions<RootStackParamList> = {
           NotesTab: 'notes',
           ExploreTab: 'explore',
           SettingsTab: 'settings',
+          CanvasList: 'canvases',
         },
       },
       NoteEditor: 'note/:noteId',
       CanvasEditor: 'canvas/:canvasId',
-      CanvasList: 'canvases',
       ChatThreadList: 'chat',
       ChatScreen: 'chat/:threadId',
       NeumorphicGallery: '__dev__/neumorphic',
@@ -129,14 +128,9 @@ export default function AppNavigator() {
               component={NoteEditorScreen}
               options={{ headerShown: false }}
             />
-            <Stack.Screen 
-              name="CanvasEditor" 
-              component={CanvasEditorScreen}
-              options={{ headerShown: false }}
-            />
             <Stack.Screen
-              name="CanvasList"
-              component={CanvasListScreen}
+              name="CanvasEditor"
+              component={CanvasEditorScreen}
               options={{ headerShown: false }}
             />
             <Stack.Screen

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -16,6 +16,7 @@ import NotesListScreen from '../screens/NotesListScreen';
 import ExploreScreen from '../screens/ExploreScreen';
 import TodoListScreen from '../screens/TodoListScreen';
 import SettingsScreen from '../screens/SettingsScreen';
+import CanvasListScreen from '../screens/CanvasListScreen';
 import { BottomTabParamList } from './types';
 import { useResponsive } from '../hooks/useResponsive';
 import { useTheme } from '../contexts/ThemeContext';
@@ -185,6 +186,11 @@ export default function TabNavigator() {
         name="SettingsTab"
         component={SettingsScreen}
         options={{ title: 'Settings' }}
+      />
+      <Tab.Screen
+        name="CanvasList"
+        component={CanvasListScreen}
+        options={{ title: 'Canvases', tabBarButton: () => null, tabBarItemStyle: { display: 'none' } }}
       />
     </Tab.Navigator>
   );

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -9,7 +9,6 @@ type ProductionStackParamList = {
   ImageViewer: { owner: string; repo: string; branch?: string; path: string; title?: string; size?: number };
   VideoViewer: { owner: string; repo: string; branch?: string; path: string; title?: string; size?: number };
   CanvasEditor: { canvasId?: string; canvasWidth?: number; canvasHeight?: number; canvasTitle?: string };
-  CanvasList: undefined;
   ChatThreadList: undefined;
   ChatScreen: { threadId: string };
   RenderStyleSettings: undefined;
@@ -31,6 +30,7 @@ export type BottomTabParamList = {
   ExploreTab: undefined;
   TodosTab: undefined;
   SettingsTab: undefined;
+  CanvasList: undefined;
 };
 
 export type Note = {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -227,7 +227,7 @@ export default function HomeScreen() {
           </Pressable>
           <Pressable
             testID="home.button.navigate"
-            onPress={() => navigation.navigate('CanvasList')}
+            onPress={() => navigation.navigate('MainTabs', { screen: 'CanvasList' })}
             style={({ pressed }) => [
               styles.bentoTile,
               { backgroundColor: colors.surface, borderColor: colors.border, opacity: pressed ? 0.92 : 1, transform: [{ scale: pressed ? 0.985 : 1 }] },


### PR DESCRIPTION
## Summary
- `CanvasList` was a sibling of `MainTabs` in the root native-stack, so opening it unmounted the bottom tab bar and left back-gesture as the only way out (#714)
- Move `CanvasList` inside `TabNavigator` with `tabBarButton: () => null` so the screen lives in the tab-aware navigator and the bar stays visible
- Update the Home tile to navigate via `MainTabs > CanvasList` and migrate the `gitnotes://canvases` deep link into the tabs `screens` map

## Test plan
- [ ] Home tab > tap Canvases (Beta) tile -> Canvases screen renders with bottom tab bar still visible
- [ ] Tap Notes / Explore / Todos / Settings tabs from Canvases screen -> switches tabs as expected
- [ ] `xcrun simctl openurl booted gitnotes://canvases` deep link still lands on the Canvases list
- [ ] Tap a canvas to open `CanvasEditor` -> still full-screen (no tab bar), back returns to Canvases list with tab bar

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)