### PR TITLE
fix(github): note sync pending forever + token permission validation

### DIFF
--- a/__tests__/ForegroundSyncService.test.ts
+++ b/__tests__/ForegroundSyncService.test.ts
@@ -1,0 +1,163 @@
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  NetInfoStateType: { wifi: 'wifi', none: 'none' },
+  default: {
+    addEventListener: jest.fn(() => jest.fn()),
+    fetch: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    drain: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/RepoPullService', () => ({
+  pullAllFromRepos: jest.fn(),
+}));
+
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import NetInfo, { NetInfoStateType, type NetInfoState } from '@react-native-community/netinfo';
+import { GitHubService } from '../src/services/GitHubService';
+import { NoteSyncQueueService } from '../src/services/NoteSyncQueueService';
+import {
+  __resetForegroundSyncForTest,
+  __runPullForTest,
+} from '../src/services/ForegroundSyncService';
+import { pullAllFromRepos } from '../src/services/RepoPullService';
+import { StorageService } from '../src/services/StorageService';
+import type { PullResult } from '../src/services/RepoPullService';
+import type { GitRepository } from '../src/services/GitService';
+
+const authMock = jest.mocked(GitHubService.isAuthenticated);
+const reposMock = jest.mocked(StorageService.getSavedRepositories);
+const netInfoFetchMock = jest.mocked(NetInfo.fetch);
+const drainMock = jest.mocked(NoteSyncQueueService.drain);
+const pullMock = jest.mocked(pullAllFromRepos);
+
+const repository: GitRepository = { id: 'repo-id', name: 'repo', path: 'owner/repo' };
+const reachableState: NetInfoState = {
+  type: NetInfoStateType.wifi,
+  isConnected: true,
+  isInternetReachable: true,
+  details: {
+    isConnectionExpensive: false,
+    ssid: null,
+    bssid: null,
+    strength: null,
+    ipAddress: null,
+    subnet: null,
+    frequency: null,
+    linkSpeed: null,
+    rxLinkSpeed: null,
+    txLinkSpeed: null,
+  },
+};
+const offlineState: NetInfoState = {
+  type: NetInfoStateType.none,
+  isConnected: false,
+  isInternetReachable: false,
+  details: null,
+};
+const pullResult: PullResult = { repos: 0, notes: 0, canvases: 0, todos: 0, templates: 0 };
+
+describe('ForegroundSyncService', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(10_000);
+    jest.clearAllMocks();
+    __resetForegroundSyncForTest();
+    authMock.mockReturnValue(true);
+    reposMock.mockResolvedValue([repository]);
+    netInfoFetchMock.mockResolvedValue(reachableState);
+    drainMock.mockResolvedValue({ succeeded: 0, failed: 0, remaining: 0 });
+    pullMock.mockResolvedValue(pullResult);
+  });
+
+  afterEach(() => {
+    __resetForegroundSyncForTest();
+    jest.useRealTimers();
+  });
+
+  test('drains queued mutations before pulling remote state', async () => {
+    const order: string[] = [];
+    drainMock.mockImplementation(async () => {
+      order.push('drain');
+      return { succeeded: 1, failed: 0, remaining: 0 };
+    });
+    pullMock.mockImplementation(async () => {
+      order.push('pull');
+      return pullResult;
+    });
+
+    await __runPullForTest();
+
+    expect(order).toEqual(['drain', 'pull']);
+  });
+
+  test('does not drain or pull while offline', async () => {
+    netInfoFetchMock.mockResolvedValue(offlineState);
+
+    await __runPullForTest();
+
+    expect(drainMock).not.toHaveBeenCalled();
+    expect(pullMock).not.toHaveBeenCalled();
+  });
+
+  test('skips a trigger while another foreground sync is in flight', async () => {
+    let resolvePull: (() => void) | undefined;
+    pullMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePull = () => resolve(pullResult);
+        }),
+    );
+
+    const firstPull = __runPullForTest('first');
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const secondPull = __runPullForTest('second');
+
+    await secondPull;
+    expect(drainMock).toHaveBeenCalledTimes(1);
+    expect(pullMock).toHaveBeenCalledTimes(1);
+
+    resolvePull?.();
+    await firstPull;
+  });
+
+  test('coalesces triggers within the existing window', async () => {
+    await __runPullForTest('first');
+    jest.setSystemTime(11000);
+    await __runPullForTest('second');
+
+    expect(drainMock).toHaveBeenCalledTimes(1);
+    expect(pullMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('recovers when draining fails without entering pull backoff', async () => {
+    drainMock.mockRejectedValueOnce(new Error('drain failed'));
+
+    await __runPullForTest('first');
+    jest.setSystemTime(40000);
+    await __runPullForTest('second');
+
+    expect(drainMock).toHaveBeenCalledTimes(2);
+    expect(pullMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/NoteSyncQueueService.test.ts
+++ b/__tests__/NoteSyncQueueService.test.ts
@@ -251,6 +251,38 @@ describe('NoteSyncQueueService', () => {
       expect(items[0].nextRetryAt!).toBeGreaterThanOrEqual(before + 500);
     });
 
+    test.each([
+      ['authentication', '401 Unauthorized'],
+      ['permission', '403 Forbidden'],
+      ['conflict', '409 Conflict'],
+    ])('drops %s failures without retaining a queue entry', async (_kind, error) => {
+      (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: false, error });
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+
+      const result = await NoteSyncQueueService.drain();
+
+      expect(result.failed).toBe(0);
+      expect(result.remaining).toBe(0);
+      expect(await NoteSyncQueueService.pendingCount()).toBe(0);
+    });
+
+    test('retains transient failures for retry', async () => {
+      (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: false, error: '503 Service Unavailable' });
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+
+      const result = await NoteSyncQueueService.drain();
+
+      expect(result.failed).toBe(1);
+      expect(result.remaining).toBe(1);
+      expect((await NoteSyncQueueService.getAll())[0].attempts).toBe(1);
+    });
+
     test('drops items after MAX_ATTEMPTS', async () => {
       (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: false, error: 'fatal' });
 

--- a/__tests__/components/useNoteEditorDocument.notFound.test.ts
+++ b/__tests__/components/useNoteEditorDocument.notFound.test.ts
@@ -1,4 +1,5 @@
-import { renderHook } from '@testing-library/react-native';
+import { renderHook, act } from '@testing-library/react-native';
+import { Alert } from 'react-native';
 
 jest.mock('expo-image-picker', () => ({}));
 
@@ -6,6 +7,7 @@ jest.mock('../../src/services/GitService', () => ({
   GitService: {
     commit: jest.fn(),
     push: jest.fn(),
+    getBranches: jest.fn(async () => []),
     getRepositoryFolders: jest.fn(async () => []),
   },
 }));
@@ -15,7 +17,7 @@ jest.mock('../../src/services/NoteGitHubSyncService', () => ({
 }));
 
 jest.mock('../../src/services/NoteSyncQueueService', () => ({
-  NoteSyncQueueService: { enqueue: jest.fn() },
+  NoteSyncQueueService: { enqueue: jest.fn(), enqueueNoteUpsert: jest.fn() },
 }));
 
 jest.mock('../../src/utils/haptics', () => ({
@@ -23,6 +25,8 @@ jest.mock('../../src/utils/haptics', () => ({
 }));
 
 import { useNoteEditorDocument } from '../../src/components/editor/useNoteEditorDocument';
+import { syncNoteToGitHub } from '../../src/services/NoteGitHubSyncService';
+import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
 
 const baseParams = {
   initialFormat: 'markdown' as const,
@@ -84,5 +88,33 @@ describe('useNoteEditorDocument notFound (issue #669)', () => {
       }),
     );
     expect(result.current.notFound).toBe(false);
+  });
+
+  test('shows actionable auth failure and does not enqueue the locally saved note', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: false, error: 'GitHub not authenticated' });
+    const createNote = jest.fn(async () => ({ id: 'new-note-1' }));
+
+    const { result } = renderHook(() =>
+      useNoteEditorDocument({
+        ...baseParams,
+        initialRepo: 'owner/repo',
+        initialTitle: 'A note',
+        createNote,
+        getNoteById: () => undefined,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Authentication Required',
+      'Reconnect your GitHub account in Settings',
+      [{ text: 'OK' }],
+    );
+    expect(NoteSyncQueueService.enqueueNoteUpsert).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
   });
 });

--- a/__tests__/repoAccessPreflight.test.ts
+++ b/__tests__/repoAccessPreflight.test.ts
@@ -1,0 +1,76 @@
+import { checkGitHubRepoAccess } from '../src/services/git/repoAccessPreflight';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const token = 'secret-token';
+
+describe('checkGitHubRepoAccess', () => {
+  let fetchSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('returns ok for an accessible writable repository', async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ permissions: { push: true } }), { status: 200 }));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toEqual({ kind: 'ok' });
+    expect(fetchSpy).toHaveBeenCalledWith('https://api.github.com/repos/octo/notes', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+      },
+    });
+  });
+
+  it('returns ok when GitHub omits permissions', async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ private: true }), { status: 200 }));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toEqual({ kind: 'ok' });
+  });
+
+  it('returns no_access for a repository that is not visible', async () => {
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 404 }));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({ kind: 'no_access' });
+  });
+
+  it('returns no_write when the repository denies push permission', async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ permissions: { push: false } }), { status: 403 }));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({ kind: 'no_write' });
+  });
+
+  it('returns saml_required for a SAML-protected organization', async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ message: 'SAML enforcement is required' }), { status: 403 }));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({ kind: 'saml_required' });
+  });
+
+  it('returns rate_limited for a rate-limited response', async () => {
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 429 }));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({ kind: 'rate_limited' });
+  });
+
+  it('returns transient for a network failure', async () => {
+    fetchSpy.mockRejectedValue(new TypeError('Network request failed'));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({ kind: 'transient' });
+  });
+
+  it('returns transient when the response body cannot be read', async () => {
+    fetchSpy.mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async (): Promise<unknown> => {
+        throw new SyntaxError('invalid JSON');
+      },
+    });
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({ kind: 'transient' });
+  });
+});

