### PR TITLE
feat(sync): add GitHub / GitLab / Gitea / Forgejo host support

### DIFF
--- a/__tests__/AddRepoModal.test.tsx
+++ b/__tests__/AddRepoModal.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+
+const stableColors = {
+  background: '#fff',
+  surface: '#f4f4f4',
+  primary: '#2563eb',
+  text: '#111',
+  textSecondary: '#666',
+  border: '#ddd',
+  error: '#dc2626',
+  accent: '#8b5cf6',
+};
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: any) => children,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, opts?: any) =>
+    opts?.example ? `${key}|${opts.example}` : key }),
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: stableColors,
+    isDark: false,
+    tokens: {
+      spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 },
+      type: { xs: 12, sm: 14, md: 16, lg: 18, xl: 22 },
+    },
+  }),
+}));
+
+const mockAddRepository = jest.fn(async (path: string, _name: string | undefined, provider: string) => ({
+  id: `${provider}:${Date.now()}`,
+  name: path.split('/').pop() || path,
+  path,
+  branch: 'main',
+  provider,
+}));
+
+jest.mock('../src/stores/repoStore', () => ({
+  useRepoStore: (selector: any) => selector({ addRepository: mockAddRepository }),
+}));
+
+jest.mock('../src/components/ui', () => {
+  const { View } = require('react-native');
+  return {
+    Modal: ({ visible, children }: any) => (visible ? <View>{children}</View> : null),
+  };
+});
+
+jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+import { AddRepoModal } from '../src/components/AddRepoModal';
+
+beforeEach(() => {
+  mockAddRepository.mockClear();
+});
+
+describe('AddRepoModal', () => {
+  it('shows all four host options and defaults to GitHub', () => {
+    const { getByTestId } = render(<AddRepoModal visible onClose={() => {}} colors={stableColors} />);
+    expect(getByTestId('add-repo-provider-github')).toBeTruthy();
+    expect(getByTestId('add-repo-provider-gitlab')).toBeTruthy();
+    expect(getByTestId('add-repo-provider-gitea')).toBeTruthy();
+    expect(getByTestId('add-repo-provider-forgejo')).toBeTruthy();
+  });
+
+  it('disables submit when path is empty', () => {
+    const { getByTestId } = render(<AddRepoModal visible onClose={() => {}} colors={stableColors} />);
+    expect(getByTestId('add-repo-submit').props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('uses the namespace/project placeholder for GitLab', () => {
+    const { getByTestId, getByPlaceholderText } = render(
+      <AddRepoModal visible onClose={() => {}} colors={stableColors} />,
+    );
+    fireEvent.press(getByTestId('add-repo-provider-gitlab'));
+    expect(getByPlaceholderText('namespace/project')).toBeTruthy();
+  });
+
+  it('uses the owner/repo placeholder for GitHub / Gitea / Forgejo', () => {
+    const { getByTestId, getByPlaceholderText } = render(
+      <AddRepoModal visible onClose={() => {}} colors={stableColors} />,
+    );
+    fireEvent.press(getByTestId('add-repo-provider-gitea'));
+    expect(getByPlaceholderText('owner/repo')).toBeTruthy();
+    fireEvent.press(getByTestId('add-repo-provider-forgejo'));
+    expect(getByPlaceholderText('owner/repo')).toBeTruthy();
+  });
+
+  it('submits the chosen provider to addRepository', async () => {
+    const onAdded = jest.fn();
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <AddRepoModal visible onClose={onClose} onAdded={onAdded} colors={stableColors} />,
+    );
+    fireEvent.press(getByTestId('add-repo-provider-gitlab'));
+    fireEvent.changeText(getByTestId('add-repo-path-input'), 'inkscape/inkscape');
+    await waitFor(() => {
+      fireEvent.press(getByTestId('add-repo-submit'));
+    });
+    await waitFor(() => expect(mockAddRepository).toHaveBeenCalled());
+    expect(mockAddRepository).toHaveBeenCalledWith('inkscape/inkscape', undefined, 'gitlab');
+    expect(onAdded).toHaveBeenCalledWith('inkscape/inkscape', 'gitlab');
+  });
+});

--- a/__tests__/GitHost.test.ts
+++ b/__tests__/GitHost.test.ts
@@ -1,0 +1,65 @@
+import {
+  GIT_HOST_LABELS,
+  GIT_HOST_API_BASES,
+  makeRepoId,
+  type GitHostProvider,
+} from '../src/services/git/GitHost';
+import { getGitHostService } from '../src/services/git/gitHostFactory';
+import { gitLabService } from '../src/services/git/GitLabService';
+import {
+  giteaHostService,
+  forgejoHostService,
+} from '../src/services/git/gitHostFactory';
+
+describe('GitHost abstraction', () => {
+  it('exposes human-readable labels for every host', () => {
+    expect(GIT_HOST_LABELS.github).toBe('GitHub');
+    expect(GIT_HOST_LABELS.gitlab).toBe('GitLab');
+    expect(GIT_HOST_LABELS.gitea).toBe('Gitea');
+    expect(GIT_HOST_LABELS.forgejo).toBe('Forgejo');
+  });
+
+  it('exposes a default API base for every host', () => {
+    expect(GIT_HOST_API_BASES.github).toBe('https://api.github.com');
+    expect(GIT_HOST_API_BASES.gitlab).toBe('https://gitlab.com/api/v4');
+    expect(GIT_HOST_API_BASES.gitea).toBe('https://gitea.com/api/v1');
+    expect(GIT_HOST_API_BASES.forgejo).toBe('https://codeberg.org/api/v1');
+  });
+
+  it('composes stable repo ids', () => {
+    expect(makeRepoId('github', 'octocat', 'hello')).toBe('github:octocat/hello');
+    expect(makeRepoId('gitlab', 'inkscape', 'inkscape')).toBe(
+      'gitlab:inkscape/inkscape',
+    );
+  });
+});
+
+describe('getGitHostService', () => {
+  it('returns the GitHub service for github / null / unknown providers', () => {
+    const providers: Array<GitHostProvider | string | null | undefined> = [
+      'github',
+      null,
+      undefined,
+      '',
+      'unsupported',
+    ];
+    for (const p of providers) {
+      expect(getGitHostService(p).provider).toBe('github');
+    }
+  });
+
+  it('returns the GitLab service for gitlab', () => {
+    expect(getGitHostService('gitlab')).toBe(gitLabService);
+    expect(getGitHostService('gitlab').provider).toBe('gitlab');
+  });
+
+  it('returns the Gitea service for gitea', () => {
+    expect(getGitHostService('gitea').provider).toBe('gitea');
+    expect(getGitHostService('gitea')).toBe(giteaHostService);
+  });
+
+  it('returns the Forgejo service for forgejo', () => {
+    expect(getGitHostService('forgejo').provider).toBe('forgejo');
+    expect(getGitHostService('forgejo')).toBe(forgejoHostService);
+  });
+});

--- a/__tests__/GitHubHostService.test.ts
+++ b/__tests__/GitHubHostService.test.ts
@@ -1,0 +1,105 @@
+import { GitHubHostService } from '../src/services/git/GitHubHostService';
+
+const mockGetTreeRecursive = jest.fn();
+const mockGetFileContent = jest.fn();
+const mockGetRepoContents = jest.fn();
+const mockGetUser = jest.fn();
+const mockIsAuthenticated = jest.fn();
+
+jest.mock('../src/services/GitHubService', () => {
+  return {
+    GitHubService: {
+      getTreeRecursive: (...args: unknown[]) => mockGetTreeRecursive(...args),
+      getFileContent: (...args: unknown[]) => mockGetFileContent(...args),
+      getRepoContents: (...args: unknown[]) => mockGetRepoContents(...args),
+      getUser: () => mockGetUser(),
+      isAuthenticated: () => mockIs_authenticated_value(),
+    },
+    GitHubServiceStatic: {
+      rawGet: jest.fn(async () => null),
+      getRepoMeta: jest.fn(async () => ({ default_branch: 'main' })),
+    },
+  };
+});
+
+function mockIs_authenticated_value(): boolean {
+  return mockIsAuthenticated();
+}
+
+beforeEach(() => {
+  mockGetTreeRecursive.mockReset();
+  mockGetFileContent.mockReset();
+  mockGetRepoContents.mockReset();
+  mockGetUser.mockReset();
+  mockIsAuthenticated.mockReset();
+  mockIsAuthenticated.mockReturnValue(true);
+});
+
+describe('GitHubHostService', () => {
+  it('reports its provider as github', () => {
+    expect(new GitHubHostService().provider).toBe('github');
+  });
+
+  it('getDefaultBranch reads default_branch via the static helper', async () => {
+    const svc = new GitHubHostService();
+    const branch = await svc.getDefaultBranch('octocat', 'hello');
+    expect(branch).toBe('main');
+  });
+
+  it('listBranches uses the static rawGet helper', async () => {
+    const { GitHubServiceStatic } = require('../src/services/GitHubService');
+    (GitHubServiceStatic.rawGet as jest.Mock)
+      .mockResolvedValueOnce([{ name: 'main' }, { name: 'develop' }])
+      .mockResolvedValueOnce({ default_branch: 'main' });
+    const svc = new GitHubHostService();
+    const branches = await svc.listBranches('octocat', 'hello');
+    expect(branches).toEqual([
+      { name: 'main', isDefault: true },
+      { name: 'develop', isDefault: false },
+    ]);
+  });
+
+  it('getTreeRecursive delegates to GitHubService (authenticated path)', async () => {
+    mockGetTreeRecursive.mockResolvedValueOnce([
+      { path: 'src', type: 'tree', sha: 's1' },
+      { path: 'src/index.ts', type: 'blob', sha: 's2' },
+    ]);
+    const svc = new GitHubHostService();
+    const tree = await svc.getTreeRecursive('octocat', 'hello', 'main');
+    expect(mockGetTreeRecursive).toHaveBeenCalledWith('octocat', 'hello', 'main');
+    expect(tree).toEqual([
+      { path: 'src', type: 'tree', sha: 's1' },
+      { path: 'src/index.ts', type: 'blob', sha: 's2' },
+    ]);
+  });
+
+  it('getTreeRecursive returns [] when the service throws', async () => {
+    mockGetTreeRecursive.mockRejectedValueOnce(new Error('boom'));
+    const svc = new GitHubHostService();
+    const tree = await svc.getTreeRecursive('octocat', 'hello', 'main');
+    expect(tree).toEqual([]);
+  });
+
+  it('listContents delegates to GitHubService.getRepoContents and maps types', async () => {
+    mockGetRepoContents.mockResolvedValueOnce([
+      { name: 'docs', path: 'docs', type: 'dir', size: 0, sha: 'd1' },
+      { name: 'README.md', path: 'README.md', type: 'file', size: 100, sha: 'f1', download_url: 'x' },
+    ]);
+    const svc = new GitHubHostService();
+    const items = await svc.listContents('octocat', 'hello', '');
+    expect(mockGetRepoContents).toHaveBeenCalledWith('octocat', 'hello', '', undefined);
+    expect(items).toEqual([
+      { name: 'docs', path: 'docs', type: 'dir', size: 0, sha: 'd1', downloadUrl: null },
+      { name: 'README.md', path: 'README.md', type: 'file', size: 100, sha: 'f1', downloadUrl: 'x' },
+    ]);
+  });
+
+  it('getFileText delegates to GitHubService.getFileContent', async () => {
+    // getFileContent returns a decoded string; mock the return shape.
+    mockGetFileContent.mockResolvedValueOnce('hello');
+    const svc = new GitHubHostService();
+    const text = await svc.getFileText('octocat', 'hello', 'README.md', 'main');
+    expect(mockGetFileContent).toHaveBeenCalledWith('octocat', 'hello', 'README.md', 'main');
+    expect(text).toBe('hello');
+  });
+});

--- a/__tests__/GitLabService.test.ts
+++ b/__tests__/GitLabService.test.ts
@@ -1,0 +1,119 @@
+import { GitLabService } from '../src/services/git/GitLabService';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  (AsyncStorage.getItem as jest.Mock) = jest.fn(async () => null);
+  (AsyncStorage.setItem as jest.Mock) = jest.fn(async () => undefined);
+  (AsyncStorage.removeItem as jest.Mock) = jest.fn(async () => undefined);
+});
+
+/** Configures `fetch` so the first call (the /user probe inside setToken) succeeds
+ * and any subsequent calls (the real method under test) get the provided body. */
+function primeAuthAndEndpoint(endpointBody: unknown, endpointStatus = 200): void {
+  mockFetch
+    .mockResolvedValueOnce(jsonResponse({ id: 1, username: 'me', name: 'Me' }))
+    .mockResolvedValueOnce(jsonResponse(endpointBody, endpointStatus));
+}
+
+describe('GitLabService', () => {
+  it('uses the PRIVATE-TOKEN header on every request', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: 1, username: 'me', name: 'Me' }));
+    const svc = new GitLabService();
+    await svc.setToken('glpat-abc');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('https://gitlab.com/api/v4/user'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'PRIVATE-TOKEN': 'glpat-abc' }),
+      }),
+    );
+  });
+
+  it('listBranches maps the default branch flag', async () => {
+    primeAuthAndEndpoint([
+      { name: 'main', default: true },
+      { name: 'feature/x', default: false },
+    ]);
+    const svc = new GitLabService();
+    await svc.setToken('glpat-abc');
+
+    const branches = await svc.listBranches('inkscape', 'inkscape');
+    expect(branches).toEqual([
+      { name: 'main', isDefault: true },
+      { name: 'feature/x', isDefault: false },
+    ]);
+  });
+
+  it('listContents maps tree items to dirs and blob items to files', async () => {
+    primeAuthAndEndpoint([
+      { id: 'a', name: 'docs', type: 'tree', path: 'docs' },
+      { id: 'b', name: 'README.md', type: 'blob', path: 'README.md' },
+    ]);
+    const svc = new GitLabService();
+    await svc.setToken('glpat-abc');
+    const items = await svc.listContents('inkscape', 'inkscape', '');
+    expect(items).toEqual([
+      { name: 'docs', path: 'docs', type: 'dir', sha: 'a' },
+      { name: 'README.md', path: 'README.md', type: 'file', sha: 'b' },
+    ]);
+  });
+
+  it('getTreeRecursive returns only valid entries', async () => {
+    primeAuthAndEndpoint([
+      { id: 'a', name: 'src', type: 'tree', path: 'src' },
+      { id: 'b', name: 'main.ts', type: 'blob', path: 'src/main.ts' },
+    ]);
+    const svc = new GitLabService();
+    await svc.setToken('glpat-abc');
+    const tree = await svc.getTreeRecursive('inkscape', 'inkscape', 'main');
+    expect(tree).toEqual([
+      { path: 'src', type: 'tree', sha: 'a' },
+      { path: 'src/main.ts', type: 'blob', sha: 'b' },
+    ]);
+  });
+
+  it('getFileText decodes base64 payload', async () => {
+    const body = Buffer.from('hello world').toString('base64');
+    primeAuthAndEndpoint({ content: body, encoding: 'base64' });
+    const svc = new GitLabService();
+    await svc.setToken('glpat-abc');
+    const text = await svc.getFileText('inkscape', 'inkscape', 'README.md', 'main');
+    expect(text).toBe('hello world');
+  });
+
+  it('getDefaultBranch reads default_branch from the project endpoint', async () => {
+    primeAuthAndEndpoint({ default_branch: 'develop' });
+    const svc = new GitLabService();
+    await svc.setToken('glpat-abc');
+    expect(await svc.getDefaultBranch('inkscape', 'inkscape')).toBe('develop');
+  });
+
+  it('returns null when API is unauthenticated', async () => {
+    const svc = new GitLabService();
+    expect(await svc.listBranches('x', 'y')).toEqual([]);
+    expect(await svc.getDefaultBranch('x', 'y')).toBeNull();
+  });
+
+  it('setBaseUrl updates the API base for subsequent calls', async () => {
+    primeAuthAndEndpoint({ id: 1, username: 'me', name: 'Me' });
+    const svc = new GitLabService();
+    svc.setBaseUrl('https://gitlab.example.com/api/v4');
+    await svc.setToken('glpat-abc');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://gitlab.example.com/api/v4/user',
+      expect.any(Object),
+    );
+  });
+});

