### PR TITLE
fix(note-viewer): show note title in header

### DIFF
--- a/src/components/editor/NoteViewer.tsx
+++ b/src/components/editor/NoteViewer.tsx
@@ -13,6 +13,7 @@ import { BacklinksSection } from '../backlinks/BacklinksSection';
 
 interface NoteViewerProps {
   noteId: string;
+  title: string;
   noteFormat: NoteFormat;
   canEdit: boolean;
   canSpeak: boolean;
@@ -44,6 +45,7 @@ interface NoteViewerProps {
 
 export function NoteViewer({
   noteId,
+  title,
   noteFormat,
   canEdit,
   canSpeak,
@@ -81,7 +83,14 @@ export function NoteViewer({
         <IconButton size="sm" testID="note-viewer.button.back" onPress={onBack} accessibilityLabel="Back">
           <Ionicons name="arrow-back" size={20} color={colors.accent} />
         </IconButton>
-        <View style={styles.flex} />
+        <Text
+          testID="note-viewer.text.title"
+          style={[styles.headerTitle, { color: colors.text }]}
+          numberOfLines={1}
+          ellipsizeMode="tail"
+        >
+          {title?.trim() || 'Untitled'}
+        </Text>
 
         {!isPdfNote && tocEntries.length > 0 ? (
           <IconButton
@@ -198,13 +207,18 @@ export function NoteViewer({
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  flex: { flex: 1 },
   header: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 8,
     paddingVertical: 12,
     borderBottomWidth: 1,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '600',
+    marginHorizontal: 4,
   },
   tocHeader: {
     flexDirection: 'row',

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -126,6 +126,7 @@ function NoteEditorScreenInner() {
     return (
         <NoteViewer
           noteId={noteId!}
+          title={document.title}
           noteFormat={document.noteFormat}
           canEdit={!isPdfNote}
           canSpeak={!isPdfNote && !!preview.speakableContent}


### PR DESCRIPTION
## Summary
- Replace the empty flex spacer in the note viewer header with a `Text` element bound to the document title.
- Use `numberOfLines={1}` + `ellipsizeMode="tail"` and matching typography (16/600) from `EditorHeader` so long titles don't break layout.
- Falls back to `Untitled` when the title is empty.

## Test plan
- [ ] Open a saved note with a normal title — header shows the title between back and speaker/edit icons.
- [ ] Open a long-titled note — title truncates with an ellipsis instead of pushing icons off-screen.
- [ ] Open an untitled note — header shows `Untitled`.
- [ ] Verify on both iPhone and iPad layouts.

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)