--- a/__tests__/syncFailure.test.ts
+++ b/__tests__/syncFailure.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  classifyGitHubSyncError,
+  isRetryableFailure,
+  type GitHubSyncFailure,
+} from '../src/services/git/syncFailure';
+
+describe('classifyGitHubSyncError', () => {
+  test('classifies authentication failures from status 401', () => {
+    // Given: GitHub rejected the credentials.
+    const error = new Error('GitHub API error: 401');
+
+    // When: the delivery error is classified.
+    const failure = classifyGitHubSyncError(error, 401);
+
+    // Then: authentication failures are not retryable.
+    expect(failure).toEqual({
+      kind: 'authentication',
+      message: 'GitHub API error: 401',
+      retryable: false,
+      status: 401,
+    });
+  });
+
+  test('classifies SAML failures before general permission failures', () => {
+    // Given: GitHub requires SAML authorization for the organization.
+    const error = new Error('X-GitHub-SSO is required');
+
+    // When: the delivery error is classified.
+    const failure = classifyGitHubSyncError(error, 403);
+
+    // Then: the remediation category identifies SAML authorization.
+    expect(failure.kind).toBe('saml');
+    expect(failure.retryable).toBe(false);
+    expect(failure.status).toBe(403);
+  });
+
+  test('classifies rate-limit failures from a 403 signal', () => {
+    // Given: GitHub returned a rate-limit response using status 403.
+    const error = new Error('GitHub API rate limit exceeded');
+
+    // When: the delivery error is classified.
+    const failure = classifyGitHubSyncError(error, 403);
+
+    // Then: the caller can retry after the limit resets.
+    expect(failure.kind).toBe('rate_limit');
+    expect(failure.retryable).toBe(true);
+  });
+
+  test('classifies status 429 as a retryable rate-limit failure', () => {
+    // Given: GitHub explicitly reports too many requests.
+    const failure = classifyGitHubSyncError(new Error('Too many requests'), 429);
+
+    // When: the retry policy is checked.
+    // Then: rate limiting remains retryable.
+    expect(failure.kind).toBe('rate_limit');
+    expect(isRetryableFailure(failure)).toBe(true);
+  });
+
+  test('classifies a non-rate-limit 403 as permission denied', () => {
+    // Given: the token cannot write to the repository.
+    const failure = classifyGitHubSyncError(new Error('Resource not accessible'), 403);
+
+    // When: the retry policy is checked.
+    // Then: retrying cannot fix a permission denial.
+    expect(failure.kind).toBe('permission');
+    expect(isRetryableFailure(failure)).toBe(false);
+  });
+
+  test('classifies conflicts and missing repositories as non-retryable', () => {
+    // Given: GitHub reports two configuration or delivery outcomes.
+    const conflict = classifyGitHubSyncError(new Error('File changed'), 409);
+    const missing = classifyGitHubSyncError(new Error('Repository not found'), 404);
+
+    // When: their retry policies are checked.
+    // Then: neither outcome should be retried automatically.
+    expect(conflict.kind).toBe('conflict');
+    expect(missing.kind).toBe('not_found');
+    expect(isRetryableFailure(conflict)).toBe(false);
+    expect(isRetryableFailure(missing)).toBe(false);
+  });
+
+  test('classifies server responses as retryable', () => {
+    // Given: GitHub has a temporary server failure.
+    const failure = classifyGitHubSyncError(new Error('GitHub API error: 503'), 503);
+
+    // When: the retry policy is checked.
+    // Then: delivery may be attempted again.
+    expect(failure.kind).toBe('server');
+    expect(isRetryableFailure(failure)).toBe(true);
+  });
+
+  test('classifies network errors and removes bearer tokens from the message', () => {
+    // Given: the request failed locally and included a credential in its message.
+    const failure = classifyGitHubSyncError(new Error('fetch failed: Bearer super-secret-token'));
+
+    // When: the failure is returned to the sync queue.
+    // Then: it is retryable without retaining the credential.
+    expect(failure.kind).toBe('network');
+    expect(failure.retryable).toBe(true);
+    expect(failure.message).toBe('fetch failed: Bearer ***');
+    expect(failure.message).not.toContain('super-secret-token');
+  });
+
+  test('uses a safe retryable fallback for unknown errors', () => {
+    // Given: a thrown value has no safe message or status.
+    const failure = classifyGitHubSyncError({ detail: 'unexpected failure' });
+
+    // When: the failure is classified.
+    // Then: the fallback remains retryable and does not stringify unknown data.
+    expect(failure).toEqual({
+      kind: 'unknown',
+      message: 'Unknown GitHub sync failure',
+      retryable: true,
+    });
+  });
+
+  test('preserves an Error message for an otherwise unknown failure', () => {
+    // Given: an Error has no status or known network signal.
+    const failure = classifyGitHubSyncError(new Error('Unexpected GitHub response'));
+
+    // When: the failure is classified.
+    // Then: the original safe message is retained under the unknown category.
+    expect(failure.kind).toBe('unknown');
+    expect(failure.message).toBe('Unexpected GitHub response');
+  });
+});
+
+describe('isRetryableFailure', () => {
+  const retryabilityCases: Array<[GitHubSyncFailure['kind'], boolean]> = [
+    ['authentication', false],
+    ['permission', false],
+    ['saml', false],
+    ['rate_limit', true],
+    ['conflict', false],
+    ['not_found', false],
+    ['server', true],
+    ['network', true],
+    ['unknown', true],
+  ];
+
+  test.each(retryabilityCases)('returns %s=%s', (kind, retryable) => {
+    // Given: a typed failure category with a deliberately opposite flag.
+    const failure: GitHubSyncFailure = {
+      kind,
+      message: 'safe message',
+      retryable: !retryable,
+    };
+
+    // When: the category predicate is evaluated.
+    const result = isRetryableFailure(failure);
+
+    // Then: policy follows the category, not caller-provided metadata.
+    expect(result).toBe(retryable);
+  });
+});

