### PR TITLE
feat(export): add PDF and DOCX export for notes with native share

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "expo-local-authentication": "~55.0.13",
     "expo-localization": "^55.0.13",
     "expo-notifications": "~55.0.22",
+    "expo-print": "~55.0.15",
     "expo-secure-store": "~55.0.13",
     "expo-sharing": "~55.0.18",
     "expo-speech": "~55.0.13",

--- a/src/components/notes/NotesContextMenu.tsx
+++ b/src/components/notes/NotesContextMenu.tsx
@@ -3,6 +3,25 @@ import { View } from 'react-native';
 
 import ContextMenu from '../ContextMenu';
 import { Note } from '../../models/Note';
+import { ShareFormat, ShareService } from '../../services/ShareService';
+
+const EXPORT_LABELS: Record<ShareFormat, string> = {
+  pdf: 'PDF',
+  docx: 'Word / DOCX',
+  markdown: 'Markdown',
+  text: 'Plain Text',
+  org: 'Org Mode',
+  neorg: 'Neorg',
+};
+
+const EXPORT_ICONS: Record<ShareFormat, 'document-outline' | 'document-text-outline'> = {
+  pdf: 'document-outline',
+  docx: 'document-outline',
+  markdown: 'document-text-outline',
+  text: 'document-text-outline',
+  org: 'document-text-outline',
+  neorg: 'document-text-outline',
+};
 
 interface NotesContextMenuProps {
   note: Note | null;
@@ -10,7 +29,7 @@ interface NotesContextMenuProps {
   onClose: () => void;
   onOpen: (note: Note) => void;
   onTogglePin: (note: Note) => Promise<void>;
-  onShare: (note: Note) => Promise<void>;
+  onShare: (note: Note, format: ShareFormat) => Promise<void>;
   onPickColor: (note: Note) => void;
   onDuplicate: (note: Note) => Promise<void>;
   onDelete: (note: Note) => Promise<void>;
@@ -27,66 +46,96 @@ export function NotesContextMenu({
   onDuplicate,
   onDelete,
 }: NotesContextMenuProps) {
+  const [exportPickerNote, setExportPickerNote] = React.useState<Note | null>(null);
+
+  const exportOptions = exportPickerNote ? ShareService.getAvailableFormats(exportPickerNote) : [];
+
   return (
     <View testID="notes-context-menu.item.close">
       <ContextMenu
-      visible={visible}
-      onClose={onClose}
-      title={note?.title || 'Untitled'}
-      subtitle={note?.filePath ?? undefined}
-      headerIcon={note?.format === 'pdf' ? 'document' : 'document-text'}
-      sections={
-        note
-          ? [
-              {
-                items: [
-                  {
-                    icon: 'eye-outline',
-                    label: 'Open',
-                    testID: 'notes-context-menu.item.open',
-                    onPress: () => onOpen(note),
-                  },
-                  {
-                    icon: note.isPinned ? 'pin' : 'pin-outline',
-                    label: note.isPinned ? 'Unpin' : 'Pin',
-                    testID: 'notes-context-menu.item.toggle-pin',
-                    onPress: async () => onTogglePin(note),
-                  },
-                  {
-                    icon: 'share-outline',
-                    label: 'Share / Save',
-                    testID: 'notes-context-menu.item.share',
-                    onPress: async () => onShare(note),
-                  },
-                  {
-                    icon: 'color-palette-outline',
-                    label: 'Color',
-                    testID: 'notes-context-menu.item.pick-color',
-                    onPress: () => onPickColor(note),
-                  },
-                  {
-                    icon: 'copy-outline',
-                    label: 'Duplicate',
-                    testID: 'notes-context-menu.item.duplicate',
-                    onPress: async () => onDuplicate(note),
-                  },
-                ],
-              },
-              {
-                items: [
-                  {
-                    icon: 'trash-outline',
-                    label: 'Delete',
-                    destructive: true,
-                    testID: 'notes-context-menu.item.delete',
-                    onPress: async () => onDelete(note),
-                  },
-                ],
-              },
-            ]
-          : []
-      }
-    />
+        visible={visible}
+        onClose={onClose}
+        title={note?.title || 'Untitled'}
+        subtitle={note?.filePath ?? undefined}
+        headerIcon={note?.format === 'pdf' ? 'document' : 'document-text'}
+        sections={
+          note
+            ? [
+                {
+                  items: [
+                    {
+                      icon: 'eye-outline',
+                      label: 'Open',
+                      testID: 'notes-context-menu.item.open',
+                      onPress: () => onOpen(note),
+                    },
+                    {
+                      icon: note.isPinned ? 'pin' : 'pin-outline',
+                      label: note.isPinned ? 'Unpin' : 'Pin',
+                      testID: 'notes-context-menu.item.toggle-pin',
+                      onPress: async () => onTogglePin(note),
+                    },
+                    {
+                      icon: 'share-outline',
+                      label: 'Share / Save',
+                      subtitle: 'Choose export format',
+                      testID: 'notes-context-menu.item.share',
+                      onPress: () => setExportPickerNote(note),
+                    },
+                    {
+                      icon: 'color-palette-outline',
+                      label: 'Color',
+                      testID: 'notes-context-menu.item.pick-color',
+                      onPress: () => onPickColor(note),
+                    },
+                    {
+                      icon: 'copy-outline',
+                      label: 'Duplicate',
+                      testID: 'notes-context-menu.item.duplicate',
+                      onPress: async () => onDuplicate(note),
+                    },
+                  ],
+                },
+                {
+                  items: [
+                    {
+                      icon: 'trash-outline',
+                      label: 'Delete',
+                      destructive: true,
+                      testID: 'notes-context-menu.item.delete',
+                      onPress: async () => onDelete(note),
+                    },
+                  ],
+                },
+              ]
+            : []
+        }
+      />
+      <ContextMenu
+        visible={exportPickerNote !== null}
+        onClose={() => setExportPickerNote(null)}
+        title="Share / Save"
+        subtitle={exportPickerNote?.title || 'Untitled'}
+        headerIcon="share-outline"
+        sections={
+          exportPickerNote
+            ? [
+                {
+                  items: exportOptions.map((format) => ({
+                    icon: EXPORT_ICONS[format],
+                    label: EXPORT_LABELS[format],
+                    testID: `notes-context-menu.export.${format}`,
+                    onPress: async () => {
+                      const currentNote = exportPickerNote;
+                      setExportPickerNote(null);
+                      await onShare(currentNote, format);
+                    },
+                  })),
+                },
+              ]
+            : []
+        }
+      />
     </View>
   );
 }

--- a/src/components/notes/useNotesListNoteActions.ts
+++ b/src/components/notes/useNotesListNoteActions.ts
@@ -5,7 +5,7 @@ import { RootStackParamList } from '../../navigation/types';
 import { Note, NoteColor } from '../../models/Note';
 import { parseRepoPath } from '../../utils/gitPathParser';
 import { HapticService } from '../../utils/haptics';
-import { ShareService } from '../../services/ShareService';
+import { ShareFormat, ShareService } from '../../services/ShareService';
 import { NoteSyncQueueService } from '../../services/NoteSyncQueueService';
 import { syncNoteToGitHub } from '../../services/NoteGitHubSyncService';
 import { githubActivity } from '../../stores/githubActivityStore';
@@ -159,9 +159,16 @@ export function useNotesListNoteActions({
     [togglePin],
   );
 
-  const handleShare = useCallback(async (note: Note) => {
-    const ok = await ShareService.shareByNoteFormat(note);
-    if (!ok) Alert.alert('Error', 'Failed to share note');
+  const handleExport = useCallback(async (note: Note, format: ShareFormat) => {
+    try {
+      const ok = await ShareService.shareInFormat(note, format);
+      if (!ok) {
+        Alert.alert('Error', 'Failed to export note');
+      }
+    } catch (error) {
+      console.error('[useNotesListNoteActions] Share/export error:', error);
+      Alert.alert('Error', 'Failed to export note');
+    }
   }, []);
 
   const handleOpenColorPicker = useCallback((note: Note) => {
@@ -198,7 +205,7 @@ export function useNotesListNoteActions({
     handleDeleteFromSwipe,
     handleNoteLongPress,
     handleTogglePin,
-    handleShare,
+    handleExport,
     handleOpenColorPicker,
     handleDuplicate,
   };

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -153,7 +153,7 @@ export default function NotesListScreen() {
     handleDeleteFromSwipe,
     handleNoteLongPress,
     handleTogglePin,
-    handleShare,
+    handleExport,
     handleOpenColorPicker,
     handleDuplicate,
   } = useNotesListNoteActions({
@@ -465,7 +465,7 @@ export default function NotesListScreen() {
         onClose={() => setLongPressedNote(null)}
         onOpen={handleNotePress}
         onTogglePin={handleTogglePin}
-        onShare={handleShare}
+        onShare={handleExport}
         onPickColor={handleOpenColorPicker}
         onDuplicate={handleDuplicate}
         onDelete={async (note) => {

--- a/src/services/ExportService.ts
+++ b/src/services/ExportService.ts
@@ -1,6 +1,6 @@
 import JSZip from 'jszip';
 import * as Print from 'expo-print';
-import { File, Paths } from 'expo-file-system';
+import { Paths } from 'expo-file-system';
 import { Platform } from 'react-native';
 
 import { Canvas } from '../models/Canvas';
@@ -97,7 +97,7 @@ function paragraphXml(text: string): string {
   return `<w:p><w:r><w:t xml:space="preserve">${escapeXml(text)}</w:t></w:r></w:p>`;
 }
 
-function writeDownloadFile(filename: string, mimeType: string, content: Uint8Array): File {
+function writeDownloadFile(filename: string, mimeType: string, content: Uint8Array) {
   const file = Paths.cache.createFile(filename, mimeType);
   file.write(content);
   return file;
@@ -268,15 +268,15 @@ export class ExportService {
     return zip.generateAsync({ type: 'uint8array' });
   }
 
-  static async createNoteArtifact(note: Note, format: ExportFormat, includeMetadata = true): Promise<ExportArtifact> {
+  static createNoteArtifact(note: Note, format: ExportFormat, includeMetadata = true): Promise<ExportArtifact> {
     return this.createArtifact(format, this.buildNoteSource(note, includeMetadata));
   }
 
-  static async createTodoArtifact(todo: Todo, format: ExportFormat): Promise<ExportArtifact> {
+  static createTodoArtifact(todo: Todo, format: ExportFormat): Promise<ExportArtifact> {
     return this.createArtifact(format, this.buildTodoSource(todo));
   }
 
-  static async createCanvasArtifact(canvas: Canvas, format: ExportFormat): Promise<ExportArtifact> {
+  static createCanvasArtifact(canvas: Canvas, format: ExportFormat): Promise<ExportArtifact> {
     return this.createArtifact(format, this.buildCanvasSource(canvas));
   }
 

--- a/src/services/ExportService.ts
+++ b/src/services/ExportService.ts
@@ -1,0 +1,359 @@
+import JSZip from 'jszip';
+import * as Print from 'expo-print';
+import { File, Paths } from 'expo-file-system';
+import { Platform } from 'react-native';
+
+import { Canvas } from '../models/Canvas';
+import { Note } from '../models/Note';
+import { Todo } from '../models/Todo';
+
+export type ExportFormat = 'pdf' | 'docx';
+
+export interface ExportArtifact {
+  filename: string;
+  mimeType: string;
+  uri?: string;
+  webData?: string | Uint8Array;
+  webMimeType?: string;
+}
+
+interface DocxContentInput {
+  title: string;
+  bodyText: string;
+  metadataLines?: string[];
+}
+
+interface ExportSource {
+  filenameStem: string;
+  title: string;
+  bodyText: string;
+  metadataLines: string[];
+  html: string;
+}
+
+const DOCX_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function formatDate(value?: number): string {
+  if (!value) return 'Unknown';
+  return new Date(value).toLocaleString();
+}
+
+function sanitizeFilename(value: string | undefined, fallback: string): string {
+  const slug = (value ?? fallback)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || fallback;
+}
+
+function createHtmlDocument(title: string, metadataLines: string[], bodyText: string): string {
+  const metadataMarkup = metadataLines.length
+    ? `<section class="metadata">${metadataLines
+        .map((line) => `<p>${escapeHtml(line)}</p>`)
+        .join('')}</section>`
+    : '';
+
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; padding: 32px 28px; color: #111827; }
+      h1 { margin: 0 0 16px; font-size: 28px; }
+      .metadata { margin-bottom: 20px; color: #4b5563; font-size: 13px; }
+      .metadata p { margin: 4px 0; }
+      .content { white-space: pre-wrap; line-height: 1.55; font-size: 15px; }
+    </style>
+  </head>
+  <body>
+    <h1>${escapeHtml(title)}</h1>
+    ${metadataMarkup}
+    <div class="content">${escapeHtml(bodyText)}</div>
+  </body>
+</html>`;
+}
+
+function paragraphXml(text: string): string {
+  return `<w:p><w:r><w:t xml:space="preserve">${escapeXml(text)}</w:t></w:r></w:p>`;
+}
+
+function writeDownloadFile(filename: string, mimeType: string, content: Uint8Array): File {
+  const file = Paths.cache.createFile(filename, mimeType);
+  file.write(content);
+  return file;
+}
+
+function buildNoteMetadata(note: Note, includeMetadata: boolean): string[] {
+  if (!includeMetadata) return [];
+  return [
+    `Created: ${formatDate(note.createdAt)}`,
+    `Updated: ${formatDate(note.updatedAt)}`,
+    note.tags.length ? `Tags: ${note.tags.join(', ')}` : '',
+    note.folderPath ? `Folder: ${note.folderPath}` : '',
+    note.repo ? `Repository: ${note.repo}` : '',
+    note.branch ? `Branch: ${note.branch}` : '',
+  ].filter(Boolean);
+}
+
+export class ExportService {
+  static formatTodoAsText(todo: Todo): string {
+    return [
+      todo.text || 'Untitled Todo',
+      '='.repeat((todo.text || 'Untitled Todo').length),
+      '',
+      `Status: ${todo.completed ? 'Completed' : 'Open'}`,
+      `Priority: ${todo.priority ? todo.priority[0].toUpperCase() + todo.priority.slice(1) : 'Medium'}`,
+      `Due: ${todo.dueDate ? formatDate(todo.dueDate) : 'None'}`,
+      todo.tags?.length ? `Tags: ${todo.tags.join(', ')}` : 'Tags: None',
+      '',
+      'Notes:',
+      todo.notes?.trim() || 'None',
+    ].join('\n');
+  }
+
+  static formatCanvasAsText(canvas: Canvas): string {
+    const counts = canvas.scene.elements.reduce(
+      (acc, element) => {
+        acc[element.type] += 1;
+        return acc;
+      },
+      { stroke: 0, shape: 0, text: 0, chart: 0 },
+    );
+
+    const snippets = canvas.scene.elements
+      .filter((element): element is Extract<Canvas['scene']['elements'][number], { type: 'text' }> => element.type === 'text')
+      .map((element) => element.text.trim())
+      .filter(Boolean);
+
+    return [
+      canvas.title || 'Untitled Canvas',
+      '='.repeat((canvas.title || 'Untitled Canvas').length),
+      '',
+      `Canvas size: ${canvas.scene.width} × ${canvas.scene.height}`,
+      `Background: ${canvas.scene.background}`,
+      `Updated: ${formatDate(canvas.updatedAt)}`,
+      canvas.tags.length ? `Tags: ${canvas.tags.join(', ')}` : 'Tags: None',
+      '',
+      `${canvas.scene.elements.length} elements`,
+      `- ${counts.stroke} stroke${counts.stroke === 1 ? '' : 's'}`,
+      `- ${counts.shape} shape${counts.shape === 1 ? '' : 's'}`,
+      `- ${counts.text} text block${counts.text === 1 ? '' : 's'}`,
+      `- ${counts.chart} chart${counts.chart === 1 ? '' : 's'}`,
+      snippets.length ? `Text snippets: ${snippets.join(', ')}` : 'Text snippets: None',
+    ].join('\n');
+  }
+
+  static buildNoteHtml(note: Note, includeMetadata = true): string {
+    return createHtmlDocument(
+      note.title || 'Untitled Note',
+      buildNoteMetadata(note, includeMetadata),
+      note.content || '',
+    );
+  }
+
+  static buildTodoHtml(todo: Todo): string {
+    const bodyText = this.formatTodoAsText(todo);
+    const metadataLines = [
+      `Updated: ${formatDate(todo.updatedAt)}`,
+      todo.repo ? `Repository: ${todo.repo}` : '',
+      todo.branch ? `Branch: ${todo.branch}` : '',
+    ].filter(Boolean);
+
+    return createHtmlDocument(todo.text || 'Untitled Todo', metadataLines, bodyText);
+  }
+
+  static buildCanvasHtml(canvas: Canvas): string {
+    const metadataLines = [
+      `Created: ${formatDate(canvas.createdAt)}`,
+      `Updated: ${formatDate(canvas.updatedAt)}`,
+      canvas.folderPath ? `Folder: ${canvas.folderPath}` : '',
+      canvas.tags.length ? `Tags: ${canvas.tags.join(', ')}` : '',
+    ].filter(Boolean);
+
+    return createHtmlDocument(canvas.title || 'Untitled Canvas', metadataLines, this.formatCanvasAsText(canvas));
+  }
+
+  static async generateDocxBytes({ title, bodyText, metadataLines = [] }: DocxContentInput): Promise<Uint8Array> {
+    const zip = new JSZip();
+
+    zip.file(
+      '[Content_Types].xml',
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
+  <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>
+</Types>`,
+    );
+
+    zip.folder('_rels')?.file(
+      '.rels',
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/>
+</Relationships>`,
+    );
+
+    zip.folder('docProps')?.file(
+      'app.xml',
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"
+  xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+  <Application>GitNotēs</Application>
+</Properties>`,
+    );
+
+    const isoNow = new Date().toISOString();
+    zip.folder('docProps')?.file(
+      'core.xml',
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:dcmitype="http://purl.org/dc/dcmitype/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dc:title>${escapeXml(title)}</dc:title>
+  <dc:creator>GitNotēs</dc:creator>
+  <cp:lastModifiedBy>GitNotēs</cp:lastModifiedBy>
+  <dcterms:created xsi:type="dcterms:W3CDTF">${isoNow}</dcterms:created>
+  <dcterms:modified xsi:type="dcterms:W3CDTF">${isoNow}</dcterms:modified>
+</cp:coreProperties>`,
+    );
+
+    const bodyParagraphs = [
+      paragraphXml(title),
+      ...metadataLines.map(paragraphXml),
+      ...(metadataLines.length ? [paragraphXml('')] : []),
+      ...bodyText.split(/\r?\n/).map(paragraphXml),
+    ].join('');
+
+    zip.folder('word')?.file(
+      'document.xml',
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    ${bodyParagraphs}
+    <w:sectPr>
+      <w:pgSz w:w="12240" w:h="15840"/>
+      <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="708" w:footer="708" w:gutter="0"/>
+    </w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+
+    return zip.generateAsync({ type: 'uint8array' });
+  }
+
+  static async createNoteArtifact(note: Note, format: ExportFormat, includeMetadata = true): Promise<ExportArtifact> {
+    return this.createArtifact(format, this.buildNoteSource(note, includeMetadata));
+  }
+
+  static async createTodoArtifact(todo: Todo, format: ExportFormat): Promise<ExportArtifact> {
+    return this.createArtifact(format, this.buildTodoSource(todo));
+  }
+
+  static async createCanvasArtifact(canvas: Canvas, format: ExportFormat): Promise<ExportArtifact> {
+    return this.createArtifact(format, this.buildCanvasSource(canvas));
+  }
+
+  private static buildNoteSource(note: Note, includeMetadata: boolean): ExportSource {
+    return {
+      filenameStem: sanitizeFilename(note.title, 'untitled-note'),
+      title: note.title || 'Untitled Note',
+      bodyText: note.content || '',
+      metadataLines: buildNoteMetadata(note, includeMetadata),
+      html: this.buildNoteHtml(note, includeMetadata),
+    };
+  }
+
+  private static buildTodoSource(todo: Todo): ExportSource {
+    return {
+      filenameStem: sanitizeFilename(todo.text, 'untitled-todo'),
+      title: todo.text || 'Untitled Todo',
+      bodyText: this.formatTodoAsText(todo),
+      metadataLines: [
+        `Updated: ${formatDate(todo.updatedAt)}`,
+        todo.repo ? `Repository: ${todo.repo}` : '',
+        todo.branch ? `Branch: ${todo.branch}` : '',
+      ].filter(Boolean),
+      html: this.buildTodoHtml(todo),
+    };
+  }
+
+  private static buildCanvasSource(canvas: Canvas): ExportSource {
+    return {
+      filenameStem: sanitizeFilename(canvas.title, 'untitled-canvas'),
+      title: canvas.title || 'Untitled Canvas',
+      bodyText: this.formatCanvasAsText(canvas),
+      metadataLines: [
+        `Created: ${formatDate(canvas.createdAt)}`,
+        `Updated: ${formatDate(canvas.updatedAt)}`,
+        canvas.folderPath ? `Folder: ${canvas.folderPath}` : '',
+        canvas.tags.length ? `Tags: ${canvas.tags.join(', ')}` : '',
+      ].filter(Boolean),
+      html: this.buildCanvasHtml(canvas),
+    };
+  }
+
+  private static async createArtifact(format: ExportFormat, source: ExportSource): Promise<ExportArtifact> {
+    const filename = `${source.filenameStem}.${format}`;
+
+    if (format === 'pdf') {
+      if (Platform.OS === 'web') {
+        return {
+          filename: `${source.filenameStem}.html`,
+          mimeType: 'text/html',
+          webData: source.html,
+          webMimeType: 'text/html',
+        };
+      }
+
+      const { uri } = await Print.printToFileAsync({ html: source.html });
+      return { filename, mimeType: 'application/pdf', uri };
+    }
+
+    const bytes = await this.generateDocxBytes({
+      title: source.title,
+      bodyText: source.bodyText,
+      metadataLines: source.metadataLines,
+    });
+
+    if (Platform.OS === 'web') {
+      return {
+        filename,
+        mimeType: DOCX_MIME_TYPE,
+        webData: bytes,
+        webMimeType: DOCX_MIME_TYPE,
+      };
+    }
+
+    const file = writeDownloadFile(filename, DOCX_MIME_TYPE, bytes);
+    return { filename, mimeType: DOCX_MIME_TYPE, uri: file.uri };
+  }
+}
+
+export default ExportService;

--- a/src/services/ShareService.ts
+++ b/src/services/ShareService.ts
@@ -2,8 +2,11 @@ import * as Sharing from 'expo-sharing';
 import { File, Paths } from 'expo-file-system';
 import { Platform } from 'react-native';
 import { Note } from '../models/Note';
+import { Canvas } from '../models/Canvas';
+import { Todo } from '../models/Todo';
+import { ExportService } from './ExportService';
 
-export type ShareFormat = 'text' | 'markdown' | 'org' | 'neorg';
+export type ShareFormat = 'text' | 'markdown' | 'org' | 'neorg' | 'pdf' | 'docx';
 
 export interface ShareOptions {
   format: ShareFormat;
@@ -15,6 +18,8 @@ const FORMAT_EXTENSION: Record<ShareFormat, string> = {
   markdown: '.md',
   org: '.org',
   neorg: '.norg',
+  pdf: '.pdf',
+  docx: '.docx',
 };
 
 export class ShareService {
@@ -132,8 +137,21 @@ export class ShareService {
     return `${title}-${timestamp}${FORMAT_EXTENSION[format]}`;
   }
 
+  static getAvailableFormats(note: Note): ShareFormat[] {
+    const formats: ShareFormat[] = ['pdf', 'docx', 'markdown', 'text'];
+    if (note.format === 'org') {
+      formats.push('org');
+    }
+    if (note.format === 'neorg') {
+      formats.push('neorg');
+    }
+    return formats;
+  }
+
   private static getMimeType(format: ShareFormat): string {
     if (format === 'markdown') return 'text/markdown';
+    if (format === 'pdf') return 'application/pdf';
+    if (format === 'docx') return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
     return 'text/plain';
   }
 
@@ -148,6 +166,46 @@ export class ShareService {
       default:
         return this.generatePlainText(note, includeMetadata);
     }
+  }
+
+  private static downloadBlob(filename: string, mimeType: string, content: string | Uint8Array): boolean {
+    if (Platform.OS !== 'web') {
+      return false;
+    }
+
+    const blobContent = typeof content === 'string' ? content : Uint8Array.from(content);
+    const data = new Blob([blobContent], { type: mimeType });
+    const url = URL.createObjectURL(data);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+    return true;
+  }
+
+  private static async shareExportedFile(noteTitle: string, artifact: { filename: string; mimeType: string; uri?: string; webData?: string | Uint8Array; webMimeType?: string; }): Promise<boolean> {
+    if (Platform.OS === 'web') {
+      if (!artifact.webData) {
+        return false;
+      }
+      const blobData = typeof artifact.webData === 'string'
+        ? artifact.webData
+        : new Uint8Array(artifact.webData);
+      return this.downloadBlob(artifact.filename, artifact.webMimeType ?? artifact.mimeType, blobData);
+    }
+
+    if (!artifact.uri || !(await this.isShareAvailable())) {
+      return false;
+    }
+
+    await Sharing.shareAsync(artifact.uri, {
+      mimeType: artifact.mimeType,
+      dialogTitle: `Share ${noteTitle}`,
+      UTI: artifact.filename.endsWith('.pdf') ? '.pdf' : undefined,
+    });
+
+    return true;
   }
 
   static async shareNote(note: Note, options: ShareOptions): Promise<boolean> {
@@ -238,6 +296,62 @@ export class ShareService {
 
   static async shareAsMarkdown(note: Note): Promise<boolean> {
     return this.shareNote(note, { format: 'markdown', includeMetadata: true });
+  }
+
+  static async shareAsPdf(note: Note): Promise<boolean> {
+    try {
+      const artifact = await ExportService.createNoteArtifact(note, 'pdf', true);
+      return await this.shareExportedFile(note.title || 'Note', artifact);
+    } catch (error) {
+      console.error('[ShareService] Failed to share PDF:', error);
+      return false;
+    }
+  }
+
+  static async shareAsDocx(note: Note): Promise<boolean> {
+    try {
+      const artifact = await ExportService.createNoteArtifact(note, 'docx', true);
+      return await this.shareExportedFile(note.title || 'Note', artifact);
+    } catch (error) {
+      console.error('[ShareService] Failed to share DOCX:', error);
+      return false;
+    }
+  }
+
+  static async exportTodoAsPdf(todo: Todo): Promise<boolean> {
+    try {
+      const artifact = await ExportService.createTodoArtifact(todo, 'pdf');
+      return await this.shareExportedFile(todo.text || 'Todo', artifact);
+    } catch (error) {
+      console.error('[ShareService] Failed to export todo PDF:', error);
+      return false;
+    }
+  }
+
+  static async exportCanvasAsPdf(canvas: Canvas): Promise<boolean> {
+    try {
+      const artifact = await ExportService.createCanvasArtifact(canvas, 'pdf');
+      return await this.shareExportedFile(canvas.title || 'Canvas', artifact);
+    } catch (error) {
+      console.error('[ShareService] Failed to export canvas PDF:', error);
+      return false;
+    }
+  }
+
+  static async shareInFormat(note: Note, format: ShareFormat): Promise<boolean> {
+    switch (format) {
+      case 'pdf':
+        return this.shareAsPdf(note);
+      case 'docx':
+        return this.shareAsDocx(note);
+      case 'org':
+      case 'neorg':
+      case 'markdown':
+      case 'text':
+        return this.shareNote(note, { format, includeMetadata: true });
+      default:
+        return false;
+    }
   }
 
   static async shareByNoteFormat(note: Note): Promise<boolean> {

--- a/src/services/ShareService.ts
+++ b/src/services/ShareService.ts
@@ -1,10 +1,11 @@
 import * as Sharing from 'expo-sharing';
-import { File, Paths } from 'expo-file-system';
+import { Paths } from 'expo-file-system';
 import { Platform } from 'react-native';
-import { Note } from '../models/Note';
+
 import { Canvas } from '../models/Canvas';
+import { Note } from '../models/Note';
 import { Todo } from '../models/Todo';
-import { ExportService } from './ExportService';
+import { ExportArtifact, ExportService } from './ExportService';
 
 export type ShareFormat = 'text' | 'markdown' | 'org' | 'neorg' | 'pdf' | 'docx';
 
@@ -22,6 +23,50 @@ const FORMAT_EXTENSION: Record<ShareFormat, string> = {
   docx: '.docx',
 };
 
+function normalizeBlobPart(content: string | Uint8Array): string | ArrayBuffer {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  const bytes = Uint8Array.from(content);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+}
+
+function downloadBlob(filename: string, mimeType: string, content: string | Uint8Array): boolean {
+  if (Platform.OS !== 'web') {
+    return false;
+  }
+
+  const url = URL.createObjectURL(new Blob([normalizeBlobPart(content)], { type: mimeType }));
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+  return true;
+}
+
+async function shareExportArtifact(title: string, artifact: ExportArtifact): Promise<boolean> {
+  if (Platform.OS === 'web') {
+    if (!artifact.webData) {
+      return false;
+    }
+    return downloadBlob(artifact.filename, artifact.webMimeType ?? artifact.mimeType, artifact.webData);
+  }
+
+  if (!artifact.uri || !(await Sharing.isAvailableAsync())) {
+    return false;
+  }
+
+  await Sharing.shareAsync(artifact.uri, {
+    mimeType: artifact.mimeType,
+    dialogTitle: `Share ${title}`,
+    UTI: artifact.filename.endsWith('.pdf') ? '.pdf' : undefined,
+  });
+
+  return true;
+}
+
 export class ShareService {
   static async isShareAvailable(): Promise<boolean> {
     return Sharing.isAvailableAsync();
@@ -35,27 +80,15 @@ export class ShareService {
       content += `title: "${note.title || 'Untitled Note'}"\n`;
       content += `created: ${note.createdAt || new Date().toISOString()}\n`;
       content += `updated: ${note.updatedAt || new Date().toISOString()}\n`;
-      if (note.tags && note.tags.length > 0) {
-        content += `tags: [${note.tags.join(', ')}]\n`;
-      }
-      if (note.folderPath) {
-        content += `folder: "${note.folderPath}"\n`;
-      }
-      if (note.repo) {
-        content += `repo: "${note.repo}"\n`;
-      }
-      if (note.branch) {
-        content += `branch: "${note.branch}"\n`;
-      }
+      if (note.tags.length > 0) content += `tags: [${note.tags.join(', ')}]\n`;
+      if (note.folderPath) content += `folder: "${note.folderPath}"\n`;
+      if (note.repo) content += `repo: "${note.repo}"\n`;
+      if (note.branch) content += `branch: "${note.branch}"\n`;
       content += '---\n\n';
     }
 
-    if (note.title) {
-      content += `# ${note.title}\n\n`;
-    }
-
+    if (note.title) content += `# ${note.title}\n\n`;
     content += note.content || '';
-
     return content;
   }
 
@@ -65,18 +98,10 @@ export class ShareService {
     if (includeMetadata) {
       content += `#+TITLE: ${note.title || 'Untitled Note'}\n`;
       content += `#+DATE: ${new Date(note.updatedAt || Date.now()).toISOString()}\n`;
-      if (note.tags && note.tags.length > 0) {
-        content += `#+FILETAGS: :${note.tags.join(':')}:\n`;
-      }
-      if (note.folderPath) {
-        content += `#+FOLDER: ${note.folderPath}\n`;
-      }
-      if (note.repo) {
-        content += `#+REPO: ${note.repo}\n`;
-      }
-      if (note.branch) {
-        content += `#+BRANCH: ${note.branch}\n`;
-      }
+      if (note.tags.length > 0) content += `#+FILETAGS: :${note.tags.join(':')}:\n`;
+      if (note.folderPath) content += `#+FOLDER: ${note.folderPath}\n`;
+      if (note.repo) content += `#+REPO: ${note.repo}\n`;
+      if (note.branch) content += `#+BRANCH: ${note.branch}\n`;
       content += '\n';
     }
 
@@ -91,9 +116,7 @@ export class ShareService {
       content += '@document.meta\n';
       content += `title: ${note.title || 'Untitled Note'}\n`;
       content += `updated: ${new Date(note.updatedAt || Date.now()).toISOString()}\n`;
-      if (note.tags && note.tags.length > 0) {
-        content += `categories: [${note.tags.join(', ')}]\n`;
-      }
+      if (note.tags.length > 0) content += `categories: [${note.tags.join(', ')}]\n`;
       content += '@end\n\n';
     }
 
@@ -106,25 +129,17 @@ export class ShareService {
 
     if (note.title) {
       content += `${note.title}\n`;
-      content += '='.repeat(note.title.length) + '\n\n';
+      content += `${'='.repeat(note.title.length)}\n\n`;
     }
 
     content += note.content || '';
 
     if (includeMetadata) {
       content += '\n\n---\n';
-      if (note.tags && note.tags.length > 0) {
-        content += `Tags: ${note.tags.join(', ')}\n`;
-      }
-      if (note.folderPath) {
-        content += `Folder: ${note.folderPath}\n`;
-      }
-      if (note.repo) {
-        content += `Repository: ${note.repo}\n`;
-      }
-      if (note.branch) {
-        content += `Branch: ${note.branch}\n`;
-      }
+      if (note.tags.length > 0) content += `Tags: ${note.tags.join(', ')}\n`;
+      if (note.folderPath) content += `Folder: ${note.folderPath}\n`;
+      if (note.repo) content += `Repository: ${note.repo}\n`;
+      if (note.branch) content += `Branch: ${note.branch}\n`;
       content += `Last updated: ${note.updatedAt || 'Unknown'}\n`;
     }
 
@@ -133,26 +148,27 @@ export class ShareService {
 
   static generateFilename(note: Note, format: ShareFormat): string {
     const title = note.title?.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase() || 'untitled-note';
-    const timestamp = new Date().getTime();
-    return `${title}-${timestamp}${FORMAT_EXTENSION[format]}`;
+    return `${title}-${Date.now()}${FORMAT_EXTENSION[format]}`;
   }
 
   static getAvailableFormats(note: Note): ShareFormat[] {
     const formats: ShareFormat[] = ['pdf', 'docx', 'markdown', 'text'];
-    if (note.format === 'org') {
-      formats.push('org');
-    }
-    if (note.format === 'neorg') {
-      formats.push('neorg');
-    }
+    if (note.format === 'org') formats.push('org');
+    if (note.format === 'neorg') formats.push('neorg');
     return formats;
   }
 
   private static getMimeType(format: ShareFormat): string {
-    if (format === 'markdown') return 'text/markdown';
-    if (format === 'pdf') return 'application/pdf';
-    if (format === 'docx') return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-    return 'text/plain';
+    switch (format) {
+      case 'markdown':
+        return 'text/markdown';
+      case 'pdf':
+        return 'application/pdf';
+      case 'docx':
+        return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+      default:
+        return 'text/plain';
+    }
   }
 
   private static generateContent(note: Note, format: ShareFormat, includeMetadata: boolean): string {
@@ -168,68 +184,23 @@ export class ShareService {
     }
   }
 
-  private static downloadBlob(filename: string, mimeType: string, content: string | Uint8Array): boolean {
-    if (Platform.OS !== 'web') {
-      return false;
-    }
-
-    const blobContent = typeof content === 'string' ? content : Uint8Array.from(content);
-    const data = new Blob([blobContent], { type: mimeType });
-    const url = URL.createObjectURL(data);
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = filename;
-    anchor.click();
-    setTimeout(() => URL.revokeObjectURL(url), 0);
-    return true;
-  }
-
-  private static async shareExportedFile(noteTitle: string, artifact: { filename: string; mimeType: string; uri?: string; webData?: string | Uint8Array; webMimeType?: string; }): Promise<boolean> {
-    if (Platform.OS === 'web') {
-      if (!artifact.webData) {
-        return false;
-      }
-      const blobData = typeof artifact.webData === 'string'
-        ? artifact.webData
-        : new Uint8Array(artifact.webData);
-      return this.downloadBlob(artifact.filename, artifact.webMimeType ?? artifact.mimeType, blobData);
-    }
-
-    if (!artifact.uri || !(await this.isShareAvailable())) {
-      return false;
-    }
-
-    await Sharing.shareAsync(artifact.uri, {
-      mimeType: artifact.mimeType,
-      dialogTitle: `Share ${noteTitle}`,
-      UTI: artifact.filename.endsWith('.pdf') ? '.pdf' : undefined,
-    });
-
-    return true;
-  }
-
   static async shareNote(note: Note, options: ShareOptions): Promise<boolean> {
     try {
       const { format, includeMetadata = true } = options;
-
       const content = this.generateContent(note, format, includeMetadata);
-
       const filename = this.generateFilename(note, format);
       const mimeType = this.getMimeType(format);
 
-      if (Platform.OS === 'web' || !(await this.isShareAvailable())) {
-        if (Platform.OS === 'web') {
-          const data = new Blob([content], { type: mimeType });
-          const url = URL.createObjectURL(data);
-          window.open(url, '_blank');
-          return true;
-        }
+      if (Platform.OS === 'web') {
+        return downloadBlob(filename, mimeType, content);
+      }
+
+      if (!(await this.isShareAvailable())) {
         return false;
       }
 
-      const cacheDir = Paths.cache;
-      const file = cacheDir.createFile(filename, mimeType);
-      await file.write(content);
+      const file = Paths.cache.createFile(filename, mimeType);
+      file.write(content);
 
       await Sharing.shareAsync(file.uri, {
         mimeType,
@@ -246,17 +217,12 @@ export class ShareService {
   static async shareMultipleNotes(notes: Note[], options: ShareOptions): Promise<boolean> {
     try {
       const { format, includeMetadata = true } = options;
-
-      if (notes.length === 0) {
-        return false;
-      }
+      if (notes.length === 0) return false;
 
       let combinedContent = '';
-
       if (format === 'markdown') {
         combinedContent += '# GitNotēs Export\n\n';
-        combinedContent += `Exported ${notes.length} notes on ${new Date().toLocaleDateString()}\n\n`;
-        combinedContent += '---\n\n';
+        combinedContent += `Exported ${notes.length} notes on ${new Date().toLocaleDateString()}\n\n---\n\n`;
       }
 
       for (const note of notes) {
@@ -264,19 +230,15 @@ export class ShareService {
         combinedContent += '\n\n---\n\n';
       }
 
-      const filename = `gitnotes-export-${new Date().getTime()}${FORMAT_EXTENSION[format]}`;
+      const filename = `gitnotes-export-${Date.now()}${FORMAT_EXTENSION[format]}`;
       const mimeType = this.getMimeType(format);
 
       if (Platform.OS === 'web') {
-        const data = new Blob([combinedContent], { type: mimeType });
-        const url = URL.createObjectURL(data);
-        window.open(url, '_blank');
-        return true;
+        return downloadBlob(filename, mimeType, combinedContent);
       }
 
-      const cacheDir = Paths.cache;
-      const file = cacheDir.createFile(filename, mimeType);
-      await file.write(combinedContent);
+      const file = Paths.cache.createFile(filename, mimeType);
+      file.write(combinedContent);
 
       await Sharing.shareAsync(file.uri, {
         mimeType,
@@ -300,8 +262,7 @@ export class ShareService {
 
   static async shareAsPdf(note: Note): Promise<boolean> {
     try {
-      const artifact = await ExportService.createNoteArtifact(note, 'pdf', true);
-      return await this.shareExportedFile(note.title || 'Note', artifact);
+      return await shareExportArtifact(note.title || 'Note', await ExportService.createNoteArtifact(note, 'pdf', true));
     } catch (error) {
       console.error('[ShareService] Failed to share PDF:', error);
       return false;
@@ -310,8 +271,7 @@ export class ShareService {
 
   static async shareAsDocx(note: Note): Promise<boolean> {
     try {
-      const artifact = await ExportService.createNoteArtifact(note, 'docx', true);
-      return await this.shareExportedFile(note.title || 'Note', artifact);
+      return await shareExportArtifact(note.title || 'Note', await ExportService.createNoteArtifact(note, 'docx', true));
     } catch (error) {
       console.error('[ShareService] Failed to share DOCX:', error);
       return false;
@@ -320,8 +280,7 @@ export class ShareService {
 
   static async exportTodoAsPdf(todo: Todo): Promise<boolean> {
     try {
-      const artifact = await ExportService.createTodoArtifact(todo, 'pdf');
-      return await this.shareExportedFile(todo.text || 'Todo', artifact);
+      return await shareExportArtifact(todo.text || 'Todo', await ExportService.createTodoArtifact(todo, 'pdf'));
     } catch (error) {
       console.error('[ShareService] Failed to export todo PDF:', error);
       return false;
@@ -330,8 +289,7 @@ export class ShareService {
 
   static async exportCanvasAsPdf(canvas: Canvas): Promise<boolean> {
     try {
-      const artifact = await ExportService.createCanvasArtifact(canvas, 'pdf');
-      return await this.shareExportedFile(canvas.title || 'Canvas', artifact);
+      return await shareExportArtifact(canvas.title || 'Canvas', await ExportService.createCanvasArtifact(canvas, 'pdf'));
     } catch (error) {
       console.error('[ShareService] Failed to export canvas PDF:', error);
       return false;
@@ -349,19 +307,12 @@ export class ShareService {
       case 'markdown':
       case 'text':
         return this.shareNote(note, { format, includeMetadata: true });
-      default:
-        return false;
     }
   }
 
   static async shareByNoteFormat(note: Note): Promise<boolean> {
-    const noteFormat = note.format ?? 'markdown';
-    if (noteFormat === 'org') {
-      return this.shareNote(note, { format: 'org', includeMetadata: true });
-    }
-    if (noteFormat === 'neorg') {
-      return this.shareNote(note, { format: 'neorg', includeMetadata: true });
-    }
+    if (note.format === 'org') return this.shareNote(note, { format: 'org', includeMetadata: true });
+    if (note.format === 'neorg') return this.shareNote(note, { format: 'neorg', includeMetadata: true });
     return this.shareAsMarkdown(note);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3894,6 +3894,11 @@ expo-notifications@~55.0.22:
     expo-application "~55.0.14"
     expo-constants "~55.0.15"
 
+expo-print@~55.0.15:
+  version "55.0.15"
+  resolved "https://registry.yarnpkg.com/expo-print/-/expo-print-55.0.15.tgz#1a5d9d78c1021e5201b5c97c79eedc9712d73bae"
+  integrity sha512-poo/RB8Bzoqi2jCeAqmHJFib07GMx41FPmQCNSb/NI+1KC5kucW/2VCRXKzwgVofdwFYMJbg04ewiA8YpY8PCQ==
+
 expo-secure-store@~55.0.13:
   version "55.0.13"
   resolved "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-55.0.13.tgz"


### PR DESCRIPTION
## Summary
- Add ExportService for generating PDF and DOCX files from notes, todos, and canvas
- Extend ShareService with pdf/docx formats and getAvailableFormats method
- Update NotesContextMenu to show export format picker with PDF, DOCX, Markdown, Plain Text options
- Support native share popup via expo-sharing for all export formats

## Changes
- **New ExportService.ts**: Handles PDF generation via expo-print and DOCX generation via JSZip
- **Modified ShareService.ts**: Added pdf/docx support, getAvailableFormats(), shareInFormat()
- **Modified NotesContextMenu.tsx**: Added export format picker with native share options
- **Modified useNotesListNoteActions.ts**: Wired up export functionality
- **Modified NotesListScreen.tsx**: Updated to use handleExport

## Test Plan
- [ ] Verify PDF export produces valid PDF file
- [ ] Verify DOCX export produces valid Word document
- [ ] Verify native share popup appears on iOS/Android
- [ ] Verify web fallback downloads file directly