### PR TITLE
fix(home): use stable slot-index testIDs on bento tiles

### DIFF
--- a/e2e/coverage-manifest.json
+++ b/e2e/coverage-manifest.json
@@ -2477,7 +2477,7 @@
     "component": "BentoTile",
     "elementType": "button",
     "action": "onPress",
-    "testID": "bento-tile.button.press",
+    "testID": "bento-tile.button.press-${slot}",
     "flowId": "home-nav",
     "platform": ["ios", "android"]
   },

--- a/src/components/home/BentoRecent.tsx
+++ b/src/components/home/BentoRecent.tsx
@@ -32,13 +32,21 @@ export function BentoRecent({ items, onOpen }: Props) {
     <View testID="bento-recent.button.open" style={styles.section}>
       <Text style={[styles.heading, { color: colors.textSecondary }]}>Recent</Text>
       <View style={styles.column}>
-        {rows.map((row, idx) => (
-          <View key={`recent-row-${idx}`} style={styles.row}>
-            {row.map((item) => (
-              <View key={`${item.kind}-${item.data.id}`} style={styles.cell}>
-                <BentoTile item={item} size="medium" onPress={() => onOpen(item)} />
-              </View>
-            ))}
+        {rows.map((row, rowIdx) => (
+          <View key={`recent-row-${rowIdx}`} style={styles.row}>
+            {row.map((item, colIdx) => {
+              const flatIdx = rowIdx * 2 + colIdx;
+              return (
+                <View key={`${item.kind}-${item.data.id}`} style={styles.cell}>
+                  <BentoTile
+                    item={item}
+                    size="medium"
+                    onPress={() => onOpen(item)}
+                    testIDSlot={`recent-${flatIdx}`}
+                  />
+                </View>
+              );
+            })}
             {row.length === 1 ? <View style={styles.cell} /> : null}
           </View>
         ))}

--- a/src/components/home/BentoTile.tsx
+++ b/src/components/home/BentoTile.tsx
@@ -14,6 +14,9 @@ interface Props {
   onPress: () => void;
   widthOverride?: number;
   hidePinGlyph?: boolean;
+  // Stable slot label for testIDs — render-order index from the parent list.
+  // Maestro can't pin against the dynamic note id (changes every install).
+  testIDSlot: string;
 }
 
 function relativeTime(ms: number): string {
@@ -128,7 +131,7 @@ const TILE_WIDTH_HINT: Record<BentoSize, number> = { large: 320, medium: 160, sm
 const SNIPPET_LINES: Record<BentoSize, number> = { large: 3, medium: 2, small: 1, pinned: 2 };
 const COLOR_STRIPE_WIDTH = 4;
 
-export function BentoTile({ item, size, onPress, widthOverride, hidePinGlyph }: Props) {
+export function BentoTile({ item, size, onPress, widthOverride, hidePinGlyph, testIDSlot }: Props) {
   const { colors } = useTheme();
   const isLarge = size === 'large';
   const isMedium = size === 'medium';
@@ -161,7 +164,7 @@ export function BentoTile({ item, size, onPress, widthOverride, hidePinGlyph }: 
     const scene = item.data.scene;
     return (
       <Pressable
-        testID={`bento-tile.button.press-${item.data.id}`}
+        testID={`bento-tile.button.press-${testIDSlot}`}
         onPress={onPress}
         style={({ pressed }) => [
           styles.tile,
@@ -213,7 +216,7 @@ export function BentoTile({ item, size, onPress, widthOverride, hidePinGlyph }: 
 
     return (
       <Pressable
-        testID={`bento-tile.button.press-${item.data.id}`}
+        testID={`bento-tile.button.press-${testIDSlot}`}
         onPress={onPress}
         style={({ pressed }) => [
           styles.tile,
@@ -274,7 +277,7 @@ export function BentoTile({ item, size, onPress, widthOverride, hidePinGlyph }: 
 
   return (
     <Pressable
-      testID={`bento-tile.button.press-${item.data.id}`}
+      testID={`bento-tile.button.press-${testIDSlot}`}
       onPress={onPress}
       style={({ pressed }) => [
         styles.tile,

--- a/src/components/home/QuickAccessShelf.tsx
+++ b/src/components/home/QuickAccessShelf.tsx
@@ -28,7 +28,7 @@ export function QuickAccessShelf({ items, onOpen }: Props) {
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.row}
       >
-        {items.map((item) => (
+        {items.map((item, idx) => (
           <BentoTile
             key={`${item.kind}-${item.data.id}`}
             item={item}
@@ -36,6 +36,7 @@ export function QuickAccessShelf({ items, onOpen }: Props) {
             widthOverride={CARD_WIDTH}
             hidePinGlyph
             onPress={() => onOpen(item)}
+            testIDSlot={`pinned-${idx}`}
           />
         ))}
       </ScrollView>


### PR DESCRIPTION
## Summary
- Bento tiles emitted `bento-tile.button.press-<noteId>` where the note id is a `${Date.now()}-${random}` suffix baked at install time, making them unmatchable in Maestro across reinstalls.
- Switched to a render-order slot label threaded from each parent list: `recent-0..N` for the Recent grid, `pinned-0..N` for Quick Access.
- Coverage manifest updated to the templated `press-${slot}` form, matching the convention used by note-card, sort-option, and the todo priority chips (#711).

## Test plan
- [ ] Open Home with at least one recent note and one pinned tile.
- [ ] Dump UI hierarchy via Maestro and confirm `bento-tile.button.press-recent-0` and `bento-tile.button.press-pinned-0` are present.
- [ ] Reinstall the app and confirm the same testIDs appear (no timestamp suffix).
- [ ] Tap one and confirm navigation still works.

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)