### PR TITLE
fix(todos): give each priority chip a unique testID

### DIFF
--- a/e2e/coverage-manifest.json
+++ b/e2e/coverage-manifest.json
@@ -1495,7 +1495,7 @@
     "component": "TodoEditorModal",
     "elementType": "button",
     "action": "onChangePriority",
-    "testID": "todo-editor.button.priority",
+    "testID": "todo-editor.button.priority-${priority}",
     "flowId": "todos",
     "platform": ["ios", "android"]
   },

--- a/src/components/todos/TodoEditorModal.tsx
+++ b/src/components/todos/TodoEditorModal.tsx
@@ -128,7 +128,7 @@ export function TodoEditorModal({
               {(['low', 'medium', 'high'] as TodoPriority[]).map((priority) => (
                 <TouchableOpacity
                   key={priority}
-                  testID="todo-editor.button.priority"
+                  testID={`todo-editor.button.priority-${priority}`}
                   style={[
                     styles.priorityOption,
                     { borderColor: colors.border },


### PR DESCRIPTION
## Summary
- All three priority chips (Low/Medium/High) in `TodoEditorModal` shared `testID="todo-editor.button.priority"`, breaking unique-element selection in e2e flows.
- Suffix the testID with the priority value, yielding `todo-editor.button.priority-low|-medium|-high`.
- Coverage manifest updated to the templated `${priority}` form already used by other multi-instance entries (note-card, sort-option).

## Test plan
- [ ] Open the Todo editor (new or edit) and dump the view hierarchy.
- [ ] Confirm three distinct testIDs: `todo-editor.button.priority-low`, `todo-editor.button.priority-medium`, `todo-editor.button.priority-high`.
- [ ] Tap each chip individually via its unique testID and verify the matching priority is selected.
- [ ] `bun run e2e/scripts/validate-coverage.ts` (or `npx tsx`) — priority entry remains covered (prefix match still works).

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)