### PR TITLE
fix(ui): remove FAB hub text labels and fix screen header padding

### DIFF
--- a/src/components/ai/FloatingAIHubMenu.tsx
+++ b/src/components/ai/FloatingAIHubMenu.tsx
@@ -40,10 +40,10 @@ interface HubItem {
 }
 
 const HUB_ITEMS = [
-  { id: 'new-chat', label: 'New chat', icon: 'add', x: 58, y: 110 },
-  { id: 'chat-history', label: 'Chat history', icon: 'chatbubbles-outline', x: 110, y: 66 },
-  { id: 'ai-settings', label: 'AI settings', icon: 'options-outline', x: 110, y: 6 },
-  { id: 'thought-dump', label: 'Thought dump', icon: 'bulb-outline', x: 58, y: -62 },
+  { id: 'new-chat', label: 'New chat', icon: 'add', x: 68, y: 90 },
+  { id: 'chat-history', label: 'Chat history', icon: 'chatbubbles-outline', x: 100, y: 55 },
+  { id: 'ai-settings', label: 'AI settings', icon: 'options-outline', x: 100, y: 5 },
+  { id: 'thought-dump', label: 'Thought dump', icon: 'bulb-outline', x: 68, y: -55 },
 ] as const satisfies readonly HubItem[];
 
 interface MenuGeometryProps {

--- a/src/components/ai/FloatingAIHubMenu.tsx
+++ b/src/components/ai/FloatingAIHubMenu.tsx
@@ -1,4 +1,4 @@
-import { Pressable, StyleSheet, Text } from 'react-native';
+import { Pressable, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import {
   Blur,
@@ -13,8 +13,7 @@ import Animated, {
   useDerivedValue,
   type SharedValue,
 } from 'react-native-reanimated';
-import { RADII, SPACING, TYPE } from '../../theme/tokens';
-import { Surface } from '../ui/Surface';
+import { RADII } from '../../theme/tokens';
 
 const BUTTON_SIZE = 56;
 const LIQUID_CANVAS_SIZE = 296;
@@ -73,8 +72,6 @@ function LiquidSatellite({
 
 interface HubMenuItemProps extends MenuGeometryProps {
   readonly iconColor: string;
-  readonly labelColor: string;
-  readonly surfaceColor: string;
   readonly onPress: (itemId: HubItemId) => void;
 }
 
@@ -84,8 +81,6 @@ function HubMenuItem({
   verticalDirection,
   progress,
   iconColor,
-  labelColor,
-  surfaceColor,
   onPress,
 }: HubMenuItemProps) {
   const animatedStyle = useAnimatedStyle(() => ({
@@ -107,21 +102,6 @@ function HubMenuItem({
         style={styles.satelliteButton}
       >
         <Ionicons name={item.icon} size={22} color={iconColor} />
-        <Surface
-          elevation="floating"
-          radius="pill"
-          style={[
-            styles.satelliteLabel,
-            horizontalDirection === -1
-              ? styles.satelliteLabelLeft
-              : styles.satelliteLabelRight,
-            { backgroundColor: surfaceColor },
-          ]}
-        >
-          <Text style={[styles.satelliteLabelText, { color: labelColor }]}>
-            {item.label}
-          </Text>
-        </Surface>
       </Pressable>
     </Animated.View>
   );
@@ -148,8 +128,6 @@ export function FloatingAIHubMenu({
   progress,
   primaryColor,
   iconColor,
-  labelColor,
-  surfaceColor,
   onItemPress,
 }: FloatingAIHubMenuProps) {
   return (
@@ -191,8 +169,6 @@ export function FloatingAIHubMenu({
           verticalDirection={verticalDirection}
           progress={progress}
           iconColor={iconColor}
-          labelColor={labelColor}
-          surfaceColor={surfaceColor}
           onPress={onItemPress}
         />
       ))}
@@ -222,22 +198,5 @@ const styles = StyleSheet.create({
     borderRadius: RADII.pill,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  satelliteLabel: {
-    position: 'absolute',
-    top: SPACING[1],
-    minHeight: 40,
-    justifyContent: 'center',
-    paddingHorizontal: SPACING[3],
-  },
-  satelliteLabelLeft: {
-    right: SATELLITE_SIZE + SPACING[2],
-  },
-  satelliteLabelRight: {
-    left: SATELLITE_SIZE + SPACING[2],
-  },
-  satelliteLabelText: {
-    fontSize: TYPE.sm,
-    fontWeight: '600',
   },
 });

--- a/src/components/ai/FloatingAIHubMenu.tsx
+++ b/src/components/ai/FloatingAIHubMenu.tsx
@@ -40,10 +40,10 @@ interface HubItem {
 }
 
 const HUB_ITEMS = [
-  { id: 'new-chat', label: 'New chat', icon: 'add', x: 68, y: 90 },
-  { id: 'chat-history', label: 'Chat history', icon: 'chatbubbles-outline', x: 100, y: 55 },
-  { id: 'ai-settings', label: 'AI settings', icon: 'options-outline', x: 100, y: 5 },
-  { id: 'thought-dump', label: 'Thought dump', icon: 'bulb-outline', x: 68, y: -55 },
+  { id: 'new-chat', label: 'New chat', icon: 'add', x: 58, y: 85 },
+  { id: 'chat-history', label: 'Chat history', icon: 'chatbubbles-outline', x: 80, y: 43 },
+  { id: 'ai-settings', label: 'AI settings', icon: 'options-outline', x: 90, y: 1 },
+  { id: 'thought-dump', label: 'Thought dump', icon: 'bulb-outline', x: 80, y: -41 },
 ] as const satisfies readonly HubItem[];
 
 interface MenuGeometryProps {

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -160,7 +160,7 @@ export default function ExploreScreen() {
         <View style={{ paddingTop: headerHeight }}>
           <OfflineBanner />
         </View>
-        <View className="px-4 pt-2 pb-3">
+        <View className="px-4 pb-3" style={{ paddingTop: headerHeight + 8 }}>
           <SearchBar
             testID="explore.search-bar.repo-search"
             value={repoSearch}

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -204,7 +204,7 @@ export default function ExploreScreen() {
           <OfflineBanner />
         </View>
 
-        <View className="mx-4 mt-4 rounded-sm border p-4" style={{ backgroundColor: colors.surface, borderColor: colors.border + '30' }}>
+        <View className="mx-4 mt-4 rounded-sm border p-4" style={{ paddingTop: headerHeight + 16, backgroundColor: colors.surface, borderColor: colors.border + '30' }}>
           <View className="flex-row items-center gap-3.5">
             <View className="w-13 h-13 rounded-sm items-center justify-center" style={{ backgroundColor: colors.primary + '15', width: 52, height: 52, borderRadius: 14 }}>
               <Ionicons name="git-branch" size={28} color={colors.primary} />

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -429,8 +429,8 @@ export default function NotesListScreen() {
   return (
     <SafeAreaView edges={[]} className="flex-1" style={{ backgroundColor: colors.background }}>
       {isDeleting ? <GitHubActivityIndicator /> : null}
-      <View style={{ flex: 1 }}>
-      <View style={{ paddingTop: headerHeight }}>
+      <View style={{ flex: 1, paddingTop: headerHeight }}>
+      <View>
         <OfflineBanner />
         <ConflictBanner />
       </View>

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -430,8 +430,8 @@ export default function TodoListScreen() {
 
   return (
     <SafeAreaView edges={[]} className="flex-1" style={{ backgroundColor: colors.background }}>
-      <View style={{ flex: 1 }}>
-      <View style={{ paddingTop: headerHeight }}>
+      <View style={{ flex: 1, paddingTop: headerHeight }}>
+      <View>
         <OfflineBanner />
         <ConflictBanner />
       </View>
@@ -582,5 +582,4 @@ export default function TodoListScreen() {
     </SafeAreaView>
   );
 }
-
 


### PR DESCRIPTION
## Summary

Fixes two UI issues reported by users:

1. **Floating AI hub labels stacked** — Multi-word labels like "Thought dump" wrapped into tiny vertical columns inside 48px satellite buttons. Removed text entirely, keeping clean circular icon buttons.

2. **Screen content rendered under titles** — A UI kit migration left the `paddingTop: headerHeight` offset on a banner-only wrapper that collapses to zero height when no banners are present. Search bars and content rendered behind the translucent `ScreenHeader`.

## Changes

### Floating AI Hub (FloatingAIHubMenu.tsx)
- Removed the `<Surface>`/label `<Text>` and all associated styles (`satelliteLabel`, `satelliteLabelLeft`, `satelliteLabelRight`, `satelliteLabelText`)
- Retuned `HUB_ITEMS` xy coordinates to a smooth, evenly-spaced arc (`x: 58/80/90/80`, `y: 85/43/1/-41`, ~42px step)
- All four icon buttons remain: add, chatbubbles-outline, options-outline, bulb-outline

### Screen header padding
- **NotesListScreen**: moved `paddingTop: headerHeight` to the parent content wrapper
- **TodoListScreen**: same pattern
- **ExploreScreen (repoList)**: added `paddingTop: headerHeight + 8` to SearchBar wrapper
- **ExploreScreen (repoDetail)**: added `paddingTop: headerHeight + 16` to repo info card wrapper

## Verification

- `npx tsc --noEmit --types jest`: exit 0
- `npm run lint`: exit 0 (560 pre-existing warnings, 0 errors)
- Focused ESLint on all 4 changed files: 0 errors
- iOS simulator screenshots (7): Notes/Todos/Explore/Canvases confirm search bars sit below headers without overlap; AI hub shows 4 icon-only buttons in a smooth arc

## Out of scope (observed separately)
- Settings screen appeared blank during QA — verified as pre-existing (SettingsScreen.tsx untouched by these commits, `git diff HEAD~7 HEAD -- src/screens/SettingsScreen.tsx` is empty). Separate issue.
- AI SDK v6 Metro bundling TS2708 errors on plain `tsc --noEmit` — pre-existing Jest/TypeScript 6 namespace conflict in `jest.setup.ts`, unchanged.

## Commits (7)
- `74569ac` fix(ui): remove text labels from floating AI hub menu
- `f15564d` fix(ui): tune floating AI hub satellite positions
- `2acdd0a` fix(layout): fix NotesListScreen content padding under header
- `ee2e821` fix(layout): fix ExploreScreen repo detail padding under header
- `99fcf17` fix(layout): fix ExploreScreen repo list padding under header
- `93c2cf0` fix(layout): fix TodoListScreen content padding under header
- `451e155` fix(ui): even out AI hub satellite y-spacing for smoother arc
