### PR TITLE
fix(export): block pdf/docx in shareMultipleNotes

### DIFF
--- a/src/services/ShareService.ts
+++ b/src/services/ShareService.ts
@@ -219,6 +219,11 @@ export class ShareService {
       const { format, includeMetadata = true } = options;
       if (notes.length === 0) return false;
 
+      if (format === 'pdf' || format === 'docx') {
+        console.warn('[ShareService] shareMultipleNotes does not support PDF/DOCX export');
+        return false;
+      }
+
       let combinedContent = '';
       if (format === 'markdown') {
         combinedContent += '# GitNotēs Export\n\n';


### PR DESCRIPTION
## Summary
Block pdf/docx format in shareMultipleNotes since multi-note export to these formats doesn't make sense.

## Changes
- Add guard in ShareService.shareMultipleNotes to reject pdf/docx formats with console.warn and return false

## Test Plan
- [ ] Verify shareMultipleNotes with pdf format returns false
- [ ] Verify shareMultipleNotes with docx format returns false
- [ ] Verify shareMultipleNotes with markdown format still works