### PR TITLE
fix(ux): enable keyboard autocomplete and spell-check across text inputs

### DIFF
--- a/src/components/FolderSelectionDialog.tsx
+++ b/src/components/FolderSelectionDialog.tsx
@@ -274,6 +274,8 @@ export default function FolderSelectionDialog({
               placeholderTextColor={colors.textSecondary}
               value={newFolderName}
               onChangeText={setNewFolderName}
+              autoCapitalize="none"
+              autoCorrect={false}
               autoFocus
               maxLength={50}
             />

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -273,8 +273,6 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(fun
         placeholderTextColor={colors.textSecondary}
         multiline
         textAlignVertical="top"
-        autoCorrect={false}
-        spellCheck={false}
         selection={selection}
         onSelectionChange={(e) => {
           const { start, end } = e.nativeEvent.selection;

--- a/src/components/MoveNoteDialog.tsx
+++ b/src/components/MoveNoteDialog.tsx
@@ -534,6 +534,8 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
                 onChangeText={setNewFolderName}
                 placeholder="Folder name"
                 placeholderTextColor={colors.textSecondary}
+                autoCapitalize="none"
+                autoCorrect={false}
                 onSubmitEditing={handleCreateFolder}
                 returnKeyType="done"
                 autoFocus

--- a/src/components/ReorderableChecklist.tsx
+++ b/src/components/ReorderableChecklist.tsx
@@ -218,6 +218,7 @@ const ChecklistRow = memo(function ChecklistRow({
         onChangeText={(text) => onTextChange(index, text)}
         placeholder="List item"
         placeholderTextColor={colors.textSecondary}
+        autoCapitalize="sentences"
         style={[
           styles.input,
           {

--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -114,6 +114,8 @@ export default function TemplateSelector({ visible, onClose, onSelect }: Templat
               onChangeText={setSearchQuery}
               placeholder="Search templates..."
               placeholderTextColor={colors.textSecondary}
+              autoCapitalize="none"
+              autoCorrect={false}
             />
           </View>
         </View>

--- a/src/components/ai/ChatInputBar.tsx
+++ b/src/components/ai/ChatInputBar.tsx
@@ -164,6 +164,7 @@ export function ChatInputBar({
           }}
           placeholder="Type a message..."
           placeholderTextColor={colors.textSecondary}
+          autoCapitalize="sentences"
           multiline
           value={text}
           onChangeText={handleTextChange}

--- a/src/components/canvas/CanvasEditorContent.tsx
+++ b/src/components/canvas/CanvasEditorContent.tsx
@@ -1022,6 +1022,7 @@ export default function CanvasEditorContent() {
           onChangeText={setTitle}
           placeholder="Canvas Title"
           placeholderTextColor={colors.textSecondary}
+          autoCapitalize="sentences"
         />
         <TouchableOpacity testID="canvas-editor.button.save" onPress={saveCanvas} style={styles.saveBtn}>
           <Text style={styles.saveBtnText}>Save</Text>
@@ -1167,6 +1168,7 @@ export default function CanvasEditorContent() {
               value={textInput}
               onChangeText={setTextInput}
               autoFocus
+              autoCapitalize="sentences"
               placeholder="Type here..."
               placeholderTextColor={colors.textSecondary}
             />

--- a/src/components/editor/NoteEditorForm.tsx
+++ b/src/components/editor/NoteEditorForm.tsx
@@ -88,6 +88,7 @@ export function NoteEditorForm({
         value={title}
         onChangeText={onTitleChange}
         maxLength={100}
+        autoCapitalize="sentences"
         returnKeyType="next"
         // Pressing Return on the keyboard hops into the body editor (#628)
         // — gives a deterministic way to leave the title field even when the

--- a/src/components/templates/TemplateEditorModal.tsx
+++ b/src/components/templates/TemplateEditorModal.tsx
@@ -94,6 +94,7 @@ export function TemplateEditorModal({
             onChangeText={onNameChange}
             placeholder="My template"
             placeholderTextColor={colors.textSecondary}
+            autoCapitalize="sentences"
             style={[styles.nameInput, { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
             maxLength={60}
           />
@@ -127,6 +128,7 @@ export function TemplateEditorModal({
             onChangeText={onDescriptionChange}
             placeholder="e.g. Weekly retrospective"
             placeholderTextColor={colors.textSecondary}
+            autoCapitalize="sentences"
             style={[styles.nameInput, { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
             maxLength={120}
           />
@@ -138,6 +140,7 @@ export function TemplateEditorModal({
             onChangeText={onTitleChange}
             placeholder="e.g. Standup - "
             placeholderTextColor={colors.textSecondary}
+            autoCapitalize="sentences"
             style={[styles.nameInput, { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
             maxLength={80}
           />
@@ -183,6 +186,7 @@ export function TemplateEditorModal({
             onChangeText={onContentChange}
             placeholder={'## Heading\n\nWrite something...'}
             placeholderTextColor={colors.textSecondary}
+            autoCapitalize="sentences"
             multiline
             textAlignVertical="top"
             style={[styles.contentInput, { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}

--- a/src/components/todos/TodoEditorModal.tsx
+++ b/src/components/todos/TodoEditorModal.tsx
@@ -108,6 +108,7 @@ export function TodoEditorModal({
               onChangeText={onChangeText}
               placeholder="What needs to be done?"
               placeholderTextColor={colors.textSecondary}
+              autoCapitalize="sentences"
               returnKeyType="done"
             />
 
@@ -119,6 +120,7 @@ export function TodoEditorModal({
               onChangeText={onChangeNotes}
               placeholder="Additional notes..."
               placeholderTextColor={colors.textSecondary}
+              autoCapitalize="sentences"
               multiline
               numberOfLines={3}
             />

--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -231,6 +231,7 @@ export default function CanvasListScreen() {
               onChangeText={setCanvasTitle}
               placeholder="Canvas name"
               placeholderTextColor={colors.textSecondary}
+              autoCapitalize="sentences"
               maxLength={60}
             />
 


### PR DESCRIPTION
## Summary

- Removed `autoCorrect={false}` and `spellCheck={false}` from the MarkdownEditor, which was blocking predictive text and spell-check on the primary note body editor
- Added `autoCapitalize="sentences"` to 11 content-entry text inputs (note title, todo text/notes, chat messages, canvas titles, template fields, checklist items) that had no explicit keyboard configuration
- Added `autoCapitalize="none"` + `autoCorrect={false}` to folder-name and template-search inputs where autocorrect is undesirable

## Why

Users reported that autocomplete was not working for most text boxes. The root cause was twofold:
1. The MarkdownEditor (the main note body editor) explicitly disabled both `autoCorrect` and `spellCheck`, which on iOS also disables the predictive text bar
2. Many content-entry inputs relied on OS defaults without explicit props, leading to inconsistent keyboard behavior across platforms

## Files changed

| File | Change |
|------|--------|
| `MarkdownEditor.tsx` | Removed `autoCorrect={false}` and `spellCheck={false}` |
| `NoteEditorForm.tsx` | Added `autoCapitalize="sentences"` to note title |
| `TodoEditorModal.tsx` | Added `autoCapitalize="sentences"` to todo text and notes |
| `ChatInputBar.tsx` | Added `autoCapitalize="sentences"` to chat message input |
| `TemplateEditorModal.tsx` | Added `autoCapitalize="sentences"` to name, description, title, content |
| `CanvasEditorContent.tsx` | Added `autoCapitalize="sentences"` to canvas title and text element |
| `CanvasListScreen.tsx` | Added `autoCapitalize="sentences"` to canvas name |
| `ReorderableChecklist.tsx` | Added `autoCapitalize="sentences"` to checklist items |
| `MoveNoteDialog.tsx` | Added `autoCapitalize="none"` + `autoCorrect={false}` to folder name |
| `FolderSelectionDialog.tsx` | Added `autoCapitalize="none"` + `autoCorrect={false}` to folder name |
| `TemplateSelector.tsx` | Added `autoCapitalize="none"` + `autoCorrect={false}` to search input |

💘 Generated with Heretic