### PR TITLE
fix(ipad): align tab-bar testIDs with contract

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -77,7 +77,7 @@ function TabletRail({ state, navigation }: BottomTabBarProps) {
           return (
             <TouchableOpacity
               key={route.key}
-              testID={`tab-bar-nav.tab.press-${route.name}`}
+              testID={`tab-bar.tab.press-${route.name}`}
               accessibilityRole="tab"
               accessibilityState={isFocused ? { selected: true } : {}}
               accessibilityLabel={t(config.labelKey)}


### PR DESCRIPTION
## Summary

- iPad sidebar (`TabletRail` in `src/navigation/TabNavigator.tsx`) emitted `tab-bar-nav.tab.press-<name>`, breaking the `e2e/TESTID_CONTRACT.md` `scope.elementType.action` rule and diverging from the iPhone canonical `tab-bar.tab.press-<name>`.
- Renamed the iPad prefix to match the iPhone `TabBar` so a single Maestro selector works on both form factors.

## Test plan

- [ ] Boot iPad simulator
- [ ] Run Maestro hierarchy dump and confirm tabs expose `tab-bar.tab.press-*` (not `tab-bar-nav.*`)
- [ ] `yarn e2e:testid:validate` passes

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)