### PR TITLE
fix AI chat path handling and expand QA coverage

### DIFF
--- a/.maestro/ai-openrouter-e2e.yaml
+++ b/.maestro/ai-openrouter-e2e.yaml
@@ -37,6 +37,13 @@ appId: com.xaventra.gitnotes
           timeout: 800
 
 # Add provider only if OpenRouter doesn't already exist.
+- scrollUntilVisible:
+    element:
+      id: "settings.button.add-provider"
+    direction: DOWN
+    speed: 30
+    timeout: 8000
+    visibilityPercentage: 30
 - runFlow:
     when:
       notVisible:
@@ -132,6 +139,13 @@ appId: com.xaventra.gitnotes
                 timeout: 1000
 
 # --- Pick a free OpenRouter model ---------------------------------
+- scrollUntilVisible:
+    element:
+      id: "settings.button.model-selector"
+    direction: UP
+    speed: 30
+    timeout: 8000
+    visibilityPercentage: 30
 - tapOn:
     id: "settings.button.model-selector"
 - waitForAnimationToEnd:

--- a/.maestro/import-buttons.yaml
+++ b/.maestro/import-buttons.yaml
@@ -1,0 +1,22 @@
+appId: com.xaventra.gitnotes
+---
+- stopApp
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd:
+    timeout: 1500
+- tapOn:
+    id: "tab-bar.*tab.press-SettingsTab"
+- waitForAnimationToEnd:
+    timeout: 1200
+- scrollUntilVisible:
+    element:
+      id: "settings-import.button.google-keep"
+    direction: DOWN
+    speed: 30
+    timeout: 10000
+    visibilityPercentage: 30
+- assertVisible:
+    id: "settings-import.button.google-keep"
+- assertVisible:
+    id: "settings-import.button.apple-notes"

--- a/.maestro/voice-input.yaml
+++ b/.maestro/voice-input.yaml
@@ -1,0 +1,43 @@
+appId: com.xaventra.gitnotes
+---
+- stopApp
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd:
+    timeout: 1500
+- tapOn:
+    id: "tab-bar.*tab.press-NotesTab"
+- waitForAnimationToEnd:
+    timeout: 1200
+- tapOn:
+    id: "notes-list.button.press-card-0"
+- waitForAnimationToEnd:
+    timeout: 1800
+- tapOn:
+    id: "note-viewer.button.edit"
+- waitForAnimationToEnd:
+    timeout: 1200
+- assertVisible:
+    id: "note-editor.toolbar.voice-input"
+- tapOn:
+    id: "note-editor.toolbar.voice-input"
+- waitForAnimationToEnd:
+    timeout: 1200
+- assertVisible:
+    text: ".*Voice Input.*"
+- assertVisible:
+    text: ".*Speech recognition not available on this device.*|.*Your speech will appear here.*|.*Tap to speak.*"
+- runFlow:
+    when:
+      visible:
+        id: "voice-input-modal.button.close-unavailable"
+    commands:
+      - tapOn:
+          id: "voice-input-modal.button.close-unavailable"
+- runFlow:
+    when:
+      visible:
+        id: "voice-input-modal.button.close"
+    commands:
+      - tapOn:
+          id: "voice-input-modal.button.close"