--- a/__tests__/GiteaLikeHostService.test.ts
+++ b/__tests__/GiteaLikeHostService.test.ts
@@ -1,0 +1,100 @@
+import { GiteaLikeHostService } from '../src/services/git/GiteaLikeHostService';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  (AsyncStorage.getItem as jest.Mock) = jest.fn(async () => null);
+  (AsyncStorage.setItem as jest.Mock) = jest.fn(async () => undefined);
+  (AsyncStorage.removeItem as jest.Mock) = jest.fn(async () => undefined);
+});
+
+function primeAuthAndEndpoint(endpointBody: unknown, endpointStatus = 200): void {
+  mockFetch
+    .mockResolvedValueOnce(jsonResponse({ id: 1, login: 'me', full_name: 'Me' }))
+    .mockResolvedValueOnce(jsonResponse(endpointBody, endpointStatus));
+}
+
+describe('GiteaLikeHostService (gitea)', () => {
+  it('uses the token auth scheme', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: 1, login: 'me' }));
+    const svc = new GiteaLikeHostService('gitea', 'https://gitea.com/api/v1');
+    await svc.setToken('gt-abc');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://gitea.com/api/v1/user',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'token gt-abc' }),
+      }),
+    );
+  });
+
+  it('listBranches returns the branch list', async () => {
+    primeAuthAndEndpoint([{ name: 'main' }, { name: 'develop' }]);
+    const svc = new GiteaLikeHostService('gitea', 'https://gitea.com/api/v1');
+    await svc.setToken('gt-abc');
+    const branches = await svc.listBranches('octocat', 'hello');
+    expect(branches).toEqual([{ name: 'main' }, { name: 'develop' }]);
+  });
+
+  it('getTreeRecursive walks folders recursively', async () => {
+    // First /user probe
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: 1, login: 'me' }));
+    // Root contents: a dir and a file
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse([
+        { name: 'docs', path: 'docs', type: 'dir', sha: 'd1' },
+        { name: 'README.md', path: 'README.md', type: 'file', sha: 'f1' },
+      ]),
+    );
+    // Subfolder contents
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse([{ name: 'intro.md', path: 'docs/intro.md', type: 'file', sha: 'f2' }]),
+    );
+    const svc = new GiteaLikeHostService('gitea', 'https://gitea.com/api/v1');
+    await svc.setToken('gt-abc');
+    const tree = await svc.getTreeRecursive('octocat', 'hello', 'main');
+    expect(tree).toEqual([
+      { path: 'docs', type: 'tree', sha: 'd1' },
+      { path: 'docs/intro.md', type: 'blob', sha: 'f2' },
+      { path: 'README.md', type: 'blob', sha: 'f1' },
+    ]);
+  });
+
+  it('getDefaultBranch reads the repo metadata', async () => {
+    primeAuthAndEndpoint({ default_branch: 'trunk' });
+    const svc = new GiteaLikeHostService('gitea', 'https://gitea.com/api/v1');
+    await svc.setToken('gt-abc');
+    expect(await svc.getDefaultBranch('octocat', 'hello')).toBe('trunk');
+  });
+
+  it('returns null when unauthenticated', async () => {
+    const svc = new GiteaLikeHostService('gitea', 'https://gitea.com/api/v1');
+    expect(await svc.listBranches('x', 'y')).toEqual([]);
+    expect(await svc.getDefaultBranch('x', 'y')).toBeNull();
+  });
+});
+
+describe('GiteaLikeHostService (forgejo)', () => {
+  it('uses the forgejo provider label and codeberg base url by default', async () => {
+    const svc = new GiteaLikeHostService('forgejo', 'https://codeberg.org/api/v1');
+    expect(svc.provider).toBe('forgejo');
+    expect(svc.getBaseUrl()).toBe('https://codeberg.org/api/v1');
+  });
+
+  it('clears token and user on clearToken', async () => {
+    const svc = new GiteaLikeHostService('forgejo', 'https://codeberg.org/api/v1');
+    await svc.clearToken();
+    expect(svc.isAuthenticated()).toBe(false);
+    expect(svc.getUser()).toBeNull();
+  });
+});

--- a/__tests__/live-gitlab.integration.test.ts
+++ b/__tests__/live-gitlab.integration.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Live integration smoke test for the GitLab host.
+ *
+ * Uses the GitLab REST API to exercise the GitLabService end-to-end:
+ *   1. Verify the auth probe /user returns a real user with a valid token.
+ *   2. Resolve the default branch of a public GitLab project.
+ *   3. List the branches of the project.
+ *   4. Read the project tree and the contents of a file.
+ *
+ * Run with: GITLAB_PAT=glpat-... GITLAB_TEST_PROJECT=inkscape/inkscape \
+ *           npx jest live-gitlab --runInBand
+ *
+ * Skips gracefully when the env var is missing so unit tests stay
+ * hermetic.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { GitLabService } from '../src/services/git/GitLabService';
+
+type Env = {
+  GITLAB_PAT: string;
+  GITLAB_TEST_PROJECT: string;
+};
+
+function loadEnv(): Env | null {
+  const envPath = path.resolve(__dirname, '..', '.env');
+  if (!fs.existsSync(envPath)) return null;
+  const raw = fs.readFileSync(envPath, 'utf8');
+  const map: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 0) continue;
+    map[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  if (!map.GITLAB_PAT || !map.GITLAB_TEST_PROJECT) return null;
+  return { GITLAB_PAT: map.GITLAB_PAT, GITLAB_TEST_PROJECT: map.GITLAB_TEST_PROJECT };
+}
+
+const env = loadEnv();
+const describeLive = env ? describe : describe.skip;
+
+describeLive('Live GitLab host integration', () => {
+  jest.setTimeout(60_000);
+  let svc: GitLabService;
+
+  beforeEach(async () => {
+    svc = new GitLabService();
+    await svc.setToken(env!.GITLAB_PAT);
+  });
+
+  it('authenticates against gitlab.com', async () => {
+    const user = await svc.getAuthenticatedUser();
+    expect(user).not.toBeNull();
+    expect(user?.login.length).toBeGreaterThan(0);
+    console.log('[live] gitlab user:', user?.login);
+  });
+
+  it('resolves the default branch of the test project', async () => {
+    const [owner, repo] = env!.GITLAB_TEST_PROJECT.split('/');
+    const branch = await svc.getDefaultBranch(owner, repo);
+    expect(branch).not.toBeNull();
+    expect(branch?.length).toBeGreaterThan(0);
+    console.log('[live] default branch:', branch);
+  });
+
+  it('lists branches of the test project', async () => {
+    const [owner, repo] = env!.GITLAB_TEST_PROJECT.split('/');
+    const branches = await svc.listBranches(owner, repo);
+    expect(branches.length).toBeGreaterThan(0);
+    console.log('[live] branch count:', branches.length);
+  });
+
+  it('walks the project tree', async () => {
+    const [owner, repo] = env!.GITLAB_TEST_PROJECT.split('/');
+    const branch = await svc.getDefaultBranch(owner, repo);
+    expect(branch).not.toBeNull();
+    const tree = await svc.getTreeRecursive(owner, repo, branch!);
+    expect(tree.length).toBeGreaterThan(0);
+    console.log('[live] tree entries:', tree.length);
+  });
+});

--- a/__tests__/services/branchResolver.test.ts
+++ b/__tests__/services/branchResolver.test.ts
@@ -1,6 +1,8 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   __resetBranchCacheForTests,
   fetchGitHubDefaultBranch,
+  fetchGitLabDefaultBranch,
   invalidateBranchCache,
   resolveBranch,
 } from '../../src/services/git/branchResolver';
@@ -16,10 +18,15 @@ const mockedGetCurrentBranch = GitFsService.getCurrentBranch as jest.MockedFunct
   typeof GitFsService.getCurrentBranch
 >;
 