--- a/src/components/ConnectHostModal.tsx
+++ b/src/components/ConnectHostModal.tsx
@@ -352,6 +352,18 @@ export function ConnectHostModal({
             </TouchableOpacity>
           </View>
 
+          {provider === 'github' ? (
+            <Text
+              style={{
+                color: colors.textSecondary,
+                fontSize: 12,
+                marginBottom: spacing[2],
+              }}
+            >
+              {t('connectHost.help.github')}
+            </Text>
+          ) : null}
+
           <View style={[styles.row, { marginTop: spacing[2] }]}>
             <TouchableOpacity
               onPress={onClose}

--- a/src/components/editor/useNoteEditorDocument.ts
+++ b/src/components/editor/useNoteEditorDocument.ts
@@ -13,11 +13,44 @@ import { HapticService } from '../../utils/haptics';
 import { useUndo } from '../../utils/useUndo';
 import { syncNoteToGitHub } from '../../services/NoteGitHubSyncService';
 import { NoteSyncQueueService } from '../../services/NoteSyncQueueService';
+import { classifyGitHubSyncError, isRetryableFailure } from '../../services/git/syncFailure';
 import { githubActivity } from '../../stores/githubActivityStore';
 import { canvasToLink } from '../../models/Canvas';
 import { getExtensionForFormat, extractCanvasJsonRefs, slugifyLocal } from './editorShared';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'NoteEditor'>;
+
+function showDurableSyncFailureAlert(kind: ReturnType<typeof classifyGitHubSyncError>['kind']): void {
+  switch (kind) {
+    case 'authentication':
+      Alert.alert('Authentication Required', 'Reconnect your GitHub account in Settings', [{ text: 'OK' }]);
+      return;
+    case 'permission':
+    case 'saml':
+      Alert.alert(
+        'Permission Required',
+        'This token cannot write to this repository. Check your token permissions in Settings.',
+        [{ text: 'OK' }],
+      );
+      return;
+    case 'conflict':
+      Alert.alert('Sync Conflict', 'This note was modified on GitHub. Pull to get the latest version.', [{ text: 'OK' }]);
+      return;
+    case 'not_found':
+      Alert.alert('Invalid Repository', 'The repository path is invalid. Please check your settings.', [{ text: 'OK' }]);
+      return;
+    default:
+      return;
+  }
+}
+
+function syncStatusForError(message: string): number | undefined {
+  const statusMatch = message.match(/\b(401|403|404|409|429|5\d{2})\b/);
+  if (statusMatch?.[1]) return Number(statusMatch[1]);
+  if (/not authenticated/i.test(message)) return 401;
+  if (/conflict/i.test(message)) return 409;
+  return undefined;
+}
 
 interface NoteEditorDocumentParams {
   noteId?: string;
@@ -309,31 +342,11 @@ export function useNoteEditorDocument({
             }
           } else {
             const error = syncResult.error!;
-            if (error.includes('Conflict') || error.includes('conflict')) {
-              Alert.alert(
-                'Sync Conflict',
-                'This note was modified on GitHub since you last loaded it. Pull to get the latest version and resolve the conflict.',
-                [{ text: 'OK' }],
-              );
-            } else if (error.includes('not authenticated') || error.includes('401') || error.includes('403')) {
-              Alert.alert(
-                'Authentication Required',
-                'Please check your GitHub credentials in Settings.',
-                [{ text: 'OK' }],
-              );
-            } else if (error.includes('Invalid repo') || error.includes('invalid repo')) {
-              Alert.alert(
-                'Invalid Repository',
-                'The repository path is invalid. Please check your settings.',
-                [{ text: 'OK' }],
-              );
-            } else if (error.includes('exceeding 5 MB') || error.includes('too large')) {
-              Alert.alert(
-                'File Too Large',
-                'This note exceeds the 5 MB size limit and cannot be synced.',
-                [{ text: 'OK' }],
-              );
-            } else {
+            const failure = classifyGitHubSyncError(
+              new Error(error),
+              syncStatusForError(error),
+            );
+            if (isRetryableFailure(failure)) {
               try {
                 await NoteSyncQueueService.enqueueNoteUpsert(syncParams, savedNoteId);
                 Alert.alert(
@@ -348,6 +361,8 @@ export function useNoteEditorDocument({
                   [{ text: 'OK' }],
                 );
               }
+            } else {
+              showDurableSyncFailureAlert(failure.kind);
             }
           }
         } catch (error) {
@@ -364,19 +379,28 @@ export function useNoteEditorDocument({
             tags,
             color: existingForColor?.color ?? null,
           };
-          try {
-            await NoteSyncQueueService.enqueueNoteUpsert(syncParams, savedNoteId);
-            Alert.alert(
-              'Note Saved Locally',
-              'Your note was saved but could not be pushed to GitHub yet. It will sync automatically when connection is restored.',
-              [{ text: 'OK' }],
-            );
-          } catch {
-            Alert.alert(
-              'Save Failed',
-              'Your note was saved locally but could not be queued for sync. Please try again.',
-              [{ text: 'OK' }],
-            );
+          const thrownMessage = error instanceof Error ? error.message : String(error);
+          const failure = classifyGitHubSyncError(
+            error,
+            syncStatusForError(thrownMessage),
+          );
+          if (!isRetryableFailure(failure)) {
+            showDurableSyncFailureAlert(failure.kind);
+          } else {
+            try {
+              await NoteSyncQueueService.enqueueNoteUpsert(syncParams, savedNoteId);
+              Alert.alert(
+                'Note Saved Locally',
+                'Your note was saved but could not be pushed to GitHub yet. It will sync automatically when connection is restored.',
+                [{ text: 'OK' }],
+              );
+            } catch {
+              Alert.alert(
+                'Save Failed',
+                'Your note was saved locally but could not be queued for sync. Please try again.',
+                [{ text: 'OK' }],
+              );
+            }
           }
         } finally {
           githubActivity.end();

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -257,6 +257,9 @@
     "show": "Show",
     "hide": "Hide",
     "connectHost": "Connect host",
+    "help": {
+      "github": "Feingranulare Tokens benötigen „Contents: Read and write“ für jedes Repository. Klassische Tokens benötigen den Bereich „repo“."
+    },
     "success": {
       "testTitle": "Success",
       "testBody": "Token accepted."

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -289,7 +289,7 @@
     "branch": "Branch: {{branch}}",
     "branchDefault": "main",
     "addGitHubAccount": "Add GitHub Account",
-    "tokenDescription": "Fine-grained Personal Access Token with read/write access to your repositories.",
+    "tokenDescription": "Fine-grained Personal Access Token with Contents: Read and write access to your repositories.",
     "openGithubTokenSettings": "Open GitHub token settings",
     "hideToken": "Hide token",
     "showToken": "Show token",
@@ -381,6 +381,9 @@
     "show": "Show",
     "hide": "Hide",
     "connectHost": "Connect host",
+    "help": {
+      "github": "Fine-grained tokens need Contents: Read and write for each repository. Classic tokens need the repo scope."
+    },
     "success": {
       "testTitle": "Success",
       "testBody": "Token accepted. Press Save to keep it."

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -257,6 +257,9 @@
     "show": "Show",
     "hide": "Hide",
     "connectHost": "Connect host",
+    "help": {
+      "github": "Los tokens de grano fino necesitan «Contents: Read and write» para cada repositorio. Los tokens clásicos necesitan el ámbito repo."
+    },
     "success": {
       "testTitle": "Success",
       "testBody": "Token accepted."

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -257,6 +257,9 @@
     "show": "Show",
     "hide": "Hide",
     "connectHost": "Connect host",
+    "help": {
+      "github": "Les jetons à granularité fine nécessitent l’autorisation « Contents: Read and write » pour chaque dépôt. Les jetons classiques nécessitent la portée repo."
+    },
     "success": {
       "testTitle": "Success",
       "testBody": "Token accepted."

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -257,6 +257,9 @@
     "show": "Show",
     "hide": "Hide",
     "connectHost": "Connect host",
+    "help": {
+      "github": "きめ細かいトークンには、各リポジトリの「Contents: Read and write」権限が必要です。クラシックトークンには repo スコープが必要です。"
+    },
     "success": {
       "testTitle": "Success",
       "testBody": "Token accepted."

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -257,6 +257,9 @@
     "show": "Show",
     "hide": "Hide",
     "connectHost": "Connect host",
+    "help": {
+      "github": "세분화된 토큰은 각 저장소에 'Contents: Read and write' 권한이 필요합니다. 클래식 토큰은 repo 스코프가 필요합니다."
+    },
     "success": {
       "testTitle": "Success",
       "testBody": "Token accepted."

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -131,7 +131,7 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
 
             <Text style={[styles.title, { color: colors.text }]}>Connect GitHub</Text>
             <Text style={[styles.description, { color: colors.textSecondary }]}>
-              Enter a Fine-grained Personal Access Token to link your notes to GitHub repositories. Create one with read/write access to your chosen repositories. You can skip this and add it later in Settings.
+              Enter a Fine-grained Personal Access Token with Contents: Read and write access to each repository, or a classic token with the repo scope. You can skip this and add it later in Settings.
             </Text>
 
             <Button

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -41,6 +41,7 @@ import { CloneProgressModal, type CloneProgress } from '../components/settings/C
 import { settingsStyles as styles } from '../components/settings/settingsStyles';
 import type { GitRepository } from '../services/GitService';
 import { useTranslation } from 'react-i18next';
+import { RepoAccessPreflightError } from '../services/git/repoAccessPreflight';
 
 export default function SettingsScreen() {
   const { t } = useTranslation();
@@ -456,6 +457,10 @@ export default function SettingsScreen() {
     } catch (error) {
       console.warn('[SettingsScreen] handleSelectGithubRepo failed:', error);
       HapticService.error();
+      if (error instanceof RepoAccessPreflightError) {
+        Alert.alert('Repository Access', error.message);
+        return;
+      }
       Alert.alert('Error', 'Failed to add repository.');
     } finally {
       setIsAddingRepo(false);
@@ -475,6 +480,10 @@ export default function SettingsScreen() {
     } catch (error) {
       console.warn('[SettingsScreen] handleAddManualRepo failed:', error);
       HapticService.error();
+      if (error instanceof RepoAccessPreflightError) {
+        Alert.alert('Repository Access', error.message);
+        return;
+      }
       Alert.alert('Error', 'Failed to add repository.');
     } finally {
       setIsAddingRepo(false);

--- a/src/services/ForegroundSyncService.ts
+++ b/src/services/ForegroundSyncService.ts
@@ -2,6 +2,7 @@ import { AppState, type AppStateStatus, type NativeEventSubscription } from 'rea
 import NetInfo, { type NetInfoSubscription } from '@react-native-community/netinfo';
 import { GitHubService } from './GitHubService';
 import { StorageService } from './StorageService';
+import { NoteSyncQueueService } from './NoteSyncQueueService';
 import { pullAllFromRepos } from './RepoPullService';
 
 /**
@@ -95,6 +96,7 @@ async function runPull(reason: string): Promise<void> {
 
   let watchdogTimedOut = false;
   let watchdog: ReturnType<typeof setTimeout> | null = null;
+  let pullTimeout: ReturnType<typeof setTimeout> | null = null;
   watchdog = setTimeout(() => {
     watchdogTimedOut = true;
     console.warn(`[ForegroundSync] pull (${reason}) exceeded ${PULL_WATCHDOG_MS}ms`);
@@ -105,10 +107,20 @@ async function runPull(reason: string): Promise<void> {
   const PULL_TIMEOUT_MS = 600_000;
   try {
     await Promise.race([
-      pullAllFromRepos(),
-      new Promise<void>((_, reject) =>
-        setTimeout(() => reject(new Error(`Pull timed out after ${PULL_TIMEOUT_MS}ms`)), PULL_TIMEOUT_MS)
-      ),
+      (async () => {
+        try {
+          await NoteSyncQueueService.drain();
+        } catch (error) {
+          console.warn(`[ForegroundSync] drain (${reason}) failed:`, error);
+        }
+        await pullAllFromRepos();
+      })(),
+      new Promise<void>((_, reject) => {
+        pullTimeout = setTimeout(
+          () => reject(new Error(`Pull timed out after ${PULL_TIMEOUT_MS}ms`)),
+          PULL_TIMEOUT_MS,
+        );
+      }),
     ]);
     success = true;
     if (__DEV__) {
@@ -118,6 +130,7 @@ async function runPull(reason: string): Promise<void> {
     console.warn(`[ForegroundSync] pull (${reason}) failed after ${Date.now() - startedAt}ms:`, error);
   } finally {
     if (watchdog !== null) clearTimeout(watchdog);
+    if (pullTimeout !== null) clearTimeout(pullTimeout);
     inFlight = false;
     lastRunAt = Date.now();
     if (watchdogTimedOut) {

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -8,6 +8,7 @@ import { StorageService } from './StorageService';
 import { SyncEngineService } from './SyncEngineService';
 import { AuthService } from './AuthService';
 import { LocalGitWriter } from './git/LocalGitWriter';
+import { classifyGitHubSyncError, isRetryableFailure } from './git/syncFailure';
 import { NoteColor, NoteFormat } from '../models/Note';
 
 const QUEUE_KEY = '@gitnotes:sync_queue_v1';
@@ -25,6 +26,15 @@ const BACKOFF_CAP_MS = 30_000;
  */
 function backoffMsForAttempts(attempts: number): number {
   return Math.min(BACKOFF_BASE_MS * 2 ** Math.max(0, attempts - 1), BACKOFF_CAP_MS);
+}
+
+function syncStatusForError(message: string | undefined): number | undefined {
+  if (!message) return undefined;
+  const statusMatch = message.match(/\b(401|403|404|409|429|5\d{2})\b/);
+  if (statusMatch?.[1]) return Number(statusMatch[1]);
+  if (/not authenticated/i.test(message)) return 401;
+  if (/conflict/i.test(message)) return 409;
+  return undefined;
 }
 
 export interface NoteUpsertParams {
@@ -330,7 +340,16 @@ class NoteSyncQueueServiceClass {
             });
 
       if (!result.success) {
-        recordFailure(item, result.error);
+        const failure = classifyGitHubSyncError(
+          new Error(result.error ?? 'Unknown GitHub sync failure'),
+          syncStatusForError(result.error),
+        );
+        if (!isRetryableFailure(failure)) {
+          console.warn('[NoteSyncQueue] dropped durable failure:', failure.kind);
+          droppedIds.add(item.id);
+        } else {
+          recordFailure(item, result.error);
+        }
         continue;
       }
 

--- a/src/services/git/repoAccessPreflight.ts
+++ b/src/services/git/repoAccessPreflight.ts
@@ -1,0 +1,97 @@
+import { classifyGitHubSyncError } from './syncFailure';
+import { parseRepoPath } from '../../utils/gitPathParser';
+
+export type RepoAccessResult =
+  | { readonly kind: 'ok' }
+  | { readonly kind: 'no_access'; readonly message: string }
+  | { readonly kind: 'no_write'; readonly message: string }
+  | { readonly kind: 'saml_required'; readonly message: string }
+  | { readonly kind: 'rate_limited'; readonly message: string }
+  | { readonly kind: 'transient'; readonly message: string };
+
+export class RepoAccessPreflightError extends Error {
+  readonly name = 'RepoAccessPreflightError';
+
+  constructor(readonly result: Exclude<RepoAccessResult, { readonly kind: 'ok' }>) {
+    super(result.message);
+  }
+}
+
+type RepoResponse = {
+  readonly message?: string;
+  readonly permissions?: {
+    readonly push?: boolean;
+  };
+};
+
+function responseDetails(value: unknown): RepoResponse {
+  if (typeof value !== 'object' || value === null) return {};
+  if (!('message' in value) && !('permissions' in value)) return {};
+
+  const message = 'message' in value && typeof value.message === 'string' ? value.message : undefined;
+  const permissionsValue = 'permissions' in value ? value.permissions : undefined;
+  if (typeof permissionsValue !== 'object' || permissionsValue === null) return { message };
+  const push = 'push' in permissionsValue && typeof permissionsValue.push === 'boolean'
+    ? permissionsValue.push
+    : undefined;
+  return { message, permissions: { push } };
+}
+
+function failure(kind: Exclude<RepoAccessResult['kind'], 'ok'>, message: string): RepoAccessResult {
+  return { kind, message };
+}
+
+function classifyResponse(status: number, details: RepoResponse): RepoAccessResult {
+  const classified = classifyGitHubSyncError({ message: details.message }, status);
+  switch (classified.kind) {
+    case 'not_found':
+    case 'authentication':
+      return failure('no_access', 'This GitHub repository is not accessible with the current account.');
+    case 'saml':
+      return failure('saml_required', 'GitHub requires SAML SSO authorization for this repository.');
+    case 'rate_limit':
+      return failure('rate_limited', 'GitHub is rate limiting requests. Please try again later.');
+    case 'permission':
+      return failure('no_write', 'The current GitHub account cannot write to this repository.');
+    case 'server':
+    case 'network':
+    case 'unknown':
+    case 'conflict':
+      return failure('transient', 'GitHub repository access could not be verified right now.');
+    default: {
+      const exhaustiveCheck: never = classified.kind;
+      return exhaustiveCheck;
+    }
+  }
+}
+
+export async function checkGitHubRepoAccess(repoPath: string, token: string): Promise<RepoAccessResult> {
+  const parsed = parseRepoPath(repoPath);
+  if (!parsed) return failure('no_access', 'The GitHub repository path is invalid or inaccessible.');
+
+  const url = `https://api.github.com/repos/${encodeURIComponent(parsed.owner)}/${encodeURIComponent(parsed.repo)}`;
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+      },
+    });
+    let details: RepoResponse = {};
+    try {
+      details = responseDetails(await response.json());
+    } catch {
+      if (response.ok) return failure('transient', 'GitHub repository access could not be verified right now.');
+    }
+
+    if (response.ok) {
+      if (details.permissions?.push === false) {
+        return failure('no_write', 'The current GitHub account cannot write to this repository.');
+      }
+      return { kind: 'ok' };
+    }
+    return classifyResponse(response.status, details);
+  } catch {
+    return failure('transient', 'GitHub repository access could not be verified right now.');
+  }
+}

--- a/src/services/git/syncFailure.ts
+++ b/src/services/git/syncFailure.ts
@@ -1,0 +1,87 @@
+export type GitHubSyncFailure = {
+  readonly kind:
+    | 'authentication'
+    | 'permission'
+    | 'saml'
+    | 'rate_limit'
+    | 'conflict'
+    | 'not_found'
+    | 'server'
+    | 'network'
+    | 'unknown';
+  readonly message: string;
+  readonly retryable: boolean;
+  readonly status?: number;
+};
+
+type ErrorDetails = {
+  readonly message?: string;
+  readonly status?: number;
+};
+
+function errorDetails(error: unknown): ErrorDetails {
+  if (typeof error !== 'object' || error === null) return {};
+
+  const details: { message?: string; status?: number } = {};
+  if ('message' in error && typeof error.message === 'string') details.message = error.message;
+  if ('status' in error && typeof error.status === 'number') details.status = error.status;
+  return details;
+}
+
+function sanitizeMessage(message: string | undefined): string {
+  return message?.replace(/Bearer\s+\S+/gi, 'Bearer ***').trim() || 'Unknown GitHub sync failure';
+}
+
+function failure(
+  kind: GitHubSyncFailure['kind'],
+  message: string,
+  retryable: boolean,
+  status: number | undefined,
+): GitHubSyncFailure {
+  return status === undefined ? { kind, message, retryable } : { kind, message, retryable, status };
+}
+
+export function classifyGitHubSyncError(error: unknown, status?: number): GitHubSyncFailure {
+  const details = errorDetails(error);
+  const resolvedStatus = status ?? details.status;
+  const message = sanitizeMessage(details.message);
+  const haystack = message.toLowerCase();
+  const hasSamlSignal = haystack.includes('saml') || haystack.includes('x-github-sso');
+  const hasRateLimitSignal = haystack.includes('rate limit') || haystack.includes('rate-limit')
+    || haystack.includes('ratelimit') || haystack.includes('too many requests');
+
+  if (resolvedStatus === 401) return failure('authentication', message, false, resolvedStatus);
+  if (resolvedStatus === 403 && hasSamlSignal) return failure('saml', message, false, resolvedStatus);
+  if (resolvedStatus === 403 && hasRateLimitSignal) return failure('rate_limit', message, true, resolvedStatus);
+  if (resolvedStatus === 403) return failure('permission', message, false, resolvedStatus);
+  if (resolvedStatus === 429) return failure('rate_limit', message, true, resolvedStatus);
+  if (resolvedStatus === 409) return failure('conflict', message, false, resolvedStatus);
+  if (resolvedStatus === 404) return failure('not_found', message, false, resolvedStatus);
+  if (resolvedStatus !== undefined && resolvedStatus >= 500 && resolvedStatus <= 599) {
+    return failure('server', message, true, resolvedStatus);
+  }
+
+  const networkSignal = /network|offline|fetch|econn|timeout|connection|enotfound|dns/i.test(haystack);
+  if (networkSignal) return failure('network', message, true, resolvedStatus);
+  return failure('unknown', message, true, resolvedStatus);
+}
+
+export function isRetryableFailure(failureResult: GitHubSyncFailure): boolean {
+  switch (failureResult.kind) {
+    case 'rate_limit':
+    case 'server':
+    case 'network':
+    case 'unknown':
+      return true;
+    case 'authentication':
+    case 'permission':
+    case 'saml':
+    case 'conflict':
+    case 'not_found':
+      return false;
+    default: {
+      const exhaustiveCheck: never = failureResult.kind;
+      return exhaustiveCheck;
+    }
+  }
+}

--- a/src/stores/repoStore.ts
+++ b/src/stores/repoStore.ts
@@ -5,6 +5,11 @@ import { useNoteStore } from './noteStore';
 import { useCanvasStore } from './canvasStore';
 import { useTodoStore } from './todoStore';
 import type { GitHostProvider } from '../services/git/GitHost';
+import { getActiveGitHost } from '../services/git/activeHost';
+import {
+  checkGitHubRepoAccess,
+  RepoAccessPreflightError,
+} from '../services/git/repoAccessPreflight';
 
 interface RepoState {
   repositories: GitRepository[];
@@ -34,6 +39,18 @@ export const useRepoStore = create<RepoState & RepoActions>()((set, get) => ({
   },
 
   addRepository: async (path, name, provider = 'github') => {
+    if (provider === 'github') {
+      const activeHost = await getActiveGitHost();
+      if (activeHost?.provider === 'github') {
+        const access = await checkGitHubRepoAccess(path, activeHost.token);
+        if (access.kind !== 'ok' && access.kind !== 'transient') {
+          throw new RepoAccessPreflightError(access);
+        }
+        if (access.kind === 'transient') {
+          console.warn('[RepoStore] GitHub repository access preflight was inconclusive:', access.message);
+        }
+      }
+    }
     const repo = await GitService.addRepository(path, name, provider);
     const updated = await StorageService.getSavedRepositories();
     set({ repositories: updated });


### PR DESCRIPTION
## Summary

Fixes two related GitHub integration bugs:

1. **Notes stuck pending indefinitely** — queued note edits only retried on startup/activation/manual sync; open-app foreground interval never drained the queue.
2. **No token permission validation** — tokens with insufficient repository access were accepted silently; permission errors looked like offline failures.

## Changes

### fix(sync): add GitHub sync-failure classifier
Typed failure categories (authentication, permission, saml, rate_limit, conflict, not_found, server, network, unknown) with `isRetryableFailure` predicate. Bearer tokens stripped from message fields.

### fix(sync): drain queued note mutations during foreground sync
Every foreground cycle (interval, app-active, online) now calls `NoteSyncQueueService.drain()` before `pullAllFromRepos()`. Drain failures are logged without incrementing pull-failure backoff.

### fix(sync): drop non-retryable failures from note sync queue
Auth, permission, SAML, and conflict failures are removed from the queue immediately without consuming retry attempts. Transient failures continue backoff/retry as before.

### fix(notes): surface non-retryable GitHub save errors in editor
Auth → "Reconnect in Settings"; permission/SAML → "token cannot write to this repository"; conflict → "Pull to resolve". Only retryable failures enqueue.

### feat(github): validate repository access before configuration
Non-mutating `GET /repos/{owner}/{repo}` preflight before a repository is persisted. Definitive failures (no_access, no_write, saml_required) are rejected with a user-facing alert. No probe files written.

### feat(auth): explain GitHub token repository permissions in UX
Token entry surfaces (onboarding + ConnectHostModal) now show GitHub-only copy: fine-grained tokens need `Contents: Read and write`, classic tokens need the `repo` scope.

### feat(i18n): add GitHub token permission keys to all locales
`connectHost.help.github` added to en, de, es, fr, ja, ko.

## Testing
- 1,452 tests pass · 0 failures · 172 suites
- New test files: `syncFailure.test.ts`, `ForegroundSyncService.test.ts`, `repoAccessPreflight.test.ts`
- Extended: `NoteSyncQueueService.test.ts`, `useNoteEditorDocument.notFound.test.ts`
