### PR TITLE
fix(notes): render private-repo images via authenticated Contents API

### DIFF
--- a/src/components/editor/useNoteEditorPreview.ts
+++ b/src/components/editor/useNoteEditorPreview.ts
@@ -11,6 +11,7 @@ import { PositionMemoryService } from '../../services/PositionMemoryService';
 import { HapticService } from '../../utils/haptics';
 import { getMarkdownStyles } from '../../utils/preview';
 import { NotePreviewRenderer } from '../../utils/markdownRenderer';
+import { hasGitnotesImageUris, resolveGitnotesImageUris } from '../../utils/gitnotesImageResolver';
 import CanvasPreview from '../CanvasPreview';
 import {
   APPROX_LINE_PX,
@@ -81,7 +82,37 @@ export function useNoteEditorPreview({
     return `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`;
   }, []);
 
-  const previewContent = useMemo(() => getPreviewContent(content, noteFormat), [content, noteFormat]);
+  const rawPreviewContent = useMemo(() => getPreviewContent(content, noteFormat), [content, noteFormat]);
+
+  // Private-repo images are persisted as `gitnotes://repo-image/...` URIs by
+  // the upload path (#733) because GitHub's raw URLs 404 without a token and
+  // the signed `?token=` form expires within minutes — too short to ever
+  // pin into markdown. The resolver fetches each URI via the authenticated
+  // Contents API and substitutes a `data:image/...;base64,...` URI in
+  // memory for the renderer. Resolutions are cached per-process so reopens
+  // are free; first render of a note with N private images costs N parallel
+  // GETs. Public-repo images keep using the cheap raw URL — `previewContent`
+  // is identity-equal to `rawPreviewContent` in that case.
+  const [resolvedPreviewContent, setResolvedPreviewContent] = useState(rawPreviewContent);
+  useEffect(() => {
+    if (!hasGitnotesImageUris(rawPreviewContent)) {
+      setResolvedPreviewContent(rawPreviewContent);
+      return;
+    }
+    let cancelled = false;
+    // Show the markdown immediately with the unresolved URIs so layout is
+    // stable; expo-image will render its placeholder for the gitnotes://
+    // sources until the data: URIs land a tick later.
+    setResolvedPreviewContent(rawPreviewContent);
+    resolveGitnotesImageUris(rawPreviewContent).then((resolved) => {
+      if (cancelled) return;
+      if (resolved !== rawPreviewContent) setResolvedPreviewContent(resolved);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [rawPreviewContent]);
+  const previewContent = resolvedPreviewContent;
 
   useEffect(() => {
     headingPositionsRef.current.clear();

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -178,8 +178,50 @@ class GitHubServiceClass {
    */
   private shaCache = new Map<string, string>();
 
+  /**
+   * Per-process cache of `(owner/repo) → private`. Avoids a /repos/{owner}/{repo}
+   * round-trip on every save when deciding whether to write a public raw URL or
+   * the auth-required `gitnotes://repo-image/...` scheme for uploaded images
+   * (#733). Lifetime is the JS bundle — not durable, but a flipped visibility
+   * is rare enough that we accept the staleness window vs. plumbing storage.
+   */
+  private repoPrivacyCache = new Map<string, boolean>();
+
   private shaCacheKey(owner: string, repo: string, path: string, ref?: string): string {
     return `${owner}/${repo}/${path}@${ref ?? ''}`;
+  }
+
+  /**
+   * Returns the `private` flag for `owner/repo`. Cached per process.
+   * Falls back to `null` on lookup failure so callers can choose a safe
+   * default (#733 picks "treat as private" — the worst case is a new
+   * upload uses the auth-resolved scheme on a public repo, which still
+   * renders correctly).
+   */
+  async getRepoPrivacy(
+    owner: string,
+    repo: string,
+    opts?: TokenOpts,
+  ): Promise<boolean | null> {
+    const key = `${owner}/${repo}`;
+    const cached = this.repoPrivacyCache.get(key);
+    if (cached !== undefined) return cached;
+    try {
+      const data = await this.request<{ private?: boolean }>(
+        `https://api.github.com/repos/${owner}/${repo}`,
+        'GET',
+        undefined,
+        opts,
+      );
+      if (typeof data?.private === 'boolean') {
+        this.repoPrivacyCache.set(key, data.private);
+        return data.private;
+      }
+      return null;
+    } catch (error) {
+      console.warn('[GitHubService] Failed to get repo privacy:', error);
+      return null;
+    }
   }
 
   invalidateShaCache(owner: string, repo: string, path: string, ref?: string): void {
@@ -402,6 +444,35 @@ class GitHubServiceClass {
       return null;
     } catch (error) {
       console.warn('[GitHubService] Failed to get file content:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Fetches a file via the Contents API and returns the raw base64 (no UTF-8
+   * decode). Used by the renderer to inline private-repo image bytes as
+   * `data:` URIs for #733. Files larger than ~1 MB return empty `content`
+   * from this endpoint — for those callers should fall back to the blobs
+   * API; image attachments are well under that bound in practice.
+   */
+  async getFileBase64(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+    opts?: TokenOpts,
+  ): Promise<string | null> {
+    try {
+      const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+      let url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
+      if (ref) url += `?ref=${encodeURIComponent(ref)}`;
+      const data = await this.request(url, 'GET', undefined, opts);
+      if (data?.type === 'file' && typeof data.content === 'string' && data.content.length > 0) {
+        return data.content.replace(/\n/g, '');
+      }
+      return null;
+    } catch (error) {
+      console.warn('[GitHubService] Failed to get file base64:', error);
       return null;
     }
   }

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -233,6 +233,7 @@ async function uploadLocalImages(
   repo: string,
   branch: string,
   noteSlug: string,
+  opts?: { tokenOverride?: string },
 ): Promise<string> {
   const imageRegex = /(!\[[^\]]*\]\()([^)]+)(\))/g;
   let updatedContent = content;
@@ -246,6 +247,21 @@ async function uploadLocalImages(
     }
     match = imageRegex.exec(content);
   }
+
+  if (matches.length === 0) return updatedContent;
+
+  // Resolve once per save: a public repo gets the cheap raw URL (works
+  // unauthenticated, cacheable on CDNs); a private repo gets a stable
+  // `gitnotes://repo-image/...` scheme that the renderer resolves to a
+  // `data:` URI via the authenticated Contents API at view time. We can't
+  // pin a `?token=` raw URL because GitHub's signed download URLs expire
+  // after a few minutes — once persisted in markdown they 404 forever
+  // (#733).
+  const isPrivate = await GitHubService.getRepoPrivacy(owner, repo, opts);
+  // Conservative default on lookup failure: assume private. A public repo
+  // misclassified as private still renders correctly via the auth path; the
+  // reverse silently 404s for the user.
+  const usePrivateScheme = isPrivate !== false;
 
   for (const img of matches) {
     try {
@@ -271,10 +287,12 @@ async function uploadLocalImages(
       );
 
       if (uploadResult) {
-        const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${imagePath}`;
+        const persistedUrl = usePrivateScheme
+          ? `gitnotes://repo-image/${owner}/${repo}/${encodeURIComponent(branch)}/${imagePath}`
+          : `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${imagePath}`;
         updatedContent = updatedContent.replace(
           `${img.fullPrefix}${img.uri}${img.fullSuffix}`,
-          `${img.fullPrefix}${rawUrl}${img.fullSuffix}`,
+          `${img.fullPrefix}${persistedUrl}${img.fullSuffix}`,
         );
       } else {
         console.warn('[NoteGitHubSync] Failed to upload image:', imageName);
@@ -427,7 +445,7 @@ export async function syncNoteToGitHub(params: {
   let finalContent = applyNoteTagsToContent(content, format, tags);
   finalContent = applyNoteColorToContent(finalContent, format, color);
   try {
-    finalContent = await uploadLocalImages(finalContent, repoInfo.owner, repoInfo.repo, targetBranch, noteSlug);
+    finalContent = await uploadLocalImages(finalContent, repoInfo.owner, repoInfo.repo, targetBranch, noteSlug, opts);
   } catch (error) {
     console.warn('[NoteGitHubSync] Image upload failed, syncing note without images:', error);
   }

--- a/src/utils/gitnotesImageResolver.ts
+++ b/src/utils/gitnotesImageResolver.ts
@@ -1,0 +1,159 @@
+// Resolves the app-internal `gitnotes://repo-image/<owner>/<repo>/<branch>/<path>`
+// image scheme that `NoteGitHubSyncService.uploadLocalImages` writes for
+// **private** repos (#733). The renderer can't load these directly because
+// `https://raw.githubusercontent.com/...` 404s on private repos and signed
+// `?token=` raw URLs expire after a few minutes — so we fetch the bytes via
+// the authenticated Contents API on demand and inline them as a `data:` URI.
+//
+// Public-repo images keep using the cheap raw URL (cacheable on GitHub's CDN,
+// no token needed). This module is a no-op for content that contains no
+// `gitnotes://repo-image/...` URIs.
+
+import { GitHubService } from '../services/GitHubService';
+
+const GITNOTES_IMAGE_URI_RE = /gitnotes:\/\/repo-image\/([^/\s)]+)\/([^/\s)]+)\/([^/\s)]+)\/([^\s)]+)/g;
+
+// Per-process cache: `gitnotes://...` URI → resolved `data:` URI. Resolution
+// is deterministic given the same URI for as long as the file's bytes haven't
+// changed on GitHub. A ref pinned to a branch can shift, but in practice the
+// upload writes a single immutable image path per attachment, so re-edits of
+// the *note* don't need to re-fetch the *image*. We accept that an out-of-band
+// overwrite of the image at the same path won't be picked up until the JS
+// bundle restarts — that mirrors how the rest of the app caches GitHub reads.
+const dataUriCache = new Map<string, string>();
+
+// Per-process in-flight dedupe so two simultaneous renders of the same note
+// (preview + viewer, mode flips) don't issue parallel Contents API calls for
+// the same image.
+const inFlight = new Map<string, Promise<string | null>>();
+
+function mimeFromPath(path: string): string {
+  const lower = path.toLowerCase();
+  const dot = lower.lastIndexOf('.');
+  const ext = dot >= 0 ? lower.slice(dot + 1) : '';
+  switch (ext) {
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'png':
+      return 'image/png';
+    case 'gif':
+      return 'image/gif';
+    case 'webp':
+      return 'image/webp';
+    case 'svg':
+      return 'image/svg+xml';
+    case 'bmp':
+      return 'image/bmp';
+    default:
+      // Best-effort fallback. Most note images are jpg/png from the picker.
+      return 'image/jpeg';
+  }
+}
+
+interface ParsedGitnotesImage {
+  uri: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  path: string;
+}
+
+function parseGitnotesImage(uri: string): ParsedGitnotesImage | null {
+  const m = uri.match(/^gitnotes:\/\/repo-image\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/);
+  if (!m) return null;
+  try {
+    return {
+      uri,
+      owner: decodeURIComponent(m[1]),
+      repo: decodeURIComponent(m[2]),
+      branch: decodeURIComponent(m[3]),
+      path: m[4],
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function resolveOne(parsed: ParsedGitnotesImage, opts?: { tokenOverride?: string }): Promise<string | null> {
+  const cached = dataUriCache.get(parsed.uri);
+  if (cached) return cached;
+
+  const inflight = inFlight.get(parsed.uri);
+  if (inflight) return inflight;
+
+  const promise = (async () => {
+    try {
+      const base64 = await GitHubService.getFileBase64(
+        parsed.owner,
+        parsed.repo,
+        parsed.path,
+        parsed.branch,
+        opts,
+      );
+      if (!base64) return null;
+      const dataUri = `data:${mimeFromPath(parsed.path)};base64,${base64}`;
+      dataUriCache.set(parsed.uri, dataUri);
+      return dataUri;
+    } catch (error) {
+      console.warn('[gitnotesImageResolver] Failed to resolve image:', parsed.uri, error);
+      return null;
+    } finally {
+      inFlight.delete(parsed.uri);
+    }
+  })();
+
+  inFlight.set(parsed.uri, promise);
+  return promise;
+}
+
+/**
+ * Returns true iff `content` contains at least one `gitnotes://repo-image/`
+ * URI. Cheap pre-check so callers can skip the resolver entirely for the
+ * common case (most notes have no images, or only the public raw URL form).
+ */
+export function hasGitnotesImageUris(content: string): boolean {
+  return content.includes('gitnotes://repo-image/');
+}
+
+/**
+ * Walks `content`, fetches every `gitnotes://repo-image/...` image via the
+ * authenticated Contents API, and replaces each occurrence with a
+ * `data:<mime>;base64,...` URI. Failures leave the original URI in place
+ * (the renderer will show its built-in broken-image fallback).
+ *
+ * Resolutions are cached in-memory keyed by the URI, so repeat renders of
+ * the same note don't re-hit the network.
+ */
+export async function resolveGitnotesImageUris(
+  content: string,
+  opts?: { tokenOverride?: string },
+): Promise<string> {
+  if (!hasGitnotesImageUris(content)) return content;
+
+  // Collect unique URIs first so a note with the same image inserted twice
+  // only fetches once.
+  const seen = new Set<string>();
+  const targets: ParsedGitnotesImage[] = [];
+  let match: RegExpExecArray | null;
+  GITNOTES_IMAGE_URI_RE.lastIndex = 0;
+  while ((match = GITNOTES_IMAGE_URI_RE.exec(content)) !== null) {
+    const uri = match[0];
+    if (seen.has(uri)) continue;
+    seen.add(uri);
+    const parsed = parseGitnotesImage(uri);
+    if (parsed) targets.push(parsed);
+  }
+  if (targets.length === 0) return content;
+
+  const resolutions = await Promise.all(targets.map((t) => resolveOne(t, opts)));
+
+  let out = content;
+  targets.forEach((target, i) => {
+    const replacement = resolutions[i];
+    if (!replacement) return;
+    // Replace every occurrence of this URI in the content.
+    out = out.split(target.uri).join(replacement);
+  });
+  return out;
+}


### PR DESCRIPTION
## Summary

- **Upload-side** (`NoteGitHubSyncService.uploadLocalImages`): for private repos, write a stable `gitnotes://repo-image/<owner>/<repo>/<branch>/<path>` scheme into the markdown instead of the unauth `https://raw.githubusercontent.com/...` URL — that URL 404s on private repos, and the signed `?token=` form expires within minutes so it can't be persisted. Public repos keep the cheap raw URL (no behavior change).
- **Render-side** (`src/utils/gitnotesImageResolver.ts` + `useNoteEditorPreview`): a resolver walks `previewContent`, fetches each `gitnotes://repo-image/...` URI as base64 via `GitHubService.getFileBase64` (new — Contents API), and substitutes a `data:<mime>;base64,...` URI before the renderer sees it.
- **Caching**: per-process `Map` keyed by URI for resolved data URIs; in-flight dedupe so simultaneous render passes (preview + viewer) collapse to one fetch. Repo-privacy lookups are also cached per process to avoid `/repos/{owner}/{repo}` round-trips on every save.
- **Migration**: out of scope. Notes saved before this change still have the broken raw URLs in their markdown — they'll continue to render blank until re-saved. New uploads use the new scheme; renderer only resolves the new scheme.

## Test plan

- [ ] **Private repo**: insert an image into a note, save, navigate away, reopen → image renders (not blank).
- [ ] **Private repo**: kill and reopen the app, open the same note → image still renders (resolver re-fetches; no stale local-only state required).
- [ ] **Private repo**: open the note on a second device after sync → image renders there too (URL no longer pinned to a single auth context).
- [ ] **Public repo**: insert an image into a note, save, reopen → image renders (still served via raw URL CDN, no auth round-trip).
- [ ] **No images**: notes without images and notes with only the legacy raw URL render unchanged.

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)