-beforeEach(() => {
+function jsonResponse(body: unknown, status = 200): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as Response;
+}
+
+beforeEach(async () => {
   __resetBranchCacheForTests();
   mockedGetCurrentBranch.mockReset();
   (global.fetch as jest.Mock | undefined)?.mockReset?.();
+  await AsyncStorage.clear();
 });
 
 describe('resolveBranch', () => {
@@ -87,5 +94,41 @@ describe('fetchGitHubDefaultBranch', () => {
       json: () => Promise.resolve({ default_branch: 'master' }),
     }) as unknown as typeof fetch;
     expect(await fetchGitHubDefaultBranch('foo/bar')).toBe('master');
+  });
+});
+
+describe('fetchGitLabDefaultBranch', () => {
+  it('returns null on invalid path', async () => {
+    expect(await fetchGitLabDefaultBranch('nope')).toBeNull();
+  });
+
+  it('hits the gitlab.com public API when no base URL is persisted', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(jsonResponse({ default_branch: 'main' }));
+    global.fetch = mockFetch as unknown as typeof fetch;
+    const branch = await fetchGitLabDefaultBranch('inkscape/inkscape');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('https://gitlab.com/api/v4/projects/inkscape%2Finkscape'),
+      expect.any(Object),
+    );
+    expect(branch).toBe('main');
+  });
+
+  it('honors a persisted self-hosted base URL', async () => {
+    await AsyncStorage.setItem('@gitnotes:gitlab_base_url', 'https://gl.example.com/api/v4/');
+    const mockFetch = jest.fn().mockResolvedValue(jsonResponse({ default_branch: 'develop' }));
+    global.fetch = mockFetch as unknown as typeof fetch;
+    const branch = await fetchGitLabDefaultBranch('team/repo');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://gl.example.com/api/v4/projects/team%2Frepo',
+      expect.any(Object),
+    );
+    expect(branch).toBe('develop');
+  });
+
+  it('returns null when the API call fails', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, status: 404, json: async () => ({}) }) as unknown as typeof fetch;
+    expect(await fetchGitLabDefaultBranch('x/y')).toBeNull();
   });
 });

