### PR TITLE
fix(settings): sync-engine enable testID conforms to contract

### DIFF
--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -454,7 +454,7 @@ export function SettingsContent(props: SettingsContentProps) {
                       </View>
                     ) : (
                       <View testID="settings.button.enable-clone">
-                        <TouchableOpacity testID={`sync-engine-enable-${repo.path}`} onPress={() => onEnableCloneMode(repo)} style={{ padding: 4 }}>
+                        <TouchableOpacity testID={`settings.toggle.sync-engine-enable-${repo.path.replace('/', '-')}`} onPress={() => onEnableCloneMode(repo)} style={{ padding: 4 }}>
                           <Text style={[styles.settingLabel, { color: colors.primary }]}>Clone</Text>
                         </TouchableOpacity>
                       </View>


### PR DESCRIPTION
## Summary

- Renames the Settings repo sync-engine enable toggle from `sync-engine-enable-${repo.path}` to `settings.toggle.sync-engine-enable-${owner}-${repo}`, satisfying the `scope.elementType.action[-variant]` rule in `e2e/TESTID_CONTRACT.md`.
- Replaces the `/` in `owner/repo` with `-` so Maestro selectors no longer choke on the slash.
- testID validator left untouched: adding a slash/dot rule was optional and would balloon the change beyond a surgical fix; can land in a follow-up.

## Test plan

- [ ] Open Settings, scroll to a repo whose sync engine is `api` (Clone button visible).
- [ ] Dump Maestro hierarchy and confirm the toggle's testID is `settings.toggle.sync-engine-enable-<owner>-<repo>` (e.g. `settings.toggle.sync-engine-enable-vidwadeseram-test-notes`).
- [ ] Verify tapping it still triggers `onEnableCloneMode` (Cloning spinner / `Use API` swap).

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)