### PR TITLE
fix(ai): create_note tool now syncs to GitHub

### DIFF
--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -3,7 +3,6 @@ import { TodoCreateInput, TodoPriority, TodoUpdateInput } from '../../models/Tod
 import { useNoteStore } from '../../stores/noteStore';
 import { useTodoStore } from '../../stores/todoStore';
 import { useAIStore } from '../../stores/aiStore';
-import { getExtensionForFormat, slugifyLocal } from '../../components/editor/editorShared';
 import { NoteSyncQueueService } from '../NoteSyncQueueService';
 
 export interface ProposedChange {
@@ -177,14 +176,21 @@ export async function executeToolCall(
         // Enqueue an upsert so the note is pushed to GitHub on the next
         // queue drain. Other app sessions pick it up via the foreground
         // pull watcher (typically within the configured interval).
+        //
+        // Omit filePath so syncNoteToGitHub derives `notes/${slug}${ext}`
+        // and treats this as a brand-new file (#732). Pre-computing a
+        // bare `${slug}${ext}` here both pointed the file at repo root
+        // and tripped the updateFile "remote was deleted" guard, leaving
+        // the queue stuck with "GitHub API returned no result". The
+        // store-side Note record gets its filePath populated from the
+        // sync result on success (see applyPostSyncStorageUpdate), so
+        // mirror the manual-note path in useNoteEditorDocument.
         if (repoPath) {
-          const filePath = `${slugifyLocal(input.title)}${getExtensionForFormat(input.format)}`;
           try {
             await NoteSyncQueueService.enqueueNoteUpsert(
               {
                 repo: repoPath,
                 branch,
-                filePath,
                 title: input.title,
                 content: input.content,
                 format: input.format,


### PR DESCRIPTION
## Summary
- AI `create_note` was pre-computing `filePath = ${slug}${ext}` in `actionExecutor.ts`. That bare path landed the file at repo root (instead of `notes/`) because `syncNoteToGitHub` only auto-prefixes `notes/` when filePath is undefined.
- A truthy filePath also flipped `updateFile` into `expectExists: true`, so the missing remote sha was read as "remote was deleted, refuse to resurrect" — sync queue stuck with `lastError: "GitHub API returned no result"`.
- Fix mirrors the manual-note path in `useNoteEditorDocument.ts`: omit `filePath` from the enqueue call so `syncNoteToGitHub` derives `notes/${slug}${ext}` itself with `expectExists=false`. The local Note record still gets its filePath populated from the sync result via `applyPostSyncStorageUpdate`.

Closes #732

## Test plan
- [ ] Ask the AI: "create a note titled MaestroAITest with body Hello world".
- [ ] Confirm the note appears under `notes/maestroaitest.md` in the GitHub repo (not at repo root).
- [ ] Confirm the sync queue clears and no `GitHub API returned no result` error remains.
- [ ] Reopen the note in the app and verify it has a filePath set on the local Note record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)