### PR TITLE
fix(notes): note-card and search-bar emit duplicate testIDs

### DIFF
--- a/.maestro/context-menu.yaml
+++ b/.maestro/context-menu.yaml
@@ -13,8 +13,7 @@ appId: com.xaventra.gitnotes
 # Long-press the first list card. Avoids depending on a specific
 # note title, which depends on the active sort order.
 - longPressOn:
-    id: "notes-list-card.button.press"
-    index: 0
+    id: "notes-list.button.press-card-0"
 - waitForAnimationToEnd:
     timeout: 1000
 

--- a/.maestro/editor-search.yaml
+++ b/.maestro/editor-search.yaml
@@ -12,8 +12,7 @@ appId: com.xaventra.gitnotes
 - waitForAnimationToEnd:
     timeout: 1500
 - tapOn:
-    id: "notes-list-card.button.press"
-    index: 0
+    id: "notes-list.button.press-card-0"
 - waitForAnimationToEnd:
     timeout: 1500
 - tapOn:

--- a/.maestro/editor-toolbar.yaml
+++ b/.maestro/editor-toolbar.yaml
@@ -20,8 +20,7 @@ appId: com.xaventra.gitnotes
     timeout: 800
 
 - tapOn:
-    id: "notes-list-card.button.press"
-    index: 0
+    id: "notes-list.button.press-card-0"
 - waitForAnimationToEnd:
     timeout: 1500
 - tapOn:

--- a/.maestro/note-duplicate.yaml
+++ b/.maestro/note-duplicate.yaml
@@ -21,8 +21,7 @@ appId: com.xaventra.gitnotes
     timeout: 800
 
 - longPressOn:
-    id: "notes-list-card.button.press"
-    index: 0
+    id: "notes-list.button.press-card-0"
 - waitForAnimationToEnd:
     timeout: 1000
 
@@ -37,8 +36,6 @@ appId: com.xaventra.gitnotes
 # rename pattern, so just verify two list cards exist (we already had
 # >=2 before — point is no crash).
 - assertVisible:
-    id: "notes-list-card.button.press"
-    index: 0
+    id: "notes-list.button.press-card-0"
 - assertVisible:
-    id: "notes-list-card.button.press"
-    index: 1
+    id: "notes-list.button.press-card-1"

--- a/.maestro/note-edit-body.yaml
+++ b/.maestro/note-edit-body.yaml
@@ -42,8 +42,7 @@ appId: com.xaventra.gitnotes
 
 # Re-open it for editing.
 - tapOn:
-    id: "notes-list-card.button.press"
-    index: 0
+    id: "notes-list.button.press-card-0"
 - waitForAnimationToEnd:
     timeout: 1500
 - tapOn:

--- a/.maestro/note-open.yaml
+++ b/.maestro/note-open.yaml
@@ -12,8 +12,7 @@ appId: com.xaventra.gitnotes
 
 # Open the first note in the list — order-independent.
 - tapOn:
-    id: "notes-list-card.button.press"
-    index: 0
+    id: "notes-list.button.press-card-0"
 - waitForAnimationToEnd:
     timeout: 2000
 

--- a/.maestro/pull-refresh.yaml
+++ b/.maestro/pull-refresh.yaml
@@ -20,5 +20,4 @@ appId: com.xaventra.gitnotes
 # Any note card is fine — we just need proof the list rendered after
 # the refresh finished, not a specific seed.
 - assertVisible:
-    id: "notes-list-card.button.press"
-    index: 0
+    id: "notes-list.button.press-card-0"

--- a/e2e/coverage-manifest.json
+++ b/e2e/coverage-manifest.json
@@ -388,20 +388,11 @@
     "platform": ["ios", "android"]
   },
   {
-    "file": "src/screens/NotesListScreen.tsx",
+    "file": "src/components/notes/NoteCard.tsx",
     "component": "NotesListCard",
     "elementType": "button",
     "action": "press-note",
-    "testID": "notes-list-card.button.press",
-    "flowId": "notes",
-    "platform": ["ios", "android"]
-  },
-  {
-    "file": "src/screens/NotesListScreen.tsx",
-    "component": "NotesListCard",
-    "elementType": "button",
-    "action": "long-press-note",
-    "testID": "note-card-${id}",
+    "testID": "notes-list.button.press-card-${index}",
     "flowId": "notes",
     "platform": ["ios", "android"]
   },
