### PR TITLE
fix(ai-chat): unblock outer scroll + decode over-escaped JSON text chunks

### DIFF
--- a/src/components/ai/ChatMessageBubble.tsx
+++ b/src/components/ai/ChatMessageBubble.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { View, Text, Platform, Pressable } from 'react-native';
+import React, { Fragment, useEffect, useMemo, useState } from 'react';
+import { View, Text, Platform, Pressable, useColorScheme } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { ChatMessage } from '../../models/Chat';
@@ -7,7 +7,7 @@ import { useTokens, useTheme } from '../../contexts/ThemeContext';
 import { formatDistanceToNow } from 'date-fns';
 import { Ionicons } from '@expo/vector-icons';
 import { Surface } from '../ui/Surface';
-import Markdown, { type MarkedStyles } from 'react-native-marked';
+import { useMarkdown, type MarkedStyles } from 'react-native-marked';
 import type { ViewStyle } from 'react-native';
 import type { RootStackParamList } from '../../navigation/types';
 
@@ -35,6 +35,7 @@ export interface ChatMessageBubbleProps {
 function ChatMessageBubbleImpl({ message, isStreaming, onLongPress }: ChatMessageBubbleProps) {
   const { colors, spacing, type } = useTokens();
   const { isDark } = useTheme();
+  const colorScheme = useColorScheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const [dotStep, setDotStep] = useState(0);
@@ -61,6 +62,39 @@ function ChatMessageBubbleImpl({ message, isStreaming, onLongPress }: ChatMessag
 
   const timestamp = formatDistanceToNow(message.timestamp, { addSuffix: true });
 
+  const isUser = message.role === 'user';
+  const textColor = isUser ? '#ffffff' : colors.text;
+  const markdownTheme = useMemo(() => ({
+    colors: {
+      text: textColor,
+      code: textColor,
+      link: colors.primary,
+      border: isDark ? '#444' : '#ddd',
+      background: 'transparent' as const,
+    },
+  }), [textColor, colors.primary, isDark]);
+  const markdownStyles = useMemo<MarkedStyles>(() => ({
+    paragraph: { backgroundColor: 'transparent', marginVertical: 0, paddingVertical: 0 },
+    text: { color: textColor, backgroundColor: 'transparent' },
+    em: { color: textColor },
+    strong: { color: textColor },
+    li: { color: textColor },
+    codespan: { color: textColor, backgroundColor: isDark ? '#1c1c1e' : '#e8e8e8' },
+    code: { backgroundColor: isDark ? '#1c1c1e' : '#e8e8e8' },
+    blockquote: { backgroundColor: 'transparent', borderLeftColor: isDark ? '#444' : '#ddd' },
+  }), [textColor, isDark]);
+  // react-native-marked's <Markdown> wraps output in a FlatList that captures
+  // pan gestures even with `scrollEnabled: false`, which deadlocks the outer
+  // ChatScreen FlatList on iOS for long bubbles (see #748). Render via the
+  // `useMarkdown` hook directly into a plain <View> instead — same tokens,
+  // no inner virtualized list. Hook must run unconditionally so it sits
+  // above the early returns below.
+  const markdownNodes = useMarkdown(message.content ?? '', {
+    theme: markdownTheme,
+    styles: markdownStyles,
+    colorScheme,
+  });
+
   if (message.role === 'system') {
     return (
       <View style={{ alignItems: 'center', marginVertical: spacing[2] }}>
@@ -71,7 +105,6 @@ function ChatMessageBubbleImpl({ message, isStreaming, onLongPress }: ChatMessag
     );
   }
 
-  const isUser = message.role === 'user';
   const isStreamingPlaceholder = !isUser && isStreaming && !message.content && !message.toolCallName;
 
   if (isStreamingPlaceholder) {
@@ -109,35 +142,6 @@ function ChatMessageBubbleImpl({ message, isStreaming, onLongPress }: ChatMessag
     borderTopRightRadius: 16,
     borderBottomLeftRadius: isUser ? 16 : 4,
     borderBottomRightRadius: isUser ? 4 : 16,
-  };
-
-  const textColor = isUser ? '#ffffff' : colors.text;
-
-  const markdownTheme = {
-    colors: {
-      text: textColor,
-      code: textColor,
-      link: colors.primary,
-      border: isDark ? '#444' : '#ddd',
-      background: 'transparent' as const,
-    }
-  };
-
-  const markdownStyles: MarkedStyles = {
-    paragraph: { backgroundColor: 'transparent', marginVertical: 0, paddingVertical: 0 },
-    text: { color: textColor, backgroundColor: 'transparent' },
-    em: { color: textColor },
-    strong: { color: textColor },
-    li: { color: textColor },
-    codespan: { color: textColor, backgroundColor: isDark ? '#1c1c1e' : '#e8e8e8' },
-    code: { backgroundColor: isDark ? '#1c1c1e' : '#e8e8e8' },
-    blockquote: { backgroundColor: 'transparent', borderLeftColor: isDark ? '#444' : '#ddd' },
-  };
-
-  const markdownFlatListProps = {
-    style: { backgroundColor: 'transparent' },
-    contentContainerStyle: { backgroundColor: 'transparent' },
-    scrollEnabled: false,
   };
 
   return (
@@ -207,12 +211,11 @@ function ChatMessageBubbleImpl({ message, isStreaming, onLongPress }: ChatMessag
             {message.content}
           </Text>
         ) : (
-          <Markdown
-            value={message.content}
-            theme={markdownTheme}
-            styles={markdownStyles}
-            flatListProps={markdownFlatListProps}
-          />
+          <View>
+            {markdownNodes.map((node, idx) => (
+              <Fragment key={idx}>{node}</Fragment>
+            ))}
+          </View>
         )}
       </View>
       {isUser && message.attachedContexts && message.attachedContexts.length > 0 && (

--- a/src/components/chat/chatScreenShared.ts
+++ b/src/components/chat/chatScreenShared.ts
@@ -57,6 +57,29 @@ export function parseToolEvent(chunk: string): ToolEvent | null {
   }
 }
 
+// Some providers (notably Ring-2.6-1T via OpenRouter) emit assistant text as a
+// JSON-stringified value — a quoted string with `\n`/`\t`/`\"` escape
+// sequences. The Markdown renderer takes that literally and shows backslash-n
+// instead of newlines. Detect over-escaped chunks and decode them so the
+// reader sees real whitespace. Conservative: only triggers on chunks that
+// (a) parse as a JSON string AND (b) look quoted/escaped, so plain markdown
+// text — which never starts with a `"` or `{` — passes through untouched.
+export function decodeOverEscapedChunk(chunk: string): string {
+  if (!chunk) return chunk;
+  const trimmed = chunk.trim();
+  if (!trimmed) return chunk;
+  const looksQuoted = trimmed.startsWith('"') && trimmed.endsWith('"');
+  const looksEscaped = trimmed.includes('\\n') || trimmed.includes('\\t') || trimmed.includes('\\"');
+  if (!looksQuoted || !looksEscaped) return chunk;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed === 'string') return parsed;
+  } catch (error) {
+    void error;
+  }
+  return chunk;
+}
+
 export function parseToolArgs(value: unknown, fallback = ''): Record<string, unknown> {
   if (isRecord(value)) return value;
   if (!fallback.trim()) return {};

--- a/src/components/chat/useChatScreenController.ts
+++ b/src/components/chat/useChatScreenController.ts
@@ -19,6 +19,7 @@ import { useNoteStore } from '../../stores/noteStore';
 import { useTodoStore } from '../../stores/todoStore';
 import { generateId } from '../../utils/ids';
 import {
+  decodeOverEscapedChunk,
   dedupeContexts,
   formatExecutorResult,
   formatHistoryMessage,
@@ -166,7 +167,7 @@ export function useChatScreenController(threadId: string) {
         if (abortController.signal.aborted) break;
         const toolEvent = parseToolEvent(chunk);
         if (!toolEvent) {
-          assistantText += chunk;
+          assistantText += decodeOverEscapedChunk(chunk);
           scheduleFlush();
           continue;
         }


### PR DESCRIPTION
## Summary

- **Bug A — outer FlatList stops scrolling on long bubbles.** `react-native-marked`'s `<Markdown>` always wraps its output in a FlatList that captures pan gestures even with `scrollEnabled: false`, deadlocking the outer ChatScreen list on iOS. Switched to the library's exported `useMarkdown` hook and rendered the resulting nodes into a plain `<View>` — same tokens, no inner virtualized list, scroll gesture flows back to the outer list.
- **Bug B — `\n` rendered literally.** Some providers (notably Ring-2.6-1T via OpenRouter) emit assistant text as a JSON-stringified value with literal `\n`/`\t`/`\"`. The Markdown renderer took those literally and showed backslash-n. Added a conservative `decodeOverEscapedChunk` helper in `chatScreenShared.ts` that only fires when the chunk looks quoted AND contains escape sequences AND parses as a JSON string — normal markdown text passes through untouched.
- Hooks rule: `useMarkdown` must run unconditionally, so the markdown theme/styles/hook moved above the early returns for `system`/streaming-placeholder cases.
- WHY comments inline next to both fixes since the workaround rationale is non-obvious.

## Test plan

- [ ] Ask Ring-2.6-1T (or any model that emits long unstructured text) for a long answer in chat; confirm the outer chat list scrolls smoothly while the bubble is on screen.
- [ ] Reproduce the Ring "raw JSON" case (e.g. ask for a multi-paragraph answer); confirm `\n` becomes real newlines instead of backslash-n.
- [ ] Send a normal markdown reply (headers, bold, code spans, list items); confirm rendering is unchanged.
- [ ] Send a tool-call message and confirm the tool-result bubble still renders correctly (this path doesn't go through markdown).

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)