### PR TITLE
feat(sync): add per-host connection UI for GitLab, Gitea, and Forgejo

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -19,6 +19,7 @@ import { ThemeProvider } from './src/contexts/ThemeContext';
 import { FolderProvider } from './src/contexts/FolderContext';
 import { ViewModeProvider } from './src/contexts/ViewModeContext';
 import { AuthProvider } from './src/contexts/AuthContext';
+import { HostAuthProvider } from './src/contexts/HostAuthContext';
 import { TodoProvider } from './src/contexts/TodoContext';
 import { CanvasProvider } from './src/contexts/CanvasContext';
 import { RepoProvider } from './src/contexts/RepoContext';
@@ -134,7 +135,8 @@ export default function App() {
     <SafeAreaProvider>
       <ThemeProvider>
         <AuthProvider>
-          <RepoProvider>
+          <HostAuthProvider>
+            <RepoProvider>
             <FolderProvider>
               <NoteProvider>
                 <BacklinksProvider>
@@ -156,6 +158,7 @@ export default function App() {
               </NoteProvider>
             </FolderProvider>
           </RepoProvider>
+          </HostAuthProvider>
         </AuthProvider>
       </ThemeProvider>
     </SafeAreaProvider>

--- a/__tests__/GitProvidersSection.test.tsx
+++ b/__tests__/GitProvidersSection.test.tsx
@@ -1,0 +1,344 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import { GitProvidersSection } from '../src/components/settings/GitProvidersSection';
+import { HostAuthProvider } from '../src/contexts/HostAuthContext';
+import { gitLabService } from '../src/services/git/GitLabService';
+import {
+  giteaHostService,
+  forgejoHostService,
+} from '../src/services/git/gitHostFactory';
+import { GitHubService } from '../src/services/GitHubService';
+
+const stableColors = {
+  background: '#fff',
+  surface: '#f4f4f4',
+  primary: '#2563eb',
+  text: '#111',
+  textSecondary: '#666',
+  border: '#ddd',
+  error: '#dc2626',
+  accent: '#8b5cf6',
+};
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: any) => children,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts && Object.keys(opts).length > 0
+        ? `${key}|${JSON.stringify(opts)}`
+        : key,
+  }),
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: stableColors,
+    isDark: false,
+    tokens: {
+      spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 },
+      type: { xs: 12, sm: 14, md: 16, lg: 18, xl: 22 },
+    },
+  }),
+  useTokens: () => ({
+    colors: stableColors,
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 },
+    type: { xs: 12, sm: 14, md: 16, lg: 18, xl: 22 },
+  }),
+}));
+
+jest.mock('../src/components/ui', () => {
+  const { View } = require('react-native');
+  return {
+    Group: ({ children }: any) => <View>{children}</View>,
+    GroupRow: ({ children, leading, trailing, onPress, testID }: any) => (
+      <View testID={testID} onClick={onPress}>
+        {leading}
+        {children}
+        {trailing}
+      </View>
+    ),
+    Modal: ({ visible, children }: any) => (visible ? <View>{children}</View> : null),
+  };
+});
+
+jest.mock('../src/components/ui/HintIcon', () => ({
+  HintIcon: () => null,
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    initialize: jest.fn(),
+    setToken: jest.fn(),
+    clearToken: jest.fn(),
+    isAuthenticated: jest.fn(),
+    getUser: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/git/GitLabService', () => ({
+  gitLabService: {
+    initialize: jest.fn(),
+    setToken: jest.fn(),
+    clearToken: jest.fn(),
+    isAuthenticated: jest.fn(),
+    getUser: jest.fn(),
+    getBaseUrl: jest.fn(),
+    setBaseUrl: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/git/gitHostFactory', () => {
+  const actual = jest.requireActual('../src/services/git/gitHostFactory');
+  return {
+    ...actual,
+    giteaHostService: {
+      provider: 'gitea',
+      initialize: jest.fn(),
+      setToken: jest.fn(),
+      clearToken: jest.fn(),
+      isAuthenticated: jest.fn(),
+      getUser: jest.fn(),
+      getBaseUrl: jest.fn(),
+      setBaseUrl: jest.fn(),
+    },
+    forgejoHostService: {
+      provider: 'forgejo',
+      initialize: jest.fn(),
+      setToken: jest.fn(),
+      clearToken: jest.fn(),
+      isAuthenticated: jest.fn(),
+      getUser: jest.fn(),
+      getBaseUrl: jest.fn(),
+      setBaseUrl: jest.fn(),
+    },
+  };
+});
+
+const mockedGitHub = GitHubService as jest.Mocked<typeof GitHubService>;
+const mockedGitLab = gitLabService as jest.Mocked<typeof gitLabService>;
+const mockedGitea = giteaHostService as unknown as {
+  initialize: jest.Mock;
+  setToken: jest.Mock;
+  clearToken: jest.Mock;
+  isAuthenticated: jest.Mock;
+  getUser: jest.Mock;
+  getBaseUrl: jest.Mock;
+  setBaseUrl: jest.Mock;
+};
+const mockedForgejo = forgejoHostService as unknown as {
+  initialize: jest.Mock;
+  setToken: jest.Mock;
+  clearToken: jest.Mock;
+  isAuthenticated: jest.Mock;
+  getUser: jest.Mock;
+  getBaseUrl: jest.Mock;
+  setBaseUrl: jest.Mock;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+  mockedGitHub.initialize.mockResolvedValue(undefined);
+  mockedGitHub.isAuthenticated.mockReturnValue(false);
+  mockedGitHub.getUser.mockReturnValue(null);
+  mockedGitHub.setToken.mockResolvedValue(null);
+  mockedGitHub.clearToken.mockResolvedValue(undefined);
+
+  mockedGitLab.initialize.mockResolvedValue(undefined);
+  mockedGitLab.isAuthenticated.mockReturnValue(false);
+  mockedGitLab.getUser.mockReturnValue(null);
+  mockedGitLab.setToken.mockResolvedValue(null);
+  mockedGitLab.clearToken.mockResolvedValue(undefined);
+  mockedGitLab.getBaseUrl.mockReturnValue('https://gitlab.com/api/v4');
+
+  mockedGitea.initialize.mockResolvedValue(undefined);
+  mockedGitea.isAuthenticated.mockReturnValue(false);
+  mockedGitea.getUser.mockReturnValue(null);
+  mockedGitea.setToken.mockResolvedValue(null);
+  mockedGitea.clearToken.mockResolvedValue(undefined);
+  mockedGitea.getBaseUrl.mockReturnValue('https://gitea.com/api/v1');
+
+  mockedForgejo.initialize.mockResolvedValue(undefined);
+  mockedForgejo.isAuthenticated.mockReturnValue(false);
+  mockedForgejo.getUser.mockReturnValue(null);
+  mockedForgejo.setToken.mockResolvedValue(null);
+  mockedForgejo.clearToken.mockResolvedValue(undefined);
+  mockedForgejo.getBaseUrl.mockReturnValue('https://codeberg.org/api/v1');
+});
+
+function renderSection() {
+  return render(
+    <HostAuthProvider>
+      <GitProvidersSection colors={stableColors} />
+    </HostAuthProvider>,
+  );
+}
+
+describe('GitProvidersSection', () => {
+  it('renders a row for each of the four supported providers', async () => {
+    const { getByTestId } = renderSection();
+    await waitFor(() => {
+      expect(mockedGitHub.initialize).toHaveBeenCalled();
+    });
+    expect(getByTestId('git-providers.row-github')).toBeTruthy();
+    expect(getByTestId('git-providers.row-gitlab')).toBeTruthy();
+    expect(getByTestId('git-providers.row-gitea')).toBeTruthy();
+    expect(getByTestId('git-providers.row-forgejo')).toBeTruthy();
+  });
+
+  it('opens the edit modal for GitLab on press and shows a base URL field', async () => {
+    const { getByTestId } = renderSection();
+    await waitFor(() => expect(mockedGitHub.initialize).toHaveBeenCalled());
+
+    fireEvent.press(getByTestId('git-providers.row-gitlab'));
+
+    expect(getByTestId('git-providers.token-input')).toBeTruthy();
+    expect(getByTestId('git-providers.base-url-input')).toBeTruthy();
+  });
+
+  it('opens the edit modal for GitHub without a base URL field', async () => {
+    const { getByTestId, queryByTestId } = renderSection();
+    await waitFor(() => expect(mockedGitHub.initialize).toHaveBeenCalled());
+
+    fireEvent.press(getByTestId('git-providers.row-github'));
+
+    expect(getByTestId('git-providers.token-input')).toBeTruthy();
+    expect(queryByTestId('git-providers.base-url-input')).toBeNull();
+  });
+
+  it('submits the token to GitLab service and closes the modal on success', async () => {
+    mockedGitLab.setToken.mockResolvedValue({
+      id: 1,
+      username: 'gl-user',
+      name: 'GL',
+      email: 'gl@example.com',
+      avatar_url: null,
+    });
+
+    const { getByTestId, queryByTestId } = renderSection();
+    await waitFor(() => expect(mockedGitLab.initialize).toHaveBeenCalled());
+
+    fireEvent.press(getByTestId('git-providers.row-gitlab'));
+    fireEvent.changeText(getByTestId('git-providers.token-input'), 'glpat-xxx');
+    fireEvent.press(getByTestId('git-providers.submit'));
+
+    await waitFor(() => {
+      expect(mockedGitLab.setToken).toHaveBeenCalledWith('glpat-xxx', 'https://gitlab.com/api/v4');
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId('git-providers.token-input')).toBeNull();
+    });
+  });
+
+  it('forwards custom baseUrl to GitLab service', async () => {
+    mockedGitLab.setToken.mockResolvedValue({
+      id: 1,
+      username: 'gl-user',
+      name: 'GL',
+      email: null,
+      avatar_url: null,
+    });
+
+    const { getByTestId } = renderSection();
+    await waitFor(() => expect(mockedGitLab.initialize).toHaveBeenCalled());
+
+    fireEvent.press(getByTestId('git-providers.row-gitlab'));
+    fireEvent.changeText(getByTestId('git-providers.token-input'), 'glpat-xxx');
+    fireEvent.changeText(
+      getByTestId('git-providers.base-url-input'),
+      'https://gl.example.com/api/v4',
+    );
+    fireEvent.press(getByTestId('git-providers.submit'));
+
+    await waitFor(() => {
+      expect(mockedGitLab.setToken).toHaveBeenCalledWith(
+        'glpat-xxx',
+        'https://gl.example.com/api/v4',
+      );
+    });
+  });
+
+  it('shows an alert when the token is rejected', async () => {
+    mockedGitLab.setToken.mockResolvedValue(null);
+
+    const { getByTestId } = renderSection();
+    await waitFor(() => expect(mockedGitLab.initialize).toHaveBeenCalled());
+
+    fireEvent.press(getByTestId('git-providers.row-gitlab'));
+    fireEvent.changeText(getByTestId('git-providers.token-input'), 'bad-token');
+    fireEvent.press(getByTestId('git-providers.submit'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'gitProviders.invalidTokenTitle',
+        'gitProviders.invalidTokenBody',
+      );
+    });
+  });
+
+  it('routes a Gitea submit to giteaHostService.setToken', async () => {
+    mockedGitea.setToken.mockResolvedValue({
+      id: 5,
+      login: 'g-user',
+      full_name: 'G',
+      email: null,
+      avatar_url: null,
+    });
+
+    const { getByTestId } = renderSection();
+    await waitFor(() => expect(mockedGitea.initialize).toHaveBeenCalled());
+
+    fireEvent.press(getByTestId('git-providers.row-gitea'));
+    fireEvent.changeText(getByTestId('git-providers.token-input'), 'gt-xxx');
+    fireEvent.press(getByTestId('git-providers.submit'));
+
+    await waitFor(() => {
+      expect(mockedGitea.setToken).toHaveBeenCalledWith('gt-xxx', 'https://gitea.com/api/v1');
+    });
+  });
+
+  it('disables submit when token is empty', async () => {
+    const { getByTestId } = renderSection();
+    await waitFor(() => expect(mockedGitHub.initialize).toHaveBeenCalled());
+
+    fireEvent.press(getByTestId('git-providers.row-github'));
+    const submit = getByTestId('git-providers.submit');
+    expect(submit.props.accessibilityState?.disabled).toBe(true);
+    expect(mockedGitHub.setToken).not.toHaveBeenCalled();
+  });
+
+  it('disconnects the host via clearToken after alert confirmation', async () => {
+    mockedGitHub.isAuthenticated.mockReturnValue(true);
+    mockedGitHub.getUser.mockReturnValue({
+      id: 1,
+      login: 'octocat',
+      name: 'Octo',
+      email: null,
+      avatar_url: null,
+    });
+
+    const { getByTestId } = renderSection();
+    await waitFor(() => expect(mockedGitHub.initialize).toHaveBeenCalled());
+
+    fireEvent.press(getByTestId('git-providers.disconnect-github'));
+
+    expect(Alert.alert).toHaveBeenCalled();
+    const alertArgs = (Alert.alert as jest.Mock).mock.calls[0];
+    const destructive = alertArgs[2].find((b: any) => b.style === 'destructive');
+    await destructive.onPress();
+
+    expect(mockedGitHub.clearToken).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/HostAuthContext.test.tsx
+++ b/__tests__/HostAuthContext.test.tsx
@@ -1,0 +1,355 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
+
+import {
+  HostAuthProvider,
+  useHostAuth,
+  useHostAuthFor,
+  useHostProvidersOrder,
+} from '../src/contexts/HostAuthContext';
+import { GitHubService } from '../src/services/GitHubService';
+import { gitLabService } from '../src/services/git/GitLabService';
+import {
+  giteaHostService,
+  forgejoHostService,
+} from '../src/services/git/gitHostFactory';
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    initialize: jest.fn(),
+    setToken: jest.fn(),
+    clearToken: jest.fn(),
+    isAuthenticated: jest.fn(),
+    getUser: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/git/GitLabService', () => ({
+  gitLabService: {
+    initialize: jest.fn(),
+    setToken: jest.fn(),
+    clearToken: jest.fn(),
+    isAuthenticated: jest.fn(),
+    getUser: jest.fn(),
+    getBaseUrl: jest.fn(),
+    setBaseUrl: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/git/gitHostFactory', () => {
+  const actual = jest.requireActual('../src/services/git/gitHostFactory');
+  return {
+    ...actual,
+    giteaHostService: {
+      provider: 'gitea',
+      initialize: jest.fn(),
+      setToken: jest.fn(),
+      clearToken: jest.fn(),
+      isAuthenticated: jest.fn(),
+      getUser: jest.fn(),
+      getBaseUrl: jest.fn(),
+      setBaseUrl: jest.fn(),
+    },
+    forgejoHostService: {
+      provider: 'forgejo',
+      initialize: jest.fn(),
+      setToken: jest.fn(),
+      clearToken: jest.fn(),
+      isAuthenticated: jest.fn(),
+      getUser: jest.fn(),
+      getBaseUrl: jest.fn(),
+      setBaseUrl: jest.fn(),
+    },
+  };
+});
+
+const mockedGitHub = GitHubService as jest.Mocked<typeof GitHubService>;
+const mockedGitLab = gitLabService as jest.Mocked<typeof gitLabService>;
+const mockedGitea = giteaHostService as unknown as {
+  initialize: jest.Mock;
+  setToken: jest.Mock;
+  clearToken: jest.Mock;
+  isAuthenticated: jest.Mock;
+  getUser: jest.Mock;
+  getBaseUrl: jest.Mock;
+  setBaseUrl: jest.Mock;
+};
+const mockedForgejo = forgejoHostService as unknown as {
+  initialize: jest.Mock;
+  setToken: jest.Mock;
+  clearToken: jest.Mock;
+  isAuthenticated: jest.Mock;
+  getUser: jest.Mock;
+  getBaseUrl: jest.Mock;
+  setBaseUrl: jest.Mock;
+};
+
+function Probe() {
+  const { hosts, status } = useHostAuth();
+  const ordered = useHostProvidersOrder();
+  const gitlab = useHostAuthFor('gitlab');
+  return (
+    <>
+      <Text testID="status">{status}</Text>
+      <Text testID="order">{ordered.join(',')}</Text>
+      <Text testID="github-auth">{String(hosts.github.isAuthenticated)}</Text>
+      <Text testID="gitlab-login">{gitlab.user?.login ?? 'none'}</Text>
+      <Text testID="gitea-auth">{String(hosts.gitea.isAuthenticated)}</Text>
+      <Text testID="forgejo-auth">{String(hosts.forgejo.isAuthenticated)}</Text>
+    </>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGitHub.initialize.mockResolvedValue(undefined);
+  mockedGitHub.isAuthenticated.mockReturnValue(false);
+  mockedGitHub.getUser.mockReturnValue(null);
+  mockedGitHub.setToken.mockResolvedValue(null);
+  mockedGitHub.clearToken.mockResolvedValue(undefined);
+
+  mockedGitLab.initialize.mockResolvedValue(undefined);
+  mockedGitLab.isAuthenticated.mockReturnValue(false);
+  mockedGitLab.getUser.mockReturnValue(null);
+  mockedGitLab.setToken.mockResolvedValue(null);
+  mockedGitLab.clearToken.mockResolvedValue(undefined);
+  mockedGitLab.getBaseUrl.mockReturnValue('https://gitlab.com/api/v4');
+
+  mockedGitea.initialize.mockResolvedValue(undefined);
+  mockedGitea.isAuthenticated.mockReturnValue(false);
+  mockedGitea.getUser.mockReturnValue(null);
+  mockedGitea.setToken.mockResolvedValue(null);
+  mockedGitea.clearToken.mockResolvedValue(undefined);
+  mockedGitea.getBaseUrl.mockReturnValue('https://gitea.com/api/v1');
+
+  mockedForgejo.initialize.mockResolvedValue(undefined);
+  mockedForgejo.isAuthenticated.mockReturnValue(false);
+  mockedForgejo.getUser.mockReturnValue(null);
+  mockedForgejo.setToken.mockResolvedValue(null);
+  mockedForgejo.clearToken.mockResolvedValue(undefined);
+  mockedForgejo.getBaseUrl.mockReturnValue('https://codeberg.org/api/v1');
+});
+
+describe('HostAuthContext', () => {
+  it('initializes all four hosts on mount and reaches ready status', async () => {
+    const { getByTestId } = render(
+      <HostAuthProvider>
+        <Probe />
+      </HostAuthProvider>,
+    );
+
+    expect(mockedGitHub.initialize).toHaveBeenCalledTimes(1);
+    expect(mockedGitLab.initialize).toHaveBeenCalledTimes(1);
+    expect(mockedGitea.initialize).toHaveBeenCalledTimes(1);
+    expect(mockedForgejo.initialize).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(getByTestId('status').props.children).toBe('ready');
+    });
+  });
+
+  it('exposes provider order: github, gitlab, gitea, forgejo', async () => {
+    const { getByTestId } = render(
+      <HostAuthProvider>
+        <Probe />
+      </HostAuthProvider>,
+    );
+    await waitFor(() => {
+      expect(getByTestId('status').props.children).toBe('ready');
+    });
+    expect(getByTestId('order').props.children).toBe('github,gitlab,gitea,forgejo');
+  });
+
+  it('reflects authenticated state for each host via snapshots', async () => {
+    mockedGitHub.isAuthenticated.mockReturnValue(true);
+    mockedGitHub.getUser.mockReturnValue({
+      id: 1,
+      login: 'octocat',
+      name: 'The Octocat',
+      email: 'octo@github.com',
+      avatar_url: null,
+    });
+
+    const { getByTestId } = render(
+      <HostAuthProvider>
+        <Probe />
+      </HostAuthProvider>,
+    );
+    await waitFor(() => {
+      expect(getByTestId('status').props.children).toBe('ready');
+    });
+    expect(getByTestId('github-auth').props.children).toBe('true');
+  });
+
+  it('setToken dispatches to the correct host service and refreshes state', async () => {
+    const ghUser = {
+      id: 7,
+      login: 'octocat',
+      name: 'Octo',
+      email: 'octo@github.com',
+      avatar_url: null,
+    };
+    mockedGitHub.setToken.mockResolvedValue(ghUser);
+    mockedGitHub.isAuthenticated.mockReturnValue(true);
+    mockedGitHub.getUser.mockReturnValue(ghUser);
+
+    let captured: ReturnType<typeof useHostAuth> | null = null;
+    function Capture() {
+      captured = useHostAuth();
+      return <Text testID="cap">ok</Text>;
+    }
+
+    render(
+      <HostAuthProvider>
+        <Capture />
+      </HostAuthProvider>,
+    );
+    await waitFor(() => {
+      expect(mockedGitHub.initialize).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      await captured!.setToken('github', 'ghp_xxx');
+    });
+
+    expect(mockedGitHub.setToken).toHaveBeenCalledWith('ghp_xxx');
+    expect(captured!.hosts.github.isAuthenticated).toBe(true);
+  });
+
+  it('setToken forwards baseUrl to GitLab', async () => {
+    mockedGitLab.setToken.mockResolvedValue({
+      id: 2,
+      username: 'gl-user',
+      name: 'GL',
+      email: 'gl@example.com',
+      avatar_url: null,
+    });
+
+    let captured: ReturnType<typeof useHostAuth> | null = null;
+    function Capture() {
+      captured = useHostAuth();
+      return <Text testID="cap">ok</Text>;
+    }
+
+    render(
+      <HostAuthProvider>
+        <Capture />
+      </HostAuthProvider>,
+    );
+    await waitFor(() => expect(mockedGitLab.initialize).toHaveBeenCalled());
+
+    await act(async () => {
+      await captured!.setToken('gitlab', 'glpat-xxx', 'https://gl.example.com/api/v4');
+    });
+
+    expect(mockedGitLab.setToken).toHaveBeenCalledWith(
+      'glpat-xxx',
+      'https://gl.example.com/api/v4',
+    );
+  });
+
+  it('setToken maps GiteaLikeUser into GitHostUser shape', async () => {
+    const giteaUser = {
+      id: 3,
+      login: 'gitea-user',
+      full_name: 'Gitea User',
+      email: 'g@example.com',
+      avatar_url: 'https://example.com/a.png',
+    };
+    mockedGitea.setToken.mockResolvedValue(giteaUser);
+
+    let captured: ReturnType<typeof useHostAuth> | null = null;
+    function Capture() {
+      captured = useHostAuth();
+      return <Text testID="cap">ok</Text>;
+    }
+
+    render(
+      <HostAuthProvider>
+        <Capture />
+      </HostAuthProvider>,
+    );
+    await waitFor(() => expect(mockedGitea.initialize).toHaveBeenCalled());
+
+    let result: Awaited<ReturnType<NonNullable<typeof captured>['setToken']>> = null;
+    await act(async () => {
+      result = await captured!.setToken('gitea', 'gt-xxx');
+    });
+
+    expect(mockedGitea.setToken).toHaveBeenCalledWith('gt-xxx', undefined);
+    expect(result).toEqual({
+      id: 3,
+      login: 'gitea-user',
+      name: 'Gitea User',
+      email: 'g@example.com',
+      avatarUrl: 'https://example.com/a.png',
+    });
+  });
+
+  it('clearToken routes to the correct service for each provider', async () => {
+    let captured: ReturnType<typeof useHostAuth> | null = null;
+    function Capture() {
+      captured = useHostAuth();
+      return null;
+    }
+
+    render(
+      <HostAuthProvider>
+        <Capture />
+      </HostAuthProvider>,
+    );
+    await waitFor(() => expect(mockedGitHub.initialize).toHaveBeenCalled());
+
+    await act(async () => {
+      await captured!.clearToken('github');
+      await captured!.clearToken('gitlab');
+      await captured!.clearToken('gitea');
+      await captured!.clearToken('forgejo');
+    });
+
+    expect(mockedGitHub.clearToken).toHaveBeenCalledTimes(1);
+    expect(mockedGitLab.clearToken).toHaveBeenCalledTimes(1);
+    expect(mockedGitea.clearToken).toHaveBeenCalledTimes(1);
+    expect(mockedForgejo.clearToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('useHostAuth throws when used outside HostAuthProvider', () => {
+    function Naked() {
+      useHostAuth();
+      return null;
+    }
+    // Suppress React error logging for the expected throw.
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    expect(() => render(<Naked />)).toThrow(
+      /useHostAuth must be used within a HostAuthProvider/,
+    );
+    spy.mockRestore();
+  });
+
+  it('ignores GitHub and uses GitLab / Gitea baseUrl for setBaseUrl', async () => {
+    let captured: ReturnType<typeof useHostAuth> | null = null;
+    function Capture() {
+      captured = useHostAuth();
+      return null;
+    }
+
+    render(
+      <HostAuthProvider>
+        <Capture />
+      </HostAuthProvider>,
+    );
+    await waitFor(() => expect(mockedGitLab.initialize).toHaveBeenCalled());
+
+    await act(async () => {
+      await captured!.setBaseUrl('github', 'https://x.example');
+      await captured!.setBaseUrl('gitlab', 'https://gl.example/api/v4');
+      await captured!.setBaseUrl('gitea', 'https://gt.example/api/v1');
+    });
+
+    // setBaseUrl is a no-op for github
+    expect(mockedGitHub.initialize).toHaveBeenCalledTimes(1);
+    expect(mockedGitLab.setBaseUrl).toHaveBeenCalledWith('https://gl.example/api/v4');
+    expect(mockedGitea.setBaseUrl).toHaveBeenCalledWith('https://gt.example/api/v1');
+  });
+});

--- a/src/components/settings/GitProvidersSection.tsx
+++ b/src/components/settings/GitProvidersSection.tsx
@@ -1,0 +1,397 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Ionicons } from '@expo/vector-icons';
+import { Group, GroupRow, Modal } from '../ui';
+import {
+  useHostAuth,
+  useHostProvidersOrder,
+  type HostAuthState,
+} from '../../contexts/HostAuthContext';
+import { GIT_HOST_API_BASES, GIT_HOST_LABELS, type GitHostProvider } from '../../services/git/GitHost';
+import { settingsStyles as styles } from './settingsStyles';
+
+type ThemeColors = {
+  text: string;
+  textSecondary: string;
+  primary: string;
+  surface: string;
+  border: string;
+  error: string;
+  background: string;
+};
+
+interface GitProvidersSectionProps {
+  colors: ThemeColors;
+}
+
+function providerIcon(provider: GitHostProvider): keyof typeof Ionicons.glyphMap {
+  switch (provider) {
+    case 'github':
+      return 'logo-github';
+    case 'gitlab':
+      return 'git-branch-outline';
+    case 'gitea':
+      return 'server-outline';
+    case 'forgejo':
+      return 'git-network-outline';
+  }
+}
+
+function allowsBaseUrl(provider: GitHostProvider): boolean {
+  return provider !== 'github';
+}
+
+function defaultBaseUrl(provider: GitHostProvider): string {
+  return GIT_HOST_API_BASES[provider];
+}
+
+export function GitProvidersSection({ colors }: GitProvidersSectionProps) {
+  const { t } = useTranslation();
+  const { hosts, status, setToken, clearToken } = useHostAuth();
+  const order = useHostProvidersOrder();
+  const [editing, setEditing] = useState<GitHostProvider | null>(null);
+
+  const ready = status === 'ready';
+
+  const onPressConnect = useCallback(
+    (provider: GitHostProvider) => setEditing(provider),
+    [],
+  );
+
+  const onPressDisconnect = useCallback(
+    (provider: GitHostProvider, login: string | null) => {
+      Alert.alert(
+        t('gitProviders.disconnectTitle', { host: GIT_HOST_LABELS[provider] }),
+        t('gitProviders.disconnectBody', { host: GIT_HOST_LABELS[provider], login: login ?? '' }),
+        [
+          { text: t('common.cancel'), style: 'cancel' },
+          {
+            text: t('gitProviders.disconnect'),
+            style: 'destructive',
+            onPress: () => void clearToken(provider),
+          },
+        ],
+      );
+    },
+    [clearToken, t],
+  );
+
+  return (
+    <>
+      <Group title={t('gitProviders.title')} footer={t('gitProviders.footer')}>
+        {order.map((provider) => (
+          <ProviderRow
+            key={provider}
+            host={hosts[provider]}
+            ready={ready}
+            colors={colors}
+            onConnect={onPressConnect}
+            onDisconnect={onPressDisconnect}
+          />
+        ))}
+      </Group>
+
+      <ProviderEditModal
+        visible={editing !== null}
+        provider={editing}
+        onClose={() => setEditing(null)}
+        colors={colors}
+        setToken={setToken}
+      />
+    </>
+  );
+}
+
+interface ProviderRowProps {
+  host: HostAuthState;
+  ready: boolean;
+  colors: ThemeColors;
+  onConnect: (provider: GitHostProvider) => void;
+  onDisconnect: (provider: GitHostProvider, login: string | null) => void;
+}
+
+function ProviderRow({
+  host,
+  ready,
+  colors,
+  onConnect,
+  onDisconnect,
+}: ProviderRowProps) {
+  const trailing = useMemo(() => {
+    if (!ready) {
+      return (
+        <Text style={[styles.settingValue, { color: colors.textSecondary }]}>
+          …
+        </Text>
+      );
+    }
+    if (host.isAuthenticated && host.user) {
+      return (
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+          <Text
+            style={[styles.settingValue, { color: colors.textSecondary }]}
+            numberOfLines={1}
+          >
+            {host.user.login}
+          </Text>
+          <TouchableOpacity
+            testID={`git-providers.disconnect-${host.provider}`}
+            onPress={() => onDisconnect(host.provider, host.user?.login ?? null)}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons name="trash-outline" size={18} color={colors.error} />
+          </TouchableOpacity>
+        </View>
+      );
+    }
+    return (
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+        <Text style={[styles.settingValue, { color: colors.textSecondary }]}>
+          —
+        </Text>
+        <Ionicons name="chevron-forward" size={16} color={colors.textSecondary} />
+      </View>
+    );
+  }, [ready, host, colors, onDisconnect]);
+
+  return (
+    <GroupRow
+      testID={`git-providers.row-${host.provider}`}
+      onPress={() => onConnect(host.provider)}
+      leading={
+        <Ionicons
+          name={providerIcon(host.provider)}
+          size={20}
+          color={colors.text}
+        />
+      }
+      trailing={trailing}
+    >
+      <Text style={[styles.settingLabel, { color: colors.text }]}>
+        {host.label}
+      </Text>
+      {host.baseUrl && host.provider !== 'github' ? (
+        <Text
+          style={[styles.settingValue, { color: colors.textSecondary }]}
+          numberOfLines={1}
+        >
+          {host.baseUrl}
+        </Text>
+      ) : null}
+    </GroupRow>
+  );
+}
+
+interface ProviderEditModalProps {
+  visible: boolean;
+  provider: GitHostProvider | null;
+  onClose: () => void;
+  colors: ThemeColors;
+  setToken: (
+    provider: GitHostProvider,
+    token: string,
+    baseUrl?: string,
+  ) => Promise<{ login: string } | null>;
+}
+
+function ProviderEditModal({
+  visible,
+  provider,
+  onClose,
+  colors,
+  setToken,
+}: ProviderEditModalProps) {
+  const { t } = useTranslation();
+  const [token, setTokenInput] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  React.useEffect(() => {
+    if (visible && provider) {
+      setTokenInput('');
+      setBaseUrl(allowsBaseUrl(provider) ? defaultBaseUrl(provider) : '');
+    }
+  }, [visible, provider]);
+
+  const showBaseUrl = provider !== null && allowsBaseUrl(provider);
+  const canSubmit = !!provider && token.trim().length > 0 && !isSubmitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!provider) return;
+    setIsSubmitting(true);
+    try {
+      const user = await setToken(
+        provider,
+        token.trim(),
+        showBaseUrl ? baseUrl.trim() || undefined : undefined,
+      );
+      if (!user) {
+        Alert.alert(
+          t('gitProviders.invalidTokenTitle'),
+          t('gitProviders.invalidTokenBody'),
+        );
+        return;
+      }
+      onClose();
+    } catch (error) {
+      Alert.alert(
+        t('gitProviders.failedTitle'),
+        error instanceof Error ? error.message : t('gitProviders.failedBody'),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [provider, setToken, token, baseUrl, showBaseUrl, onClose, t]);
+
+  if (!provider) return null;
+
+  return (
+    <Modal
+      visible={visible}
+      onRequestClose={onClose}
+      bottomSheet
+      contentStyle={{ padding: 16, paddingBottom: 34, backgroundColor: colors.background }}
+    >
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 16,
+        }}
+      >
+        <Text style={{ fontSize: 18, fontWeight: '600', color: colors.text }}>
+          {t('gitProviders.connectTitle', { host: GIT_HOST_LABELS[provider] })}
+        </Text>
+        <TouchableOpacity onPress={onClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <Ionicons name="close" size={22} color={colors.textSecondary} />
+        </TouchableOpacity>
+      </View>
+
+      <Text style={{ color: colors.textSecondary, fontSize: 13, marginBottom: 8 }}>
+        {t('gitProviders.tokenLabel')}
+      </Text>
+      <TextInput
+        value={token}
+        onChangeText={setTokenInput}
+        placeholder={t('gitProviders.tokenPlaceholder')}
+        placeholderTextColor={colors.textSecondary}
+        autoCapitalize="none"
+        autoCorrect={false}
+        secureTextEntry
+        testID="git-providers.token-input"
+        style={{
+          borderWidth: 1,
+          borderColor: colors.border,
+          borderRadius: 12,
+          paddingHorizontal: 12,
+          paddingVertical: 12,
+          color: colors.text,
+          backgroundColor: colors.surface,
+          fontSize: 14,
+        }}
+      />
+
+      {showBaseUrl ? (
+        <>
+          <Text
+            style={{
+              color: colors.textSecondary,
+              fontSize: 13,
+              marginBottom: 8,
+              marginTop: 16,
+            }}
+          >
+            {t('gitProviders.baseUrlLabel')}
+          </Text>
+          <TextInput
+            value={baseUrl}
+            onChangeText={setBaseUrl}
+            placeholder={defaultBaseUrl(provider)}
+            placeholderTextColor={colors.textSecondary}
+            autoCapitalize="none"
+            autoCorrect={false}
+            testID="git-providers.base-url-input"
+            style={{
+              borderWidth: 1,
+              borderColor: colors.border,
+              borderRadius: 12,
+              paddingHorizontal: 12,
+              paddingVertical: 12,
+              color: colors.text,
+              backgroundColor: colors.surface,
+              fontSize: 14,
+            }}
+          />
+          <Text
+            style={{
+              color: colors.textSecondary,
+              fontSize: 12,
+              marginTop: 6,
+            }}
+          >
+            {t('gitProviders.baseUrlHelp', { host: GIT_HOST_LABELS[provider] })}
+          </Text>
+        </>
+      ) : null}
+
+      <View
+        style={{
+          flexDirection: 'row',
+          gap: 8,
+          marginTop: 24,
+        }}
+      >
+        <TouchableOpacity
+          onPress={onClose}
+          style={{
+            flex: 1,
+            paddingVertical: 12,
+            borderRadius: 12,
+            alignItems: 'center',
+            borderWidth: 1,
+            borderColor: colors.border,
+          }}
+        >
+          <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600' }}>
+            {t('common.cancel')}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={handleSubmit}
+          disabled={!canSubmit}
+          testID="git-providers.submit"
+          style={{
+            flex: 1,
+            paddingVertical: 12,
+            borderRadius: 12,
+            alignItems: 'center',
+            backgroundColor: canSubmit ? colors.primary : colors.surface,
+            borderWidth: 1,
+            borderColor: canSubmit ? colors.primary : colors.border,
+            opacity: canSubmit ? 1 : 0.6,
+          }}
+        >
+          <Text
+            style={{
+              color: canSubmit ? '#fff' : colors.textSecondary,
+              fontSize: 14,
+              fontWeight: '600',
+            }}
+          >
+            {t('gitProviders.connect')}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+}
+
+export default GitProvidersSection;

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../i18n';
 import { ImportSection } from './ImportSection';
 import { ScheduledLearningSection } from './ScheduledLearningSection';
+import { GitProvidersSection } from './GitProvidersSection';
 import { settingsStyles as styles } from './settingsStyles';
 import type { GitRepository } from '../../services/GitService';
 import type { TemplateRepoPreference } from '../../services/TemplateRepoPreferenceService';
@@ -393,6 +394,8 @@ export function SettingsContent(props: SettingsContentProps) {
           </GroupRow>
         )}
       </Group>
+
+      <GitProvidersSection colors={colors} />
 
       <Group title="Repositories">
         {repositories.length === 0 ? (

--- a/src/contexts/HostAuthContext.tsx
+++ b/src/contexts/HostAuthContext.tsx
@@ -1,0 +1,267 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { GitHubService } from '../services/GitHubService';
+import { gitLabService } from '../services/git/GitLabService';
+import {
+  giteaHostService,
+  forgejoHostService,
+} from '../services/git/gitHostFactory';
+import {
+  GIT_HOST_API_BASES,
+  GIT_HOST_LABELS,
+  type GitHostProvider,
+  type GitHostUser,
+} from '../services/git/GitHost';
+import type { GiteaLikeUser } from '../services/git/GiteaLikeHostService';
+
+export type HostAuthStatus = 'unknown' | 'ready';
+
+export interface HostAuthState {
+  provider: GitHostProvider;
+  label: string;
+  user: GitHostUser | null;
+  isAuthenticated: boolean;
+  baseUrl: string;
+}
+
+export interface HostAuthContextValue {
+  hosts: Record<GitHostProvider, HostAuthState>;
+  status: HostAuthStatus;
+  refresh: () => Promise<void>;
+  setToken: (
+    provider: GitHostProvider,
+    token: string,
+    baseUrl?: string,
+  ) => Promise<GitHostUser | null>;
+  clearToken: (provider: GitHostProvider) => Promise<void>;
+  setBaseUrl: (provider: GitHostProvider, baseUrl: string) => Promise<void>;
+}
+
+const HOST_ORDER: GitHostProvider[] = ['github', 'gitlab', 'gitea', 'forgejo'];
+
+const HostAuthContext = createContext<HostAuthContextValue | undefined>(undefined);
+
+function giteaUserToHostUser(
+  provider: GitHostProvider,
+  user: GiteaLikeUser | null,
+): GitHostUser | null {
+  if (!user) return null;
+  return {
+    id: user.id,
+    login: user.login,
+    name: user.full_name ?? user.login,
+    email: user.email ?? null,
+    avatarUrl: user.avatar_url ?? null,
+  };
+}
+
+function snapshotGitHub(): HostAuthState {
+  const u = GitHubService.getUser();
+  return {
+    provider: 'github',
+    label: GIT_HOST_LABELS.github,
+    user: u
+      ? {
+          id: u.id,
+          login: u.login,
+          name: u.name ?? null,
+          email: u.email ?? null,
+          avatarUrl: u.avatar_url ?? null,
+        }
+      : null,
+    isAuthenticated: GitHubService.isAuthenticated(),
+    baseUrl: GIT_HOST_API_BASES.github,
+  };
+}
+
+function snapshotGitLab(): HostAuthState {
+  const u = gitLabService.getUser();
+  return {
+    provider: 'gitlab',
+    label: GIT_HOST_LABELS.gitlab,
+    user: u
+      ? {
+          id: u.id,
+          login: u.username,
+          name: u.name,
+          email: u.email ?? null,
+          avatarUrl: u.avatar_url ?? null,
+        }
+      : null,
+    isAuthenticated: gitLabService.isAuthenticated(),
+    baseUrl: gitLabService.getBaseUrl(),
+  };
+}
+
+function snapshotGiteaLike(provider: 'gitea' | 'forgejo'): HostAuthState {
+  const svc = provider === 'gitea' ? giteaHostService : forgejoHostService;
+  return {
+    provider,
+    label: GIT_HOST_LABELS[provider],
+    user: giteaUserToHostUser(provider, svc.getUser()),
+    isAuthenticated: svc.isAuthenticated(),
+    baseUrl: svc.getBaseUrl(),
+  };
+}
+
+function snapshotAll(): Record<GitHostProvider, HostAuthState> {
+  return {
+    github: snapshotGitHub(),
+    gitlab: snapshotGitLab(),
+    gitea: snapshotGiteaLike('gitea'),
+    forgejo: snapshotGiteaLike('forgejo'),
+  };
+}
+
+interface HostAuthProviderProps {
+  children: ReactNode;
+}
+
+export function HostAuthProvider({ children }: HostAuthProviderProps) {
+  const [hosts, setHosts] = useState<Record<GitHostProvider, HostAuthState>>(
+    () => snapshotAll(),
+  );
+  const [status, setStatus] = useState<HostAuthStatus>('unknown');
+
+  const refresh = useCallback(async () => {
+    setHosts(snapshotAll());
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await Promise.all([
+          GitHubService.initialize(),
+          gitLabService.initialize(),
+          giteaHostService.initialize(),
+          forgejoHostService.initialize(),
+        ]);
+      } catch (err) {
+        console.warn('[HostAuthContext] initialize failed:', err);
+      }
+      if (!cancelled) {
+        setHosts(snapshotAll());
+        setStatus('ready');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setToken = useCallback(
+    async (
+      provider: GitHostProvider,
+      token: string,
+      baseUrl?: string,
+    ): Promise<GitHostUser | null> => {
+      let user: GitHostUser | null = null;
+      if (provider === 'github') {
+        const gh = await GitHubService.setToken(token);
+        user = gh
+          ? {
+              id: gh.id,
+              login: gh.login,
+              name: gh.name ?? null,
+              email: gh.email ?? null,
+              avatarUrl: gh.avatar_url ?? null,
+            }
+          : null;
+      } else if (provider === 'gitlab') {
+        const gl = await gitLabService.setToken(token, baseUrl);
+        user = gl
+          ? {
+              id: gl.id,
+              login: gl.username,
+              name: gl.name,
+              email: gl.email ?? null,
+              avatarUrl: gl.avatar_url ?? null,
+            }
+          : null;
+      } else if (provider === 'gitea' || provider === 'forgejo') {
+        const svc = provider === 'gitea' ? giteaHostService : forgejoHostService;
+        const gl = await svc.setToken(token, baseUrl);
+        user = giteaUserToHostUser(provider, gl);
+      }
+      await refresh();
+      return user;
+    },
+    [refresh],
+  );
+
+  const clearToken = useCallback(
+    async (provider: GitHostProvider): Promise<void> => {
+      if (provider === 'github') {
+        await GitHubService.clearToken();
+      } else if (provider === 'gitlab') {
+        await gitLabService.clearToken();
+      } else if (provider === 'gitea') {
+        await giteaHostService.clearToken();
+      } else if (provider === 'forgejo') {
+        await forgejoHostService.clearToken();
+      }
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const setBaseUrl = useCallback(
+    async (provider: GitHostProvider, baseUrl: string): Promise<void> => {
+      if (provider === 'gitlab') {
+        gitLabService.setBaseUrl(baseUrl);
+        await gitLabService.initialize();
+      } else if (provider === 'gitea') {
+        giteaHostService.setBaseUrl(baseUrl);
+        await giteaHostService.initialize();
+      } else if (provider === 'forgejo') {
+        forgejoHostService.setBaseUrl(baseUrl);
+        await forgejoHostService.initialize();
+      }
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const value = useMemo<HostAuthContextValue>(
+    () => ({
+      hosts,
+      status,
+      refresh,
+      setToken,
+      clearToken,
+      setBaseUrl,
+    }),
+    [hosts, status, refresh, setToken, clearToken, setBaseUrl],
+  );
+
+  return (
+    <HostAuthContext.Provider value={value}>{children}</HostAuthContext.Provider>
+  );
+}
+
+export function useHostAuth(): HostAuthContextValue {
+  const ctx = useContext(HostAuthContext);
+  if (!ctx) {
+    throw new Error('useHostAuth must be used within a HostAuthProvider');
+  }
+  return ctx;
+}
+
+export function useHostAuthFor(provider: GitHostProvider): HostAuthState {
+  const { hosts } = useHostAuth();
+  return hosts[provider];
+}
+
+export function useHostProvidersOrder(): readonly GitHostProvider[] {
+  return HOST_ORDER;
+}
+
+export default HostAuthContext;

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -228,5 +228,22 @@
     "invalidBody": "Verwende das Format «{{example}}».",
     "failedTitle": "Repository konnte nicht hinzugefügt werden",
     "failedBody": "Unbekannter Fehler"
+  },
+  "gitProviders": {
+    "title": "Git-Anbieter",
+    "footer": "Verbinde einen persönlichen Zugriffstoken für jeden Anbieter, mit dem du synchronisieren möchtest. Token werden im Geräte-Tresor gespeichert.",
+    "connectTitle": "{{host}} verbinden",
+    "connect": "Verbinden",
+    "disconnect": "Trennen",
+    "disconnectTitle": "{{host}} trennen?",
+    "disconnectBody": "Gespeicherten Token für {{host}}{{login}} entfernen? Bestehende Repositories auf diesem Anbieter werden nicht mehr synchronisiert.",
+    "tokenLabel": "Persönlicher Zugriffstoken",
+    "tokenPlaceholder": "Token einfügen",
+    "baseUrlLabel": "API-Basis-URL",
+    "baseUrlHelp": "Für selbstgehostete {{host}}-Instanzen überschreiben.",
+    "invalidTokenTitle": "Ungültiger Token",
+    "invalidTokenBody": "Authentifizierung mit diesem Token fehlgeschlagen. Wert prüfen und erneut versuchen.",
+    "failedTitle": "Token konnte nicht gespeichert werden",
+    "failedBody": "Unbekannter Fehler"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -233,5 +233,22 @@
     "invalidBody": "Use the format «{{example}}».",
     "failedTitle": "Could not add the repository",
     "failedBody": "Unknown error"
+  },
+  "gitProviders": {
+    "title": "Git Providers",
+    "footer": "Connect a personal access token for each host you want to sync with. Tokens are stored in the device keystore.",
+    "connectTitle": "Connect {{host}}",
+    "connect": "Connect",
+    "disconnect": "Disconnect",
+    "disconnectTitle": "Disconnect {{host}}?",
+    "disconnectBody": "Remove the saved token for {{host}}{{login}}? Existing repositories on this host will stop syncing.",
+    "tokenLabel": "Personal access token",
+    "tokenPlaceholder": "Paste your token",
+    "baseUrlLabel": "API base URL",
+    "baseUrlHelp": "Override for self-hosted {{host}} instances.",
+    "invalidTokenTitle": "Invalid token",
+    "invalidTokenBody": "Could not authenticate with that token. Check the value and try again.",
+    "failedTitle": "Could not save the token",
+    "failedBody": "Unknown error"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -228,5 +228,22 @@
     "invalidBody": "Usa el formato «{{example}}».",
     "failedTitle": "No se pudo añadir el repositorio",
     "failedBody": "Error desconocido"
+  },
+  "gitProviders": {
+    "title": "Proveedores de Git",
+    "footer": "Conecta un token de acceso personal para cada host con el que quieras sincronizar. Los tokens se guardan en el almacén seguro del dispositivo.",
+    "connectTitle": "Conectar {{host}}",
+    "connect": "Conectar",
+    "disconnect": "Desconectar",
+    "disconnectTitle": "¿Desconectar {{host}}?",
+    "disconnectBody": "¿Eliminar el token guardado de {{host}}{{login}}? Los repositorios existentes en este host dejarán de sincronizarse.",
+    "tokenLabel": "Token de acceso personal",
+    "tokenPlaceholder": "Pega tu token",
+    "baseUrlLabel": "URL base de la API",
+    "baseUrlHelp": "Anula la URL para instancias autoalojadas de {{host}}.",
+    "invalidTokenTitle": "Token inválido",
+    "invalidTokenBody": "No se pudo autenticar con ese token. Comprueba el valor e inténtalo de nuevo.",
+    "failedTitle": "No se pudo guardar el token",
+    "failedBody": "Error desconocido"
   }
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -228,5 +228,22 @@
     "invalidBody": "Utilisez le format «{{example}}».",
     "failedTitle": "Impossible d'ajouter le dépôt",
     "failedBody": "Erreur inconnue"
+  },
+  "gitProviders": {
+    "title": "Hébergeurs Git",
+    "footer": "Connectez un jeton d'accès personnel pour chaque hébergeur avec lequel vous souhaitez synchroniser. Les jetons sont stockés dans le coffre de l'appareil.",
+    "connectTitle": "Connecter {{host}}",
+    "connect": "Connecter",
+    "disconnect": "Déconnecter",
+    "disconnectTitle": "Déconnecter {{host}} ?",
+    "disconnectBody": "Supprimer le jeton enregistré pour {{host}}{{login}} ? Les dépôts existants sur cet hébergeur cesseront de se synchroniser.",
+    "tokenLabel": "Jeton d'accès personnel",
+    "tokenPlaceholder": "Collez votre jeton",
+    "baseUrlLabel": "URL de base de l'API",
+    "baseUrlHelp": "Remplacer pour les instances auto-hébergées de {{host}}.",
+    "invalidTokenTitle": "Jeton invalide",
+    "invalidTokenBody": "Impossible de s'authentifier avec ce jeton. Vérifiez la valeur et réessayez.",
+    "failedTitle": "Impossible d'enregistrer le jeton",
+    "failedBody": "Erreur inconnue"
   }
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -228,5 +228,22 @@
     "invalidBody": "「{{example}}」形式で入力してください。",
     "failedTitle": "リポジトリを追加できませんでした",
     "failedBody": "不明なエラー"
+  },
+  "gitProviders": {
+    "title": "Git プロバイダー",
+    "footer": "同期したいホストごとに個人アクセストークンを接続してください。トークンは端末のキーストアに保存されます。",
+    "connectTitle": "{{host}} を接続",
+    "connect": "接続",
+    "disconnect": "切断",
+    "disconnectTitle": "{{host}} を切断しますか?",
+    "disconnectBody": "{{host}}{{login}} の保存済みトークンを削除しますか?このホストの既存リポジトリは同期されなくなります。",
+    "tokenLabel": "個人アクセストークン",
+    "tokenPlaceholder": "トークンを貼り付け",
+    "baseUrlLabel": "API ベース URL",
+    "baseUrlHelp": "セルフホストの {{host}} インスタンス用に上書きします。",
+    "invalidTokenTitle": "無効なトークン",
+    "invalidTokenBody": "そのトークンで認証できませんでした。値を確認して再試行してください。",
+    "failedTitle": "トークンを保存できませんでした",
+    "failedBody": "不明なエラー"
   }
 }

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -228,5 +228,22 @@
     "invalidBody": "«{{example}}» 형식을 사용하세요.",
     "failedTitle": "저장소를 추가할 수 없습니다",
     "failedBody": "알 수 없는 오류"
+  },
+  "gitProviders": {
+    "title": "Git 제공자",
+    "footer": "동기화하려는 각 호스트의 개인 액세스 토큰을 연결하세요. 토큰은 기기 키스토어에 저장됩니다.",
+    "connectTitle": "{{host}} 연결",
+    "connect": "연결",
+    "disconnect": "연결 해제",
+    "disconnectTitle": "{{host}} 연결을 해제하시겠어요?",
+    "disconnectBody": "{{host}}{{login}}의 저장된 토큰을 삭제할까요? 이 호스트의 기존 저장소는 동기화가 중지됩니다.",
+    "tokenLabel": "개인 액세스 토큰",
+    "tokenPlaceholder": "토큰 붙여넣기",
+    "baseUrlLabel": "API 기본 URL",
+    "baseUrlHelp": "자체 호스팅된 {{host}} 인스턴스용으로 재정의합니다.",
+    "invalidTokenTitle": "잘못된 토큰",
+    "invalidTokenBody": "해당 토큰으로 인증할 수 없습니다. 값을 확인하고 다시 시도하세요.",
+    "failedTitle": "토큰을 저장할 수 없습니다",
+    "failedBody": "알 수 없는 오류"
   }
 }


### PR DESCRIPTION
## Summary

Users can now connect a personal access token for each non-GitHub host (GitLab, Gitea, Forgejo) from Settings, without having to add a repository first.

- **HostAuthContext** initializes and exposes auth state for all four providers in a single React context. Components that only need one host can call `useHostAuthFor(provider)`.
- **GitProvidersSection** renders one row per host with a connect / disconnect flow. GitLab, Gitea, and Forgejo additionally accept a custom API base URL so self-hosted instances work without code changes.
- This sits on top of the existing `GitLabService` and `GiteaLikeHostService` adapters from the multi-host write work, so repos added through `AddRepoModal` keep syncing once their host is connected here.

## Why

The host abstraction landed with no way to actually authenticate against GitLab / Gitea / Forgejo from the app. Users had to drop their tokens into storage manually. This closes the loop: connect a host here, then add a repo pointing at it.

## Changes

- `src/contexts/HostAuthContext.tsx` — new unified context, dispatches `setToken` / `clearToken` / `setBaseUrl` to the correct service per provider.
- `src/components/settings/GitProvidersSection.tsx` — new settings section with one row per host, modal for connect, alert confirmation for disconnect.
- `App.tsx` — wraps the tree in `HostAuthProvider` so the section (and any future per-host UI) can read state.
- `src/components/settings/SettingsContent.tsx` — mounts the new section between the GitHub auth group and the Repositories group.
- `src/i18n/{en,es,fr,de,ja,ko}.json` — new `gitProviders` namespace.
- `__tests__/HostAuthContext.test.tsx` and `__tests__/GitProvidersSection.test.tsx` — 18 tests, all passing.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint` clean on the changed files.
- [x] `npx jest HostAuthContext GitProvidersSection` — 18 / 18 passing.
- [x] `npx jest GitHost GitLab Gitea GitHubHostService` — 126 / 130 passing (4 skipped integration tests, 0 regressions).

## Risks

- The disconnect alert path fires `clearToken` on the singleton `GitHubService`, which is the same path used by the legacy "Remove GitHub Account" button. Behavior matches what was already there.
- The Gitea / Forgejo services share storage keys with their own provider id, so disconnecting one does not affect the other. Verified by reading `GiteaLikeHostService.tokenKey()`.

💘 Generated with Heretic