@@ -1592,27 +1583,9 @@
   {
     "file": "src/components/notes/NoteCard.tsx",
     "component": "NoteCard",
-    "elementType": "button",
-    "action": "onPress",
-    "testID": "note-card.button.press",
-    "flowId": "notes",
-    "platform": ["ios", "android"]
-  },
-  {
-    "file": "src/components/notes/NoteCard.tsx",
-    "component": "NoteCard",
     "elementType": "swipe-action",
     "action": "onSwipe",
     "testID": "note-card.swipe.action",
-    "flowId": "notes",
-    "platform": ["ios", "android"]
-  },
-  {
-    "file": "src/components/notes/NotesListHeader.tsx",
-    "component": "NotesListHeader",
-    "elementType": "search-bar",
-    "action": "onSearchChange",
-    "testID": "notes-list-header.search-bar.search",
     "flowId": "notes",
     "platform": ["ios", "android"]
   },
@@ -2213,15 +2186,6 @@
   {
     "file": "src/components/SearchBar.tsx",
     "component": "SearchBar",
-    "elementType": "search-bar",
-    "action": "onChangeText",
-    "testID": "search-bar.input.search",
-    "flowId": "home-nav",
-    "platform": ["ios", "android"]
-  },
-  {
-    "file": "src/components/SearchBar.tsx",
-    "component": "SearchBar",
     "elementType": "icon-button",
     "action": "onClear",
     "testID": "search-bar.icon-button.clear",
@@ -2622,15 +2586,6 @@
     "elementType": "toolbar-action",
     "action": "onToolbarAction",
     "testID": "markdown-editor.toolbar-action.press",
-    "flowId": "notes",
-    "platform": ["ios", "android"]
-  },
-  {
-    "file": "src/components/NoteCard.tsx",
-    "component": "NoteCard",
-    "elementType": "button",
-    "action": "onPress",
-    "testID": "note-card-root.button.press",
     "flowId": "notes",
     "platform": ["ios", "android"]
   },

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -53,8 +53,7 @@ function NoteCardImpl({
   const { allTags: mergedTags } = useNoteTags(note.tags ?? [], note.content ?? '');
 
   return (
-    <View testID="note-card.button.press">
-      <TouchableOpacity
+    <TouchableOpacity
       style={[
         styles.card,
         {
@@ -69,7 +68,6 @@ function NoteCardImpl({
         noteColorStyle,
         highlighted && { borderWidth: 2, borderColor: colors.primary },
       ]}
-      testID={`note-card-${note.id}`}
       onPress={() => onPress(note)}
       onLongPress={() => onLongPress?.(note)}
       activeOpacity={0.7}
@@ -81,7 +79,6 @@ function NoteCardImpl({
       )}
       <View style={styles.header}>
         <Text
-          testID={`note-card-title-${note.id}`}
           style={[styles.title, { color: titleColor }, showCompact && styles.titleCompact]}
           numberOfLines={showCompact ? 1 : 2}
         >
@@ -89,7 +86,6 @@ function NoteCardImpl({
         </Text>
         {!showCompact && (
           <Text
-            testID={`note-card-content-${note.id}`}
             style={[styles.content, { color: colors.textSecondary }]}
             numberOfLines={isCard ? 3 : 2}
           >
@@ -160,7 +156,6 @@ function NoteCardImpl({
         </View>
       )}
     </TouchableOpacity>
-    </View>
   );
 }
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -37,8 +37,7 @@ export default function SearchBar({
       autoCorrect={false}
       autoCapitalize="none"
       containerStyle={style}
-      surfaceTestID={testID}
-      testID="search-bar.input.search"
+      testID={testID}
       leading={<Ionicons name="search" size={20} color={colors.textSecondary} />}
       trailing={
         value.length > 0 ? (

--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -18,6 +18,8 @@ interface NotesNoteCardProps {
   onTagPress?: (tag: string) => void;
   /** Date key (yyyy-MM-dd) of the previous note in the list, used by journal view to group entries under one header per day. */
   prevDateKey?: string;
+  /** Render-order index from the parent list — used for the canonical card testID so Maestro can target stable slots. */
+  index: number;
 }
 
 function journalDateKey(timestamp: number | undefined): string {
@@ -35,11 +37,12 @@ function NotesNoteCardImpl({
   isCached,
   onTagPress,
   prevDateKey,
+  index,
 }: NotesNoteCardProps) {
   const { colors } = useTheme();
 
   const content = (
-    <View testID="notes-list-card.button.press" {...({ note } as { note: Note })}>
+    <View testID={`notes-list.button.press-card-${index}`} {...({ note } as { note: Note })}>
       <BaseNoteCard
         note={note}
         onPress={onPress}
@@ -56,18 +59,16 @@ function NotesNoteCardImpl({
     const currentDateKey = journalDateKey(note.updatedAt);
     const showDate = currentDateKey !== '' && currentDateKey !== prevDateKey;
     return (
-      <View testID="note-card-root.button.press">
-        <View {...({ note } as { note: Note })} style={styles.journalItem}>
-          {showDate ? (
-            <Text style={[styles.journalDate, { color: colors.textSecondary }]}>{currentDateKey}</Text>
-          ) : null}
-          {content}
-        </View>
+      <View {...({ note } as { note: Note })} style={styles.journalItem}>
+        {showDate ? (
+          <Text style={[styles.journalDate, { color: colors.textSecondary }]}>{currentDateKey}</Text>
+        ) : null}
+        {content}
       </View>
     );
   }
 
-  return <View testID="note-card-root.button.press">{content}</View>;
+  return content;
 }
 
 export const NoteCard = memo(NotesNoteCardImpl, (prev, next) => {
@@ -80,7 +81,8 @@ export const NoteCard = memo(NotesNoteCardImpl, (prev, next) => {
     prev.onPress === next.onPress &&
     prev.onLongPress === next.onLongPress &&
     prev.onTagPress === next.onTagPress &&
-    prev.prevDateKey === next.prevDateKey
+    prev.prevDateKey === next.prevDateKey &&
+    prev.index === next.index
   );
 });
 

--- a/src/components/notes/NotesListHeader.tsx
+++ b/src/components/notes/NotesListHeader.tsx
@@ -42,7 +42,7 @@ export function NotesListHeader({
 
   return (
     <>
-      <View testID="notes-list-header.search-bar.search" style={styles.topBar}>
+      <View style={styles.topBar}>
         <SearchBar
           testID="notes-list.search-bar.search"
           value={searchQuery}

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -347,6 +347,7 @@ export default function NotesListScreen() {
             isCached={!!item.content?.trim()}
             onTagPress={handleTagPress}
             prevDateKey={prevDateKey}
+            index={index}
           />
         </SwipeableListItem>
       );


### PR DESCRIPTION
## Summary
- Note rows now emit a single canonical `notes-list.button.press-card-${index}` testID. Drops the three wrapper duplicates (`note-card.button.press`, `note-card-root.button.press`, `notes-list-card.button.press`) and the unstable per-id variants (`note-card-${id}`, `-title-`, `-content-`) that baked install-time `Date.now()` randomness Maestro can't pin against.
- Slot index is threaded from the `NotesListScreen` FlatList renderer, mirroring the bento-tile fix in PR #742 / #715.
- Search bar: route the parent-supplied testID straight through to the inner TextInput (drops `surfaceTestID` double-tag) and remove the hardcoded `search-bar.input.search` fallback. Each consumer (notes, todos, canvas, explore) already supplies its own screen-namespaced id; the notes-list header also drops its outer `notes-list-header.search-bar.search` wrapper. Result: one testID per TextInput.
- Maestro flows (`note-open`, `editor-toolbar`, `editor-search`, `note-edit-body`, `pull-refresh`, `note-duplicate`, `context-menu`) and `e2e/coverage-manifest.json` updated to the new canonical ids.

## Test plan
- [ ] Open the Notes tab and dump the view hierarchy; each note row reports exactly one testID matching `notes-list.button.press-card-<n>` (no `note-card.*`, no `note-card-root.*`, no `notes-list-card.button.press`).
- [ ] Search bar in the notes header reports only `notes-list.search-bar.search` (no `search-bar.input.search`, no `notes-list-header.search-bar.search`).
- [ ] Maestro: `note-open`, `note-duplicate`, `pull-refresh`, `editor-toolbar`, `editor-search`, `note-edit-body`, `context-menu` flows still resolve the first card and exercise the long-press / tap actions.
- [ ] `notes-list.search-bar.search` flows (`e2e/{ios,android}/smoke/navigation.yaml`, `e2e/android/full/notes-list.yaml`) still type into the search box.

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)