### PR TITLE
feat(ai): show in-flight chat status strip with model, timer, cancel

### DIFF
--- a/src/components/ai/ChatLoadingStrip.tsx
+++ b/src/components/ai/ChatLoadingStrip.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import { Platform, Pressable, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTokens } from '../../contexts/ThemeContext';
+
+export interface ChatLoadingStripProps {
+  visible: boolean;
+  model?: string;
+  provider?: string;
+  startedAt: number;
+  onCancel: () => void;
+}
+
+export function ChatLoadingStrip({ visible, model, provider, startedAt, onCancel }: ChatLoadingStripProps) {
+  const { colors, spacing, type, radii } = useTokens();
+  const [elapsedMs, setElapsedMs] = useState(() => Math.max(0, Date.now() - startedAt));
+
+  useEffect(() => {
+    if (!visible) return;
+    setElapsedMs(Math.max(0, Date.now() - startedAt));
+    const id = setInterval(() => setElapsedMs(Math.max(0, Date.now() - startedAt)), 100);
+    return () => clearInterval(id);
+  }, [visible, startedAt]);
+
+  if (!visible) return null;
+
+  const pillLabel = [model, provider].filter(Boolean).join(' · ') || 'AI';
+
+  return (
+    <View
+      testID="chat.status.strip"
+      accessible
+      accessibilityLiveRegion="polite"
+      accessibilityLabel={`Generating with ${pillLabel}, ${(elapsedMs / 1000).toFixed(1)} seconds elapsed`}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: colors.elevated,
+        borderTopWidth: 1,
+        borderTopColor: colors.border,
+        paddingHorizontal: spacing[3],
+        paddingVertical: spacing[2],
+        gap: spacing[2],
+      }}
+    >
+      <View
+        style={{
+          flexShrink: 1,
+          backgroundColor: colors.accent + '20',
+          borderRadius: radii.sm,
+          paddingHorizontal: spacing[2],
+          paddingVertical: spacing[1],
+          maxWidth: '60%',
+        }}
+      >
+        <Text
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          style={{ fontSize: type.xs, color: colors.accent, fontWeight: '600' }}
+        >
+          {pillLabel}
+        </Text>
+      </View>
+
+      <Text
+        style={{
+          fontSize: type.xs,
+          color: colors.textSecondary,
+          fontVariant: ['tabular-nums'],
+          fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: undefined }),
+        }}
+      >
+        {(elapsedMs / 1000).toFixed(1)}s
+      </Text>
+
+      <View style={{ flex: 1 }} />
+
+      <Pressable
+        testID="chat.status.cancel"
+        accessibilityRole="button"
+        accessibilityLabel="Cancel AI response"
+        onPress={onCancel}
+        hitSlop={8}
+        style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[1] }}
+      >
+        <Ionicons name="close-circle" size={18} color={colors.textSecondary} />
+        <Text style={{ fontSize: type.xs, color: colors.textSecondary }}>Cancel</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/src/components/chat/useChatScreenController.ts
+++ b/src/components/chat/useChatScreenController.ts
@@ -59,6 +59,7 @@ export function useChatScreenController(threadId: string) {
   const [pendingConfirmation, setPendingConfirmation] = useState<PendingConfirmation | null>(null);
   const [retryPayload, setRetryPayload] = useState<RetryPayload | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [streamStartedAt, setStreamStartedAt] = useState<number>(0);
 
   const thread = activeThread?.id === threadId ? activeThread : null;
   const messages = thread?.messages ?? [];
@@ -128,6 +129,7 @@ export function useChatScreenController(threadId: string) {
     setLocalError(null);
     clearError();
     setPendingConfirmation(null);
+    setStreamStartedAt(Date.now());
     setStreaming(true);
 
     abortRef.current?.abort();
@@ -388,6 +390,7 @@ export function useChatScreenController(threadId: string) {
     messages,
     isLoading,
     isStreaming,
+    streamStartedAt,
     contextBudget: contextBudget(),
     handleSend,
     stopStreaming,

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -6,6 +6,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { ChatMessageBubble } from '../components/ai/ChatMessageBubble';
 import { ChatInputBar } from '../components/ai/ChatInputBar';
+import { ChatLoadingStrip } from '../components/ai/ChatLoadingStrip';
 import ContextPickerModal from '../components/ai/ContextPickerModal';
 import { ScreenHeader, useScreenHeaderHeight } from '../components/ui';
 import { useTokens } from '../contexts/ThemeContext';
@@ -14,6 +15,7 @@ import type { RootStackParamList } from '../navigation/types';
 import { ChatConfirmationCard } from '../components/chat/ChatConfirmationCard';
 import { ChatErrorCard } from '../components/chat/ChatErrorCard';
 import { useChatScreenController } from '../components/chat/useChatScreenController';
+import { useAIStore } from '../stores/aiStore';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'ChatScreen'>;
 type ChatScreenRouteProp = RouteProp<RootStackParamList, 'ChatScreen'>;
@@ -40,6 +42,7 @@ export default function ChatScreen() {
     messages,
     isLoading,
     isStreaming,
+    streamStartedAt,
     contextBudget,
     handleSend,
     stopStreaming,
@@ -49,6 +52,11 @@ export default function ChatScreen() {
     handleConfirmCancel,
     clearError,
   } = useChatScreenController(threadId);
+
+  const activeModel = useAIStore((state) => state.getSelectedModel());
+  const activeProvider = useAIStore((state) =>
+    activeModel ? state.providers.find((item) => item.id === activeModel.providerId) : undefined,
+  );
 
   useEffect(() => {
     if (!messages.length) return;
@@ -114,6 +122,14 @@ export default function ChatScreen() {
               setLocalError(null);
               clearError();
             }}
+          />
+
+          <ChatLoadingStrip
+            visible={isStreaming}
+            model={activeModel?.name}
+            provider={activeProvider?.name}
+            startedAt={streamStartedAt}
+            onCancel={stopStreaming}
           />
 
           <ChatInputBar


### PR DESCRIPTION
## Summary
- New `ChatLoadingStrip` component renders a compact status strip between the message list and the input bar while a chat response is in flight.
- Shows three pieces of info: a model + provider chip (e.g. `gpt-4o-mini - openrouter`), an elapsed timer that ticks every 100ms, and a Cancel button.
- Wires Cancel to the existing `stopStreaming` path in `useChatScreenController`, which calls `abortRef.current?.abort()` on the same `AbortController` passed into `AIService.streamChatResponse`.
- Auto-hides when the stream completes, errors, or is cancelled. Timer interval is cleaned up on unmount and whenever `visible` flips false.

## Test plan
- [ ] Send a long prompt to a slow model (e.g. an OpenRouter free-tier route). Confirm strip appears immediately, shows the correct model + provider, and the timer ticks at ~10Hz.
- [ ] Tap Cancel mid-stream. Response halts, strip disappears, partial assistant bubble is preserved as `Stopped.` per existing abort behaviour.
- [ ] Send a fast prompt. Strip appears briefly and clears cleanly once the response completes.
- [ ] Trigger a provider error mid-stream. Strip clears once `setStreaming(false)` runs in the controller's `finally` block.
- [ ] Verify no orphaned `setInterval` after navigating away mid-stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)