### PR TITLE
fix(canvas): swap invalid 'rectangle-outline' Ionicon for 'stop-outline'

### DIFF
--- a/src/components/CanvasModal.tsx
+++ b/src/components/CanvasModal.tsx
@@ -67,7 +67,7 @@ const TOOLS: { key: string; icon?: ToolIconName; label?: string }[] = [
   { key: 'line', icon: 'remove' as ToolIconName },
   { key: 'arrow', icon: 'arrow-forward' as ToolIconName },
   { key: 'rect', icon: 'square-outline' as ToolIconName },
-  { key: 'roundRect', icon: 'rectangle-outline' as ToolIconName },
+  { key: 'roundRect', icon: 'stop-outline' as ToolIconName },
   { key: 'ellipse', icon: 'ellipse-outline' as ToolIconName },
   { key: 'diamond', icon: 'diamond-outline' as ToolIconName },
 ];

--- a/src/components/canvas/CanvasEditorContent.tsx
+++ b/src/components/canvas/CanvasEditorContent.tsx
@@ -60,7 +60,7 @@ const TOOLS: { key: string; icon?: ToolIconName; label?: string }[] = [
   { key: 'line', icon: 'remove' as ToolIconName },
   { key: 'arrow', icon: 'arrow-forward' as ToolIconName },
   { key: 'rect', icon: 'square-outline' as ToolIconName },
-  { key: 'roundRect', icon: 'rectangle-outline' as ToolIconName },
+  { key: 'roundRect', icon: 'stop-outline' as ToolIconName },
   { key: 'ellipse', icon: 'ellipse-outline' as ToolIconName },
   { key: 'diamond', icon: 'diamond-outline' as ToolIconName },
   { key: 'text', label: 'T' },


### PR DESCRIPTION
## Summary
- `rectangle-outline` is not a valid Ionicons name, so RN logged a WARN every render of the canvas tool palette.
- Replaced it with `stop-outline` in both `CanvasModal.tsx` and `canvas/CanvasEditorContent.tsx` — the rounded-corner glyph matches the `roundRect` tool's intent.

## Test plan
- [ ] Open a canvas (modal + full editor).
- [ ] Confirm Metro/console no longer spams `"rectangle-outline" is not a valid icon name for family "ionicons"`.
- [ ] Confirm the `roundRect` tool slot renders an icon (rounded-square outline) instead of a `?` fallback.

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)