### PR TITLE
feat: expand scheduled learning with daily repeat, questioner notes, and grading

### DIFF
--- a/__tests__/ScheduledLearning.test.ts
+++ b/__tests__/ScheduledLearning.test.ts
@@ -107,6 +107,17 @@ describe('ScheduledLearning model', () => {
       dates.forEach((d) => expect(d).toBeInstanceOf(Date));
     });
 
+    it('returns single next-day date for daily repeat', () => {
+      const dates = getNextScheduledDates(['monday'], '09:00', 'daily');
+      expect(dates.length).toBe(1);
+      expect(dates[0]).toBeInstanceOf(Date);
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      expect(dates[0].getDate()).toBe(tomorrow.getDate());
+      expect(dates[0].getHours()).toBe(9);
+      expect(dates[0].getMinutes()).toBe(0);
+    });
+
     it('sets correct time on dates', () => {
       const dates = getNextScheduledDates(['tuesday'], '14:30', 'weekly');
       expect(dates.length).toBe(1);
@@ -139,6 +150,60 @@ describe('ScheduledLearning model', () => {
     it('returns short labels for 2-4 days', () => {
       expect(formatDaysOfWeek(['monday', 'wednesday'])).toBe('M, W');
       expect(formatDaysOfWeek(['tuesday', 'thursday', 'friday'])).toBe('T, T, F');
+    });
+
+    it('returns "Every day" for daily repeat regardless of days', () => {
+      expect(formatDaysOfWeek(['monday'], 'daily')).toBe('Every day');
+      expect(formatDaysOfWeek([], 'daily')).toBe('Every day');
+    });
+  });
+
+  describe('type and questioner fields', () => {
+    it('defaults type to learn', () => {
+      const item = createScheduledLearningItem({
+        tags: ['test'],
+        daysOfWeek: ['monday'],
+        time: '09:00',
+        wordCount: 500,
+      });
+      expect(item.type).toBe('learn');
+      expect(item.questionerSource).toBeNull();
+      expect(item.questionerPrompt).toBe('');
+      expect(item.questionerNoteFolder).toBeNull();
+    });
+
+    it('creates questioner item with source fields', () => {
+      const item = createScheduledLearningItem({
+        type: 'questioner',
+        tags: ['physics'],
+        daysOfWeek: ['tuesday'],
+        time: '10:00',
+        wordCount: 300,
+        repeat: 'daily',
+        questionerSource: 'prompt',
+        questionerPrompt: 'Generate physics questions about Newton laws',
+      });
+
+      expect(item.type).toBe('questioner');
+      expect(item.repeat).toBe('daily');
+      expect(item.questionerSource).toBe('prompt');
+      expect(item.questionerPrompt).toBe('Generate physics questions about Newton laws');
+    });
+
+    it('creates questioner item with folder source', () => {
+      const item = createScheduledLearningItem({
+        type: 'questioner',
+        tags: ['math'],
+        daysOfWeek: ['wednesday'],
+        time: '08:00',
+        wordCount: 500,
+        questionerSource: 'folder',
+        questionerNoteFolder: 'notes/math',
+      });
+
+      expect(item.type).toBe('questioner');
+      expect(item.questionerSource).toBe('folder');
+      expect(item.questionerNoteFolder).toBe('notes/math');
     });
   });
 });

--- a/__tests__/ScheduledLearningStore.test.ts
+++ b/__tests__/ScheduledLearningStore.test.ts
@@ -119,6 +119,26 @@ describe('ScheduledLearningStore', () => {
       expect(result).toBeNull();
       expect(useScheduledLearningStore.getState().error).toBe('Failed to create scheduled learning item');
     });
+
+    it('creates a questioner item with all fields', async () => {
+      const newItem = await useScheduledLearningStore.getState().createItem({
+        type: 'questioner',
+        tags: ['physics'],
+        daysOfWeek: ['tuesday'],
+        time: '10:00',
+        wordCount: 300,
+        repeat: 'daily',
+        questionerSource: 'prompt',
+        questionerPrompt: 'Generate Newton laws questions',
+        questionerNoteFolder: null,
+      });
+
+      expect(newItem).not.toBeNull();
+      expect(newItem?.type).toBe('questioner');
+      expect(newItem?.repeat).toBe('daily');
+      expect(newItem?.questionerSource).toBe('prompt');
+      expect(newItem?.questionerPrompt).toBe('Generate Newton laws questions');
+    });
   });
 
   describe('updateItem', () => {
@@ -241,6 +261,21 @@ describe('ScheduledLearningStore', () => {
 
       const updated = useScheduledLearningStore.getState().items.find((i) => i.id === newItem!.id);
       expect(updated?.lastGeneratedAt).not.toBeNull();
+      expect(updated?.lastGeneratedAt).toBeGreaterThan(0);
+    });
+
+    it('marks daily item as generated', async () => {
+      const newItem = await useScheduledLearningStore.getState().createItem({
+        tags: ['daily-test'],
+        daysOfWeek: ['monday'],
+        time: '09:00',
+        wordCount: 500,
+        repeat: 'daily',
+      });
+
+      await useScheduledLearningStore.getState().markGenerated(newItem!.id);
+
+      const updated = useScheduledLearningStore.getState().items.find((i) => i.id === newItem!.id);
       expect(updated?.lastGeneratedAt).toBeGreaterThan(0);
     });
   });

--- a/src/components/editor/NoteViewer.tsx
+++ b/src/components/editor/NoteViewer.tsx
@@ -40,6 +40,9 @@ interface NoteViewerProps {
   previewScrollRef: React.RefObject<ScrollView | null>;
   onPreviewScroll: (event: any) => void;
   onPreviewContentSizeChange: () => void;
+  isQuestionerNote?: boolean;
+  isGrading?: boolean;
+  onGradeAnswers?: () => void;
 }
 
 export function NoteViewer({
@@ -72,6 +75,9 @@ export function NoteViewer({
   previewScrollRef,
   onPreviewScroll,
   onPreviewContentSizeChange,
+  isQuestionerNote,
+  isGrading,
+  onGradeAnswers,
 }: NoteViewerProps) {
   const { colors } = useTheme();
   const isPdfNote = noteFormat === 'pdf';
@@ -125,6 +131,26 @@ export function NoteViewer({
           </IconButton>
         ) : null}
       </View>
+
+      {isQuestionerNote && onGradeAnswers ? (
+        <View style={[styles.gradingBar, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
+          <TouchableOpacity
+            testID="note-viewer.button.grade-answers"
+            onPress={onGradeAnswers}
+            disabled={isGrading}
+            style={[styles.gradeButton, { backgroundColor: colors.primary, opacity: isGrading ? 0.7 : 1 }]}
+          >
+            {isGrading ? (
+              <Text style={[styles.gradeButtonText, { color: '#fff' }]}>Grading...</Text>
+            ) : (
+              <>
+                <Ionicons name="checkmark-done" size={16} color="#fff" />
+                <Text style={[styles.gradeButtonText, { color: '#fff' }]}>Grade My Answers</Text>
+              </>
+            )}
+          </TouchableOpacity>
+        </View>
+      ) : null}
 
       <NotePreviewPane
         noteFormat={noteFormat}
@@ -241,5 +267,23 @@ const styles = StyleSheet.create({
     height: 20,
     borderRadius: 1.5,
     marginRight: 10,
+  },
+  gradingBar: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+  },
+  gradeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+  },
+  gradeButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
   },
 });

--- a/src/components/settings/AddScheduledLearningScreen.tsx
+++ b/src/components/settings/AddScheduledLearningScreen.tsx
@@ -12,8 +12,13 @@ import { useAIStore } from '../../stores/aiStore';
 import { settingsStyles as styles } from './settingsStyles';
 import {
   type DayOfWeek,
+  type ScheduledLearningType,
+  type ScheduledLearningRepeat,
+  type QuestionerSource,
   DAY_OF_WEEK_OPTIONS,
   WORD_COUNT_OPTIONS,
+  SCHEDULED_LEARNING_TYPE_OPTIONS,
+  QUESTIONER_SOURCE_OPTIONS,
 } from '../../models/ScheduledLearning';
 import { ScheduledLearningService } from '../../services/ScheduledLearningService';
 import RepoFolderPickerModal from '../RepoFolderPickerModal';
@@ -48,7 +53,11 @@ export function AddScheduledLearningScreen() {
   const [selectedTime, setSelectedTime] = useState(new Date());
   const [selectedModel, setSelectedModel] = useState<string | null>(selectedModelId);
   const [selectedWordCount, setSelectedWordCount] = useState(500);
-  const [repeat, setRepeat] = useState<'weekly' | 'one-time'>('weekly');
+  const [repeat, setRepeat] = useState<ScheduledLearningRepeat>('weekly');
+  const [learningType, setLearningType] = useState<ScheduledLearningType>('learn');
+  const [questionerSource, setQuestionerSource] = useState<QuestionerSource>('tags');
+  const [questionerPrompt, setQuestionerPrompt] = useState('');
+  const [questionerNoteFolder, setQuestionerNoteFolder] = useState<string | null>(null);
 
   const [selectedRepoPath, setSelectedRepoPath] = useState<string | null>(null);
   const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
@@ -66,6 +75,10 @@ export function AddScheduledLearningScreen() {
     setSelectedModel(selectedModelId);
     setSelectedWordCount(500);
     setRepeat('weekly');
+    setLearningType('learn');
+    setQuestionerSource('tags');
+    setQuestionerPrompt('');
+    setQuestionerNoteFolder(null);
     setSelectedRepoPath(null);
     setSelectedBranch(null);
     setSelectedFolderPath(null);
@@ -135,6 +148,7 @@ export function AddScheduledLearningScreen() {
     });
 
     const newItem = await createItem({
+      type: learningType,
       tags,
       description,
       daysOfWeek: selectedDays,
@@ -145,6 +159,9 @@ export function AddScheduledLearningScreen() {
       branch: selectedBranch,
       wordCount: selectedWordCount,
       repeat,
+      questionerSource: learningType === 'questioner' ? questionerSource : undefined,
+      questionerPrompt: learningType === 'questioner' ? questionerPrompt : undefined,
+      questionerNoteFolder: learningType === 'questioner' ? questionerNoteFolder : undefined,
     });
 
     if (newItem) {
@@ -153,7 +170,7 @@ export function AddScheduledLearningScreen() {
 
     resetForm();
     navigation.goBack();
-  }, [tags, description, selectedDays, selectedTime, selectedModel, selectedFolderPath, selectedRepoPath, selectedBranch, selectedWordCount, repeat, createItem, resetForm, navigation]);
+  }, [tags, description, selectedDays, selectedTime, selectedModel, selectedFolderPath, selectedRepoPath, selectedBranch, selectedWordCount, repeat, learningType, questionerSource, questionerPrompt, questionerNoteFolder, createItem, resetForm, navigation]);
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }} edges={['bottom']}>
@@ -168,6 +185,37 @@ export function AddScheduledLearningScreen() {
           gap: spacing[4],
         }}
       >