--- a/__tests__/components/chatScreenShared.test.ts
+++ b/__tests__/components/chatScreenShared.test.ts
@@ -1,0 +1,44 @@
+import {
+  decodeOverEscapedChunk,
+  formatExecutorResult,
+  formatToolResult,
+} from '../../src/components/chat/chatScreenShared';
+
+describe('decodeOverEscapedChunk', () => {
+  test('decodes JSON-stringified assistant chunks', () => {
+    expect(decodeOverEscapedChunk('"line 1\\nline 2"')).toBe('line 1\nline 2');
+  });
+
+  test('decodes shell-escaped Maestro screenshot paths', () => {
+    expect(
+      decodeOverEscapedChunk(
+        '/Users/vidwadeseram/Desktop/Simulator\\ Screenshot\\ -\\ iPhone\\ 17\\ Pro\\ -\\ 2026-05-13\\ at\\ 15.35.18.png',
+      ),
+    ).toBe('/Users/vidwadeseram/Desktop/Simulator Screenshot - iPhone 17 Pro - 2026-05-13 at 15.35.18.png');
+  });
+
+  test('leaves non-path shell-like content untouched', () => {
+    expect(decodeOverEscapedChunk('Hello\\ world')).toBe('Hello\\ world');
+  });
+});
+
+describe('formatToolResult', () => {
+  test('decodes shell-escaped string results', () => {
+    expect(
+      formatToolResult(
+        '/Users/vidwadeseram/Desktop/Simulator\\ Screenshot\\ -\\ iPhone\\ 17\\ Pro\\ -\\ 2026-05-13\\ at\\ 15.35.18.png',
+      ),
+    ).toBe('/Users/vidwadeseram/Desktop/Simulator Screenshot - iPhone 17 Pro - 2026-05-13 at 15.35.18.png');
+  });
+});
+
+describe('formatExecutorResult', () => {
+  test('decodes shell-escaped error text', () => {
+    expect(
+      formatExecutorResult({
+        success: false,
+        error: '/Users/vidwadeseram/Desktop/Simulator\\ Screenshot\\ -\\ iPhone\\ 17\\ Pro\\ -\\ 2026-05-13\\ at\\ 15.35.18.png',
+      } as never),
+    ).toBe('/Users/vidwadeseram/Desktop/Simulator Screenshot - iPhone 17 Pro - 2026-05-13 at 15.35.18.png');
+  });
+});

--- a/__tests__/services/formatSyncError.test.ts
+++ b/__tests__/services/formatSyncError.test.ts
@@ -1,0 +1,13 @@
+import { formatSyncError } from '../../src/services/git/formatSyncError';
+
+describe('formatSyncError', () => {
+  test('maps raw Axios 409 copy to a GitHub conflict message', () => {
+    expect(formatSyncError('Request failed with status code 409', 'upsert')).toBe(
+      'This file changed on GitHub. Pull and try again.',
+    );
+  });
+
+  test('falls back for unknown sync errors', () => {
+    expect(formatSyncError('Something unusual happened', 'upsert')).toBe('Sync to GitHub failed');
+  });
+});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -52,6 +52,16 @@ jest.mock('expo-blur', () => {
   };
 });
 
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const Icon = (props: Record<string, unknown>) =>
+    React.createElement(Text, props, String(props.name ?? 'icon'));
+  return {
+    Ionicons: Icon,
+  };
+});
+
 // Minimal reanimated stub — official mock pulls in TS source that the
 // jest transform pipeline can't load. We only need the surface area used
 // by neumorphic primitives (useSharedValue, useAnimatedStyle, withSpring,
@@ -128,6 +138,68 @@ jest.mock('reanimated-color-picker', () => {
     ExtraThumb: Stub,
     colorKit: {},
     useColorPickerContext: () => ({}),
+  };
+});
+
+jest.mock('react-native-gesture-handler', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const makeGesture = () => {
+    const api: Record<string, () => Record<string, unknown>> = {};
+    for (const key of [
+      'enabled',
+      'onBegin',
+      'onStart',
+      'onUpdate',
+      'onEnd',
+      'onFinalize',
+      'simultaneousWithExternalGesture',
+      'requireExternalGestureToFail',
+      'hitSlop',
+      'activeOffsetX',
+      'activeOffsetY',
+      'failOffsetX',
+      'failOffsetY',
+      'minDistance',
+      'manualActivation',
+      'runOnJS',
+      'numberOfPointers',
+      'direction',
+      'withTestId',
+    ]) {
+      api[key] = () => api;
+    }
+    return api;
+  };
+  return {
+    GestureDetector: ({ children }: { children?: React.ReactNode }) => React.createElement(View, null, children),
+    GestureHandlerRootView: View,
+    PanGestureHandler: View,
+    TapGestureHandler: View,
+    LongPressGestureHandler: View,
+    FlingGestureHandler: View,
+    ForceTouchGestureHandler: View,
+    PinchGestureHandler: View,
+    RotationGestureHandler: View,
+    NativeViewGestureHandler: View,
+    Swipeable: View,
+    DrawerLayout: View,
+    State: {},
+    Directions: {},
+    Gesture: {
+      Tap: makeGesture,
+      Pan: makeGesture,
+      LongPress: makeGesture,
+      Pinch: makeGesture,
+      Rotation: makeGesture,
+      Fling: makeGesture,
+      ForceTouch: makeGesture,
+      Manual: makeGesture,
+      Native: makeGesture,
+      Simultaneous: () => makeGesture(),
+      Exclusive: () => makeGesture(),
+      Race: () => makeGesture(),
+    },
   };
 });
 

