### PR TITLE
fix(editor): keep note body TextInput visible above keyboard

### DIFF
--- a/src/components/editor/NoteEditorForm.tsx
+++ b/src/components/editor/NoteEditorForm.tsx
@@ -60,7 +60,15 @@ export function NoteEditorForm({
 
   return (
     <View style={styles.container}>
-    <ScrollView style={styles.scrollView} contentContainerStyle={styles.editorContent} keyboardShouldPersistTaps="handled">
+    <ScrollView
+      style={styles.scrollView}
+      contentContainerStyle={styles.editorContent}
+      keyboardShouldPersistTaps="handled"
+      // Keep the focused body TextInput visible above the keyboard +
+      // sticky format toolbar (#727) — without this the multiline input
+      // sits behind the keyboard and users type blind on iOS.
+      automaticallyAdjustKeyboardInsets
+    >
       <View testID="note-editor-form.picker.repo" style={styles.gitContextContainer}>
         <GitContextPicker
           repo={repo}


### PR DESCRIPTION
## Summary
- The multiline note body `TextInput` lived inside a `ScrollView` with no keyboard inset adjustment, so on iOS the cursor sat behind the keyboard + sticky format toolbar (#698) and users typed blind.
- Enable `automaticallyAdjustKeyboardInsets` on the form's parent `ScrollView` so it lifts the focused input above the keyboard while the surrounding `KeyboardAvoidingView` keeps the toolbar pinned.
- Surgical one-prop change scoped to the body area; title/tags inputs are unaffected.

## Test plan
- [ ] Home -> Create New Note -> Markdown
- [ ] Tap into the body, type several lines and confirm the cursor + freshly-typed characters remain visible above the keyboard and format toolbar
- [ ] Confirm the title and tags inputs still behave normally
- [ ] Repeat on Android (KeyboardAvoidingView `height` behavior already in place)

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)