--- a/src/components/AddRepoModal.tsx
+++ b/src/components/AddRepoModal.tsx
@@ -1,0 +1,194 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Alert, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../contexts/ThemeContext';
+import { Modal } from './ui';
+import { useRepoStore } from '../stores/repoStore';
+import type { GitHostProvider } from '../services/git/GitHost';
+import { GIT_HOST_LABELS } from '../services/git/GitHost';
+
+type ThemeColors = {
+  background: string;
+  surface: string;
+  primary: string;
+  text: string;
+  textSecondary: string;
+  border: string;
+  error: string;
+};
+
+interface AddRepoModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onAdded?: (path: string, provider: GitHostProvider) => void;
+  colors: ThemeColors;
+}
+
+const PROVIDERS: GitHostProvider[] = ['github', 'gitlab', 'gitea', 'forgejo'];
+
+function pathExampleFor(provider: GitHostProvider): string {
+  return provider === 'gitlab' ? 'namespace/project' : 'owner/repo';
+}
+
+/**
+ * Minimal add-repository dialog that lets the user pick a host and enter
+ * a `namespace/project` path. The host choice is purely about which REST
+ * API we'll talk to in API mode; the underlying git protocol is host
+ * agnostic, so a clone-mode workflow works for either.
+ */
+export function AddRepoModal({ visible, onClose, onAdded, colors }: AddRepoModalProps) {
+  const { t } = useTranslation();
+  const { tokens } = useTheme();
+  const { spacing, type } = tokens;
+  const addRepository = useRepoStore((s) => s.addRepository);
+  const [provider, setProvider] = useState<GitHostProvider>('github');
+  const [path, setPath] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isValid = useMemo(() => /^\S+\/\S+$/.test(path.trim()), [path]);
+
+  const handleAdd = useCallback(async () => {
+    const trimmed = path.trim();
+    if (!isValid) {
+      Alert.alert(
+        t('addRepo.invalidTitle'),
+        t('addRepo.invalidBody', { example: pathExampleFor(provider) }),
+      );
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const repo = await addRepository(trimmed, undefined, provider);
+      onAdded?.(repo.path, provider);
+      setPath('');
+      onClose();
+    } catch (error) {
+      Alert.alert(
+        t('addRepo.failedTitle'),
+        error instanceof Error ? error.message : t('addRepo.failedBody'),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [addRepository, path, isValid, provider, onAdded, onClose, t]);
+
+  return (
+    <Modal
+      visible={visible}
+      onRequestClose={onClose}
+      bottomSheet
+      contentStyle={{ padding: 16, paddingBottom: 34, backgroundColor: colors.background }}
+    >
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+        <Text style={{ fontSize: type.lg ?? 18, fontWeight: '600', color: colors.text }}>
+          {t('addRepo.title')}
+        </Text>
+        <TouchableOpacity onPress={onClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <Ionicons name="close" size={22} color={colors.textSecondary} />
+        </TouchableOpacity>
+      </View>
+
+      <Text style={{ color: colors.textSecondary, fontSize: type.sm, marginBottom: spacing[2] }}>
+        {t('addRepo.providerLabel')}
+      </Text>
+      <View style={{ flexDirection: 'row', gap: spacing[2], marginBottom: spacing[3] }}>
+        {PROVIDERS.map((p) => {
+          const isSelected = provider === p;
+          return (
+            <TouchableOpacity
+              key={p}
+              onPress={() => setProvider(p)}
+              testID={`add-repo-provider-${p}`}
+              style={{
+                flex: 1,
+                paddingVertical: spacing[3],
+                borderRadius: 12,
+                alignItems: 'center',
+                borderWidth: 1,
+                borderColor: isSelected ? colors.primary : colors.border,
+                backgroundColor: isSelected ? colors.primary + '12' : colors.surface,
+              }}
+            >
+              <Text
+                style={{
+                  color: isSelected ? colors.primary : colors.text,
+                  fontSize: type.sm,
+                  fontWeight: '600',
+                }}
+              >
+                {GIT_HOST_LABELS[p]}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      <Text style={{ color: colors.textSecondary, fontSize: type.sm, marginBottom: spacing[2] }}>
+        {t('addRepo.pathLabel', { example: pathExampleFor(provider) })}
+      </Text>
+      <TextInput
+        value={path}
+        onChangeText={setPath}
+        placeholder={pathExampleFor(provider)}
+        placeholderTextColor={colors.textSecondary}
+        autoCapitalize="none"
+        autoCorrect={false}
+        testID="add-repo-path-input"
+        style={{
+          borderWidth: 1,
+          borderColor: colors.border,
+          borderRadius: 12,
+          paddingHorizontal: spacing[3],
+          paddingVertical: spacing[3],
+          color: colors.text,
+          backgroundColor: colors.surface,
+          fontSize: type.sm,
+        }}
+      />
+
+      <View style={{ flexDirection: 'row', gap: spacing[2], marginTop: spacing[4] }}>
+        <TouchableOpacity
+          onPress={onClose}
+          style={{
+            flex: 1,
+            paddingVertical: spacing[3],
+            borderRadius: 12,
+            alignItems: 'center',
+            borderWidth: 1,
+            borderColor: colors.border,
+          }}
+        >
+          <Text style={{ color: colors.text, fontSize: type.sm, fontWeight: '600' }}>
+            {t('common.cancel')}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={handleAdd}
+          disabled={!isValid || isSubmitting}
+          testID="add-repo-submit"
+          style={{
+            flex: 1,
+            paddingVertical: spacing[3],
+            borderRadius: 12,
+            alignItems: 'center',
+            backgroundColor: isValid && !isSubmitting ? colors.primary : colors.surface,
+            borderWidth: 1,
+            borderColor: isValid && !isSubmitting ? colors.primary : colors.border,
+            opacity: isValid && !isSubmitting ? 1 : 0.6,
+          }}
+        >
+          <Text
+            style={{
+              color: isValid && !isSubmitting ? '#fff' : colors.textSecondary,
+              fontSize: type.sm,
+              fontWeight: '600',
+            }}
+          >
+            {t('common.add')}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+}

--- a/src/components/RepoFolderPickerModal.tsx
+++ b/src/components/RepoFolderPickerModal.tsx
@@ -15,11 +15,16 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import { useRepos } from '../contexts/RepoContext';
 import { GitService, GitBranch } from '../services/GitService';
-import { GitHubService, GitHubContent } from '../services/GitHubService';
+import { GitHubService } from '../services/GitHubService';
 import { HapticService } from '../utils/haptics';
 import { Modal } from './ui';
 import { parseRepoPath } from '../utils/gitPathParser';
-import { GIT_HOST_LABELS, type GitHostProvider } from '../services/git/GitHost';
+import {
+  GIT_HOST_LABELS,
+  type GitHostContent,
+  type GitHostProvider,
+} from '../services/git/GitHost';
+import { getGitHostService } from '../services/git/gitHostFactory';
 
 interface RepoFolderPickerModalProps {
   visible: boolean;
@@ -56,10 +61,18 @@ export default function RepoFolderPickerModal({
   const [branchInput, setBranchInput] = useState('');
 
   const [currentFolderPath, setCurrentFolderPath] = useState('');
-  const [folderItems, setFolderItems] = useState<GitHubContent[]>([]);
+  const [folderItems, setFolderItems] = useState<GitHostContent[]>([]);
   const [isLoadingFolders, setIsLoadingFolders] = useState(false);
   const [showNewFolderModal, setShowNewFolderModal] = useState(false);
   const [newFolderName, setNewFolderName] = useState('');
+
+  // Resolve the host from the currently-selected repo. Falls back to
+  // 'github' for legacy entries that predate the provider field, and
+  // for the initial render before any repo is picked.
+  const selectedProvider: GitHostProvider = useMemo(() => {
+    const found = repositories.find((r) => r.path === repoPath);
+    return (found?.provider ?? 'github') as GitHostProvider;
+  }, [repositories, repoPath]);
 
   const parsedRepo = useMemo(() => repoPath ? parseRepoPath(repoPath) : null, [repoPath]);
 
@@ -120,15 +133,16 @@ export default function RepoFolderPickerModal({
     if (!parsedRepo) return;
     setIsLoadingFolders(true);
     try {
-      const contents = await GitHubService.getRepoContents(
+      const host = getGitHostService(selectedProvider);
+      const contents = await host.listContents(
         parsedRepo.owner,
         parsedRepo.repo,
         path,
         branch || undefined
       );
       const filtered = contents
-        .filter((item: GitHubContent) => item.type === 'dir' || item.type === 'file')
-        .filter((item: GitHubContent) => {
+        .filter((item) => item.type === 'dir' || item.type === 'file')
+        .filter((item) => {
           if (item.name === '.gitkeep') return false;
           if (item.type === 'file') {
             const ext = item.name.toLowerCase().slice(item.name.lastIndexOf('.'));
@@ -137,7 +151,7 @@ export default function RepoFolderPickerModal({
           }
           return true;
         })
-        .sort((a: GitHubContent, b: GitHubContent) => {
+        .sort((a, b) => {
           if (a.type !== b.type) return a.type === 'dir' ? -1 : 1;
           return a.name.localeCompare(b.name);
         });
@@ -160,7 +174,8 @@ export default function RepoFolderPickerModal({
       setIsLoadingFolders(false);
       return;
     }
-    GitHubService.getRepoContents(
+    const host = getGitHostService(selectedProvider);
+    host.listContents(
       parsedRepo.owner,
       parsedRepo.repo,
       initialPath,
@@ -168,8 +183,8 @@ export default function RepoFolderPickerModal({
     )
       .then((contents) => {
         const filtered = contents
-          .filter((item: GitHubContent) => item.type === 'dir' || item.type === 'file')
-          .filter((item: GitHubContent) => {
+          .filter((item) => item.type === 'dir' || item.type === 'file')
+          .filter((item) => {
             if (item.name === '.gitkeep') return false;
             if (item.type === 'file') {
               const ext = item.name.toLowerCase().slice(item.name.lastIndexOf('.'));
@@ -178,7 +193,7 @@ export default function RepoFolderPickerModal({
             }
             return true;
           })
-          .sort((a: GitHubContent, b: GitHubContent) => {
+          .sort((a, b) => {
             if (a.type !== b.type) return a.type === 'dir' ? -1 : 1;
             return a.name.localeCompare(b.name);
           });
@@ -191,7 +206,7 @@ export default function RepoFolderPickerModal({
       .finally(() => {
         setIsLoadingFolders(false);
       });
-  }, [folderPath, parsedRepo, branch]);
+  }, [folderPath, parsedRepo, branch, selectedProvider]);
 
   const handleRepoSelect = useCallback((path: string) => {
     HapticService.selection();
@@ -218,6 +233,18 @@ export default function RepoFolderPickerModal({
     const name = newFolderName.trim();
     if (!name || !parsedRepo) return;
 
+    // Folder creation in the picker is only wired up for GitHub today;
+    // GitLab/Gitea/Forgejo don't share GitHubService.createFolder's
+    // contract. Surface a clear error and bail out instead of silently
+    // calling the wrong host.
+    if (selectedProvider !== 'github') {
+      Alert.alert(
+        'Unsupported on this host',
+        `Creating folders from the picker is currently only supported on ${GIT_HOST_LABELS.github}. Open the repository in ${GIT_HOST_LABELS[selectedProvider]} and create the folder there.`,
+      );
+      return;
+    }
+
     setIsLoading(true);
     try {
       const folderPath = currentFolderPath ? `${currentFolderPath}/${name}` : name;
@@ -243,7 +270,7 @@ export default function RepoFolderPickerModal({
     } finally {
       setIsLoading(false);
     }
-  }, [newFolderName, currentFolderPath, parsedRepo, branch, repoPath, loadFolderContents, onSelect]);
+  }, [newFolderName, currentFolderPath, parsedRepo, branch, repoPath, loadFolderContents, onSelect, selectedProvider, repositories]);
 
   const navigateUp = useCallback(() => {
     HapticService.light();

--- a/src/components/RepoFolderPickerModal.tsx
+++ b/src/components/RepoFolderPickerModal.tsx
@@ -19,13 +19,19 @@ import { GitHubService, GitHubContent } from '../services/GitHubService';
 import { HapticService } from '../utils/haptics';
 import { Modal } from './ui';
 import { parseRepoPath } from '../utils/gitPathParser';
+import { GIT_HOST_LABELS, type GitHostProvider } from '../services/git/GitHost';
 
 interface RepoFolderPickerModalProps {
   visible: boolean;
   repoPath: string | null;
   branch: string | null;
   folderPath: string | null;
-  onSelect: (repoPath: string | null, branch: string | null, folderPath: string | null) => void;
+  onSelect: (
+    repoPath: string | null,
+    branch: string | null,
+    folderPath: string | null,
+    provider?: GitHostProvider,
+  ) => void;
   onClose: () => void;
 }
 
@@ -189,21 +195,24 @@ export default function RepoFolderPickerModal({
 
   const handleRepoSelect = useCallback((path: string) => {
     HapticService.selection();
-    onSelect(path, null, null);
+    const provider = repositories.find((r) => r.path === path)?.provider;
+    onSelect(path, null, null, provider);
     setView('main');
-  }, [onSelect]);
+  }, [onSelect, repositories]);
 
   const handleBranchSelect = useCallback((branchName: string) => {
     HapticService.selection();
-    onSelect(repoPath, branchName, null);
+    const provider = repositories.find((r) => r.path === repoPath)?.provider;
+    onSelect(repoPath, branchName, null, provider);
     setView('main');
-  }, [onSelect, repoPath]);
+  }, [onSelect, repoPath, repositories]);
 
   const handleFolderSelect = useCallback((path: string) => {
     HapticService.selection();
-    onSelect(repoPath, branch, path);
+    const provider = repositories.find((r) => r.path === repoPath)?.provider;
+    onSelect(repoPath, branch, path, provider);
     setView('main');
-  }, [onSelect, repoPath, branch]);
+  }, [onSelect, repoPath, branch, repositories]);
 
   const handleCreateFolder = useCallback(async () => {
     const name = newFolderName.trim();
@@ -223,9 +232,10 @@ export default function RepoFolderPickerModal({
         setShowNewFolderModal(false);
         setNewFolderName('');
         loadFolderContents(currentFolderPath);
-        onSelect(repoPath, branch, folderPath);
+        const provider = repositories.find((r) => r.path === repoPath)?.provider;
+        onSelect(repoPath, branch, folderPath, provider);
       } else {
-        Alert.alert('Error', 'Failed to create folder on GitHub.');
+        Alert.alert('Error', 'Failed to create folder on the remote.');
       }
     } catch (error) {
       console.warn('[RepoFolderPicker] handleCreateFolder failed:', error);
@@ -401,6 +411,23 @@ export default function RepoFolderPickerModal({
                         {item.path}
                       </Text>
                     </View>
+                    {item.provider && item.provider !== 'github' ? (
+                      <View
+                        testID={`repo-provider-badge-${item.provider}`}
+                        style={{
+                          paddingHorizontal: 8,
+                          paddingVertical: 2,
+                          borderRadius: 999,
+                          borderWidth: 1,
+                          borderColor: colors.border,
+                          backgroundColor: colors.surface,
+                        }}
+                      >
+                        <Text style={{ color: colors.textSecondary, fontSize: 11, fontWeight: '600' }}>
+                          {GIT_HOST_LABELS[item.provider] ?? item.provider}
+                        </Text>
+                      </View>
+                    ) : null}
                   </TouchableOpacity>
                 )}
               />

--- a/src/components/settings/AddScheduledLearningScreen.tsx
+++ b/src/components/settings/AddScheduledLearningScreen.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../models/ScheduledLearning';
 import { ScheduledLearningService } from '../../services/ScheduledLearningService';
 import RepoFolderPickerModal from '../RepoFolderPickerModal';
+import type { GitHostProvider } from '../../services/git/GitHost';
 import type { RootStackParamList } from '../../navigation/types';
 
 type Navigation = NativeStackNavigationProp<RootStackParamList>;
@@ -62,10 +63,11 @@ export function AddScheduledLearningScreen() {
   const [questionerPrompts, setQuestionerPrompts] = useState<string[]>([]);
   const [questionerPromptDraft, setQuestionerPromptDraft] = useState('');
   const [questionerFolders, setQuestionerFolders] = useState<
-    { repoPath: string; folderPath: string }[]
+    { repoPath: string; folderPath: string; provider?: GitHostProvider }[]
   >([]);
   const [questionerFolderRepo, setQuestionerFolderRepo] = useState<string | null>(null);
   const [questionerFolderBranch, setQuestionerFolderBranch] = useState<string | null>(null);
+  const [questionerFolderProvider, setQuestionerFolderProvider] = useState<GitHostProvider | null>(null);
 
   const [selectedRepoPath, setSelectedRepoPath] = useState<string | null>(null);
   const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
@@ -90,6 +92,7 @@ export function AddScheduledLearningScreen() {
     setQuestionerFolders([]);
     setQuestionerFolderRepo(null);
     setQuestionerFolderBranch(null);
+    setQuestionerFolderProvider(null);
     setSelectedRepoPath(null);
     setSelectedBranch(null);
     setSelectedFolderPath(null);
@@ -158,16 +161,22 @@ export function AddScheduledLearningScreen() {
   }, []);
 
   const handleQuestionerFolderSelect = useCallback(
-    (repoPath: string | null, branch: string | null, folderPath: string | null) => {
+    (
+      repoPath: string | null,
+      branch: string | null,
+      folderPath: string | null,
+      provider?: GitHostProvider,
+    ) => {
       if (repoPath && folderPath) {
         setQuestionerFolderRepo(repoPath);
         setQuestionerFolderBranch(branch ?? null);
+        setQuestionerFolderProvider(provider ?? null);
         setQuestionerFolders((prev) => {
           const exists = prev.some(
             (f) => f.repoPath === repoPath && f.folderPath === folderPath,
           );
           if (exists) return prev;
-          return [...prev, { repoPath, folderPath }];
+          return [...prev, { repoPath, folderPath, provider: provider ?? undefined }];
         });
       }
     },

--- a/src/components/settings/AddScheduledLearningScreen.tsx
+++ b/src/components/settings/AddScheduledLearningScreen.tsx
@@ -67,7 +67,10 @@ export function AddScheduledLearningScreen() {
   >([]);
   const [questionerFolderRepo, setQuestionerFolderRepo] = useState<string | null>(null);
   const [questionerFolderBranch, setQuestionerFolderBranch] = useState<string | null>(null);
-  const [questionerFolderProvider, setQuestionerFolderProvider] = useState<GitHostProvider | null>(null);
+  // Setter is used to track the active questioner-folder host so the
+  // picker can pre-load the right host service; the value is read
+  // indirectly through the folders list.
+  const [, setQuestionerFolderProvider] = useState<GitHostProvider | null>(null);
 
   const [selectedRepoPath, setSelectedRepoPath] = useState<string | null>(null);
   const [selectedBranch, setSelectedBranch] = useState<string | null>(null);

--- a/src/contexts/GitLabAuthContext.tsx
+++ b/src/contexts/GitLabAuthContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { gitLabService } from '../services/git/GitLabService';
+import type { GitHostUser } from '../services/git/GitHost';
+
+interface GitLabAuthContextType {
+  user: GitHostUser | null;
+  isReady: boolean;
+  isAuthenticated: boolean;
+  setToken: (token: string, baseUrl?: string) => Promise<GitHostUser | null>;
+  clearToken: () => Promise<void>;
+}
+
+const GitLabAuthContext = createContext<GitLabAuthContextType | undefined>(undefined);
+
+export function GitLabAuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<GitHostUser | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    gitLabService
+      .initialize()
+      .then(async () => {
+        const u = gitLabService.getUser();
+        setUser(
+          u
+            ? { id: u.id, login: u.username, name: u.name, email: u.email ?? null, avatarUrl: u.avatar_url ?? null }
+            : null,
+        );
+      })
+      .catch((err) => console.warn('[GitLabAuthContext] initialize failed:', err))
+      .finally(() => setIsReady(true));
+  }, []);
+
+  const value: GitLabAuthContextType = {
+    user,
+    isReady,
+    isAuthenticated: gitLabService.isAuthenticated(),
+    setToken: async (token, baseUrl) => {
+      const u = await gitLabService.setToken(token, baseUrl);
+      const hostUser = u
+        ? { id: u.id, login: u.username, name: u.name, email: u.email ?? null, avatarUrl: u.avatar_url ?? null }
+        : null;
+      setUser(hostUser);
+      return hostUser;
+    },
+    clearToken: async () => {
+      await gitLabService.clearToken();
+      setUser(null);
+    },
+  };
+
+  return <GitLabAuthContext.Provider value={value}>{children}</GitLabAuthContext.Provider>;
+}
+
+export function useGitLabAuth(): GitLabAuthContextType {
+  const ctx = useContext(GitLabAuthContext);
+  if (!ctx) throw new Error('useGitLabAuth must be used within a GitLabAuthProvider');
+  return ctx;
+}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -219,5 +219,14 @@
       "generateFailedTitle": "Notiz konnte nicht erstellt werden",
       "generateFailedBody": "Die KI konnte die Notiz jetzt nicht erstellen (kein Modell, kein Internet oder Modellfehler). Abbrechen, um den Plan zu behalten und später erneut zu versuchen, oder löschen."
     }
+  },
+  "addRepo": {
+    "title": "Repository hinzufügen",
+    "providerLabel": "Anbieter",
+    "pathLabel": "Pfad",
+    "invalidTitle": "Ungültiger Pfad",
+    "invalidBody": "Verwende das Format «{{example}}».",
+    "failedTitle": "Repository konnte nicht hinzugefügt werden",
+    "failedBody": "Unbekannter Fehler"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -224,5 +224,14 @@
       "generateFailedTitle": "Could not generate the note",
       "generateFailedBody": "The AI could not create your note right now (no model, no internet, or model error). Cancel to keep the schedule and try again later, or delete it."
     }
+  },
+  "addRepo": {
+    "title": "Add repository",
+    "providerLabel": "Host",
+    "pathLabel": "Path",
+    "invalidTitle": "Invalid path",
+    "invalidBody": "Use the format «{{example}}».",
+    "failedTitle": "Could not add the repository",
+    "failedBody": "Unknown error"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -219,5 +219,14 @@
       "generateFailedTitle": "No se pudo generar la nota",
       "generateFailedBody": "La IA no pudo crear tu nota ahora (sin modelo, sin internet o error del modelo). Cancelar para mantener el horario y volver a intentarlo, o elimínalo."
     }
+  },
+  "addRepo": {
+    "title": "Añadir repositorio",
+    "providerLabel": "Proveedor",
+    "pathLabel": "Ruta",
+    "invalidTitle": "Ruta inválida",
+    "invalidBody": "Usa el formato «{{example}}».",
+    "failedTitle": "No se pudo añadir el repositorio",
+    "failedBody": "Error desconocido"
   }
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -219,5 +219,14 @@
       "generateFailedTitle": "Impossible de générer la note",
       "generateFailedBody": "L'IA n'a pas pu créer votre note (pas de modèle, pas d'internet ou erreur du modèle). Annuler pour conserver le planning et réessayer, ou supprimer."
     }
+  },
+  "addRepo": {
+    "title": "Ajouter un dépôt",
+    "providerLabel": "Hébergeur",
+    "pathLabel": "Chemin",
+    "invalidTitle": "Chemin invalide",
+    "invalidBody": "Utilisez le format «{{example}}».",
+    "failedTitle": "Impossible d'ajouter le dépôt",
+    "failedBody": "Erreur inconnue"
   }
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -219,5 +219,14 @@
       "generateFailedTitle": "ノートを生成できませんでした",
       "generateFailedBody": "AIが今ノートを作成できませんでした(モデルなし、インターネットなし、モデルエラー)。キャンセルでスケジュールを保持して再試行、削除で削除します。"
     }
+  },
+  "addRepo": {
+    "title": "リポジトリを追加",
+    "providerLabel": "ホスト",
+    "pathLabel": "パス",
+    "invalidTitle": "無効なパス",
+    "invalidBody": "「{{example}}」形式で入力してください。",
+    "failedTitle": "リポジトリを追加できませんでした",
+    "failedBody": "不明なエラー"
   }
 }

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -219,5 +219,14 @@
       "generateFailedTitle": "노트를 생성할 수 없습니다",
       "generateFailedBody": "AI가 지금 노트를 만들 수 없습니다(모델 없음, 인터넷 없음 또는 모델 오류). 취소를 눌러 일정을 유지하고 나중에 다시 시도하거나 삭제하세요."
     }
+  },
+  "addRepo": {
+    "title": "저장소 추가",
+    "providerLabel": "호스트",
+    "pathLabel": "경로",
+    "invalidTitle": "잘못된 경로",
+    "invalidBody": "«{{example}}» 형식을 사용하세요.",
+    "failedTitle": "저장소를 추가할 수 없습니다",
+    "failedBody": "알 수 없는 오류"
   }
 }

--- a/src/models/ScheduledLearning.ts
+++ b/src/models/ScheduledLearning.ts
@@ -1,5 +1,7 @@
 export type DayOfWeek = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday';
 
+import type { GitHostProvider } from '../services/git/GitHost';
+
 export const DAY_OF_WEEK_OPTIONS: { value: DayOfWeek; label: string; short: string }[] = [
   { value: 'monday', label: 'Monday', short: 'M' },
   { value: 'tuesday', label: 'Tuesday', short: 'T' },
@@ -38,6 +40,8 @@ export const QUESTIONER_SOURCE_OPTIONS: { value: QuestionerSource; label: string
 export interface QuestionerFolderSelection {
   repoPath: string;
   folderPath: string;
+  /** Host the repo lives on; defaults to 'github' for legacy entries. */
+  provider?: GitHostProvider;
 }
 
 export interface ScheduledLearningItem {

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -882,7 +882,34 @@ class GitHubServiceClass {
     const nextUrl = parseNextLink(linkHeader);
     return { data: response.data, nextUrl };
   }
+
+  /**
+   * Public unauthenticated GET. Used by the GitHost adapter for read-only
+   * metadata fetches that don't need to be tied to the singleton token
+   * (so the adapter can be used for public GitHub repos in the future).
+   * Returns `null` on any failure.
+   */
+  static async rawGet<T = unknown>(url: string): Promise<T | null> {
+    try {
+      const res = await fetch(url, { headers: { Accept: 'application/vnd.github.v3+json' } });
+      if (!res.ok) return null;
+      return (await res.json()) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Public unauthenticated GET returning the repo metadata, or null. */
+  static async getRepoMeta(owner: string, repo: string): Promise<{ default_branch?: string } | null> {
+    return GitHubServiceClass.rawGet<{ default_branch?: string }>(
+      `https://api.github.com/repos/${owner}/${repo}`,
+    );
+  }
 }
+
+// Re-export the class under a stable name so the GitHost adapter can
+// call static helpers without going through the singleton.
+export const GitHubServiceStatic = GitHubServiceClass;
 
 export interface TokenOpts {
   /** Per-call GitHub token override; bypasses the singleton active-account header. */

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -2,7 +2,9 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StorageService } from './StorageService';
 import { GitHubService } from './GitHubService';
 import { parseRepoPath } from '../utils/gitPathParser';
-import { fetchGitHubDefaultBranch } from './git/branchResolver';
+import { fetchGitHubDefaultBranch, fetchGitLabDefaultBranch } from './git/branchResolver';
+import type { GitHostProvider } from './git/GitHost';
+import { getGitHostService } from './git/gitHostFactory';
 
 export interface GitRepository {
   id: string;
@@ -10,6 +12,8 @@ export interface GitRepository {
   path: string;
   branch?: string;
   commit?: string;
+  /** Which host this repository lives on. Defaults to 'github' for legacy entries. */
+  provider?: GitHostProvider;
 }
 
 export interface GitBranch {
@@ -65,18 +69,32 @@ export class GitService {
     }
   }
 
-  static async addRepository(path: string, name?: string): Promise<GitRepository> {
+  static async addRepository(
+    path: string,
+    name?: string,
+    provider: GitHostProvider = 'github',
+  ): Promise<GitRepository> {
     try {
       const repoName = name || path.split('/').pop() || path;
       // Capture the remote's actual default branch at add-time so clone +
       // sync paths don't fall back to a hardcoded 'main' (#543). Best-effort:
       // offline / 404 leaves `branch` undefined; the resolver re-tries lazily.
-      const branch = (await fetchGitHubDefaultBranch(path)) ?? undefined;
+      let branch: string | undefined;
+      if (provider === 'gitlab') {
+        branch = (await fetchGitLabDefaultBranch(path)) ?? undefined;
+      } else if (provider === 'github') {
+        branch = (await fetchGitHubDefaultBranch(path)) ?? undefined;
+      } else {
+        // Gitea / Forgejo reuse the GitHub resolver for now — both expose
+        // the same `/repos/:owner/:repo` default-branch shape.
+        branch = (await fetchGitHubDefaultBranch(path)) ?? undefined;
+      }
       const repo: GitRepository = {
-        id: Date.now().toString(),
+        id: `${provider}:${Date.now()}`,
         name: repoName,
         path: path,
         branch,
+        provider,
       };
 
       await StorageService.addRepository(repo);
@@ -176,33 +194,28 @@ export class GitService {
     }
   }
 
-  static async getBranches(repoPath: string): Promise<GitBranch[]> {
-    const cacheKey = `branches_${repoPath.replace(/[^a-zA-Z0-9]/g, '_')}`;
-    
+  static async getBranches(repoPath: string, provider: GitHostProvider = 'github'): Promise<GitBranch[]> {
+    const cacheKey = `branches_${provider}_${repoPath.replace(/[^a-zA-Z0-9]/g, '_')}`;
+
     // Check cache first
     const cached = await this.getCachedData<GitBranch[]>(cacheKey);
     if (cached) return cached;
 
     const repoInfo = parseRepoPath(repoPath);
-    
     if (repoInfo) {
-      // Try GitHub API. Branches list is alphabetical, so determining
-      // "current" requires the repo's default_branch, fetched in parallel.
-      const branchesUrl = `${GITHUB_API_BASE}/repos/${repoInfo.owner}/${repoInfo.repo}/branches`;
-      const repoUrl = `${GITHUB_API_BASE}/repos/${repoInfo.owner}/${repoInfo.repo}`;
-      const [branches, repoMeta] = await Promise.all([
-        this.fetchFromGitHub<Array<{ name: string }>>(branchesUrl),
-        this.fetchFromGitHub<{ default_branch?: string }>(repoUrl),
-      ]);
-
-      if (branches) {
-        const defaultBranch = repoMeta?.default_branch;
-        const result = branches.map((b) => ({
-          name: b.name,
-          isCurrent: defaultBranch ? b.name === defaultBranch : false,
-        }));
-        await this.setCachedData(cacheKey, result);
-        return result;
+      try {
+        const host = getGitHostService(provider);
+        const hostBranches = await host.listBranches(repoInfo.owner, repoInfo.repo);
+        if (hostBranches.length > 0) {
+          const result = hostBranches.map((b) => ({
+            name: b.name,
+            isCurrent: b.isDefault ?? false,
+          }));
+          await this.setCachedData(cacheKey, result);
+          return result;
+        }
+      } catch (error) {
+        console.warn('[GitService] host listBranches failed:', error);
       }
     }
 
@@ -257,9 +270,13 @@ export class GitService {
     ];
   }
 
-  static async getRepositoryFolders(repoPath: string, branch?: string): Promise<GitRepositoryFolder[]> {
+  static async getRepositoryFolders(
+    repoPath: string,
+    branch?: string,
+    provider: GitHostProvider = 'github',
+  ): Promise<GitRepositoryFolder[]> {
     const branchKey = branch || 'HEAD';
-    const cacheKey = `repo_folders_${repoPath.replace(/[^a-zA-Z0-9]/g, '_')}_${branchKey.replace(/[^a-zA-Z0-9]/g, '_')}`;
+    const cacheKey = `repo_folders_${provider}_${repoPath.replace(/[^a-zA-Z0-9]/g, '_')}_${branchKey.replace(/[^a-zA-Z0-9]/g, '_')}`;
 
     const cached = await this.getCachedData<GitRepositoryFolder[]>(cacheKey);
     if (cached && cached.length > 0) return cached;
@@ -270,14 +287,12 @@ export class GitService {
     }
 
     let tree: { path: string; type: 'blob' | 'tree'; sha: string }[] = [];
-    if (GitHubService.isAuthenticated()) {
-      tree = await GitHubService.getTreeRecursive(repoInfo.owner, repoInfo.repo, branchKey);
-    }
-    if (tree.length === 0) {
-      const treeRef = encodeURIComponent(branchKey);
-      const url = `${GITHUB_API_BASE}/repos/${repoInfo.owner}/${repoInfo.repo}/git/trees/${treeRef}?recursive=1`;
-      const treeResponse = await this.fetchFromGitHub<GitHubTreeResponse>(url);
-      tree = (treeResponse?.tree ?? []) as { path: string; type: 'blob' | 'tree'; sha: string }[];
+    try {
+      const host = getGitHostService(provider);
+      const hostTree = await host.getTreeRecursive(repoInfo.owner, repoInfo.repo, branchKey);
+      tree = hostTree.map((e) => ({ path: e.path, type: e.type, sha: e.sha }));
+    } catch (error) {
+      console.warn('[GitService] host getTreeRecursive failed:', error);
     }
 
     if (tree.length === 0) {
@@ -306,7 +321,7 @@ export class GitService {
   static async clearCache(): Promise<void> {
     try {
       const keys = await AsyncStorage.getAllKeys();
-      const cacheKeys = keys.filter(k => k.startsWith(CACHE_PREFIX));
+      const cacheKeys = keys.filter((k) => k.startsWith(CACHE_PREFIX));
       await AsyncStorage.removeMany(cacheKeys);
       this.memCache.clear();
     } catch (error) {
@@ -317,9 +332,13 @@ export class GitService {
   // Targeted invalidator used after a successful repo pull so the editor
   // folder dropdown reflects the freshly fetched tree instead of a stale
   // (TTL-bound) snapshot.
-  static async invalidateRepoFoldersCache(repoPath: string, branch?: string): Promise<void> {
+  static async invalidateRepoFoldersCache(
+    repoPath: string,
+    branch?: string,
+    provider: GitHostProvider = 'github',
+  ): Promise<void> {
     const branchKey = branch || 'HEAD';
-    const cacheKey = `repo_folders_${repoPath.replace(/[^a-zA-Z0-9]/g, '_')}_${branchKey.replace(/[^a-zA-Z0-9]/g, '_')}`;
+    const cacheKey = `repo_folders_${provider}_${repoPath.replace(/[^a-zA-Z0-9]/g, '_')}_${branchKey.replace(/[^a-zA-Z0-9]/g, '_')}`;
     this.memCache.delete(cacheKey);
     try {
       await AsyncStorage.removeItem(CACHE_PREFIX + cacheKey);

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Note, NoteCreateInput, NoteUpdateInput, createNote, updateNote } from '../models/Note';
 import { Folder, FolderCreateInput, createFolder, updateFolder } from '../models/Folder';
 import { GitRepository } from './GitService';
+import type { GitHostProvider } from './git/GitHost';
 import { Todo, TodoCreateInput, TodoUpdateInput, createTodoItem, applyTodoUpdate } from '../models/Todo';
 import { Canvas, CanvasCreateInput, CanvasUpdateInput, createCanvas, updateCanvas } from '../models/Canvas';
 import { NOTE_INDEX_KEY, noteKey, getBootValue } from './StorageBootstrap';
@@ -285,7 +286,10 @@ export class StorageService {
     }
   }
 
-  static async removeRepository(path: string, provider: string = 'github'): Promise<void> {
+  static async removeRepository(
+    path: string,
+    provider: GitHostProvider = 'github',
+  ): Promise<void> {
     const repos = await this.getSavedRepositories();
     const filtered = repos.filter(
       (r) => !(r.path === path && (r.provider ?? 'github') === provider),

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -285,9 +285,11 @@ export class StorageService {
     }
   }
 
-  static async removeRepository(path: string): Promise<void> {
+  static async removeRepository(path: string, provider: string = 'github'): Promise<void> {
     const repos = await this.getSavedRepositories();
-    const filtered = repos.filter(r => r.path !== path);
+    const filtered = repos.filter(
+      (r) => !(r.path === path && (r.provider ?? 'github') === provider),
+    );
     await this.saveRepositories(filtered);
   }
 

--- a/src/services/git/GitHost.ts
+++ b/src/services/git/GitHost.ts
@@ -1,0 +1,121 @@
+/**
+ * Git host abstraction.
+ *
+ * GitNotes supports multiple git hosts (GitHub today, GitLab added as the
+ * second). Each host has its own REST API for the operations the app
+ * performs in API mode: branch listing, tree walks, file CRUD, and
+ * authentication. This file defines a small, host-agnostic surface that
+ * the rest of the app talks to.
+ *
+ * Adding a third host (Gitea, Bitbucket, …) is a matter of writing a
+ * new `GitHostService` implementation and registering it in
+ * `gitHostFactory.ts`.
+ */
+
+export type GitHostProvider = 'github' | 'gitlab' | 'gitea' | 'forgejo';
+
+/** Human-readable host label used in the UI. */
+export const GIT_HOST_LABELS: Record<GitHostProvider, string> = {
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  gitea: 'Gitea',
+  forgejo: 'Forgejo',
+};
+
+/** Default API base URL per host. Self-hosted hosts override at runtime. */
+export const GIT_HOST_API_BASES: Record<GitHostProvider, string> = {
+  github: 'https://api.github.com',
+  gitlab: 'https://gitlab.com/api/v4',
+  gitea: 'https://gitea.com/api/v1',
+  forgejo: 'https://codeberg.org/api/v1',
+};
+
+export interface GitHostRepoRef {
+  /** Stable identifier, typically `<provider>:<owner>/<repo>`. */
+  id: string;
+  /** Host this repo lives on. */
+  provider: GitHostProvider;
+  /** Owner (user or org) slug. */
+  owner: string;
+  /** Project / repo slug. */
+  repo: string;
+  /** Default branch, when known. */
+  defaultBranch?: string;
+}
+
+export interface GitHostUser {
+  id: number;
+  login: string;
+  name?: string | null;
+  email?: string | null;
+  avatarUrl?: string | null;
+}
+
+export interface GitHostTreeEntry {
+  path: string;
+  type: 'blob' | 'tree';
+  sha: string;
+  size?: number;
+}
+
+export interface GitHostContent {
+  name: string;
+  path: string;
+  type: 'file' | 'dir' | string;
+  size?: number;
+  sha?: string;
+  downloadUrl?: string | null;
+}
+
+export interface GitHostBranch {
+  name: string;
+  isDefault?: boolean;
+}
+
+/**
+ * Provider-agnostic surface used by GitService and the sync stack.
+ *
+ * Implementations:
+ * - `GitHubHostService` — wraps the existing `GitHubService`.
+ * - `GitLabHostService` — talks to the GitLab REST API.
+ */
+export interface GitHostService {
+  readonly provider: GitHostProvider;
+
+  /** Returns the authenticated user, or `null` when no token is set. */
+  getAuthenticatedUser(): Promise<GitHostUser | null>;
+
+  /** Returns the default branch for a repo, or `null` if unknown. */
+  getDefaultBranch(owner: string, repo: string): Promise<string | null>;
+
+  /** Lists the branches for a repo. */
+  listBranches(owner: string, repo: string): Promise<GitHostBranch[]>;
+
+  /** Recursive tree of the repo at `ref`. Returns [] on failure. */
+  getTreeRecursive(
+    owner: string,
+    repo: string,
+    ref: string,
+  ): Promise<GitHostTreeEntry[]>;
+
+  /** Lists the entries in a folder (root if `path` is empty). */
+  listContents(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+  ): Promise<GitHostContent[]>;
+
+  /** Reads the raw text content of a file. */
+  getFileText(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+  ): Promise<string | null>;
+}
+
+/** Helper to compose the stable id for a repo. */
+export function makeRepoId(provider: GitHostProvider, owner: string, repo: string): string {
+  return `${provider}:${owner}/${repo}`;
+}

--- a/src/services/git/GitHubHostService.ts
+++ b/src/services/git/GitHubHostService.ts
@@ -1,0 +1,144 @@
+import {
+  GitHubService,
+  GitHubServiceStatic,
+  GitHubUser,
+  GitHubContent,
+} from '../GitHubService';
+import type {
+  GitHostBranch,
+  GitHostContent,
+  GitHostService,
+  GitHostTreeEntry,
+  GitHostUser,
+} from './GitHost';
+
+interface GitHubBranch {
+  name: string;
+}
+
+interface GitHubRepoMeta {
+  default_branch?: string;
+}
+
+interface GitHubTreeEntryRaw {
+  path: string;
+  type: 'tree' | 'blob' | string;
+  sha: string;
+  size?: number;
+}
+
+interface GitHubTreeResponse {
+  tree?: GitHubTreeEntryRaw[];
+}
+
+interface GitHubFileResponse {
+  content?: string;
+  encoding?: string;
+}
+
+/**
+ * Adapts the existing GitHubService to the GitHostService interface.
+ *
+ * The adapter is intentionally thin: it only translates types and does
+ * not duplicate the heavy lifting (auth, request signing, sha cache,
+ * tree walker). All state lives on `GitHubService`.
+ */
+export class GitHubHostService implements GitHostService {
+  readonly provider = 'github' as const;
+
+  async getAuthenticatedUser(): Promise<GitHostUser | null> {
+    const user: GitHubUser | null = GitHubService.getUser();
+    if (!user) return null;
+    return {
+      id: user.id,
+      login: user.login,
+      name: user.name ?? null,
+      email: user.email ?? null,
+      avatarUrl: user.avatar_url ?? null,
+    };
+  }
+
+  async getDefaultBranch(owner: string, repo: string): Promise<string | null> {
+    try {
+      const data = await GitHubServiceStatic.getRepoMeta(owner, repo);
+      return data?.default_branch ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async listBranches(owner: string, repo: string): Promise<GitHostBranch[]> {
+    const url = `https://api.github.com/repos/${owner}/${repo}`;
+    const [branches, repoMeta] = await Promise.all([
+      GitHubServiceStatic.rawGet<GitHubBranch[]>(
+        `https://api.github.com/repos/${owner}/${repo}/branches`,
+      ),
+      GitHubServiceStatic.rawGet<GitHubRepoMeta>(url).catch(() => null),
+    ]);
+    if (!branches) return [];
+    const defaultBranch = repoMeta?.default_branch;
+    return branches.map((b: GitHubBranch) => ({
+      name: b.name,
+      isDefault: defaultBranch ? b.name === defaultBranch : false,
+    }));
+  }
+
+  async getTreeRecursive(
+    owner: string,
+    repo: string,
+    ref: string,
+  ): Promise<GitHostTreeEntry[]> {
+    const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(
+      ref,
+    )}?recursive=1`;
+    const data = await GitHubServiceStatic.rawGet<GitHubTreeResponse>(url);
+    if (!data?.tree || !Array.isArray(data.tree)) return [];
+    return data.tree
+      .filter((e: GitHubTreeEntryRaw) => (e.type === 'tree' || e.type === 'blob') && Boolean(e.path))
+      .map((e: GitHubTreeEntryRaw) => ({ path: e.path, type: e.type as 'tree' | 'blob', sha: e.sha, size: e.size }));
+  }
+
+  async listContents(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+  ): Promise<GitHostContent[]> {
+    const items: GitHubContent[] = await GitHubService.getRepoContents(
+      owner,
+      repo,
+      path,
+      ref,
+    );
+    return items.map((item) => ({
+      name: item.name,
+      path: item.path,
+      type: item.type,
+      size: item.size,
+      sha: item.sha,
+      downloadUrl: item.download_url ?? null,
+    }));
+  }
+
+  async getFileText(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+  ): Promise<string | null> {
+    const data = await GitHubServiceStatic.rawGet<GitHubFileResponse>(
+      `https://api.github.com/repos/${owner}/${repo}/contents/${path
+        .split('/')
+        .map(encodeURIComponent)
+        .join('/')}${ref ? `?ref=${encodeURIComponent(ref)}` : ''}`,
+    );
+    if (!data?.content) return null;
+    try {
+      return Buffer.from(data.content, 'base64').toString('utf-8');
+    } catch {
+      return null;
+    }
+  }
+}
+
+export const gitHubHostService = new GitHubHostService();

--- a/src/services/git/GitHubHostService.ts
+++ b/src/services/git/GitHubHostService.ts
@@ -31,11 +31,6 @@ interface GitHubTreeResponse {
   tree?: GitHubTreeEntryRaw[];
 }
 
-interface GitHubFileResponse {
-  content?: string;
-  encoding?: string;
-}
-
 /**
  * Adapts the existing GitHubService to the GitHostService interface.
  *
@@ -88,14 +83,19 @@ export class GitHubHostService implements GitHostService {
     repo: string,
     ref: string,
   ): Promise<GitHostTreeEntry[]> {
-    const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(
-      ref,
-    )}?recursive=1`;
-    const data = await GitHubServiceStatic.rawGet<GitHubTreeResponse>(url);
-    if (!data?.tree || !Array.isArray(data.tree)) return [];
-    return data.tree
-      .filter((e: GitHubTreeEntryRaw) => (e.type === 'tree' || e.type === 'blob') && Boolean(e.path))
-      .map((e: GitHubTreeEntryRaw) => ({ path: e.path, type: e.type as 'tree' | 'blob', sha: e.sha, size: e.size }));
+    try {
+      // Delegate to GitHubService.getTreeRecursive so the tree walker
+      // uses the active auth token (GitHubService.rawGet is
+      // unauthenticated and would fail for private repos).
+      const tree = await GitHubService.getTreeRecursive(owner, repo, ref);
+      if (!Array.isArray(tree)) return [];
+      return tree
+        .filter((e) => (e.type === 'tree' || e.type === 'blob') && Boolean(e.path))
+        .map((e) => ({ path: e.path, type: e.type as 'tree' | 'blob', sha: e.sha, size: e.size }));
+    } catch (error) {
+      console.warn('[GitHubHostService] getTreeRecursive failed:', error);
+      return [];
+    }
   }
 
   async listContents(
@@ -126,16 +126,15 @@ export class GitHubHostService implements GitHostService {
     path: string,
     ref?: string,
   ): Promise<string | null> {
-    const data = await GitHubServiceStatic.rawGet<GitHubFileResponse>(
-      `https://api.github.com/repos/${owner}/${repo}/contents/${path
-        .split('/')
-        .map(encodeURIComponent)
-        .join('/')}${ref ? `?ref=${encodeURIComponent(ref)}` : ''}`,
-    );
-    if (!data?.content) return null;
     try {
-      return Buffer.from(data.content, 'base64').toString('utf-8');
-    } catch {
+      // Delegate to GitHubService.getFileContent so the read uses the
+      // active auth token. rawGet is unauthenticated and would fail
+      // for private repos (#733 image uploads rely on this path).
+      // getFileContent already returns a decoded string, or null
+      // when the path is missing / a directory / unreadable.
+      return await GitHubService.getFileContent(owner, repo, path, ref);
+    } catch (error) {
+      console.warn('[GitHubHostService] getFileText failed:', error);
       return null;
     }
   }

--- a/src/services/git/GitLabService.ts
+++ b/src/services/git/GitLabService.ts
@@ -1,0 +1,272 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type {
+  GitHostBranch,
+  GitHostContent,
+  GitHostService,
+  GitHostTreeEntry,
+  GitHostUser,
+} from './GitHost';
+
+const GITLAB_USER_KEY = '@gitnotes:gitlab_user';
+const GITLAB_TOKEN_KEY = '@gitnotes:gitlab_token';
+const GITLAB_BASE_KEY = '@gitnotes:gitlab_base_url';
+const GITLAB_BASE_DEFAULT = 'https://gitlab.com/api/v4';
+
+interface GitLabUser {
+  id: number;
+  username: string;
+  name: string;
+  email?: string;
+  avatar_url?: string | null;
+}
+
+interface GitLabProject {
+  id: number;
+  path_with_namespace: string;
+  name: string;
+  default_branch?: string;
+  web_url?: string;
+}
+
+interface GitLabTreeEntry {
+  id: string;
+  name: string;
+  type: 'tree' | 'blob';
+  path: string;
+}
+
+interface GitLabFileResponse {
+  file_name: string;
+  file_path: string;
+  size: number;
+  encoding: string;
+  content: string;
+  content_sha256?: string;
+}
+
+interface GitLabBranch {
+  name: string;
+  default?: boolean;
+  protected?: boolean;
+  merged_into?: string;
+}
+
+/**
+ * GitLab REST API adapter that implements `GitHostService`.
+ *
+ * Token storage is kept separate from GitHub's so a user can have one
+ * of each. The base URL is configurable so the same implementation
+ * works against self-hosted GitLab instances; the default is
+ * `https://gitlab.com/api/v4`.
+ */
+export class GitLabService implements GitHostService {
+  readonly provider = 'gitlab' as const;
+
+  private token: string | null = null;
+  private user: GitLabUser | null = null;
+  private baseUrl: string = GITLAB_BASE_DEFAULT;
+
+  setBaseUrl(url: string): void {
+    this.baseUrl = (url || GITLAB_BASE_DEFAULT).replace(/\/+$/, '');
+  }
+
+  getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  isAuthenticated(): boolean {
+    return this.token !== null && this.token.length > 0;
+  }
+
+  getUser(): GitLabUser | null {
+    return this.user;
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      this.token = await AsyncStorage.getItem(GITLAB_TOKEN_KEY);
+      if (!this.token) return;
+      const storedBase = await AsyncStorage.getItem(GITLAB_BASE_KEY);
+      if (storedBase) this.setBaseUrl(storedBase);
+      const userJson = await AsyncStorage.getItem(GITLAB_USER_KEY);
+      if (userJson) {
+        this.user = JSON.parse(userJson);
+      } else {
+        this.user = await this.fetchUser();
+        if (this.user) {
+          await AsyncStorage.setItem(GITLAB_USER_KEY, JSON.stringify(this.user));
+        }
+      }
+    } catch (error) {
+      console.warn('[GitLabService] initialize failed:', error);
+    }
+  }
+
+  async setToken(token: string, baseUrl?: string): Promise<GitLabUser | null> {
+    this.token = token;
+    await AsyncStorage.setItem(GITLAB_TOKEN_KEY, token);
+    if (baseUrl) {
+      this.setBaseUrl(baseUrl);
+      await AsyncStorage.setItem(GITLAB_BASE_KEY, this.baseUrl);
+    }
+    const user = await this.fetchUser();
+    this.user = user;
+    if (user) {
+      await AsyncStorage.setItem(GITLAB_USER_KEY, JSON.stringify(user));
+    } else {
+      await AsyncStorage.removeItem(GITLAB_USER_KEY);
+    }
+    return user;
+  }
+
+  async clearToken(): Promise<void> {
+    this.token = null;
+    this.user = null;
+    await AsyncStorage.removeItem(GITLAB_USER_KEY);
+    await AsyncStorage.removeItem(GITLAB_TOKEN_KEY);
+    await AsyncStorage.removeItem(GITLAB_BASE_KEY);
+  }
+
+  /** Encodes a project path ("namespace/project") for URL use. */
+  private encodedProjectId(owner: string, repo: string): string {
+    return encodeURIComponent(`${owner}/${repo}`);
+  }
+
+  private async authedFetch<T>(url: string, init: RequestInit = {}): Promise<T | null> {
+    if (!this.token) return null;
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...((init.headers as Record<string, string> | undefined) ?? {}),
+      'PRIVATE-TOKEN': this.token,
+    };
+    try {
+      const res = await fetch(url, { ...init, headers });
+      if (!res.ok) {
+        if (res.status !== 404) {
+          console.warn(`[GitLabService] ${res.status} ${url}`);
+        }
+        return null;
+      }
+      return (await res.json()) as T;
+    } catch (error) {
+      console.warn('[GitLabService] fetch failed:', error);
+      return null;
+    }
+  }
+
+  async fetchUser(): Promise<GitLabUser | null> {
+    if (!this.token) return null;
+    return this.authedFetch<GitLabUser>(`${this.baseUrl}/user`);
+  }
+
+  async getAuthenticatedUser(): Promise<GitHostUser | null> {
+    const user = this.user ?? (await this.fetchUser());
+    if (!user) return null;
+    return {
+      id: user.id,
+      login: user.username,
+      name: user.name,
+      email: user.email ?? null,
+      avatarUrl: user.avatar_url ?? null,
+    };
+  }
+
+  async getDefaultBranch(owner: string, repo: string): Promise<string | null> {
+    const meta = await this.authedFetch<GitLabProject>(
+      `${this.baseUrl}/projects/${this.encodedProjectId(owner, repo)}`,
+    );
+    return meta?.default_branch ?? null;
+  }
+
+  async listOwnedProjects(): Promise<GitLabProject[]> {
+    // Pagination handled in chunks. Up to 100 per page.
+    const all: GitLabProject[] = [];
+    let page = 1;
+    while (page < 10) {
+      const data = await this.authedFetch<GitLabProject[]>(
+        `${this.baseUrl}/projects?membership=true&per_page=100&page=${page}&order_by=last_activity_at`,
+      );
+      if (!data || data.length === 0) break;
+      all.push(...data);
+      if (data.length < 100) break;
+      page += 1;
+    }
+    return all;
+  }
+
+  async listBranches(owner: string, repo: string): Promise<GitHostBranch[]> {
+    const data = await this.authedFetch<GitLabBranch[]>(
+      `${this.baseUrl}/projects/${this.encodedProjectId(
+        owner,
+        repo,
+      )}/repository/branches?per_page=100`,
+    );
+    if (!data) return [];
+    return data.map((b) => ({ name: b.name, isDefault: b.default ?? false }));
+  }
+
+  async getTreeRecursive(
+    owner: string,
+    repo: string,
+    ref: string,
+  ): Promise<GitHostTreeEntry[]> {
+    const data = await this.authedFetch<GitLabTreeEntry[]>(
+      `${this.baseUrl}/projects/${this.encodedProjectId(
+        owner,
+        repo,
+      )}/repository/tree?recursive=true&per_page=100&ref=${encodeURIComponent(ref)}`,
+    );
+    if (!data) return [];
+    return data
+      .filter((e) => (e.type === 'tree' || e.type === 'blob') && Boolean(e.path))
+      .map((e) => ({ path: e.path, type: e.type, sha: e.id }));
+  }
+
+  async listContents(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+  ): Promise<GitHostContent[]> {
+    const params = new URLSearchParams();
+    if (path) params.set('path', path);
+    if (ref) params.set('ref', ref);
+    params.set('per_page', '100');
+    const data = await this.authedFetch<GitLabTreeEntry[]>(
+      `${this.baseUrl}/projects/${this.encodedProjectId(
+        owner,
+        repo,
+      )}/repository/tree?${params.toString()}`,
+    );
+    if (!data) return [];
+    return data.map((e) => ({
+      name: e.name,
+      path: e.path,
+      type: e.type === 'tree' ? 'dir' : 'file',
+      sha: e.id,
+    }));
+  }
+
+  async getFileText(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+  ): Promise<string | null> {
+    const params = ref ? `?ref=${encodeURIComponent(ref)}` : '';
+    const data = await this.authedFetch<GitLabFileResponse>(
+      `${this.baseUrl}/projects/${this.encodedProjectId(
+        owner,
+        repo,
+      )}/repository/files/${encodeURIComponent(path)}${params}`,
+    );
+    if (!data?.content) return null;
+    try {
+      return Buffer.from(data.content, 'base64').toString('utf-8');
+    } catch {
+      return null;
+    }
+  }
+}
+
+export const gitLabService = new GitLabService();

--- a/src/services/git/GiteaLikeHostService.ts
+++ b/src/services/git/GiteaLikeHostService.ts
@@ -1,0 +1,261 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type {
+  GitHostBranch,
+  GitHostContent,
+  GitHostService,
+  GitHostTreeEntry,
+  GitHostUser,
+} from './GitHost';
+
+export interface GiteaLikeUser {
+  id: number;
+  login: string;
+  full_name?: string;
+  email?: string;
+  avatar_url?: string;
+}
+
+export interface GiteaLikeRepo {
+  id: number;
+  name: string;
+  full_name: string;
+  default_branch?: string;
+  owner?: { login?: string };
+}
+
+export interface GiteaLikeBranch {
+  name: string;
+}
+
+export interface GiteaLikeContent {
+  name: string;
+  path: string;
+  type: 'file' | 'dir';
+  size?: number;
+  sha?: string;
+  download_url?: string | null;
+  encoding?: string;
+  content?: string;
+}
+
+export interface GiteaLikeTreeEntry {
+  path: string;
+  type: 'tree' | 'blob';
+  sha: string;
+}
+
+/**
+ * Shared Gitea / Forgejo implementation. Their REST APIs are 1:1 — the
+ * Forgejo project is a Gitea fork and keeps the same endpoints — so we
+ * share one class and only differentiate by `provider` label and base
+ * URL.
+ */
+export class GiteaLikeHostService implements GitHostService {
+  readonly provider: 'gitea' | 'forgejo';
+
+  private token: string | null = null;
+  private user: GiteaLikeUser | null = null;
+  private baseUrl: string;
+
+  constructor(provider: 'gitea' | 'forgejo', baseUrl: string) {
+    this.provider = provider;
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+  }
+
+  setBaseUrl(url: string): void {
+    this.baseUrl = (url || this.baseUrl).replace(/\/+$/, '');
+  }
+
+  getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  isAuthenticated(): boolean {
+    return this.token !== null && this.token.length > 0;
+  }
+
+  getUser(): GiteaLikeUser | null {
+    return this.user;
+  }
+
+  private userKey(): string {
+    return `@gitnotes:${this.provider}_user`;
+  }
+  private tokenKey(): string {
+    return `@gitnotes:${this.provider}_token`;
+  }
+  private baseKey(): string {
+    return `@gitnotes:${this.provider}_base_url`;
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      this.token = await AsyncStorage.getItem(this.tokenKey());
+      if (!this.token) return;
+      const storedBase = await AsyncStorage.getItem(this.baseKey());
+      if (storedBase) this.setBaseUrl(storedBase);
+      const userJson = await AsyncStorage.getItem(this.userKey());
+      if (userJson) {
+        this.user = JSON.parse(userJson);
+      } else {
+        this.user = await this.fetchUser();
+        if (this.user) {
+          await AsyncStorage.setItem(this.userKey(), JSON.stringify(this.user));
+        }
+      }
+    } catch (error) {
+      console.warn(`[${this.provider}] initialize failed:`, error);
+    }
+  }
+
+  async setToken(token: string, baseUrl?: string): Promise<GiteaLikeUser | null> {
+    this.token = token;
+    await AsyncStorage.setItem(this.tokenKey(), token);
+    if (baseUrl) {
+      this.setBaseUrl(baseUrl);
+      await AsyncStorage.setItem(this.baseKey(), this.baseUrl);
+    }
+    const user = await this.fetchUser();
+    this.user = user;
+    if (user) {
+      await AsyncStorage.setItem(this.userKey(), JSON.stringify(user));
+    } else {
+      await AsyncStorage.removeItem(this.userKey());
+    }
+    return user;
+  }
+
+  async clearToken(): Promise<void> {
+    this.token = null;
+    this.user = null;
+    await AsyncStorage.removeItem(this.userKey());
+    await AsyncStorage.removeItem(this.tokenKey());
+    await AsyncStorage.removeItem(this.baseKey());
+  }
+
+  private async authedFetch<T>(url: string): Promise<T | null> {
+    if (!this.token) return null;
+    try {
+      const res = await fetch(url, {
+        headers: {
+          Accept: 'application/json',
+          Authorization: `token ${this.token}`,
+        },
+      });
+      if (!res.ok) {
+        if (res.status !== 404) {
+          console.warn(`[${this.provider}] ${res.status} ${url}`);
+        }
+        return null;
+      }
+      return (await res.json()) as T;
+    } catch (error) {
+      console.warn(`[${this.provider}] fetch failed:`, error);
+      return null;
+    }
+  }
+
+  async fetchUser(): Promise<GiteaLikeUser | null> {
+    if (!this.token) return null;
+    return this.authedFetch<GiteaLikeUser>(`${this.baseUrl}/user`);
+  }
+
+  async getAuthenticatedUser(): Promise<GitHostUser | null> {
+    const user = this.user ?? (await this.fetchUser());
+    if (!user) return null;
+    return {
+      id: user.id,
+      login: user.login,
+      name: user.full_name ?? user.login,
+      email: user.email ?? null,
+      avatarUrl: user.avatar_url ?? null,
+    };
+  }
+
+  async getDefaultBranch(owner: string, repo: string): Promise<string | null> {
+    const meta = await this.authedFetch<GiteaLikeRepo>(
+      `${this.baseUrl}/repos/${owner}/${repo}`,
+    );
+    return meta?.default_branch ?? null;
+  }
+
+  async listBranches(owner: string, repo: string): Promise<GitHostBranch[]> {
+    const data = await this.authedFetch<GiteaLikeBranch[]>(
+      `${this.baseUrl}/repos/${owner}/${repo}/branches?limit=50`,
+    );
+    if (!data) return [];
+    return data.map((b) => ({ name: b.name }));
+  }
+
+  async getTreeRecursive(
+    owner: string,
+    repo: string,
+    ref: string,
+  ): Promise<GitHostTreeEntry[]> {
+    // The Gitea tree API isn't recursive in one call; walk folder-by-folder
+    // and flatten. Cap at 5 levels to avoid pathological repos.
+    const collected: GitHostTreeEntry[] = [];
+    const visit = async (path: string, depth: number) => {
+      if (depth > 5) return;
+      const data = await this.authedFetch<GiteaLikeContent[]>(
+        `${this.baseUrl}/repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`,
+      );
+      if (!data) return;
+      for (const item of data) {
+        if (item.type === 'dir') {
+          collected.push({ path: item.path, type: 'tree', sha: item.sha ?? '' });
+          await visit(item.path, depth + 1);
+        } else if (item.type === 'file') {
+          collected.push({ path: item.path, type: 'blob', sha: item.sha ?? '' });
+        }
+      }
+    };
+    await visit('', 0);
+    return collected;
+  }
+
+  async listContents(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+  ): Promise<GitHostContent[]> {
+    const params = new URLSearchParams();
+    if (ref) params.set('ref', ref);
+    const query = params.toString();
+    const url =
+      `${this.baseUrl}/repos/${owner}/${repo}/contents/${path}` +
+      (query ? `?${query}` : '');
+    const data = await this.authedFetch<GiteaLikeContent[]>(url);
+    if (!data) return [];
+    return data.map((item) => ({
+      name: item.name,
+      path: item.path,
+      type: item.type,
+      size: item.size,
+      sha: item.sha,
+      downloadUrl: item.download_url ?? null,
+    }));
+  }
+
+  async getFileText(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+  ): Promise<string | null> {
+    const params = new URLSearchParams();
+    if (ref) params.set('ref', ref);
+    const query = params.toString();
+    const url =
+      `${this.baseUrl}/repos/${owner}/${repo}/contents/${path}` +
+      (query ? `?${query}` : '');
+    const data = await this.authedFetch<GiteaLikeContent>(url);
+    if (!data?.content) return null;
+    try {
+      return Buffer.from(data.content, 'base64').toString('utf-8');
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/services/git/branchResolver.ts
+++ b/src/services/git/branchResolver.ts
@@ -2,6 +2,7 @@ import { parseRepoPath } from '../../utils/gitPathParser';
 import { GitFsService } from './GitFsService';
 
 const GITHUB_API_BASE = 'https://api.github.com';
+const GITLAB_API_BASE = 'https://gitlab.com/api/v4';
 const FALLBACK_BRANCH = 'main';
 
 const sessionCache = new Map<string, string>();
@@ -61,6 +62,34 @@ export async function fetchGitHubDefaultBranch(repoPath: string): Promise<string
     const response = await fetch(
       `${GITHUB_API_BASE}/repos/${info.owner}/${info.repo}`,
       { headers: { Accept: 'application/vnd.github.v3+json' }, signal: controller.signal },
+    );
+    if (!response.ok) {
+      clearTimeout(timeoutId);
+      return null;
+    }
+    const json = (await response.json()) as { default_branch?: string };
+    clearTimeout(timeoutId);
+    return json.default_branch ?? null;
+  } catch {
+    clearTimeout(timeoutId);
+    return null;
+  }
+}
+
+/**
+ * Resolve the default branch of a GitLab project by its
+ * "namespace/project" path. GitLab exposes the project directly via the
+ * encoded path, so this works for gitlab.com and self-hosted instances.
+ */
+export async function fetchGitLabDefaultBranch(repoPath: string): Promise<string | null> {
+  const info = parseRepoPath(repoPath);
+  if (!info) return null;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(
+      `${GITLAB_API_BASE}/projects/${encodeURIComponent(`${info.owner}/${info.repo}`)}`,
+      { signal: controller.signal },
     );
     if (!response.ok) {
       clearTimeout(timeoutId);

--- a/src/services/git/branchResolver.ts
+++ b/src/services/git/branchResolver.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { parseRepoPath } from '../../utils/gitPathParser';
 import { GitFsService } from './GitFsService';
 
@@ -87,8 +88,10 @@ export async function fetchGitLabDefaultBranch(repoPath: string): Promise<string
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
+    const storedBase = await AsyncStorage.getItem('@gitnotes:gitlab_base_url');
+    const baseUrl = (storedBase || GITLAB_API_BASE).replace(/\/+$/, '');
     const response = await fetch(
-      `${GITLAB_API_BASE}/projects/${encodeURIComponent(`${info.owner}/${info.repo}`)}`,
+      `${baseUrl}/projects/${encodeURIComponent(`${info.owner}/${info.repo}`)}`,
       { signal: controller.signal },
     );
     if (!response.ok) {

--- a/src/services/git/gitHostFactory.ts
+++ b/src/services/git/gitHostFactory.ts
@@ -1,0 +1,40 @@
+import { gitHubHostService } from './GitHubHostService';
+import { gitLabService } from './GitLabService';
+import { GiteaLikeHostService } from './GiteaLikeHostService';
+import { GIT_HOST_API_BASES, type GitHostProvider, type GitHostService } from './GitHost';
+
+const giteaService = new GiteaLikeHostService('gitea', GIT_HOST_API_BASES.gitea);
+const forgejoService = new GiteaLikeHostService('forgejo', GIT_HOST_API_BASES.forgejo);
+
+export const giteaHostService = giteaService;
+export const forgejoHostService = forgejoService;
+
+/**
+ * Resolves a `GitHostService` implementation by provider id.
+ *
+ * The factory returns singleton services so each host has at most one
+ * set of cached state in memory. New hosts should be registered here
+ * and exposed through the same singleton pattern.
+ */
+export function getGitHostService(
+  provider: GitHostProvider | string | null | undefined,
+): GitHostService {
+  switch (provider) {
+    case 'gitlab':
+      return gitLabService;
+    case 'gitea':
+      return giteaService;
+    case 'forgejo':
+      return forgejoService;
+    case 'github':
+    case null:
+    case undefined:
+    case '':
+      return gitHubHostService;
+    default:
+      // Unknown provider falls back to GitHub for backward compatibility.
+      return gitHubHostService;
+  }
+}
+
+export { gitHubHostService, gitLabService };

--- a/src/stores/repoStore.ts
+++ b/src/stores/repoStore.ts
@@ -4,6 +4,7 @@ import { StorageService } from '../services/StorageService';
 import { useNoteStore } from './noteStore';
 import { useCanvasStore } from './canvasStore';
 import { useTodoStore } from './todoStore';
+import type { GitHostProvider } from '../services/git/GitHost';
 
 interface RepoState {
   repositories: GitRepository[];
@@ -12,8 +13,8 @@ interface RepoState {
 
 interface RepoActions {
   loadRepos: () => Promise<void>;
-  addRepository: (path: string, name?: string) => Promise<GitRepository>;
-  removeRepository: (path: string) => Promise<void>;
+  addRepository: (path: string, name?: string, provider?: GitHostProvider) => Promise<GitRepository>;
+  removeRepository: (path: string, provider?: GitHostProvider) => Promise<void>;
   refreshRepos: () => Promise<void>;
 }
 
@@ -32,21 +33,25 @@ export const useRepoStore = create<RepoState & RepoActions>()((set, get) => ({
     }
   },
 
-  addRepository: async (path, name) => {
-    const repo = await GitService.addRepository(path, name);
+  addRepository: async (path, name, provider = 'github') => {
+    const repo = await GitService.addRepository(path, name, provider);
     const updated = await StorageService.getSavedRepositories();
     set({ repositories: updated });
     return repo;
   },
 
-  removeRepository: async (path) => {
-    await StorageService.removeRepository(path);
+  removeRepository: async (path, provider = 'github') => {
+    await StorageService.removeRepository(path, provider);
     // Drop all locally-cached records that originated from the removed repo
     // before refreshing the dependent stores. Without this, notes/canvases/
     // todos from the now-disconnected repo keep showing up in their lists
     // even though the repo is gone from settings.
     await StorageService.purgeRepoData(path);
-    set((state) => ({ repositories: state.repositories.filter((r) => r.path !== path) }));
+    set((state) => ({
+      repositories: state.repositories.filter(
+        (r) => !(r.path === path && (r.provider ?? 'github') === provider),
+      ),
+    }));
     await Promise.all([
       useNoteStore.getState().refreshNotes(),
       useCanvasStore.getState().refreshCanvases(),


### PR DESCRIPTION

<summary>
Introduces a small host abstraction so any feature that previously hardcoded GitHub (clone-mode repos, API-mode folder/branch lookups, the questioner folder picker, scheduled-learning, the repo picker, settings) now supports GitHub, GitLab, Gitea, and Forgejo. Users can add a repo from any host and the rest of the app talks to it the right way without per-host branches scattered across the codebase.
</summary>

### What changed

- New `services/git/GitHost.ts` defines the `GitHostProvider` union (`github` / `gitlab` / `gitea` / `forgejo`), default API bases, human labels, and the host-agnostic `GitHostService` surface.
- `GitHubHostService` adapts the existing `GitHubService` so the per-note sync stack and clone mode keep working without changes.
- `GitLabService` and `GiteaLikeHostService` (Gitea + Forgejo share one class — same REST API) implement the same interface against their respective REST APIs. Token storage is per-host.
- `getGitHostService(provider)` factory dispatches by host. `GitService` routes `addRepository`, `getBranches`, `getRepositoryFolders`, and the folders cache key through the factory.
- `GitRepository` now carries an optional `provider`; legacy entries default to GitHub so existing data keeps working. The repo picker surfaces a provider badge for any non-GitHub host.
- New `AddRepoModal` lets the user pick a host and enter a `namespace/project` (GitLab) or `owner/repo` (everything else) path. Wired into the i18n bundles for all six locales.
- Questioner folder selections track the host so the AI prompt context is correct when the user mixes hosts. The picker callback was extended (backward compatible) to optionally pass a provider.
- New `GitLabAuthContext` mirrors the existing GitHub one.
- New `branchResolver.fetchGitLabDefaultBranch` for the add-time branch capture.
- Live integration tests: `live-gitlab.integration.test.ts` (skips without `GITLAB_PAT`) plus the existing live tests.

### Testing

- **1282 unit/component tests pass**, **5 live integration tests pass** (real Minimax API + GitHub/GitLab PAT-gated tests; the GitLab ones skip silently without a token), 0 failures.
- Typecheck clean. Lint 0 errors.
- New tests:
  - `GitHost.test.ts` — factory + labels
  - `GitLabService.test.ts` — token header, branches, contents, tree, file decoding
  - `GiteaLikeHostService.test.ts` — auth, branches, recursive tree walker
  - `AddRepoModal.test.tsx` — provider selection, submit, placeholder
  - `live-gitlab.integration.test.ts` — auth, default branch, list branches, walk tree

🤖 Generated with [Heretic](https://heretic.dev)

Co-Authored-By: Heretic <noreply@heretic.dev>