--- a/src/components/chat/chatScreenShared.ts
+++ b/src/components/chat/chatScreenShared.ts
@@ -64,19 +64,33 @@ export function parseToolEvent(chunk: string): ToolEvent | null {
 // reader sees real whitespace. Conservative: only triggers on chunks that
 // (a) parse as a JSON string AND (b) look quoted/escaped, so plain markdown
 // text — which never starts with a `"` or `{` — passes through untouched.
+//
+// Additionally handle shell-escaped file paths from Maestro screenshot tools,
+// where spaces are escaped as `\ ` (e.g., "Simulator\ Screenshot\ -\ iPhone").
 export function decodeOverEscapedChunk(chunk: string): string {
   if (!chunk) return chunk;
   const trimmed = chunk.trim();
   if (!trimmed) return chunk;
+
+  // Handle JSON-stringified escape sequences (\n, \t, \")
   const looksQuoted = trimmed.startsWith('"') && trimmed.endsWith('"');
   const looksEscaped = trimmed.includes('\\n') || trimmed.includes('\\t') || trimmed.includes('\\"');
-  if (!looksQuoted || !looksEscaped) return chunk;
-  try {
-    const parsed = JSON.parse(trimmed);
-    if (typeof parsed === 'string') return parsed;
-  } catch (error) {
-    void error;
+  if (looksQuoted && looksEscaped) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed === 'string') return parsed;
+    } catch (error) {
+      void error;
+    }
   }
+
+  // Handle shell-escaped file paths: spaces escaped as "\ " in paths like
+  // /Users/.../Simulator\ Screenshot\ -\ iPhone\ 17\ Pro.png
+  // Only unescape if chunk looks like a file path (starts with /, ~, or .)
+  if (/^[/.~]/.test(trimmed) && trimmed.includes('\\ ')) {
+    return trimmed.replace(/\\ /g, ' ');
+  }
+
   return chunk;
 }
 
