### PR TITLE
feat(chat): add voice input to AI chat UI

### DIFF
--- a/src/components/ai/ChatInputBar.tsx
+++ b/src/components/ai/ChatInputBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { View, TextInput, ScrollView, TouchableOpacity, Text, Platform } from 'react-native';
 import { BlurView } from 'expo-blur';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -18,6 +18,8 @@ export interface ChatInputBarProps {
   onStop?: () => void;
   disabled?: boolean;
   contextWarning?: { level: 'caution' | 'over' | 'none'; message: string } | null;
+  value?: string;
+  onChangeText?: (text: string) => void;
 }
 
 export function ChatInputBar({
@@ -30,8 +32,13 @@ export function ChatInputBar({
   onStop,
   disabled,
   contextWarning,
+  value,
+  onChangeText,
 }: ChatInputBarProps) {
-  const [text, setText] = useState('');
+  const [internalText, setInternalText] = useState('');
+  const isControlled = value !== undefined && !!onChangeText;
+  const text = isControlled ? value : internalText;
+  const handleTextChange = isControlled ? onChangeText : setInternalText;
   const { colors, spacing, type } = useTokens();
   const { isDark } = useTheme();
   const insets = useSafeAreaInsets();
@@ -39,7 +46,7 @@ export function ChatInputBar({
   const handleSend = () => {
     if (text.trim() && !isStreaming) {
       onSend(text);
-      setText('');
+      handleTextChange('');
     }
   };
 
@@ -159,7 +166,7 @@ export function ChatInputBar({
           placeholderTextColor={colors.textSecondary}
           multiline
           value={text}
-          onChangeText={setText}
+          onChangeText={handleTextChange}
           editable={!disabled && !isStreaming}
         />
 

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -57,13 +57,15 @@ export default function ChatScreen() {
   } = useChatScreenController(threadId);
 
   const [voiceModalVisible, setVoiceModalVisible] = useState(false);
+  const [chatText, setChatText] = useState('');
 
   const handleVoiceDone = useCallback((text: string) => {
     setVoiceModalVisible(false);
-    if (text.trim()) {
-      handleSend(text);
+    const trimmed = text.trim();
+    if (trimmed) {
+      setChatText((prev) => (prev.trim() ? `${prev.trim()} ${trimmed}` : trimmed));
     }
-  }, [handleSend]);
+  }, []);
 
   const selectedModelId = useAIStore((state) => state.selectedModelId);
   const providers = useAIStore((state) => state.providers);
@@ -179,6 +181,8 @@ export default function ChatScreen() {
             onStop={stopStreaming}
             disabled={!thread && !isLoading}
             contextWarning={contextBudget.message ? { level: contextBudget.warningLevel, message: contextBudget.message } : null}
+            value={chatText}
+            onChangeText={setChatText}
           />
         </View>
       </KeyboardAvoidingView>


### PR DESCRIPTION
## Summary
Add voice recording/prompting capability to the AI chat UI.

### Changes
- **ChatInputBar**: Added  prop and mic button (shown when provided)
- **ChatInputBar**: Added  +  props for controlled mode
- **ChatInputBar**: Fixed partial-controlled edge case (requires both value AND onChangeText for controlled mode)
- **ChatScreen**: Wire VoiceInputModal for voice transcription
- **ChatScreen**: Voice text inserts into chat draft (user can edit before sending)
- **ChatScreen**: Trim whitespace from voice transcription

### UX Flow
1. User taps mic button in chat bar → modal opens
2. User speaks → transcript appears in modal
3. User taps "Insert" → modal closes, transcript appended to chat draft
4. User can edit the text before sending
5. User taps send button → message is sent

### Technical Details
- Reuses existing  component (already used in NoteEditorScreen)
-  now supports both controlled (parent-managed) and uncontrolled (self-managed) text input modes
- Voice text is trimmed before inserting to avoid whitespace issues