### PR TITLE
feat(e2e): add Android-specific Maestro tests

### DIFF
--- a/e2e/android/full/canvas.yaml
+++ b/e2e/android/full/canvas.yaml
@@ -1,0 +1,88 @@
+appId: com.gitnotes.app
+name: Android - Canvas Flow
+tags:
+  - full
+  - android
+  - canvas
+---
+
+- launchApp
+
+- tapOn:
+    id: "tab-bar.tab.press-HomeTab"
+
+- tapOn:
+    text: ".*Canvases.*"
+
+- waitForAnimationToEnd:
+    timeout: 1500
+
+- assertVisible:
+    id: "canvas-list.overlay.size-picker"
+    optional: true
+
+- runFlow:
+    when:
+      visible:
+        id: "canvas-list.overlay.size-picker"
+    commands:
+      - tapOn:
+          id: "canvas-list.button.pick-size-phone"
+      - waitForAnimationToEnd:
+          timeout: 1500
+
+- runFlow:
+    when:
+      notVisible:
+        id: "canvas-list.overlay.size-picker"
+    commands:
+      - tapOn:
+          id: "canvas-list.icon-button.new-canvas"
+          optional: true
+      - waitForAnimationToEnd:
+          timeout: 1500
+      - assertVisible:
+          id: "canvas-list.overlay.size-picker"
+      - tapOn:
+          id: "canvas-list.button.pick-size-phone"
+      - waitForAnimationToEnd:
+          timeout: 1500
+
+- assertVisible:
+    id: "canvas-editor.input.title"
+
+- tapOn:
+    id: "canvas-editor.input.title"
+
+- inputText: "Maestro canvas one"
+
+- tapOn:
+    point: "50%, 5%"
+
+- waitForAnimationToEnd:
+    timeout: 700
+
+- tapOn:
+    id: "canvas-editor.button.save"
+
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- runFlow:
+    when:
+      visible:
+        text: ".*Repository Required.*"
+    commands:
+      - tapOn:
+          text: "OK"
+      - waitForAnimationToEnd:
+          timeout: 500
+      - tapOn:
+          id: "canvas-editor.button.back"
+          optional: true
+      - back
+      - waitForAnimationToEnd:
+          timeout: 2000
+
+- assertVisible:
+    text: ".*Canvases.*"

--- a/e2e/android/full/chat.yaml
+++ b/e2e/android/full/chat.yaml
@@ -1,0 +1,26 @@
+appId: com.gitnotes.app
+name: Android - Chat Thread List Flow
+tags:
+  - full
+  - android
+  - chat
+---
+
+- stopApp
+- launchApp:
+    clearState: false
+
+- tapOn:
+    id: "tab-bar.*tab.press-NotesTab"
+
+- waitForAnimationToEnd:
+    timeout: 1500
+
+- tapOn:
+    id: "floating-ai.button.navigate-chat"
+
+- waitForAnimationToEnd:
+    timeout: 1500
+
+- assertVisible:
+    text: ".*[Cc]hat.*|.*[Mm]odel.*|.*[Aa]I.*|.*[Ss]tart.*|.*New.*"

--- a/e2e/android/full/note-crud.yaml
+++ b/e2e/android/full/note-crud.yaml
@@ -1,0 +1,49 @@
+appId: com.gitnotes.app
+name: Android - Note CRUD Flow
+tags:
+  - full
+  - android
+  - notes
+  - note-crud
+---
+
+- launchApp
+
+- tapOn:
+    id: "tab-bar.*tab.press-HomeTab"
+
+- tapOn:
+    id: "home.button.create-note"
+
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- runFlow:
+    when:
+      visible:
+        id: "home.button.select-format-markdown"
+    commands:
+      - tapOn:
+          id: "home.button.select-format-markdown"
+
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- assertVisible:
+    id: "note-editor-form.input.title"
+
+- tapOn:
+    id: "note-editor-form.input.title"
+
+- inputText: "E2E CRUD Note"
+
+- pressKey: Enter
+
+- tapOn:
+    id: "note-editor.button.save"
+
+- waitForAnimationToEnd:
+    timeout: 5000
+
+- assertVisible:
+    id: "home.button.create-note"

