### PR TITLE
fix(ai): treat attached-note id as note lookup, not folder path

### DIFF
--- a/src/services/ContextService.ts
+++ b/src/services/ContextService.ts
@@ -229,23 +229,33 @@ export async function getRepoStructure(owner: string, repo: string, branch: stri
   return getFolderContents(owner, repo, branch, '');
 }
 
-export function getLocalNotesForContext(folderPath?: string): string {
-  const notes = useNoteStore.getState().notes;
-  const targetFolder = normalizeFolderPath(folderPath);
-  const filteredNotes = targetFolder
-    ? notes.filter((note) => normalizeFolderPath(note.folderPath) === targetFolder)
-    : notes;
-
-  if (!filteredNotes.length) {
+function formatNotesForContext(notes: ReturnType<typeof useNoteStore.getState>['notes']): string {
+  if (!notes.length) {
     return 'No local notes found.';
   }
 
-  return filteredNotes
+  return notes
     .map((note) => {
       const tags = note.tags.length ? note.tags.join(', ') : 'none';
       return `## ${note.title}\n${note.content}\nTags: ${tags}\n---`;
     })
     .join('\n');
+}
+
+// `arg` is dual-meaning: the picker passes a note id when a single note is attached,
+// but folder-scope attachments still pass a folder path — try id lookup first, then fall back.
+export function getLocalNotesForContext(arg?: string): string {
+  const notes = useNoteStore.getState().notes;
+  if (!arg) return formatNotesForContext(notes);
+
+  const byId = notes.find((note) => note.id === arg);
+  if (byId) return formatNotesForContext([byId]);
+
+  const targetFolder = normalizeFolderPath(arg);
+  const byFolder = targetFolder
+    ? notes.filter((note) => normalizeFolderPath(note.folderPath) === targetFolder)
+    : notes;
+  return formatNotesForContext(byFolder);
 }
 
 export function getLocalTodosForContext(): string {


### PR DESCRIPTION
## Summary
- Bug: paperclip -> Notes -> attach-note sent only the title to the AI; body came back empty because `getLocalNotesForContext` filtered by `folderPath` while the picker passes `path: item.id`.
- Fix: try note-id lookup first in `getLocalNotesForContext`, fall back to existing folder-path filter.
- Covers both arg shapes (note id / folder path) and keeps the empty-arg "all notes" branch unchanged. No picker schema change.

## Test plan
- [ ] Attach a single note via paperclip -> Notes -> pick a note, ask the AI to summarize it; model answers from the note body.
- [ ] Attach by folder scope (existing flow) still returns the matching folder's notes.
- [ ] No attachment -> AI still receives all notes when local-notes context is included.

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)