### PR TITLE
fix(notes): group journal view by day with one ISO date header

### DIFF
--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -4,6 +4,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import { Note } from '../../models/Note';
 import { ViewMode } from '../../utils/viewModes';
 import { useTheme } from '../../contexts/ThemeContext';
+import { formatJournalDate } from '../../services/JournalService';
 import BaseNoteCard from '../NoteCard';
 
 interface NotesNoteCardProps {
@@ -15,6 +16,13 @@ interface NotesNoteCardProps {
   isOffline: boolean;
   isCached: boolean;
   onTagPress?: (tag: string) => void;
+  /** Date key (yyyy-MM-dd) of the previous note in the list, used by journal view to group entries under one header per day. */
+  prevDateKey?: string;
+}
+
+function journalDateKey(timestamp: number | undefined): string {
+  if (!timestamp) return '';
+  return formatJournalDate(new Date(timestamp));
 }
 
 function NotesNoteCardImpl({
@@ -26,6 +34,7 @@ function NotesNoteCardImpl({
   isOffline,
   isCached,
   onTagPress,
+  prevDateKey,
 }: NotesNoteCardProps) {
   const { colors } = useTheme();
 
@@ -43,20 +52,22 @@ function NotesNoteCardImpl({
     </View>
   );
 
-  return (
-    <View testID="note-card-root.button.press">
-      {viewMode === 'journal' ? (
+  if (viewMode === 'journal') {
+    const currentDateKey = journalDateKey(note.updatedAt);
+    const showDate = currentDateKey !== '' && currentDateKey !== prevDateKey;
+    return (
+      <View testID="note-card-root.button.press">
         <View {...({ note } as { note: Note })} style={styles.journalItem}>
-          <Text style={[styles.journalDate, { color: colors.textSecondary }]}>
-            {note.updatedAt ? new Date(note.updatedAt).toLocaleDateString() : ''}
-          </Text>
+          {showDate ? (
+            <Text style={[styles.journalDate, { color: colors.textSecondary }]}>{currentDateKey}</Text>
+          ) : null}
           {content}
         </View>
-      ) : (
-        content
-      )}
-    </View>
-  );
+      </View>
+    );
+  }
+
+  return <View testID="note-card-root.button.press">{content}</View>;
 }
 
 export const NoteCard = memo(NotesNoteCardImpl, (prev, next) => {
@@ -68,7 +79,8 @@ export const NoteCard = memo(NotesNoteCardImpl, (prev, next) => {
     prev.isCached === next.isCached &&
     prev.onPress === next.onPress &&
     prev.onLongPress === next.onLongPress &&
-    prev.onTagPress === next.onTagPress
+    prev.onTagPress === next.onTagPress &&
+    prev.prevDateKey === next.prevDateKey
   );
 });
 

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -24,6 +24,7 @@ import { HapticService } from '../utils/haptics';
 import { useNetworkStatus } from '../hooks/useNetworkStatus';
 import { GitHubActivityIndicator } from '../components/GitHubActivityIndicator';
 import { ViewMode, VIEW_MODE_ICONS } from '../utils/viewModes';
+import { formatJournalDate } from '../services/JournalService';
 import { NoteCard as NotesListCard } from '../components/notes/NoteCard';
 import { NotesListHeader } from '../components/notes/NotesListHeader';
 import { NotesViewModePicker } from '../components/notes/NotesViewModePicker';
@@ -325,27 +326,34 @@ export default function NotesListScreen() {
   );
 
   const renderNote = useCallback(
-    ({ item, index }: { item: Note; index: number }) => (
-      <SwipeableListItem
-        itemId={item.id}
-        selected={selectedIds.has(item.id)}
-        selectionMode={selectionMode}
-        onToggleSelect={() => toggleSelected(item.id)}
-      >
-        <NotesListCard
-          note={item}
-          viewMode={viewMode}
-          onPress={handleNotePress}
-          onLongPress={handleNoteLongPress}
-          highlighted={hasActiveSearch && index === currentSearchMatchIndex}
-          isOffline={isConnected === false}
-          isCached={!!item.content?.trim()}
-          onTagPress={handleTagPress}
-        />
-      </SwipeableListItem>
-    ),
+    ({ item, index }: { item: Note; index: number }) => {
+      const prev = index > 0 ? displayNotes[index - 1] : undefined;
+      const prevDateKey =
+        viewMode === 'journal' && prev?.updatedAt ? formatJournalDate(new Date(prev.updatedAt)) : undefined;
+      return (
+        <SwipeableListItem
+          itemId={item.id}
+          selected={selectedIds.has(item.id)}
+          selectionMode={selectionMode}
+          onToggleSelect={() => toggleSelected(item.id)}
+        >
+          <NotesListCard
+            note={item}
+            viewMode={viewMode}
+            onPress={handleNotePress}
+            onLongPress={handleNoteLongPress}
+            highlighted={hasActiveSearch && index === currentSearchMatchIndex}
+            isOffline={isConnected === false}
+            isCached={!!item.content?.trim()}
+            onTagPress={handleTagPress}
+            prevDateKey={prevDateKey}
+          />
+        </SwipeableListItem>
+      );
+    },
     [
       currentSearchMatchIndex,
+      displayNotes,
       handleNoteLongPress,
       handleNotePress,
       handleTagPress,


### PR DESCRIPTION
## Summary
- Journal view no longer prints a date label above every note; the day header now appears only on the first note of each day, so a day with N notes shows one header instead of N.
- Date label uses the existing `formatJournalDate` helper (`yyyy-MM-dd`) from `JournalService`, matching the format used elsewhere in the app instead of the locale default.

## Test plan
- [ ] Create 2+ notes on the same day, switch the Notes tab to Journal view, confirm only one date header appears above the group.
- [ ] Scroll to notes from a different day and confirm a new header appears for that day.
- [ ] Confirm header reads e.g. `2026-05-11` (ISO padded), not `2026-5-11` or a locale string.
- [ ] Confirm other view modes (list, grid, etc.) are unchanged.

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)