+        <Group title="Type">
+          <View style={{ padding: spacing[4], gap: spacing[3] }}>
+            {SCHEDULED_LEARNING_TYPE_OPTIONS.map((opt) => {
+              const isSelected = learningType === opt.value;
+              return (
+                <TouchableOpacity
+                  key={opt.value}
+                  onPress={() => setLearningType(opt.value)}
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: spacing[3],
+                    padding: spacing[4],
+                    borderRadius: 16,
+                    backgroundColor: isSelected ? colors.primary + '16' : colors.surfaceSecondary,
+                    borderWidth: 1,
+                    borderColor: isSelected ? colors.primary : colors.border,
+                  }}
+                >
+                  <Ionicons name={opt.icon as any} size={24} color={isSelected ? colors.primary : colors.textSecondary} />
+                  <View style={{ flex: 1 }}>
+                    <Text style={{ color: isSelected ? colors.primary : colors.text, fontSize: type.sm, fontWeight: '600' }}>{opt.label}</Text>
+                    <Text style={{ color: colors.textSecondary, fontSize: type.xs, marginTop: 2 }}>{opt.description}</Text>
+                  </View>
+                  {isSelected ? <Ionicons name="checkmark-circle" size={22} color={colors.primary} /> : null}
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </Group>
+
         <Group title="Topic" footer={tags.length > 0 ? 'Tap a tag to remove it.' : undefined}>
           <View style={{ padding: spacing[4], gap: spacing[3] }}>
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[2] }}>
@@ -271,6 +319,20 @@ export function AddScheduledLearningScreen() {
             </View>
             <View style={{ flexDirection: 'row', gap: spacing[2] }}>
               <TouchableOpacity
+                onPress={() => setRepeat('daily')}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing[3],
+                  borderRadius: 16,
+                  alignItems: 'center',
+                  backgroundColor: repeat === 'daily' ? colors.primary : colors.surfaceSecondary,
+                  borderWidth: 1,
+                  borderColor: repeat === 'daily' ? colors.primary : colors.border,
+                }}
+              >
+                <Text style={{ color: repeat === 'daily' ? '#fff' : colors.text, fontSize: type.sm, fontWeight: '600' }}>Daily</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
                 onPress={() => setRepeat('weekly')}
                 style={{
                   flex: 1,
@@ -322,6 +384,60 @@ export function AddScheduledLearningScreen() {
             </TouchableOpacity>
           </View>
         </Group>
+
+        {learningType === 'questioner' ? (
+          <Group title="Questioner Source">
+            <View style={{ paddingHorizontal: spacing[4], paddingVertical: spacing[3], gap: spacing[3] }}>
+              {QUESTIONER_SOURCE_OPTIONS.map((opt) => {
+                const isSelected = questionerSource === opt.value;
+                return (
+                  <TouchableOpacity
+                    key={opt.value}
+                    onPress={() => setQuestionerSource(opt.value)}
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      gap: spacing[3],
+                      padding: spacing[3],
+                      borderRadius: 14,
+                      backgroundColor: isSelected ? colors.primary + '16' : colors.surfaceSecondary,
+                      borderWidth: 1,
+                      borderColor: isSelected ? colors.primary : colors.border,
+                    }}
+                  >
+                    <View style={{ flex: 1 }}>
+                      <Text style={{ color: isSelected ? colors.primary : colors.text, fontSize: type.sm, fontWeight: '600' }}>{opt.label}</Text>
+                      <Text style={{ color: colors.textSecondary, fontSize: type.xs, marginTop: 2 }}>{opt.description}</Text>
+                    </View>
+                    {isSelected ? <Ionicons name="checkmark-circle" size={20} color={colors.primary} /> : null}
+                  </TouchableOpacity>
+                );
+              })}
+
+              {questionerSource === 'prompt' ? (
+                <Input
+                  containerStyle={{ borderWidth: 1, borderColor: colors.border, borderRadius: 18 }}
+                  value={questionerPrompt}
+                  onChangeText={setQuestionerPrompt}
+                  placeholder="Describe what questions to generate..."
+                  multiline
+                  multilineMinHeight={80}
+                />
+              ) : null}
+
+              {questionerSource === 'folder' ? (
+                <Input
+                  containerStyle={{ borderWidth: 1, borderColor: colors.border, borderRadius: 18 }}
+                  value={questionerNoteFolder ?? ''}
+                  onChangeText={(text) => setQuestionerNoteFolder(text || null)}
+                  placeholder="Enter folder path (e.g. notes/physics)"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+              ) : null}
+            </View>
+          </Group>
+        ) : null}
 
         <Group title="Generation">
           <View style={{ paddingHorizontal: spacing[4], paddingVertical: spacing[3], gap: spacing[3] }}>

--- a/src/components/settings/ScheduledLearningSection.tsx
+++ b/src/components/settings/ScheduledLearningSection.tsx
@@ -65,7 +65,7 @@ export function ScheduledLearningSection({ colors }: ScheduledLearningSectionPro
         items.map((item) => (
           <GroupRow
             key={item.id}
-            leading={<Ionicons name="school-outline" size={18} color={colors.primary} />}
+            leading={<Ionicons name={item.type === 'questioner' ? 'help-circle-outline' : 'school-outline'} size={18} color={colors.primary} />}
             trailing={
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
                 <Toggle
@@ -87,7 +87,7 @@ export function ScheduledLearningSection({ colors }: ScheduledLearningSectionPro
               {item.tags.join(', ')}
             </Text>
             <Text style={[styles.settingValue, { color: colors.textSecondary }]}>
-              {formatDaysOfWeek(item.daysOfWeek)} at {item.time} · {formatWordCount(item.wordCount)}
+              {formatDaysOfWeek(item.daysOfWeek, item.repeat)} at {item.time} · {item.type === 'questioner' ? 'Questions' : 'Learn'} · {formatWordCount(item.wordCount)}
             </Text>
           </GroupRow>
         ))

--- a/src/models/ScheduledLearning.ts
+++ b/src/models/ScheduledLearning.ts
@@ -20,8 +20,24 @@ export const WORD_COUNT_OPTIONS = [
   { value: 2000, label: '2000 words' },
 ];
 
+export type ScheduledLearningType = 'learn' | 'questioner';
+export type ScheduledLearningRepeat = 'daily' | 'weekly' | 'one-time';
+export type QuestionerSource = 'tags' | 'prompt' | 'folder';
+
+export const SCHEDULED_LEARNING_TYPE_OPTIONS: { value: ScheduledLearningType; label: string; description: string; icon: string }[] = [
+  { value: 'learn', label: 'Learning Notes', description: 'AI generates educational content on your topics', icon: 'school-outline' },
+  { value: 'questioner', label: 'Questioner Notes', description: 'AI creates questions you can answer and get graded', icon: 'help-circle-outline' },
+];
+
+export const QUESTIONER_SOURCE_OPTIONS: { value: QuestionerSource; label: string; description: string }[] = [
+  { value: 'tags', label: 'From Tags', description: 'Generate questions based on topic tags' },
+  { value: 'prompt', label: 'From Prompt', description: 'Generate questions from a custom prompt' },
+  { value: 'folder', label: 'From Note Folder', description: 'Generate questions from notes in a folder' },
+];
+
 export interface ScheduledLearningItem {
   id: string;
+  type: ScheduledLearningType;
   tags: string[];
   description: string;
   daysOfWeek: DayOfWeek[];
@@ -33,17 +49,21 @@ export interface ScheduledLearningItem {
   repoPath: string | null;    // e.g. "owner/repo" - the GitHub repo
   branch: string | null;      // e.g. "main" - the branch
   wordCount: number;
-  repeat: 'weekly' | 'one-time';
+  repeat: ScheduledLearningRepeat;
   isEnabled: boolean;
   lastGeneratedAt: number | null;  // Legacy: overall last generation time (still used for one-time)
   // Per-day tracking: which days have had their most recent generation.
   // Key is DayOfWeek value, value is timestamp of last generation for that day.
   dayLastGeneratedAt: Partial<Record<DayOfWeek, number>>;
+  questionerSource: QuestionerSource | null;
+  questionerPrompt: string;
+  questionerNoteFolder: string | null;
   createdAt: number;
   updatedAt: number;
 }
 
 export interface ScheduledLearningCreateInput {
+  type?: ScheduledLearningType;
   tags: string[];
   description?: string;
   daysOfWeek: DayOfWeek[];
@@ -55,13 +75,17 @@ export interface ScheduledLearningCreateInput {
   repoPath?: string | null;
   branch?: string | null;
   wordCount: number;
-  repeat?: 'weekly' | 'one-time';
+  repeat?: ScheduledLearningRepeat;
+  questionerSource?: QuestionerSource | null;
+  questionerPrompt?: string;
+  questionerNoteFolder?: string | null;
 }
 
 export function createScheduledLearningItem(input: ScheduledLearningCreateInput): ScheduledLearningItem {
   const now = Date.now();
   return {
     id: generateId(),
+    type: input.type ?? 'learn',
     tags: input.tags,
     description: input.description ?? '',
     daysOfWeek: input.daysOfWeek,
@@ -77,6 +101,9 @@ export function createScheduledLearningItem(input: ScheduledLearningCreateInput)
     isEnabled: true,
     lastGeneratedAt: null,
     dayLastGeneratedAt: {},
+    questionerSource: input.questionerSource ?? null,
+    questionerPrompt: input.questionerPrompt ?? '',
+    questionerNoteFolder: input.questionerNoteFolder ?? null,
     createdAt: now,
     updatedAt: now,
   };
@@ -105,7 +132,7 @@ export function getDayOfWeekIndex(day: DayOfWeek): number {
 export function getNextScheduledDates(
   daysOfWeek: DayOfWeek[],
   time: string,
-  repeat: 'weekly' | 'one-time'
+  repeat: ScheduledLearningRepeat
 ): Date[] {
   const now = new Date();
   const [hours, minutes] = time.split(':').map(Number);
@@ -113,7 +140,12 @@ export function getNextScheduledDates(
 
   const dayIndices = daysOfWeek.map(getDayOfWeekIndex).sort((a, b) => a - b);
 
-  if (repeat === 'one-time') {
+  if (repeat === 'daily') {
+    const nextDate = new Date(now);
+    nextDate.setDate(now.getDate() + 1);
+    nextDate.setHours(hours, minutes, 0, 0);
+    dates.push(nextDate);
+  } else if (repeat === 'one-time') {
     let daysUntilClosest = Infinity;
     let closestIndex = -1;
 
@@ -154,7 +186,8 @@ export function getNextScheduledDates(
   return dates;
 }
 
-export function formatDaysOfWeek(days: DayOfWeek[]): string {
+export function formatDaysOfWeek(days: DayOfWeek[], repeat?: ScheduledLearningRepeat): string {
+  if (repeat === 'daily') return 'Every day';
   if (days.length === 0) return 'No days selected';
   if (days.length === 1) return DAY_OF_WEEK_OPTIONS.find((d) => d.value === days[0])?.label ?? days[0];
   if (days.length === 7) return 'Every day';

--- a/src/models/ScheduledLearning.ts
+++ b/src/models/ScheduledLearning.ts
@@ -140,6 +140,10 @@ export function getNextScheduledDates(
 
   const dayIndices = daysOfWeek.map(getDayOfWeekIndex).sort((a, b) => a - b);
 
+  if (repeat !== 'daily' && dayIndices.length === 0) {
+    return dates;
+  }
+
   if (repeat === 'daily') {
     const nextDate = new Date(now);
     nextDate.setDate(now.getDate() + 1);

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -28,6 +28,7 @@ import { NoteViewer } from '../components/editor/NoteViewer';
 import { useNoteEditorDocument } from '../components/editor/useNoteEditorDocument';
 import { useNoteEditorPreview } from '../components/editor/useNoteEditorPreview';
 import { ErrorBoundary } from '../components/ui/ErrorBoundary';
+import { ScheduledLearningService } from '../services/ScheduledLearningService';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'NoteEditor'>;
 type NoteEditorRouteProp = RouteProp<RootStackParamList, 'NoteEditor'>;
@@ -56,6 +57,7 @@ function NoteEditorScreenInner() {
   const [showCanvasModal, setShowCanvasModal] = React.useState(false);
   const [showCanvasPicker, setShowCanvasPicker] = React.useState(false);
   const [showFolderDialog, setShowFolderDialog] = React.useState(false);
+  const [isGrading, setIsGrading] = React.useState(false);
 
   const document = useNoteEditorDocument({
     noteId,
@@ -94,6 +96,24 @@ function NoteEditorScreenInner() {
     initialAnchor,
   });
   const isPdfNote = document.noteFormat === 'pdf';
+
+  const isQuestionerNote = React.useMemo(
+    () => document.tags?.includes('questioner') ?? false,
+    [document.tags],
+  );
+
+  const handleGradeAnswers = React.useCallback(async () => {
+    if (!noteId || isGrading) return;
+    setIsGrading(true);
+    try {
+      const success = await ScheduledLearningService.gradeQuestionerNote(noteId);
+      if (!success) {
+        console.warn('[NoteEditor] Grading failed');
+      }
+    } finally {
+      setIsGrading(false);
+    }
+  }, [noteId, isGrading]);
 
   // ── NOT FOUND (deep link to a noteId that isn't on this device) ──
   if (document.notFound) {
@@ -153,6 +173,9 @@ function NoteEditorScreenInner() {
           previewScrollRef={preview.previewScrollRef}
           onPreviewScroll={preview.handlePreviewScroll}
           onPreviewContentSizeChange={preview.handlePreviewContentSizeChange}
+          isQuestionerNote={isQuestionerNote}
+          isGrading={isGrading}
+          onGradeAnswers={isQuestionerNote ? handleGradeAnswers : undefined}
         />
     );
   }

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -46,6 +46,11 @@ const INFO_STEPS = [
     description: 'Pin important notes, use checklists, and track your progress.',
     icon: 'rocket-outline' as const,
   },
+  {
+    title: 'Scheduled Learning',
+    description: 'Let AI generate daily or weekly learning notes on your topics. You can also get Questioner notes with questions you answer and get graded — perfect for active recall and spaced repetition.',
+    icon: 'help-circle-outline' as const,
+  },
 ];
 
 const TOKEN_STEP = INFO_STEPS.length;

--- a/src/services/ScheduledLearningService.ts
+++ b/src/services/ScheduledLearningService.ts
@@ -7,7 +7,10 @@ import { NotificationService } from './NotificationService';
 import { ScheduledLearningItem, getNextScheduledDates, DayOfWeek } from '../models/ScheduledLearning';
 
 const NOTIFICATION_ID_PREFIX = 'scheduled-learning-';
+const QUESTIONER_MARKER_PREFIX = '<!-- sl-item-id:';
+const QUESTIONER_MARKER_SUFFIX = ' -->';
 
+const MS_23_HOURS = 23 * 60 * 60 * 1000;
 const MS_24_HOURS = 24 * 60 * 60 * 1000;
 const MS_6_DAYS = 6 * MS_24_HOURS;
 
@@ -19,6 +22,10 @@ function getDayFromDate(date: Date): DayOfWeek {
 function shouldGenerateForDay(item: ScheduledLearningItem, day: DayOfWeek): boolean {
   if (item.repeat === 'one-time') {
     return item.lastGeneratedAt === null;
+  }
+  if (item.repeat === 'daily') {
+    if (item.lastGeneratedAt === null) return true;
+    return Date.now() - item.lastGeneratedAt >= MS_23_HOURS;
   }
   const lastGen = item.dayLastGeneratedAt[day];
   if (lastGen === undefined) {
@@ -33,6 +40,13 @@ function shouldGenerateForDay(item: ScheduledLearningItem, day: DayOfWeek): bool
 
 export class ScheduledLearningService {
   static async generateAndCreateNote(item: ScheduledLearningItem, day?: DayOfWeek): Promise<boolean> {
+    if (item.type === 'questioner') {
+      return ScheduledLearningService.generateQuestionerNote(item, day);
+    }
+    return ScheduledLearningService.generateLearnNote(item, day);
+  }
+
+  private static async generateLearnNote(item: ScheduledLearningItem, day?: DayOfWeek): Promise<boolean> {
     const targetDay = day ?? getDayFromDate(new Date());
 
     if (!shouldGenerateForDay(item, targetDay)) {
@@ -121,7 +135,156 @@ export class ScheduledLearningService {
 
       return true;
     } catch (error) {
-      console.error('[ScheduledLearning] Failed to generate note:', error);
+      console.error('[ScheduledLearning] Failed to generate learn note:', error);
+      return false;
+    }
+  }
+
+  private static async resolveModel(item: ScheduledLearningItem) {
+    const aiStore = useAIStore.getState();
+    const modelId = item.modelId ?? aiStore.selectedModelId;
+    if (!modelId) {
+      console.warn('[ScheduledLearning] No model selected');
+      return null;
+    }
+    const modelConfig = aiStore.getAvailableModels().find((m) => m.id === modelId);
+    if (!modelConfig) {
+      console.warn('[ScheduledLearning] Model not found:', modelId);
+      return null;
+    }
+    const provider = aiStore.providers.find((p) =>
+      p.models.some((m) => m.id === modelId)
+    );
+    if (!provider) {
+      console.warn('[ScheduledLearning] Provider not found for model:', modelId);
+      return null;
+    }
+    const model = await initializeModel(modelConfig, provider);
+    return { model, modelId };
+  }
+
+  private static async generateQuestionerNote(item: ScheduledLearningItem, day?: DayOfWeek): Promise<boolean> {
+    const targetDay = day ?? getDayFromDate(new Date());
+    if (!shouldGenerateForDay(item, targetDay)) {
+      return false;
+    }
+
+    try {
+      const resolved = await ScheduledLearningService.resolveModel(item);
+      if (!resolved) return false;
+      const { model } = resolved;
+      const noteStore = useNoteStore.getState();
+
+      let promptContext = '';
+      const source = item.questionerSource ?? 'tags';
+
+      if (source === 'tags') {
+        promptContext = `topic tags: ${item.tags.join(', ')}`;
+      } else if (source === 'prompt') {
+        promptContext = `the following prompt: ${item.questionerPrompt || item.tags.join(', ')}`;
+      } else if (source === 'folder') {
+        const folderPath = item.questionerNoteFolder;
+        if (folderPath) {
+          const folderNotes = noteStore.notes.filter((n) => n.folderPath === folderPath);
+          const noteSummaries = folderNotes
+            .slice(0, 10)
+            .map((n) => `Title: ${n.title}\nContent preview: ${n.content.substring(0, 300)}`)
+            .join('\n\n---\n\n');
+          promptContext = `the following notes from folder "${folderPath}":\n\n${noteSummaries || '(no notes found in folder)'}`;
+        } else {
+          promptContext = `topic tags: ${item.tags.join(', ')}`;
+        }
+      }
+
+      const wordCount = item.wordCount;
+      const descriptionText = item.description ? `\n\nAdditional context: ${item.description}` : '';
+      const marker = `${QUESTIONER_MARKER_PREFIX} ${item.id}${QUESTIONER_MARKER_SUFFIX}`;
+
+      const systemPrompt = `You are an educational question generator. Create a set of questions that test knowledge on the given topic. Format the questions in markdown with clear numbering and sections. Include a mix of question types (short answer, explanation, problem-solving). Leave space after each question for the user to write their answer. Do NOT provide answers - only questions.`;
+
+      const userPrompt = `Generate questions based on ${promptContext}${descriptionText}\n\nRequirements:\n- Approximately ${wordCount} words total\n- Mix of difficulty levels\n- Clear, well-structured questions in markdown\n- Leave space for answers after each question\n- Include a section header like "## Questions" at the top`;
+
+      const result = await generateText({
+        model,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: userPrompt }],
+      });
+
+      const cleanedContent = result.text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+
+      const now = new Date();
+      const dateStr = now.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+      const title = `Questions: ${item.tags.join(', ')} - ${dateStr}`;
+
+      const content = `${marker}\n${cleanedContent}`;
+
+      await noteStore.createNote({
+        title,
+        content,
+        tags: ['scheduled-learning', 'questioner', ...item.tags],
+        folderPath: item.folderPath ?? undefined,
+        repo: item.repoPath ?? undefined,
+        branch: item.branch ?? undefined,
+        format: 'markdown',
+      });
+
+      await useScheduledLearningStore.getState().markGenerated(item.id, targetDay);
+      return true;
+    } catch (error) {
+      console.error('[ScheduledLearning] Failed to generate questioner note:', error);
+      return false;
+    }
+  }
+
+  static async gradeQuestionerNote(noteId: string): Promise<boolean> {
+    try {
+      const noteStore = useNoteStore.getState();
+      const note = noteStore.getNoteById(noteId);
+      if (!note) {
+        console.warn('[ScheduledLearning] Note not found for grading:', noteId);
+        return false;
+      }
+
+      const isQuestioner = note.tags?.includes('questioner');
+      if (!isQuestioner) {
+        console.warn('[ScheduledLearning] Note is not a questioner note:', noteId);
+        return false;
+      }
+
+      const markerMatch = note.content.match(/<!-- sl-item-id:\s*(\S+)\s*-->/);
+      const slItemId = markerMatch ? markerMatch[1] : null;
+
+      let item: ScheduledLearningItem | undefined;
+      if (slItemId) {
+        item = useScheduledLearningStore.getState().items.find((i) => i.id === slItemId);
+      }
+
+      const resolved = await ScheduledLearningService.resolveModel(
+        item ?? { modelId: null } as ScheduledLearningItem
+      );
+      if (!resolved) return false;
+      const { model } = resolved;
+
+      const systemPrompt = `You are an expert grader. The user has answered questions in a note. For each question:\n1. Evaluate if the answer is correct\n2. Provide feedback on the answer\n3. If incorrect or incomplete, provide the correct answer with explanation\n4. Give an overall grade at the end\n\nFormat your grading in clear markdown with sections for each question.`;
+
+      const userPrompt = `Grade the following questions and answers:\n\n${note.content}`;
+
+      const result = await generateText({
+        model,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: userPrompt }],
+      });
+
+      const cleanedGrading = result.text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+
+      const gradingSection = `\n\n---\n\n## Grading & Corrections\n\n${cleanedGrading}`;
+      const updatedContent = note.content + gradingSection;
+
+      await noteStore.updateNote({ id: noteId, content: updatedContent });
+
+      return true;
+    } catch (error) {
+      console.error('[ScheduledLearning] Failed to grade questioner note:', error);
       return false;
     }
   }

--- a/src/services/ScheduledLearningService.ts
+++ b/src/services/ScheduledLearningService.ts
@@ -140,7 +140,7 @@ export class ScheduledLearningService {
     }
   }
 
-  private static async resolveModel(item: ScheduledLearningItem) {
+  private static async resolveModel(item: { modelId: string | null }) {
     const aiStore = useAIStore.getState();
     const modelId = item.modelId ?? aiStore.selectedModelId;
     if (!modelId) {
@@ -260,14 +260,16 @@ export class ScheduledLearningService {
       }
 
       const resolved = await ScheduledLearningService.resolveModel(
-        item ?? { modelId: null } as ScheduledLearningItem
+        item ?? { modelId: null }
       );
       if (!resolved) return false;
       const { model } = resolved;
 
+      const contentForGrading = note.content.replace(/\n\n---\n\n## Grading & Corrections[\s\S]*$/, '');
+
       const systemPrompt = `You are an expert grader. The user has answered questions in a note. For each question:\n1. Evaluate if the answer is correct\n2. Provide feedback on the answer\n3. If incorrect or incomplete, provide the correct answer with explanation\n4. Give an overall grade at the end\n\nFormat your grading in clear markdown with sections for each question.`;
 
-      const userPrompt = `Grade the following questions and answers:\n\n${note.content}`;
+      const userPrompt = `Grade the following questions and answers:\n\n${contentForGrading}`;
 
       const result = await generateText({
         model,
@@ -278,7 +280,7 @@ export class ScheduledLearningService {
       const cleanedGrading = result.text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
 
       const gradingSection = `\n\n---\n\n## Grading & Corrections\n\n${cleanedGrading}`;
-      const updatedContent = note.content + gradingSection;
+      const updatedContent = contentForGrading + gradingSection;
 
       await noteStore.updateNote({ id: noteId, content: updatedContent });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,7 +19,7 @@
     "@ai-sdk/provider" "3.0.10"
     "@ai-sdk/provider-utils" "4.0.27"
 
-"@ai-sdk/provider-utils@4.0.27":
+"@ai-sdk/provider-utils@^4.0.1", "@ai-sdk/provider-utils@4.0.27":
   version "4.0.27"
   resolved "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz"
   integrity sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==
@@ -28,32 +28,14 @@
     "@standard-schema/spec" "^1.1.0"
     eventsource-parser "^3.0.8"
 
-"@ai-sdk/provider-utils@^4.0.1":
-  version "4.0.26"
-  resolved "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.26.tgz"
-  integrity sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==
-  dependencies:
-    "@ai-sdk/provider" "3.0.10"
-    "@standard-schema/spec" "^1.1.0"
-    eventsource-parser "^3.0.8"
-
-"@ai-sdk/provider@3.0.10", "@ai-sdk/provider@^3.0.5":
+"@ai-sdk/provider@^3.0.5", "@ai-sdk/provider@3.0.10":
   version "3.0.10"
   resolved "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz"
   integrity sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==
   dependencies:
     json-schema "^0.4.0"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.20.0", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz"
-  integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.28.5"
-    js-tokens "^4.0.0"
-    picocolors "^1.1.1"
-
-"@babel/code-frame@^7.29.7":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.20.0", "@babel/code-frame@^7.29.0", "@babel/code-frame@^7.29.7":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz"
   integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
@@ -88,18 +70,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.20.5", "@babel/generator@^7.29.0", "@babel/generator@^7.29.1", "@babel/generator@^7.7.2":
-  version "7.29.1"
-  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz"
-  integrity sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==
-  dependencies:
-    "@babel/parser" "^7.29.0"
-    "@babel/types" "^7.29.0"
-    "@jridgewell/gen-mapping" "^0.3.12"
-    "@jridgewell/trace-mapping" "^0.3.28"
-    jsesc "^3.0.2"
-
-"@babel/generator@^7.29.7":
+"@babel/generator@^7.20.5", "@babel/generator@^7.29.0", "@babel/generator@^7.29.1", "@babel/generator@^7.29.7", "@babel/generator@^7.7.2":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz"
   integrity sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==
@@ -110,14 +81,7 @@
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
-"@babel/helper-annotate-as-pure@^7.27.1", "@babel/helper-annotate-as-pure@^7.27.3":
-  version "7.27.3"
-  resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz"
-  integrity sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==
-  dependencies:
-    "@babel/types" "^7.27.3"
-
-"@babel/helper-annotate-as-pure@^7.29.7":
+"@babel/helper-annotate-as-pure@^7.27.1", "@babel/helper-annotate-as-pure@^7.27.3", "@babel/helper-annotate-as-pure@^7.29.7":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz"
   integrity sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==
@@ -168,12 +132,7 @@
     lodash.debounce "^4.0.8"
     resolve "^1.22.11"
 
-"@babel/helper-globals@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz"
-  integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
-
-"@babel/helper-globals@^7.29.7":
+"@babel/helper-globals@^7.28.0", "@babel/helper-globals@^7.29.7":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz"
   integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
@@ -186,15 +145,7 @@
     "@babel/traverse" "^7.28.5"
     "@babel/types" "^7.28.5"
 
-"@babel/helper-module-imports@^7.25.9", "@babel/helper-module-imports@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz"
-  integrity sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==
-  dependencies:
-    "@babel/traverse" "^7.28.6"
-    "@babel/types" "^7.28.6"
-
-"@babel/helper-module-imports@^7.29.7":
+"@babel/helper-module-imports@^7.25.9", "@babel/helper-module-imports@^7.28.6", "@babel/helper-module-imports@^7.29.7":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz"
   integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
@@ -218,12 +169,7 @@
   dependencies:
     "@babel/types" "^7.27.1"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.28.6", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.28.6"
-  resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz"
-  integrity sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==
-
-"@babel/helper-plugin-utils@^7.29.7":
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.28.6", "@babel/helper-plugin-utils@^7.29.7", "@babel/helper-plugin-utils@^7.8.0":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz"
   integrity sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==
@@ -254,22 +200,12 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
-"@babel/helper-string-parser@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz"
-  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
-
 "@babel/helper-string-parser@^7.29.7":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz"
   integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
 
-"@babel/helper-validator-identifier@^7.28.5":
-  version "7.28.5"
-  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz"
-  integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
-
-"@babel/helper-validator-identifier@^7.29.7":
+"@babel/helper-validator-identifier@^7.28.5", "@babel/helper-validator-identifier@^7.29.7":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz"
   integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
@@ -296,14 +232,7 @@
     "@babel/template" "^7.28.6"
     "@babel/types" "^7.29.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.24.4", "@babel/parser@^7.28.6", "@babel/parser@^7.29.0":
-  version "7.29.3"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz"
-  integrity sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==
-  dependencies:
-    "@babel/types" "^7.29.0"
-
-"@babel/parser@^7.29.7":
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.24.4", "@babel/parser@^7.29.0", "@babel/parser@^7.29.7":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz"
   integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
@@ -462,14 +391,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.28.6", "@babel/plugin-syntax-jsx@^7.7.2":
-  version "7.28.6"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz"
-  integrity sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.28.6"
-
-"@babel/plugin-syntax-jsx@^7.29.7":
+"@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.29.7", "@babel/plugin-syntax-jsx@^7.7.2":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz"
   integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
@@ -877,18 +799,7 @@
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.27.1"
 
-"@babel/plugin-transform-react-jsx@^7.27.1":
-  version "7.28.6"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz"
-  integrity sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.27.3"
-    "@babel/helper-module-imports" "^7.28.6"
-    "@babel/helper-plugin-utils" "^7.28.6"
-    "@babel/plugin-syntax-jsx" "^7.28.6"
-    "@babel/types" "^7.28.6"
-
-"@babel/plugin-transform-react-jsx@^7.28.6":
+"@babel/plugin-transform-react-jsx@^7.27.1", "@babel/plugin-transform-react-jsx@^7.28.6":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz"
   integrity sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==
@@ -1116,26 +1027,12 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
 
-"@babel/runtime@^7.18.6", "@babel/runtime@^7.20.0", "@babel/runtime@^7.25.0":
+"@babel/runtime@^7.18.6", "@babel/runtime@^7.20.0", "@babel/runtime@^7.25.0", "@babel/runtime@^7.29.2":
   version "7.29.2"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
 
-"@babel/runtime@^7.29.2":
-  version "7.29.7"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz"
-  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
-
-"@babel/template@^7.28.6", "@babel/template@^7.3.3":
-  version "7.28.6"
-  resolved "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz"
-  integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
-  dependencies:
-    "@babel/code-frame" "^7.28.6"
-    "@babel/parser" "^7.28.6"
-    "@babel/types" "^7.28.6"
-
-"@babel/template@^7.29.7":
+"@babel/template@^7.28.6", "@babel/template@^7.29.7", "@babel/template@^7.3.3":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz"
   integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
@@ -1144,20 +1041,7 @@
     "@babel/parser" "^7.29.7"
     "@babel/types" "^7.29.7"
 
-"@babel/traverse@^7.27.1", "@babel/traverse@^7.28.5", "@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz"
-  integrity sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==
-  dependencies:
-    "@babel/code-frame" "^7.29.0"
-    "@babel/generator" "^7.29.0"
-    "@babel/helper-globals" "^7.28.0"
-    "@babel/parser" "^7.29.0"
-    "@babel/template" "^7.28.6"
-    "@babel/types" "^7.29.0"
-    debug "^4.3.1"
-
-"@babel/traverse@^7.29.7":
+"@babel/traverse@^7.27.1", "@babel/traverse@^7.28.5", "@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0", "@babel/traverse@^7.29.7":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz"
   integrity sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==
@@ -1170,15 +1054,7 @@
     "@babel/types" "^7.29.7"
     debug "^4.3.1"
 
-"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.26.0", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.5", "@babel/types@^7.28.6", "@babel/types@^7.29.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
-  version "7.29.0"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz"
-  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
-  dependencies:
-    "@babel/helper-string-parser" "^7.27.1"
-    "@babel/helper-validator-identifier" "^7.28.5"
-
-"@babel/types@^7.29.7":
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.26.0", "@babel/types@^7.27.1", "@babel/types@^7.28.2", "@babel/types@^7.28.5", "@babel/types@^7.28.6", "@babel/types@^7.29.0", "@babel/types@^7.29.7", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz"
   integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
@@ -1253,7 +1129,7 @@
 
 "@expo/cli@^56.1.13":
   version "56.1.13"
-  resolved "https://registry.yarnpkg.com/@expo/cli/-/cli-56.1.13.tgz#887f549c6e1624cce64473d6151cf025e3572866"
+  resolved "https://registry.npmjs.org/@expo/cli/-/cli-56.1.13.tgz"
   integrity sha512-7n5VzlBr7TKW0BgWgpEopWy+v8buPhMvbSEsuXD+bI1YIJBopkfWAub0qTvlc357E8wWOvV5MJXYyoeRvoOjoQ==
   dependencies:
     "@expo/code-signing-certificates" "^0.0.6"
@@ -1397,7 +1273,7 @@
 
 "@expo/fingerprint@^0.19.3":
   version "0.19.3"
-  resolved "https://registry.yarnpkg.com/@expo/fingerprint/-/fingerprint-0.19.3.tgz#5fcf25adba9fd4cefd6f0e251849136a83fce3e2"
+  resolved "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.19.3.tgz"
   integrity sha512-w9Au2IVrtc0Ct+WRa05DVHGNHXYq6VyPZWuFP+5x055OeZ5q6k5Yg+aJ1gfShmjdOhDftRcsvmWmTdTZlWaTZw==
   dependencies:
     "@expo/env" "^2.3.0"
@@ -1427,7 +1303,7 @@
 
 "@expo/inline-modules@^0.0.10":
   version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@expo/inline-modules/-/inline-modules-0.0.10.tgz#9d22dfebbb08d9c40b51b0f54729e327844525d7"
+  resolved "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.0.10.tgz"
   integrity sha512-DKEfq877UTAmL/gOT5aFhlLNDg/EVmTSca7JQMKDGR6mjFSAcrmQf4GJNsi6ztiaqj6cTnIfoSz0hAYdnr6RJQ==
   dependencies:
     "@expo/config-plugins" "~56.0.8"
@@ -1442,7 +1318,7 @@
 
 "@expo/local-build-cache-provider@^56.0.8":
   version "56.0.8"
-  resolved "https://registry.yarnpkg.com/@expo/local-build-cache-provider/-/local-build-cache-provider-56.0.8.tgz#c7d411923e836e11d652e15ec733030a67674367"
+  resolved "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-56.0.8.tgz"
   integrity sha512-UsuXwpNi57MNhzZ3be4XThc8xW6nzk3Wu37s1+2qcfZGeJcMLKDFfwO6n8YXeIiGlCsOi0Ee1rsTdgjrKt/YJQ==
   dependencies:
     "@expo/config" "~56.0.9"
@@ -1459,7 +1335,7 @@
 
 "@expo/metro-config@~56.0.13":
   version "56.0.13"
-  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-56.0.13.tgz#01ce1989991ee8ab6acb14d36da9507d948f58c3"
+  resolved "https://registry.npmjs.org/@expo/metro-config/-/metro-config-56.0.13.tgz"
   integrity sha512-OPyNYiex/6Ms8zT2POdIZsLhcAZYk7O+yJvpz5uG/4QRA7aiESfCy1I+0YHewMlR4P1YQeyxIrfTurs6m9xfZA==
   dependencies:
     "@babel/code-frame" "^7.20.0"
@@ -1528,7 +1404,7 @@
 
 "@expo/package-manager@^1.12.1":
   version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@expo/package-manager/-/package-manager-1.12.1.tgz#25f6241ba7844887b74668d7c4b44336b1b381f6"
+  resolved "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.12.1.tgz"
   integrity sha512-fQLiFAcFRWF53mtuLK32SUJQ1ahhrTcBZPZPedYTiUT5ha5FF+UO6bPtCc0Y/hgj0/m3HCGBAuSHjbg2kI9oPQ==
   dependencies:
     "@expo/json-file" "^10.2.0"
@@ -1549,7 +1425,7 @@
 
 "@expo/prebuild-config@^56.0.14":
   version "56.0.14"
-  resolved "https://registry.yarnpkg.com/@expo/prebuild-config/-/prebuild-config-56.0.14.tgz#aa0159bbe6229e087dee2934dece02d18b4aa089"
+  resolved "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-56.0.14.tgz"
   integrity sha512-JHdMqR7Mf5ApLC50ZwTL0Z86ezrHOMYwoSHcWT6Pha/+1TcC+/J+i7vjhP06wGXQ2Kvjt74p/3mKg2Pd12KjhQ==
   dependencies:
     "@expo/config" "~56.0.9"
@@ -1574,7 +1450,7 @@
 
 "@expo/router-server@^56.0.12":
   version "56.0.12"
-  resolved "https://registry.yarnpkg.com/@expo/router-server/-/router-server-56.0.12.tgz#ecdaf80ee8e20d3a54aa9ce44068c368b3399179"
+  resolved "https://registry.npmjs.org/@expo/router-server/-/router-server-56.0.12.tgz"
   integrity sha512-RqKV2/Z8BH/z8l0ngSpG6//5xxJPaF5dTQvSfPQ0nrvCjikGMeIvyj3B9BeLnmZZhxb3gBtXqrj3irAoiIp2aQ==
   dependencies:
     debug "^4.3.4"
@@ -1820,19 +1696,19 @@
     strip-ansi "^6.0.0"
     v8-to-istanbul "^9.0.1"
 
-"@jest/schemas@30.0.5":
-  version "30.0.5"
-  resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz"
-  integrity sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==
-  dependencies:
-    "@sinclair/typebox" "^0.34.0"
-
 "@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz"
   integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
   dependencies:
     "@sinclair/typebox" "^0.27.8"
+
+"@jest/schemas@30.0.5":
+  version "30.0.5"
+  resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz"
+  integrity sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==
+  dependencies:
+    "@sinclair/typebox" "^0.34.0"
 
 "@jest/source-map@^29.6.3":
   version "29.6.3"
@@ -1863,26 +1739,6 @@
     jest-haste-map "^29.7.0"
     slash "^3.0.0"
 
-"@jest/transform@30.3.0":
-  version "30.3.0"
-  resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
-  integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
-  dependencies:
-    "@babel/core" "^7.27.4"
-    "@jest/types" "30.3.0"
-    "@jridgewell/trace-mapping" "^0.3.25"
-    babel-plugin-istanbul "^7.0.1"
-    chalk "^4.1.2"
-    convert-source-map "^2.0.0"
-    fast-json-stable-stringify "^2.1.0"
-    graceful-fs "^4.2.11"
-    jest-haste-map "30.3.0"
-    jest-regex-util "30.0.1"
-    jest-util "30.3.0"
-    pirates "^4.0.7"
-    slash "^3.0.0"
-    write-file-atomic "^5.0.1"
-
 "@jest/transform@^29.7.0":
   version "29.7.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz"
@@ -1904,18 +1760,25 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@30.3.0":
+"@jest/transform@30.3.0":
   version "30.3.0"
-  resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
-  integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
+  resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
+  integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
   dependencies:
-    "@jest/pattern" "30.0.1"
-    "@jest/schemas" "30.0.5"
-    "@types/istanbul-lib-coverage" "^2.0.6"
-    "@types/istanbul-reports" "^3.0.4"
-    "@types/node" "*"
-    "@types/yargs" "^17.0.33"
+    "@babel/core" "^7.27.4"
+    "@jest/types" "30.3.0"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    babel-plugin-istanbul "^7.0.1"
     chalk "^4.1.2"
+    convert-source-map "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.3.0"
+    jest-regex-util "30.0.1"
+    jest-util "30.3.0"
+    pirates "^4.0.7"
+    slash "^3.0.0"
+    write-file-atomic "^5.0.1"
 
 "@jest/types@^29.6.3":
   version "29.6.3"
@@ -1928,6 +1791,19 @@
     "@types/node" "*"
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
+
+"@jest/types@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
+  integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
+  dependencies:
+    "@jest/pattern" "30.0.1"
+    "@jest/schemas" "30.0.5"
+    "@types/istanbul-lib-coverage" "^2.0.6"
+    "@types/istanbul-reports" "^3.0.4"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.33"
+    chalk "^4.1.2"
 
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.13", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
@@ -1985,31 +1861,6 @@
   version "3.0.4"
   resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz"
   integrity sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==
-
-"@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz#c2fc0573afe08b0cf213e66eef76842b121d1577"
-  integrity sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==
-
-"@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz#4e3822f5522e18ed92611b894dc5db1bc882f39d"
-  integrity sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==
-
-"@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz#27ec4bc7eb6c311c982a50f1a6e1e1414638a6f8"
-  integrity sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==
-
-"@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz#37317d833c7d01d086f6155fa59c478adb6839f6"
-  integrity sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==
-
-"@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz#a1c79dcc9ae5f8c02aea8c2f144e5af6a822e5e8"
-  integrity sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==
 
 "@opentelemetry/api@^1.9.0":
   version "1.9.1"
@@ -2201,6 +2052,11 @@
   resolved "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.85.3.tgz"
   integrity sha512-U2+aMshIXf1uFn77tpBb/xhHWB9vkVrMpt7kkucAugF8hJKYTDGB587X7WwelHduK2KBfhl4giSv0rzZGoef9A==
 
+"@react-native/normalize-colors@^0.74.1":
+  version "0.74.89"
+  resolved "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.89.tgz"
+  integrity sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg==
+
 "@react-native/normalize-colors@0.85.2":
   version "0.85.2"
   resolved "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.85.2.tgz"
@@ -2210,11 +2066,6 @@
   version "0.85.3"
   resolved "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.85.3.tgz"
   integrity sha512-hj0PScZEhIbcOvQV5yMKX3ha4XEIOy/SVE1Rrpp0beW0dpNLOgSC7KDxGewmDnIHK9YdQUXGY9eMEfShUMIaZw==
-
-"@react-native/normalize-colors@^0.74.1":
-  version "0.74.89"
-  resolved "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.89.tgz"
-  integrity sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg==
 
 "@react-native/virtualized-lists@0.85.2":
   version "0.85.2"
@@ -2519,7 +2370,7 @@
     "@typescript-eslint/types" "8.60.0"
     "@typescript-eslint/visitor-keys" "8.60.0"
 
-"@typescript-eslint/tsconfig-utils@8.60.0", "@typescript-eslint/tsconfig-utils@^8.60.0":
+"@typescript-eslint/tsconfig-utils@^8.60.0", "@typescript-eslint/tsconfig-utils@8.60.0":
   version "8.60.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz"
   integrity sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==
@@ -2535,7 +2386,7 @@
     debug "^4.4.3"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/types@8.60.0", "@typescript-eslint/types@^8.60.0":
+"@typescript-eslint/types@^8.60.0", "@typescript-eslint/types@8.60.0":
   version "8.60.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz"
   integrity sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==
@@ -2704,12 +2555,22 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^5.0.0, ansi-styles@^5.2.0:
+ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-styles@^6.2.1, ansi-styles@^6.2.3:
+ansi-styles@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.2.1:
+  version "6.2.3"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
+ansi-styles@^6.2.3:
   version "6.2.3"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
@@ -2818,13 +2679,6 @@ babel-plugin-istanbul@^7.0.1:
     istanbul-lib-instrument "^6.0.2"
     test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@30.3.0:
-  version "30.3.0"
-  resolved "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz"
-  integrity sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==
-  dependencies:
-    "@types/babel__core" "^7.20.5"
-
 babel-plugin-jest-hoist@^29.6.3:
   version "29.6.3"
   resolved "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz"
@@ -2834,6 +2688,13 @@ babel-plugin-jest-hoist@^29.6.3:
     "@babel/types" "^7.3.3"
     "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
+
+babel-plugin-jest-hoist@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz"
+  integrity sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==
+  dependencies:
+    "@types/babel__core" "^7.20.5"
 
 babel-plugin-polyfill-corejs2@^0.4.14, babel-plugin-polyfill-corejs2@^0.4.15:
   version "0.4.17"
@@ -2879,7 +2740,7 @@ babel-plugin-react-native-web@~0.21.0:
   resolved "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.21.2.tgz"
   integrity sha512-SPD0J6qjJn8231i0HZhlAGH6NORe+QvRSQM2mwQEzJ2Fb3E4ruWTiiicPlHjmeWShDXLcvoorOCXjeR7k/lyWA==
 
-babel-plugin-syntax-hermes-parser@0.33.3, babel-plugin-syntax-hermes-parser@^0.33.3:
+babel-plugin-syntax-hermes-parser@^0.33.3, babel-plugin-syntax-hermes-parser@0.33.3:
   version "0.33.3"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.33.3.tgz"
   integrity sha512-/Z9xYdaJ1lC0pT9do6TqCqhOSLfZ5Ot8D5za1p+feEfWYupCOfGbhhEXN9r2ZgJtDNUNRw/Z+T2CvAGKBqtqWA==
@@ -2921,7 +2782,7 @@ babel-preset-current-node-syntax@^1.0.0, babel-preset-current-node-syntax@^1.2.0
 
 babel-preset-expo@~56.0.14:
   version "56.0.14"
-  resolved "https://registry.yarnpkg.com/babel-preset-expo/-/babel-preset-expo-56.0.14.tgz#aea45c5d8427c0fe8e82789cc734662d147b06e3"
+  resolved "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-56.0.14.tgz"
   integrity sha512-+JKVMYf3HajO3tPRA9DlKd/VhZOPTHyTzUo2yZajfMAoQ3l5VEdGVxm2MzX4DXMNKXwsC8GOeTRx7CrO/5dBDA==
   dependencies:
     "@babel/generator" "^7.20.5"
@@ -2967,14 +2828,6 @@ babel-preset-expo@~56.0.14:
     babel-plugin-transform-flow-enums "^0.0.2"
     debug "^4.3.4"
 
-babel-preset-jest@30.3.0:
-  version "30.3.0"
-  resolved "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz"
-  integrity sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==
-  dependencies:
-    babel-plugin-jest-hoist "30.3.0"
-    babel-preset-current-node-syntax "^1.2.0"
-
 babel-preset-jest@^29.6.3:
   version "29.6.3"
   resolved "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz"
@@ -2982,6 +2835,14 @@ babel-preset-jest@^29.6.3:
   dependencies:
     babel-plugin-jest-hoist "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
+
+babel-preset-jest@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz"
+  integrity sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==
+  dependencies:
+    babel-plugin-jest-hoist "30.3.0"
+    babel-preset-current-node-syntax "^1.2.0"
 
 badgin@^1.1.5:
   version "1.2.3"
@@ -3030,17 +2891,17 @@ bplist-creator@0.1.0:
   dependencies:
     stream-buffers "2.2.x"
 
-bplist-parser@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz"
-  integrity sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==
-  dependencies:
-    big-integer "1.6.x"
-
 bplist-parser@^0.3.1:
   version "0.3.2"
   resolved "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz"
   integrity sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==
+  dependencies:
+    big-integer "1.6.x"
+
+bplist-parser@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz"
+  integrity sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==
   dependencies:
     big-integer "1.6.x"
 
@@ -3155,7 +3016,16 @@ canvaskit-wasm@0.41.0:
   dependencies:
     "@webgpu/types" "0.1.21"
 
-chalk@^2.0.1, chalk@^2.4.2:
+chalk@^2.0.1:
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3288,15 +3158,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
-
 color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 color-string@^1.9.0:
   version "1.9.1"
@@ -3473,19 +3343,12 @@ date-fns@^4.1.0:
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz"
   integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
-debug@2.6.9, debug@^2.6.9:
+debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
-
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0, debug@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 debug@^3.1.0:
   version "3.2.7"
@@ -3493,6 +3356,20 @@ debug@^3.1.0:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0, debug@^4.4.3, debug@4:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 decode-uri-component@^0.2.2:
   version "0.2.2"
@@ -3542,7 +3419,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@2.0.0, depd@~2.0.0:
+depd@~2.0.0, depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
@@ -3766,7 +3643,12 @@ eslint-visitor-keys@^3.4.3:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint-visitor-keys@^5.0.0, eslint-visitor-keys@^5.0.1:
+eslint-visitor-keys@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz"
+  integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
+
+eslint-visitor-keys@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz"
   integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
@@ -3908,7 +3790,7 @@ expo-application@~56.0.3:
 
 expo-asset@~56.0.15:
   version "56.0.15"
-  resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-56.0.15.tgz#468b63c4d49b68a7712eeb3c136db2a71be1de42"
+  resolved "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.15.tgz"
   integrity sha512-BHGi2IAOPQTcOelkUdcz1WIknfCTRjkcpYHX1azjMwgYenrVC+J5qcqJGaC8eUOWLCRtkRJWGnmFQRYtLU1nUQ==
   dependencies:
     "@expo/image-utils" "^0.10.1"
@@ -3931,16 +3813,9 @@ expo-clipboard@~56.0.2:
   resolved "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-56.0.3.tgz"
   integrity sha512-8mCdhmAomm0yBIonJFjAhKUXvSkc2avdNh4+rBwoe7DSWF2AC4w3uy+pa419rvVFbTyVxOBmh83UHAbUwD6qAg==
 
-expo-constants@~56.0.15:
-  version "56.0.15"
-  resolved "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.15.tgz"
-  integrity sha512-7187sd55swLX+CM0noAV5LreEgkUaDG/zEXy9quonfzKpJxy8zJAszp9S++xOx/FcqBVEEEcQhE8tKTujwL8fg==
-  dependencies:
-    "@expo/env" "~2.3.0"
-
-expo-constants@~56.0.16:
+expo-constants@~56.0.15, expo-constants@~56.0.16:
   version "56.0.16"
-  resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-56.0.16.tgz#94f2ed4f83ce1b1c6a36372124c05cc9abcf8d58"
+  resolved "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.16.tgz"
   integrity sha512-6tsiN+gmTUPp/atyA+uY9Tg8VOdXdmb4s/3TVGolfn6A/oCAraw1pcPZX5XllyD+xUguxB6eBSFAT8494hZVMA==
   dependencies:
     "@expo/env" "~2.3.0"
@@ -4019,7 +3894,7 @@ expo-localization@~56.0.2:
 
 expo-modules-autolinking@~56.0.14:
   version "56.0.14"
-  resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-56.0.14.tgz#6aed55b0afe39c341bb4cc443ec142d68213dec2"
+  resolved "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.14.tgz"
   integrity sha512-9ugtZkheNPYDkW4DZopY1rH2BCbUICaafUEPxRgbLDR5UNRF5K3cdHMIMEt8pxZPq2+eX4wCm+6pbSvdY/DPHg==
   dependencies:
     "@expo/require-utils" "^56.1.3"
@@ -4029,7 +3904,7 @@ expo-modules-autolinking@~56.0.14:
 
 expo-modules-core@~56.0.14:
   version "56.0.14"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-56.0.14.tgz#620263e7265f0bcca04d7490ea0b139a5ea9bd89"
+  resolved "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.14.tgz"
   integrity sha512-dl1TlYRm1k7xk9QeAyDoMfFE2p6rNyzHUcH5ArcGwUzO8YKku+Z2tQ8+kG7zLe3OhfMoJcFR/czrFy7vGSVI6w==
   dependencies:
     "@expo/expo-modules-macros-plugin" "~0.0.9"
@@ -4078,7 +3953,7 @@ expo-sharing@~56.0.3:
 
 expo-speech-recognition@56.0.0:
   version "56.0.0"
-  resolved "https://registry.yarnpkg.com/expo-speech-recognition/-/expo-speech-recognition-56.0.0.tgz#51c4f7e11d0a5acf0448e7b8608c192d319122f8"
+  resolved "https://registry.npmjs.org/expo-speech-recognition/-/expo-speech-recognition-56.0.0.tgz"
   integrity sha512-spA6HqnA/rgwMNS5YmFktmzly7f46kGOv3tXZ2f0Xfh7x9pAsmXyG3YtPtB9sHGbW7RmUSjbMGEzsvCak2Q4sA==
 
 expo-speech@~56.0.2:
@@ -4105,7 +3980,7 @@ expo-web-browser@~56.0.2:
 
 expo@56.0.8:
   version "56.0.8"
-  resolved "https://registry.yarnpkg.com/expo/-/expo-56.0.8.tgz#1f2ff8f904e9b9502e3b6c9fcd85aba7911b6847"
+  resolved "https://registry.npmjs.org/expo/-/expo-56.0.8.tgz"
   integrity sha512-GzQi5450yrCk5JRSlm0epsmtURBErh0wS77uWLZImFdnPICuX912MaRWooR+Q1Sw/7aQjp9F+KXH+dvrqGxpeQ==
   dependencies:
     "@babel/runtime" "^7.20.0"
@@ -4301,11 +4176,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2, fsevents@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -4377,15 +4247,6 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@13.0.1:
-  version "13.0.1"
-  resolved "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz"
-  integrity sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==
-  dependencies:
-    minimatch "^10.1.2"
-    minipass "^7.1.2"
-    path-scurry "^2.0.0"
-
 glob@^13.0.0:
   version "13.0.6"
   resolved "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz"
@@ -4395,7 +4256,7 @@ glob@^13.0.0:
     minipass "^7.1.3"
     path-scurry "^2.0.2"
 
-glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.3:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -4406,6 +4267,27 @@ glob@^7.1.3, glob@^7.1.4:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^7.1.4:
+  version "7.2.3"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@13.0.1:
+  version "13.0.1"
+  resolved "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz"
+  integrity sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==
+  dependencies:
+    minimatch "^10.1.2"
+    minipass "^7.1.2"
+    path-scurry "^2.0.0"
 
 globals@^17.6.0:
   version "17.6.0"
@@ -4478,7 +4360,21 @@ hermes-estree@0.35.0:
   resolved "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz"
   integrity sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==
 
-hermes-parser@0.33.3, hermes-parser@^0.33.3:
+hermes-parser@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz"
+  integrity sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==
+  dependencies:
+    hermes-estree "0.25.1"
+
+hermes-parser@^0.33.3:
+  version "0.33.3"
+  resolved "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz"
+  integrity sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==
+  dependencies:
+    hermes-estree "0.33.3"
+
+hermes-parser@0.33.3:
   version "0.33.3"
   resolved "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz"
   integrity sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==
@@ -4491,13 +4387,6 @@ hermes-parser@0.35.0:
   integrity sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==
   dependencies:
     hermes-estree "0.35.0"
-
-hermes-parser@^0.25.1:
-  version "0.25.1"
-  resolved "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz"
-  integrity sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==
-  dependencies:
-    hermes-estree "0.25.1"
 
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"
@@ -4579,7 +4468,17 @@ ieee754@^1.2.1:
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^5.1.4, ignore@^5.2.0, ignore@^5.3.1:
+ignore@^5.1.4:
+  version "5.3.2"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+
+ignore@^5.2.0:
+  version "5.3.2"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+
+ignore@^5.3.1:
   version "5.3.2"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
@@ -4627,7 +4526,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
+inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4, inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4639,7 +4538,7 @@ inline-style-prefixer@^7.0.1:
   dependencies:
     css-in-js-utils "^3.1.0"
 
-invariant@2.2.4, invariant@^2.2.4:
+invariant@^2.2.4, invariant@2.2.4:
   version "2.2.4"
   resolved "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -4891,16 +4790,6 @@ jest-config@^29.7.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@30.3.0:
-  version "30.3.0"
-  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz"
-  integrity sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==
-  dependencies:
-    "@jest/diff-sequences" "30.3.0"
-    "@jest/get-type" "30.1.0"
-    chalk "^4.1.2"
-    pretty-format "30.3.0"
-
 jest-diff@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz"
@@ -4910,6 +4799,16 @@ jest-diff@^29.7.0:
     diff-sequences "^29.6.3"
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
+
+jest-diff@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz"
+  integrity sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==
+  dependencies:
+    "@jest/diff-sequences" "30.3.0"
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    pretty-format "30.3.0"
 
 jest-docblock@^29.7.0:
   version "29.7.0"
@@ -4946,24 +4845,6 @@ jest-get-type@^29.6.3:
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz"
   integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
 
-jest-haste-map@30.3.0:
-  version "30.3.0"
-  resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz"
-  integrity sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==
-  dependencies:
-    "@jest/types" "30.3.0"
-    "@types/node" "*"
-    anymatch "^3.1.3"
-    fb-watchman "^2.0.2"
-    graceful-fs "^4.2.11"
-    jest-regex-util "30.0.1"
-    jest-util "30.3.0"
-    jest-worker "30.3.0"
-    picomatch "^4.0.3"
-    walker "^1.0.8"
-  optionalDependencies:
-    fsevents "^2.3.3"
-
 jest-haste-map@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz"
@@ -4982,6 +4863,24 @@ jest-haste-map@^29.7.0:
     walker "^1.0.8"
   optionalDependencies:
     fsevents "^2.3.2"
+
+jest-haste-map@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz"
+  integrity sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    anymatch "^3.1.3"
+    fb-watchman "^2.0.2"
+    graceful-fs "^4.2.11"
+    jest-regex-util "30.0.1"
+    jest-util "30.3.0"
+    jest-worker "30.3.0"
+    picomatch "^4.0.3"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.3"
 
 jest-leak-detector@^29.7.0:
   version "29.7.0"
@@ -5040,15 +4939,15 @@ jest-pnp-resolver@^1.2.2:
   resolved "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz"
   integrity sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==
 
-jest-regex-util@30.0.1:
-  version "30.0.1"
-  resolved "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz"
-  integrity sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==
-
 jest-regex-util@^29.6.3:
   version "29.6.3"
   resolved "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz"
   integrity sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==
+
+jest-regex-util@30.0.1:
+  version "30.0.1"
+  resolved "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz"
+  integrity sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==
 
 jest-resolve-dependencies@^29.7.0:
   version "29.7.0"
@@ -5154,18 +5053,6 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
-jest-util@30.3.0:
-  version "30.3.0"
-  resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
-  integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
-  dependencies:
-    "@jest/types" "30.3.0"
-    "@types/node" "*"
-    chalk "^4.1.2"
-    ci-info "^4.2.0"
-    graceful-fs "^4.2.11"
-    picomatch "^4.0.3"
-
 jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz"
@@ -5177,6 +5064,18 @@ jest-util@^29.7.0:
     ci-info "^3.2.0"
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
+
+jest-util@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
+  integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    graceful-fs "^4.2.11"
+    picomatch "^4.0.3"
 
 jest-validate@^29.7.0:
   version "29.7.0"
@@ -5204,6 +5103,16 @@ jest-watcher@^29.7.0:
     jest-util "^29.7.0"
     string-length "^4.0.1"
 
+jest-worker@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz"
+  integrity sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==
+  dependencies:
+    "@types/node" "*"
+    jest-util "^29.7.0"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
 jest-worker@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz"
@@ -5214,16 +5123,6 @@ jest-worker@30.3.0:
     jest-util "30.3.0"
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
-
-jest-worker@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz"
-  integrity sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==
-  dependencies:
-    "@types/node" "*"
-    jest-util "^29.7.0"
-    merge-stream "^2.0.0"
-    supports-color "^8.0.0"
 
 jest@~29.7.0:
   version "29.7.0"
@@ -5355,60 +5254,10 @@ lighthouse-logger@^1.0.0:
     debug "^2.6.9"
     marky "^1.2.2"
 
-lightningcss-android-arm64@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz#f033885116dfefd9c6f54787523e3514b61e1968"
-  integrity sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==
-
 lightningcss-darwin-arm64@1.32.0:
   version "1.32.0"
   resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz"
   integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
-
-lightningcss-darwin-x64@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz#35f3e97332d130b9ca181e11b568ded6aebc6d5e"
-  integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
-
-lightningcss-freebsd-x64@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz#9777a76472b64ed6ff94342ad64c7bafd794a575"
-  integrity sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==
-
-lightningcss-linux-arm-gnueabihf@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz#13ae652e1ab73b9135d7b7da172f666c410ad53d"
-  integrity sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==
-
-lightningcss-linux-arm64-gnu@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz#417858795a94592f680123a1b1f9da8a0e1ef335"
-  integrity sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==
-
-lightningcss-linux-arm64-musl@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz#6be36692e810b718040802fd809623cffe732133"
-  integrity sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==
-
-lightningcss-linux-x64-gnu@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz#0b7803af4eb21cfd38dd39fe2abbb53c7dd091f6"
-  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
-
-lightningcss-linux-x64-musl@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz#88dc8ba865ddddb1ac5ef04b0f161804418c163b"
-  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
-
-lightningcss-win32-arm64-msvc@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz#4f30ba3fa5e925f5b79f945e8cc0d176c3b1ab38"
-  integrity sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==
-
-lightningcss-win32-x64-msvc@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz#141aa5605645064928902bb4af045fa7d9f4220a"
-  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
 
 lightningcss@^1.30.1:
   version "1.32.0"
@@ -5606,7 +5455,7 @@ metro-cache@0.84.4:
     https-proxy-agent "^7.0.5"
     metro-core "0.84.4"
 
-metro-config@0.84.4, metro-config@^0.84.0:
+metro-config@^0.84.0, metro-config@0.84.4:
   version "0.84.4"
   resolved "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz"
   integrity sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==
@@ -5620,7 +5469,7 @@ metro-config@0.84.4, metro-config@^0.84.0:
     metro-runtime "0.84.4"
     yaml "^2.6.1"
 
-metro-core@0.84.4, metro-core@^0.84.0:
+metro-core@^0.84.0, metro-core@0.84.4:
   version "0.84.4"
   resolved "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz"
   integrity sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==
@@ -5659,7 +5508,7 @@ metro-resolver@0.84.4:
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-metro-runtime@0.84.4, metro-runtime@^0.84.0:
+metro-runtime@^0.84.0, metro-runtime@0.84.4:
   version "0.84.4"
   resolved "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz"
   integrity sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==
@@ -5667,7 +5516,7 @@ metro-runtime@0.84.4, metro-runtime@^0.84.0:
     "@babel/runtime" "^7.25.0"
     flow-enums-runtime "^0.0.6"
 
-metro-source-map@0.84.4, metro-source-map@^0.84.0:
+metro-source-map@^0.84.0, metro-source-map@0.84.4:
   version "0.84.4"
   resolved "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz"
   integrity sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==
@@ -5725,7 +5574,7 @@ metro-transform-worker@0.84.4:
     metro-transform-plugins "0.84.4"
     nullthrows "^1.1.1"
 
-metro@0.84.4, metro@^0.84.0:
+metro@^0.84.0, metro@0.84.4:
   version "0.84.4"
   resolved "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz"
   integrity sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==
@@ -5778,15 +5627,15 @@ micromatch@^4.0.4:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@^1.54.0, "mime-db@>= 1.43.0 < 2":
+  version "1.54.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
-"mime-db@>= 1.43.0 < 2", mime-db@^1.54.0:
-  version "1.54.0"
-  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz"
-  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
 mime-types@^2.1.12, mime-types@~2.1.34:
   version "2.1.35"
@@ -5868,15 +5717,15 @@ mkdirp@^1.0.4:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+ms@^2.1.1, ms@^2.1.3, ms@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
-
-ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 msgpackr-extract@^3.0.4:
   version "3.0.4"
@@ -5914,11 +5763,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-negotiator@0.6.3:
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
-  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
 negotiator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz"
@@ -5928,6 +5772,11 @@ negotiator@~0.6.4:
   version "0.6.4"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz"
   integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
+
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 node-fetch@^2.7.0:
   version "2.7.0"
@@ -6176,7 +6025,17 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
+
+picomatch@^2.2.3:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
+
+picomatch@^2.3.1:
   version "2.3.2"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
@@ -6253,16 +6112,7 @@ prettier@^3.8.3:
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz"
   integrity sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==
 
-pretty-format@30.3.0, pretty-format@^30.0.5:
-  version "30.3.0"
-  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz"
-  integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
-  dependencies:
-    "@jest/schemas" "30.0.5"
-    ansi-styles "^5.2.0"
-    react-is "^18.3.1"
-
-pretty-format@^29.0.0, pretty-format@^29.7.0:
+pretty-format@^29.0.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz"
   integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
@@ -6270,6 +6120,24 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
+
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
+pretty-format@^30.0.5, pretty-format@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz"
+  integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
+  dependencies:
+    "@jest/schemas" "30.0.5"
+    ansi-styles "^5.2.0"
+    react-is "^18.3.1"
 
 proc-log@^4.0.0:
   version "4.2.0"
@@ -6384,7 +6252,12 @@ react-is@^16.7.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^18.0.0, react-is@^18.3.1:
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+react-is@^18.3.1:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
@@ -6477,7 +6350,7 @@ react-native-skia-apple-tvos@147.1.0:
 
 react-native-svg@15.15.5:
   version "15.15.5"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.15.5.tgz#822805c14481b8ec16d5fbac1e3ce2b27a5509d7"
+  resolved "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.5.tgz"
   integrity sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w==
   dependencies:
     css-select "^5.1.0"
@@ -6574,7 +6447,7 @@ react-refresh@^0.14.0, react-refresh@^0.14.2:
 
 react-test-renderer@19.2.3:
   version "19.2.3"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-19.2.3.tgz#d20f5193867c98b2df9e13b4e72bb83f311f6a43"
+  resolved "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz"
   integrity sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==
   dependencies:
     react-is "^19.2.3"
@@ -6582,7 +6455,7 @@ react-test-renderer@19.2.3:
 
 react@19.2.3:
   version "19.2.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.3.tgz#d83e5e8e7a258cf6b4fe28640515f99b87cd19b8"
+  resolved "https://registry.npmjs.org/react/-/react-19.2.3.tgz"
   integrity sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==
 
 readable-stream@^4.0.0:
@@ -6726,7 +6599,7 @@ rtl-detect@^1.0.2:
   resolved "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz"
   integrity sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==
 
-safe-buffer@5.2.1, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@^5.2.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -6741,22 +6614,52 @@ sax@>=0.6.0:
   resolved "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz"
   integrity sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==
 
-scheduler@0.27.0, scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
-
 scheduler@^0.25.0:
   version "0.25.0"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz"
   integrity sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==
+
+scheduler@^0.27.0, scheduler@0.27.0:
+  version "0.27.0"
+  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.1.3, semver@^7.3.5, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.3, semver@^7.7.4:
+semver@^7.1.3:
+  version "7.7.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+semver@^7.3.5:
+  version "7.7.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+semver@^7.5.3:
+  version "7.7.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+semver@^7.5.4:
+  version "7.7.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+semver@^7.6.0:
+  version "7.7.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+semver@^7.7.3:
+  version "7.7.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+semver@^7.7.4:
   version "7.7.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
@@ -6853,7 +6756,12 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-signal-exit@^4.0.1, signal-exit@^4.1.0:
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
+signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -6924,18 +6832,18 @@ source-map-js@^1.2.1:
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-source-map-support@0.5.13:
-  version "0.5.13"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz"
-  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@0.5.13:
+  version "0.5.13"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -6999,6 +6907,20 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
+string_decoder@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 string-argv@^0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz"
@@ -7012,7 +6934,25 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+string-width@^4.1.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7038,20 +6978,6 @@ string-width@^8.2.0:
     get-east-asian-width "^1.5.0"
     strip-ansi "^7.1.2"
 
-string_decoder@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
-
 strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz"
@@ -7066,7 +6992,14 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.1.0, strip-ansi@^7.1.2:
+strip-ansi@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
+
+strip-ansi@^7.1.2:
   version "7.2.0"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz"
   integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
@@ -7119,7 +7052,14 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0, supports-color@^8.1.1:
+supports-color@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -7501,7 +7441,12 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@^7, ws@^7.5.10:
+ws@^7:
+  version "7.5.10"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+
+ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==


### PR DESCRIPTION

## Summary

- **Daily repeat mode**: Scheduled learning items can now repeat daily, generating a completely new note each day (tracked via `lastGeneratedAt` with a 23-hour window)
- **Questioner notes**: New learning type where AI generates question notes the user can answer. Sources can be `tags`, a custom `prompt`, or a `folder` of existing notes
- **Grading flow**: A "Grade My Answers" button appears in the note viewer for questioner notes — pressing it sends the answered questions to the LLM which grades, corrects, and provides proper answers, appending the results to the note
- **Onboarding**: Added a 5th info step describing both Learn and Questioner features

## Key changes

- `src/models/ScheduledLearning.ts` — New `ScheduledLearningType`, `ScheduledLearningRepeat` (with `daily`), `QuestionerSource` types; extended item model with questioner fields
- `src/services/ScheduledLearningService.ts` — Added `generateQuestionerNote`, `gradeQuestionerNote`, and `resolveModel` helper; branched `generateAndCreateNote` by type
- `src/components/settings/AddScheduledLearningScreen.tsx` — Type picker cards, daily repeat button, conditional questioner config section (source picker, prompt input, folder path)
- `src/components/editor/NoteViewer.tsx` — Grading bar with button shown for questioner notes
- `src/screens/NoteEditorScreen.tsx` — Detects questioner notes by tag and wires up grading callback
- `src/screens/OnboardingScreen.tsx` — New scheduled learning info step
- `__tests__/` — Added tests for daily repeat, type fields, questioner creation, and grading

💘 Generated with Heretic