@@ -103,7 +117,7 @@ export function formatHistoryMessage(message: ChatMessage): ChatRequestMessage {
 }
 
 export function formatToolResult(value: unknown): string {
-  if (typeof value === 'string') return value;
+  if (typeof value === 'string') return decodeOverEscapedChunk(value);
   if (value == null) return 'Done.';
   try {
     return JSON.stringify(value, null, 2);
@@ -114,7 +128,7 @@ export function formatToolResult(value: unknown): string {
 }
 
 export function formatExecutorResult(result: Awaited<ReturnType<typeof executeToolCall>>): string {
-  if (!result.success) return result.error ?? 'Tool execution failed.';
+  if (!result.success) return result.error ? decodeOverEscapedChunk(result.error) : 'Tool execution failed.';
   if (result.requiresConfirmation && result.proposedChanges) return result.proposedChanges.description;
   return formatToolResult(result.data);
 }

--- a/src/components/chat/useChatScreenController.ts
+++ b/src/components/chat/useChatScreenController.ts
@@ -18,6 +18,7 @@ import { useChatStore } from '../../stores/chatStore';
 import { useNoteStore } from '../../stores/noteStore';
 import { useTodoStore } from '../../stores/todoStore';
 import { generateId } from '../../utils/ids';
+import { formatSyncError } from '../../services/git/formatSyncError';
 import {
   decodeOverEscapedChunk,
   dedupeContexts,
@@ -68,7 +69,14 @@ export function useChatScreenController(threadId: string) {
 
   const saveActiveThread = useCallback(async () => {
     const latestThread = useChatStore.getState().activeThread;
-    if (latestThread) await ChatStorageService.saveThread(latestThread);
+    if (!latestThread) return;
+    try {
+      await ChatStorageService.saveThread(latestThread);
+    } catch (error) {
+      const raw = error instanceof Error ? error.message : undefined;
+      const formatted = formatSyncError(raw, 'upsert');
+      throw new Error(formatted === 'Sync to GitHub failed' && raw ? raw : formatted);
+    }
   }, []);
 
   const getSelectedModelConfig = useCallback(() => {
@@ -275,7 +283,7 @@ export function useChatScreenController(threadId: string) {
           error instanceof ProviderUnavailableError
             ? describeAvailability(t, error.reason)
             : error instanceof Error
-              ? error.message
+              ? decodeOverEscapedChunk(error.message)
               : 'Failed to send message.';
         // Error text belongs in the banner only — keep the assistant bubble
         // for real model output. If the stream produced any text before

--- a/src/services/ai/aiServiceErrors.ts
+++ b/src/services/ai/aiServiceErrors.ts
@@ -89,7 +89,7 @@ export function extractErrorDetails(error: unknown): ErrorDetails {
   const isStatuslessParserError =
     isApi && typeof status !== 'number' && !isEmptyBody;
   const isMessageParserError =
-    !isEmptyBody && (hasParserErrorMessage(error) || hasParserErrorMessage(inner));
+    isApi && !isEmptyBody && (hasParserErrorMessage(error) || hasParserErrorMessage(inner));
   const isParserError = isStatusedParserError || isStatuslessParserError || isMessageParserError;
 
   return {

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -246,9 +246,9 @@ export class NotePreviewRenderer extends Renderer implements RendererInterface {
   }
 
   setInlineEmbeds(processed: Pick<ProcessedMarkdown, 'inlineMath' | 'wikiLinks' | 'emphases'>) {
-    this.inlineMathEmbeds = new Map(processed.inlineMath.map((segment) => [segment.token, segment]));
-    this.wikiLinkEmbeds = new Map(processed.wikiLinks.map((segment) => [segment.token, segment]));
-    this.emphasisEmbeds = new Map(processed.emphases.map((embed) => [embed.token, embed]));
+    this.inlineMathEmbeds = new Map((processed.inlineMath ?? []).map((segment) => [segment.token, segment]));
+    this.wikiLinkEmbeds = new Map((processed.wikiLinks ?? []).map((segment) => [segment.token, segment]));
+    this.emphasisEmbeds = new Map((processed.emphases ?? []).map((embed) => [embed.token, embed]));
   }
 
   private renderCanvasFallback(id: string): ReactNode {


### PR DESCRIPTION
## Summary
- normalize shell-escaped Maestro screenshot paths in AI chat stream, tool results, and error surfaces
- tighten AI parser-error classification, add native Jest stubs, and guard markdown embed setup against missing emphasis metadata
- add Maestro coverage for voice input and import entry points, and stabilize AI settings flow navigation

## Verification
- yarn ts:check
- ./node_modules/.bin/jest --runInBand --runTestsByPath __tests__/components/chatScreenShared.test.ts __tests__/services/formatSyncError.test.ts
- maestro test ".maestro/nav.yaml" ".maestro/voice-input.yaml" ".maestro/import-buttons.yaml"
- yarn e2e:testid:validate

## Notes
- full `yarn test --runInBand` still reports pre-existing/stale failures outside this change set; this branch focuses on confirmed regressions and thin mobile QA coverage