--- a/e2e/android/full/onboarding.yaml
+++ b/e2e/android/full/onboarding.yaml
@@ -1,0 +1,52 @@
+appId: com.gitnotes.app
+name: Android - Onboarding Flow
+tags:
+  - full
+  - android
+  - onboarding
+---
+
+- stopApp
+- clearState
+- launchApp
+- waitForAnimationToEnd:
+    timeout: 4000
+
+- assertVisible:
+    text: ".*Welcome to GitNot.*"
+
+- tapOn:
+    id: "onboarding.button.next"
+- waitForAnimationToEnd:
+    timeout: 500
+- tapOn:
+    id: "onboarding.button.next"
+- waitForAnimationToEnd:
+    timeout: 500
+- tapOn:
+    id: "onboarding.button.next"
+- waitForAnimationToEnd:
+    timeout: 500
+- tapOn:
+    id: "onboarding.button.next"
+- waitForAnimationToEnd:
+    timeout: 800
+
+- assertVisible:
+    text: ".*Connect GitHub.*"
+- tapOn:
+    id: "onboarding.button.next"
+- waitForAnimationToEnd:
+    timeout: 1500
+
+- assertVisible:
+    text: ".*GitNot.s AI.*"
+- tapOn:
+    id: "onboarding.button.skip-ai"
+- waitForAnimationToEnd:
+    timeout: 1500
+
+- assertVisible:
+    id: "tab-bar.*tab.press-HomeTab"
+- assertVisible:
+    id: "home.button.create-note"

--- a/e2e/android/full/open-journal.yaml
+++ b/e2e/android/full/open-journal.yaml
@@ -1,0 +1,25 @@
+appId: com.gitnotes.app
+name: Android - Open Journal Flow
+tags:
+  - full
+  - android
+  - journal
+---
+
+- launchApp:
+    clearState: false
+
+- tapOn:
+    id: "tab-bar.*tab.press-HomeTab"
+
+- tapOn:
+    id: "home.button.open-journal"
+
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- assertVisible:
+    id: "note-viewer.button.edit"
+
+- tapOn:
+    id: "note-viewer.button.back"

--- a/e2e/android/full/todo-crud.yaml
+++ b/e2e/android/full/todo-crud.yaml
@@ -1,0 +1,62 @@
+appId: com.gitnotes.app
+name: Android - Todo CRUD Flow
+tags:
+  - full
+  - android
+  - todos
+  - todo-crud
+---
+
+- launchApp
+
+- tapOn:
+    id: "tab-bar.*tab.press-TodosTab"
+
+- tapOn:
+    id: "todo-list.icon-button.add"
+
+- assertVisible:
+    id: "todo-editor.input.title"
+
+- tapOn:
+    id: "todo-editor.input.title"
+
+- inputText: "E2E CRUD Todo"
+
+- pressKey: Enter
+
+- tapOn:
+    id: "git-context-picker.button.open"
+
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- tapOn:
+    id: "todo-editor.button.repo"
+
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- tapOn:
+    id: "git-context-picker.picker.pick"
+
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- tapOn:
+    point: 50%,10%
+
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- tapOn:
+    id: "todo-editor.button.submit"
+
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- assertNotVisible:
+    id: "todo-editor.input.title"
+
+- assertVisible:
+    id: "todo-card.button.press"

--- a/e2e/android/smoke/navigation.yaml
+++ b/e2e/android/smoke/navigation.yaml
@@ -9,31 +9,31 @@ tags:
     clearState: false
 
 - assertVisible:
-    id: tab-bar.tab.press-HomeTab
+    id: "tab-bar.*tab.press-HomeTab"
 
 - tapOn:
-    id: tab-bar.tab.press-NotesTab
+    id: "tab-bar.*tab.press-NotesTab"
 
 - assertVisible:
-    id: notes-list.search-bar.search
+    id: "notes-list.search-bar.search"
 
 - tapOn:
-    id: tab-bar.tab.press-TodosTab
+    id: "tab-bar.*tab.press-TodosTab"
 
 - assertVisible:
-    id: todo-list.icon-button.add
+    id: "todo-list.icon-button.add"
 
 - tapOn:
-    id: tab-bar.tab.press-ExploreTab
+    id: "tab-bar.*tab.press-ExploreTab"
 
 - tapOn:
-    id: tab-bar.tab.press-SettingsTab
+    id: "tab-bar.*tab.press-SettingsTab"
 
 - assertVisible:
     text: "Settings"
 
 - tapOn:
-    id: tab-bar.tab.press-HomeTab
+    id: "tab-bar.*tab.press-HomeTab"
 
 - assertVisible:
     id: home.button.create-note


### PR DESCRIPTION
## Summary

This PR adds Android-specific Maestro e2e tests to the gitnotes project.

### New Tests Added
- onboarding.yaml: First-launch walkthrough verification  
- note-crud.yaml: Note creation flow with format selection
- open-journal.yaml: Journal open flow from home screen  
- todo-crud.yaml: Todo creation with repo picker
- canvas.yaml: Canvas creation flow
- chat.yaml: Chat thread list navigation via floating AI button

### Changes
- Updated navigation.yaml smoke test with iOS-style testID patterns

### Key Details
- Tests use Android appId and regex testID patterns
- Tests cover flows not previously covered for Android

**Note**: Tests could not be verified end-to-end due to an app issue preventing launch on Android.