### PR TITLE
fix(ai): stop duplicating stream-error text in chat bubble

### DIFF
--- a/src/components/chat/useChatScreenController.ts
+++ b/src/components/chat/useChatScreenController.ts
@@ -40,6 +40,7 @@ export function useChatScreenController(threadId: string) {
   const loadThread = useChatStore((state) => state.loadThread);
   const addMessage = useChatStore((state) => state.addMessage);
   const updateMessage = useChatStore((state) => state.updateMessage);
+  const removeMessage = useChatStore((state) => state.removeMessage);
   const setStreaming = useChatStore((state) => state.setStreaming);
   const clearError = useChatStore((state) => state.clearError);
   const setStorageAdapter = useChatStore((state) => state.setStorageAdapter);
@@ -276,14 +277,22 @@ export function useChatScreenController(threadId: string) {
             : error instanceof Error
               ? error.message
               : 'Failed to send message.';
+        // Error text belongs in the banner only — keep the assistant bubble
+        // for real model output. If the stream produced any text before
+        // failing, preserve it in the bubble; otherwise drop the empty
+        // placeholder so the banner isn't duplicated as a grey reply.
+        if (assistantText.trim()) {
+          updateMessage(assistantMessageId, { content: assistantText });
+        } else {
+          removeMessage(assistantMessageId);
+        }
         setLocalError(message);
-        updateMessage(assistantMessageId, { content: assistantText || message });
       }
     } finally {
       if (abortRef.current === abortController) abortRef.current = null;
       setStreaming(false);
     }
-  }, [addMessage, clearError, getSelectedModelConfig, noteCount, renameThread, runToolCall, saveActiveThread, setStreaming, t, todoCount, updateMessage]);
+  }, [addMessage, clearError, getSelectedModelConfig, noteCount, removeMessage, renameThread, runToolCall, saveActiveThread, setStreaming, t, todoCount, updateMessage]);
 
   const stopStreaming = useCallback(() => abortRef.current?.abort(), []);
 

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -51,6 +51,7 @@ interface ChatActions {
   renameThread: (input: RenameThreadInput) => void;
   addMessage: (message: ChatMessage) => void;
   updateMessage: (messageId: string, updates: Partial<ChatMessage>) => void;
+  removeMessage: (messageId: string) => void;
   truncateAfter: (messageId: string, options?: { inclusive?: boolean }) => void;
   setStreaming: (isStreaming: boolean) => void;
   clearActiveThread: () => void;
@@ -252,6 +253,23 @@ export const useChatStore = create<ChatState & ChatActions>()((set, get) => ({
         updatedAt: Date.now(),
       };
 
+      return {
+        activeThread: updatedThread,
+        threads: upsertThreadSummary(state.threads, updatedThread),
+      };
+    });
+  },
+
+  removeMessage: (messageId) => {
+    set((state) => {
+      if (!state.activeThread) return state;
+      const messages = state.activeThread.messages;
+      if (!messages.some((message) => message.id === messageId)) return state;
+      const updatedThread: ChatThread = {
+        ...state.activeThread,
+        messages: messages.filter((message) => message.id !== messageId),
+        updatedAt: Date.now(),
+      };
       return {
         activeThread: updatedThread,
         threads: upsertThreadSummary(state.threads, updatedThread),


### PR DESCRIPTION
## Summary
- Stream failures (e.g. HTTP 429) used to fill the empty assistant placeholder bubble with the error text *and* surface the same text in the red banner — duplicate, confusing UX.
- The catch block now keeps the bubble only when real assistant text streamed before the failure; otherwise it removes the empty placeholder via a new `removeMessage` chat-store action.
- The error banner is now the single owner of failure text (with Retry / Dismiss).

## Test plan
- [ ] Trigger a hard 429 (or other stream error) on first token: confirm only the red banner appears, no grey assistant bubble echoing the same text.
- [ ] Stream a partial response, then force a failure mid-stream: confirm the bubble keeps the partial text and the banner shows the error.
- [ ] Stop a stream manually: confirm the bubble still shows "Stopped." (aborted path unchanged).
- [ ] Tap Retry on the banner: confirm the request re-runs cleanly.

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)