### PR TITLE
fix(ui): repair systemic safe-area and FAB rendering

### DIFF
--- a/__tests__/FloatingAIButton.global-gesture.test.tsx
+++ b/__tests__/FloatingAIButton.global-gesture.test.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { AccessibilityInfo } from 'react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('../src/stores/aiStore', () => ({
+  useAIStore: () => ({ isEnabled: true }),
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => {
+  const { NEUMORPHIC_LIGHT, RADII } = require('../src/theme/tokens');
+
+  return {
+    useTheme: () => ({ colors: NEUMORPHIC_LIGHT, style: 'neumorphic' }),
+    useTokens: () => ({
+      colors: NEUMORPHIC_LIGHT,
+      radii: RADII,
+    }),
+  };
+});
+
+jest.mock('@shopify/react-native-skia', () => {
+  const MockView = require('react-native').View;
+
+  return {
+    Canvas: MockView,
+    Group: ({ children }: { children: ReactNode }) => children,
+    Circle: MockView,
+    Paint: ({ children }: { children: ReactNode }) => children,
+    Blur: MockView,
+    ColorMatrix: MockView,
+  };
+});
+
+import { FloatingAIButton } from '../src/components/ai/FloatingAIButton';
+
+describe('FloatingAIButton global Gesture mock', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(true);
+  });
+
+  it('renders the current pan lifecycle chain', async () => {
+    const rendered = render(<FloatingAIButton currentRouteName="Home" />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(rendered.getByTestId('floating-ai.button.navigate-chat')).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/FloatingAIButton.hub.test.tsx
+++ b/__tests__/FloatingAIButton.hub.test.tsx
@@ -2,10 +2,11 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AccessibilityInfo } from 'react-native';
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 
 const mockNavigate = jest.fn();
 const mockCreateThread = jest.fn(() => ({ id: 'thread-from-fab' }));
+const mockRunOnJSCallbacks: Array<() => void> = [];
 let mockAIState = {
   isEnabled: true,
   chatRepoOwner: 'owner',
@@ -14,6 +15,33 @@ let mockAIState = {
   selectedModelId: 'model-1',
   getAvailableModels: jest.fn(() => [{ id: 'model-1' }]),
 };
+
+interface MockPanUpdateEvent {
+  readonly translationX: number;
+  readonly translationY: number;
+}
+
+const mockPanCallbacks: {
+  begin: (() => void) | undefined;
+  start: (() => void) | undefined;
+  update: ((event: MockPanUpdateEvent) => void) | undefined;
+  end: ((successful: boolean) => void) | undefined;
+  finalize: ((successful: boolean) => void) | undefined;
+} = {
+  begin: undefined,
+  start: undefined,
+  update: undefined,
+  end: undefined,
+  finalize: undefined,
+};
+
+async function flushRunOnJSCallbacks(): Promise<void> {
+  const callbacks = mockRunOnJSCallbacks.splice(0);
+  await act(async () => {
+    for (const callback of callbacks) callback();
+    await Promise.resolve();
+  });
+}
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
@@ -78,22 +106,46 @@ jest.mock('react-native-reanimated', () => {
     useDerivedValue: (callback: () => unknown) => ({ value: callback() }),
     useAnimatedStyle: (callback: () => Record<string, unknown>) => callback(),
     withSpring: (value: unknown) => value,
-    runOnJS: (callback: (...args: readonly unknown[]) => unknown) => callback,
+    runOnJS: (callback: (...args: readonly unknown[]) => unknown) => (
+      (...args: readonly unknown[]) => {
+        mockRunOnJSCallbacks.push(() => callback(...args));
+      }
+    ),
   };
 });
 
 jest.mock('react-native-gesture-handler', () => {
-  const gesture = () => ({
-    onStart: gesture,
-    onUpdate: gesture,
-    onEnd: gesture,
-  });
+  const createGesture = () => {
+    const gesture = {
+      onBegin: (callback: (event: object) => void) => {
+        mockPanCallbacks.begin = () => callback({});
+        return gesture;
+      },
+      onStart: (callback: (event: object) => void) => {
+        mockPanCallbacks.start = () => callback({});
+        return gesture;
+      },
+      onUpdate: (callback: (event: MockPanUpdateEvent) => void) => {
+        mockPanCallbacks.update = callback;
+        return gesture;
+      },
+      onEnd: (callback: (event: object, successful: boolean) => void) => {
+        mockPanCallbacks.end = (successful) => callback({}, successful);
+        return gesture;
+      },
+      onFinalize: (callback: (event: object, successful: boolean) => void) => {
+        mockPanCallbacks.finalize = (successful) => callback({}, successful);
+        return gesture;
+      },
+    };
+    return gesture;
+  };
 
   return {
     Gesture: {
-      Pan: gesture,
-      Tap: gesture,
-      LongPress: gesture,
+      Pan: createGesture,
+      Tap: createGesture,
+      LongPress: createGesture,
       Exclusive: jest.fn((...gestures: readonly unknown[]) => ({ gestures })),
     },
     GestureDetector: ({ children }: { children: ReactNode }) => children,
@@ -104,16 +156,40 @@ import { FloatingAIButton } from '../src/components/ai/FloatingAIButton';
 import { useAIHubStore } from '../src/stores/aiHubStore';
 
 type HubHelper = 'goNewChat' | 'goChatHistory' | 'goAISettings' | 'goThoughtDump';
-const HUB_ACTION_CASES: [string, HubHelper][] = [
-  ['new-chat', 'goNewChat'],
-  ['chat-history', 'goChatHistory'],
-  ['ai-settings', 'goAISettings'],
-  ['thought-dump', 'goThoughtDump'],
-];
+interface HubActionCase {
+  readonly itemId: string;
+  readonly label: string;
+  readonly helper: HubHelper;
+}
+
+const HUB_ACTION_CASES = [
+  { itemId: 'new-chat', label: 'New chat', helper: 'goNewChat' },
+  { itemId: 'chat-history', label: 'Chat history', helper: 'goChatHistory' },
+  { itemId: 'ai-settings', label: 'AI settings', helper: 'goAISettings' },
+  { itemId: 'thought-dump', label: 'Thought dump', helper: 'goThoughtDump' },
+] as const satisfies readonly HubActionCase[];
+
+async function renderInitializedFloatingAIButton() {
+  const rendered = render(<FloatingAIButton currentRouteName="Home" />);
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await waitFor(() => {
+    expect(AccessibilityInfo.isReduceMotionEnabled).toHaveBeenCalledTimes(1);
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('ai-button-position');
+  });
+  return rendered;
+}
 
 describe('FloatingAIButton liquid hub', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockRunOnJSCallbacks.length = 0;
+    mockPanCallbacks.begin = undefined;
+    mockPanCallbacks.start = undefined;
+    mockPanCallbacks.update = undefined;
+    mockPanCallbacks.end = undefined;
+    mockPanCallbacks.finalize = undefined;
     await AsyncStorage.clear();
     useAIHubStore.setState({ pickerVisible: false });
     mockAIState = {
@@ -129,7 +205,7 @@ describe('FloatingAIButton liquid hub', () => {
 
   it('creates a thread and navigates to ChatScreen when tapped', async () => {
     const goNewChat = jest.spyOn(useAIHubStore.getState(), 'goNewChat');
-    const { getByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+    const { getByTestId } = await renderInitializedFloatingAIButton();
 
     fireEvent.press(getByTestId('floating-ai.button.navigate-chat'));
 
@@ -142,13 +218,13 @@ describe('FloatingAIButton liquid hub', () => {
     });
   });
 
-  it('opens the repo picker instead of navigating when no chat repo is configured', () => {
+  it('opens the repo picker instead of navigating when no chat repo is configured', async () => {
     mockAIState = { ...mockAIState, chatRepoOwner: '', chatRepoName: '' };
     const openChatRepoPicker = jest.spyOn(
       useAIHubStore.getState(),
       'openChatRepoPicker',
     );
-    const { getByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+    const { getByTestId } = await renderInitializedFloatingAIButton();
 
     fireEvent.press(getByTestId('floating-ai.button.navigate-chat'));
 
@@ -157,56 +233,90 @@ describe('FloatingAIButton liquid hub', () => {
   });
 
   it('shows all four hub items after a long press without navigating', async () => {
-    const { getByTestId, getByText } = render(
-      <FloatingAIButton currentRouteName="Home" />,
-    );
+    const { getByRole, getByTestId } = await renderInitializedFloatingAIButton();
 
     fireEvent(getByTestId('floating-ai.button.navigate-chat'), 'longPress');
 
     await waitFor(() => {
-      expect(getByText('New chat')).toBeTruthy();
-      expect(getByText('Chat history')).toBeTruthy();
-      expect(getByText('AI settings')).toBeTruthy();
-      expect(getByText('Thought dump')).toBeTruthy();
+      for (const item of HUB_ACTION_CASES) {
+        expect(getByTestId(`floating-ai.hub.${item.itemId}`)).toBeTruthy();
+        expect(getByRole('button', { name: item.label })).toBeTruthy();
+      }
     });
+    expect(
+      getByTestId('floating-ai.button.navigate-chat').props.accessibilityState,
+    ).toEqual({ expanded: true });
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('collapses after a second long press without navigating', async () => {
-    const { getByTestId, queryByText } = render(
-      <FloatingAIButton currentRouteName="Home" />,
+  it('closes the open hub from the central button without starting a chat', async () => {
+    // Given
+    const goNewChat = jest.spyOn(useAIHubStore.getState(), 'goNewChat');
+    const openChatRepoPicker = jest.spyOn(
+      useAIHubStore.getState(),
+      'openChatRepoPicker',
     );
+    const { getByTestId, queryByTestId } = await renderInitializedFloatingAIButton();
+    fireEvent(getByTestId('floating-ai.button.navigate-chat'), 'longPress');
+    await waitFor(() => {
+      expect(
+        getByTestId('floating-ai.button.navigate-chat').props.accessibilityState,
+      ).toEqual({ expanded: true });
+    });
+
+    // When
+    fireEvent.press(getByTestId('floating-ai.button.navigate-chat'));
+
+    // Then
+    await waitFor(() => {
+      for (const item of HUB_ACTION_CASES) {
+        expect(queryByTestId(`floating-ai.hub.${item.itemId}`)).toBeNull();
+      }
+      expect(queryByTestId('floating-ai.hub.backdrop')).toBeNull();
+      expect(
+        getByTestId('floating-ai.button.navigate-chat').props.accessibilityState,
+      ).toEqual({ expanded: false });
+    });
+    expect(goNewChat).not.toHaveBeenCalled();
+    expect(openChatRepoPicker).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('stays collapsed when pan recognition begins before a second long press', async () => {
+    const { getByTestId, queryByTestId } = await renderInitializedFloatingAIButton();
     const trigger = getByTestId('floating-ai.button.navigate-chat');
     fireEvent(trigger, 'longPress');
+    await waitFor(() => expect(getByTestId('floating-ai.hub.new-chat')).toBeTruthy());
+    expect(mockPanCallbacks.begin).toBeDefined();
+
+    act(() => mockPanCallbacks.begin?.());
+    await flushRunOnJSCallbacks();
 
     fireEvent(trigger, 'longPress');
 
-    await waitFor(() => expect(queryByText('New chat')).toBeNull());
+    await waitFor(() => expect(queryByTestId('floating-ai.hub.new-chat')).toBeNull());
+    expect(trigger.props.accessibilityState).toEqual({ expanded: false });
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it.each(HUB_ACTION_CASES)('calls %s helper and collapses after item selection', async (itemId, helper) => {
+  it.each(HUB_ACTION_CASES)('calls $helper and collapses after item selection', async ({ itemId, helper }) => {
     const action = jest.spyOn(useAIHubStore.getState(), helper).mockImplementation(() => undefined);
-    const { getByTestId, queryByText } = render(
-      <FloatingAIButton currentRouteName="Home" />,
-    );
+    const { getByTestId, queryByTestId } = await renderInitializedFloatingAIButton();
     fireEvent(getByTestId('floating-ai.button.navigate-chat'), 'longPress');
 
     fireEvent.press(getByTestId(`floating-ai.hub.${itemId}`));
 
     expect(action).toHaveBeenCalledTimes(1);
-    await waitFor(() => expect(queryByText('New chat')).toBeNull());
+    await waitFor(() => expect(queryByTestId(`floating-ai.hub.${itemId}`)).toBeNull());
   });
 
   it('collapses on backdrop press without navigating', async () => {
-    const { getByTestId, queryByText } = render(
-      <FloatingAIButton currentRouteName="Home" />,
-    );
+    const { getByTestId, queryByTestId } = await renderInitializedFloatingAIButton();
     fireEvent(getByTestId('floating-ai.button.navigate-chat'), 'longPress');
 
     fireEvent.press(getByTestId('floating-ai.hub.backdrop'));
 
-    await waitFor(() => expect(queryByText('New chat')).toBeNull());
+    await waitFor(() => expect(queryByTestId('floating-ai.hub.new-chat')).toBeNull());
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/FloatingAIButton.test.tsx
+++ b/__tests__/FloatingAIButton.test.tsx
@@ -2,11 +2,69 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AccessibilityInfo } from 'react-native';
-import { render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 
 const mockNavigate = jest.fn();
 const mockSharedValues: Array<{ value: unknown }> = [];
+const mockSpringCalls: Array<readonly [unknown, unknown]> = [];
+const mockRunOnJSCallbacks: Array<() => void> = [];
+let mockPanBegin: (() => void) | undefined;
+let mockPanStart: (() => void) | undefined;
+let mockPanUpdate: ((event: MockPanUpdateEvent) => void) | undefined;
+let mockPanEnd: ((successful: boolean) => void) | undefined;
+let mockPanFinalize: ((successful: boolean) => void) | undefined;
 let mockAIEnabled = true;
+let mockTabBarHeight = 0;
+let mockWindowDimensions = { width: 320, height: 480, scale: 2, fontScale: 1 };
+let mockSafeAreaInsets = { top: 24, right: 0, bottom: 20, left: 0 };
+
+interface Deferred<Value> {
+  readonly promise: Promise<Value>;
+  readonly resolve: (value: Value) => void;
+}
+
+interface MockPanUpdateEvent {
+  readonly translationX: number;
+  readonly translationY: number;
+}
+
+function createDeferred<Value>(): Deferred<Value> {
+  const resolver: { resolve?: (value: Value) => void } = {};
+  const promise = new Promise<Value>((resolve) => {
+    resolver.resolve = resolve;
+  });
+
+  return {
+    promise,
+    resolve: (value) => {
+      if (resolver.resolve === undefined) {
+        throw new RangeError('Expected deferred promise resolver');
+      }
+      resolver.resolve(value);
+    },
+  };
+}
+
+async function flushRunOnJSCallbacks(): Promise<void> {
+  const callbacks = mockRunOnJSCallbacks.splice(0);
+  await act(async () => {
+    for (const callback of callbacks) callback();
+    await Promise.resolve();
+  });
+}
+
+jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
+  __esModule: true,
+  default: () => mockWindowDimensions,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => mockSafeAreaInsets,
+}));
+
+jest.mock('../src/components/ui/TabBar', () => ({
+  useTabBarHeight: () => mockTabBarHeight,
+}));
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
@@ -37,28 +95,59 @@ jest.mock('react-native-reanimated', () => {
     __esModule: true,
     default: { View: MockView },
     useSharedValue: (initial: unknown) => {
-      const sharedValue = { value: initial };
-      mockSharedValues.push(sharedValue);
-      return sharedValue;
+      const React: typeof import('react') = require('react');
+      const sharedValueRef = React.useRef<{ value: unknown } | null>(null);
+      if (sharedValueRef.current === null) {
+        sharedValueRef.current = { value: initial };
+        mockSharedValues.push(sharedValueRef.current);
+      }
+      return sharedValueRef.current;
     },
     useDerivedValue: (callback: () => unknown) => ({ value: callback() }),
     useAnimatedStyle: (callback: () => Record<string, unknown>) => callback(),
-    withSpring: (value: unknown) => value,
-    runOnJS: (callback: (...args: unknown[]) => unknown) => callback,
+    withSpring: (value: unknown, config: unknown) => {
+      mockSpringCalls.push([value, config]);
+      return value;
+    },
+    runOnJS: (callback: (...args: unknown[]) => unknown) => (
+      (...args: unknown[]) => {
+        mockRunOnJSCallbacks.push(() => callback(...args));
+      }
+    ),
   };
 });
 
 jest.mock('react-native-gesture-handler', () => {
-  const gesture = () => ({
-    onStart: gesture,
-    onUpdate: gesture,
-    onEnd: gesture,
-  });
+  const createGesture = () => {
+    const gesture = {
+      onBegin: (callback: (event: object) => void) => {
+        mockPanBegin = () => callback({});
+        return gesture;
+      },
+      onStart: (callback: (event: object) => void) => {
+        mockPanStart = () => callback({});
+        return gesture;
+      },
+      onUpdate: (callback: (event: MockPanUpdateEvent) => void) => {
+        mockPanUpdate = callback;
+        return gesture;
+      },
+      onEnd: (callback: (event: object, successful: boolean) => void) => {
+        mockPanEnd = (successful) => callback({}, successful);
+        return gesture;
+      },
+      onFinalize: (callback: (event: object, successful: boolean) => void) => {
+        mockPanFinalize = (successful) => callback({}, successful);
+        return gesture;
+      },
+    };
+    return gesture;
+  };
 
   return {
     Gesture: {
-      Pan: gesture,
-      Tap: gesture,
+      Pan: createGesture,
+      Tap: createGesture,
       Exclusive: jest.fn((pan: unknown, tap: unknown) => ({ pan, tap })),
     },
     GestureDetector: ({ children }: { children: ReactNode }) => children,
@@ -84,7 +173,17 @@ describe('FloatingAIButton', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     mockSharedValues.length = 0;
+    mockSpringCalls.length = 0;
+    mockRunOnJSCallbacks.length = 0;
+    mockPanBegin = undefined;
+    mockPanStart = undefined;
+    mockPanUpdate = undefined;
+    mockPanEnd = undefined;
+    mockPanFinalize = undefined;
     mockAIEnabled = true;
+    mockTabBarHeight = 0;
+    mockWindowDimensions = { width: 320, height: 480, scale: 2, fontScale: 1 };
+    mockSafeAreaInsets = { top: 24, right: 0, bottom: 20, left: 0 };
     await AsyncStorage.clear();
     jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(false);
   });
@@ -96,6 +195,10 @@ describe('FloatingAIButton', () => {
       expect(getByTestId('floating-ai.button.navigate-chat')).toBeTruthy();
       expect(getByTestId('floating-ai.button.liquid')).toBeTruthy();
     });
+    expect(mockSpringCalls).toContainEqual([
+      0,
+      expect.objectContaining({ overshootClamping: true }),
+    ]);
   });
 
   it.each(['ChatScreen', 'ChatThreadList'])(
@@ -110,18 +213,291 @@ describe('FloatingAIButton', () => {
     },
   );
 
-  it('restores the persisted drag position', async () => {
-    await AsyncStorage.setItem('ai-button-position', JSON.stringify({ x: 40, y: 120 }));
+  it('normalizes stale left and invalid vertical persisted coordinates', async () => {
+    await AsyncStorage.setItem('ai-button-position', JSON.stringify({ x: -180, y: -90 }));
 
     render(<FloatingAIButton currentRouteName="Home" />);
 
     await waitFor(() => {
       expect(AsyncStorage.getItem).toHaveBeenCalledWith('ai-button-position');
-      expect(mockSharedValues[0]?.value).toBe(40);
-      expect(mockSharedValues[1]?.value).toBe(120);
-      expect(mockSharedValues[2]?.value).toBe(40);
-      expect(mockSharedValues[3]?.value).toBe(120);
+      expect(mockSharedValues[0]?.value).toBe(16);
+      expect(mockSharedValues[1]?.value).toBe(97);
+      expect(mockSharedValues[2]?.value).toBe(16);
+      expect(mockSharedValues[3]?.value).toBe(97);
+      expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
+        'ai-button-position',
+        JSON.stringify({ x: 16, y: 97 }),
+      );
     });
+  });
+
+  it('clamps oversized persisted coordinates to a smaller viewport', async () => {
+    mockWindowDimensions = { width: 320, height: 360, scale: 2, fontScale: 1 };
+    await AsyncStorage.setItem('ai-button-position', JSON.stringify({ x: 900, y: 1200 }));
+
+    render(<FloatingAIButton currentRouteName="Home" />);
+
+    await waitFor(() => {
+      expect(mockSharedValues[0]?.value).toBe(248);
+      expect(mockSharedValues[1]?.value).toBe(167);
+      expect(mockSharedValues[2]?.value).toBe(248);
+      expect(mockSharedValues[3]?.value).toBe(167);
+    });
+  });
+
+  it('keeps persisted right-side coordinates on the right edge', async () => {
+    await AsyncStorage.setItem('ai-button-position', JSON.stringify({ x: 260, y: 140 }));
+
+    render(<FloatingAIButton currentRouteName="Home" />);
+
+    await waitFor(() => {
+      expect(mockSharedValues[0]?.value).toBe(248);
+      expect(mockSharedValues[1]?.value).toBe(140);
+      expect(mockSharedValues[2]?.value).toBe(248);
+      expect(mockSharedValues[3]?.value).toBe(140);
+    });
+  });
+
+  it.each([
+    { tabBarHeight: 40, expectedY: 287 },
+    { tabBarHeight: 148, expectedY: 239 },
+  ])(
+    'uses max(tabBarHeight, 100) bottom clearance for height $tabBarHeight',
+    async ({ tabBarHeight, expectedY }) => {
+      mockTabBarHeight = tabBarHeight;
+      await AsyncStorage.setItem('ai-button-position', JSON.stringify({ x: 260, y: 900 }));
+
+      render(<FloatingAIButton currentRouteName="Home" />);
+
+      await waitFor(() => {
+        expect(mockSharedValues[1]?.value).toBe(expectedY);
+        expect(mockSharedValues[3]?.value).toBe(expectedY);
+      });
+    },
+  );
+
+  it('re-normalizes the saved and rendered position when the viewport shrinks', async () => {
+    await AsyncStorage.setItem('ai-button-position', JSON.stringify({ x: 260, y: 324 }));
+    const { rerender } = render(<FloatingAIButton currentRouteName="Home" />);
+    await waitFor(() => expect(mockSharedValues[1]?.value).toBe(287));
+
+    mockWindowDimensions = { width: 280, height: 360, scale: 2, fontScale: 1 };
+    rerender(<FloatingAIButton currentRouteName="Home" />);
+
+    await waitFor(() => {
+      expect(mockSharedValues[0]?.value).toBe(208);
+      expect(mockSharedValues[1]?.value).toBe(167);
+      expect(mockSharedValues[2]?.value).toBe(208);
+      expect(mockSharedValues[3]?.value).toBe(167);
+      expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
+        'ai-button-position',
+        JSON.stringify({ x: 208, y: 167 }),
+      );
+    });
+  });
+
+  it('uses resize-before-restore geometry through a real pan begin/update/end/finalize', async () => {
+    const storedPosition = createDeferred<string | null>();
+    jest.spyOn(AsyncStorage, 'getItem').mockImplementationOnce(() => storedPosition.promise);
+    const { rerender } = render(<FloatingAIButton currentRouteName="Home" />);
+
+    mockWindowDimensions = { width: 280, height: 360, scale: 2, fontScale: 1 };
+    rerender(<FloatingAIButton currentRouteName="Home" />);
+    await act(async () => {
+      storedPosition.resolve(null);
+      await storedPosition.promise;
+    });
+
+    await waitFor(() => {
+      expect(mockSharedValues[0]?.value).toBe(208);
+      expect(mockSharedValues[1]?.value).toBe(167);
+      expect(mockSharedValues[2]?.value).toBe(208);
+      expect(mockSharedValues[3]?.value).toBe(167);
+    });
+
+    expect(mockPanBegin).toBeDefined();
+    expect(mockPanStart).toBeDefined();
+    expect(mockPanUpdate).toBeDefined();
+    expect(mockPanEnd).toBeDefined();
+    expect(mockPanFinalize).toBeDefined();
+    jest.mocked(AsyncStorage.setItem).mockClear();
+
+    act(() => {
+      mockPanBegin?.();
+      mockPanStart?.();
+      mockPanUpdate?.({ translationX: 20, translationY: -50 });
+      mockPanEnd?.(true);
+      mockPanFinalize?.(true);
+    });
+    await flushRunOnJSCallbacks();
+
+    expect(mockSharedValues[0]?.value).toBe(208);
+    expect(mockSharedValues[1]?.value).toBe(117);
+    expect(mockSharedValues[2]?.value).toBe(208);
+    expect(mockSharedValues[3]?.value).toBe(117);
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'ai-button-position',
+      JSON.stringify({ x: 208, y: 117 }),
+    );
+  });
+
+  it('does not normalize or persist a canceled endpoint before latest-geometry recovery', async () => {
+    const { rerender } = render(<FloatingAIButton currentRouteName="Home" />);
+    await waitFor(() => expect(mockPanBegin).toBeDefined());
+    await waitFor(() => expect(mockSharedValues[1]?.value).toBe(287));
+    jest.mocked(AsyncStorage.setItem).mockClear();
+
+    act(() => {
+      mockPanBegin?.();
+      mockPanStart?.();
+      mockPanUpdate?.({ translationX: -180, translationY: -40 });
+    });
+    mockWindowDimensions = { width: 280, height: 360, scale: 2, fontScale: 1 };
+    rerender(<FloatingAIButton currentRouteName="Home" />);
+
+    expect(mockSharedValues[0]?.value).toBe(68);
+    expect(mockSharedValues[1]?.value).toBe(247);
+    expect(mockSharedValues[2]?.value).toBe(248);
+    expect(mockSharedValues[3]?.value).toBe(287);
+
+    act(() => mockPanEnd?.(false));
+
+    expect(mockSharedValues[0]?.value).toBe(68);
+    expect(mockSharedValues[1]?.value).toBe(247);
+    expect(mockSharedValues[2]?.value).toBe(248);
+    expect(mockSharedValues[3]?.value).toBe(287);
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+
+    act(() => mockPanFinalize?.(false));
+    await flushRunOnJSCallbacks();
+
+    expect(mockSharedValues[0]?.value).toBe(208);
+    expect(mockSharedValues[1]?.value).toBe(167);
+    expect(mockSharedValues[2]?.value).toBe(208);
+    expect(mockSharedValues[3]?.value).toBe(167);
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'ai-button-position',
+      JSON.stringify({ x: 208, y: 167 }),
+    );
+  });
+
+  it.each([
+    { storedX: 0, expectedX: 46 },
+    { storedX: 320, expectedX: 238 },
+  ])(
+    'respects asymmetric horizontal safe-area insets when snapping $storedX',
+    async ({ storedX, expectedX }) => {
+      mockSafeAreaInsets = { top: 24, right: 10, bottom: 20, left: 30 };
+      await AsyncStorage.setItem(
+        'ai-button-position',
+        JSON.stringify({ x: storedX, y: 140 }),
+      );
+
+      render(<FloatingAIButton currentRouteName="Home" />);
+
+      await waitFor(() => {
+        expect(mockSharedValues[0]?.value).toBe(expectedX);
+        expect(mockSharedValues[2]?.value).toBe(expectedX);
+      });
+    },
+  );
+
+  it('normalizes drag-end coordinates with the restore geometry', async () => {
+    render(<FloatingAIButton currentRouteName="Home" />);
+    await waitFor(() => expect(mockPanEnd).toBeDefined());
+    const renderedX = mockSharedValues[0];
+    const renderedY = mockSharedValues[1];
+    if (renderedX === undefined || renderedY === undefined) {
+      throw new RangeError('Expected rendered position shared values');
+    }
+    renderedX.value = -100;
+    renderedY.value = 900;
+    mockSpringCalls.length = 0;
+
+    act(() => {
+      mockPanEnd?.(true);
+      mockPanFinalize?.(true);
+    });
+
+    expect(mockSharedValues[0]?.value).toBe(16);
+    expect(mockSharedValues[1]?.value).toBe(287);
+    expect(mockSharedValues[2]?.value).toBe(16);
+    expect(mockSharedValues[3]?.value).toBe(287);
+    expect(mockSpringCalls).toEqual([
+      [16, expect.objectContaining({ overshootClamping: true })],
+      [287, expect.objectContaining({ overshootClamping: true })],
+    ]);
+  });
+
+  it('resolves and persists the live position before opening on long press', async () => {
+    // Given
+    const { getByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+    await waitFor(() => expect(mockSharedValues[0]).toBeDefined());
+    const renderedX = mockSharedValues[0];
+    const renderedY = mockSharedValues[1];
+    if (renderedX === undefined || renderedY === undefined) {
+      throw new RangeError('Expected rendered position shared values');
+    }
+    renderedX.value = 16;
+    renderedY.value = 60;
+
+    // When
+    fireEvent(getByTestId('floating-ai.button.navigate-chat'), 'longPress');
+
+    // Then
+    expect(mockSharedValues[0]?.value).toBe(16);
+    expect(mockSharedValues[1]?.value).toBe(97);
+    expect(mockSharedValues[2]?.value).toBe(16);
+    expect(mockSharedValues[3]?.value).toBe(97);
+    expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
+      'ai-button-position',
+      JSON.stringify({ x: 16, y: 97 }),
+    );
+    expect(getByTestId('floating-ai.button.navigate-chat').props.accessibilityState).toEqual({
+      expanded: true,
+    });
+  });
+
+  it('does not let a delayed restore overwrite a long-press placement', async () => {
+    // Given
+    const storedPosition = createDeferred<string | null>();
+    jest.spyOn(AsyncStorage, 'getItem').mockImplementationOnce(() => storedPosition.promise);
+    const { getByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+
+    // When
+    fireEvent(getByTestId('floating-ai.button.navigate-chat'), 'longPress');
+    await act(async () => {
+      storedPosition.resolve(JSON.stringify({ x: 16, y: 140 }));
+      await storedPosition.promise;
+    });
+
+    // Then
+    await waitFor(() => {
+      expect(mockSharedValues[0]?.value).toBe(248);
+      expect(mockSharedValues[1]?.value).toBe(287);
+      expect(mockSharedValues[2]?.value).toBe(248);
+      expect(mockSharedValues[3]?.value).toBe(287);
+    });
+  });
+
+  it('closes an open hub when viewport geometry changes', async () => {
+    // Given
+    const { getByTestId, queryByTestId, rerender } = render(
+      <FloatingAIButton currentRouteName="Home" />,
+    );
+    const trigger = getByTestId('floating-ai.button.navigate-chat');
+    fireEvent(trigger, 'longPress');
+    expect(getByTestId('floating-ai.hub.new-chat')).toBeTruthy();
+
+    // When
+    mockWindowDimensions = { width: 280, height: 360, scale: 2, fontScale: 1 };
+    rerender(<FloatingAIButton currentRouteName="Home" />);
+
+    // Then
+    await waitFor(() => expect(queryByTestId('floating-ai.hub.new-chat')).toBeNull());
+    expect(trigger.props.accessibilityState).toEqual({ expanded: false });
   });
 
   it('uses the current Surface visual when Reduce Motion is enabled', async () => {

--- a/__tests__/__snapshots__/theme-parity.test.tsx.snap
+++ b/__tests__/__snapshots__/theme-parity.test.tsx.snap
@@ -176,7 +176,7 @@ exports[`NativeWind theme parity matches the pre-migration key-kit snapshots in 
     </Text>
   </View>
   <View
-    className="bg-surface rounded-md"
+    className="flex-row items-center bg-surface rounded-md"
     style={
       [
         {
@@ -426,7 +426,7 @@ exports[`NativeWind theme parity matches the pre-migration key-kit snapshots in 
     </Text>
   </View>
   <View
-    className="bg-surface rounded-md"
+    className="flex-row items-center bg-surface rounded-md"
     style={
       [
         {

--- a/__tests__/e2e-thought-dump-loop.test.tsx
+++ b/__tests__/e2e-thought-dump-loop.test.tsx
@@ -53,7 +53,13 @@ jest.mock('react-native-gesture-handler', () => {
     GestureDetector: ({ children }: any) => children,
     Gesture: {
       Pan: () => ({
-        onStart: () => ({ onUpdate: () => ({ onEnd: () => ({}) }) }),
+        onBegin: () => ({
+          onStart: () => ({
+            onUpdate: () => ({
+              onEnd: () => ({ onFinalize: () => ({}) }),
+            }),
+          }),
+        }),
       }),
     },
     PanGestureHandler: React.forwardRef((props: any, ref: any) =>
@@ -93,8 +99,12 @@ jest.mock('../src/utils/haptics', () => ({
   },
 }));
 
+const mockPositionRestoreResolvers: Array<(value: null) => void> = [];
+
 jest.mock('@react-native-async-storage/async-storage', () => ({
-  getItem: jest.fn(async () => null),
+  getItem: jest.fn(() => new Promise<null>((resolve) => {
+    mockPositionRestoreResolvers.push(resolve);
+  })),
   setItem: jest.fn(async () => {}),
   removeItem: jest.fn(async () => {}),
 }));
@@ -217,7 +227,7 @@ jest.mock('../src/services/ai/systemPrompt', () => ({
   }),
 }));
 
-import { act, fireEvent, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import * as FileSystem from 'expo-file-system/legacy';
 import { aiMemoryIndex } from '../src/services/ai/AIMemoryIndexService';
 import { ThoughtDumpService } from '../src/services/ThoughtDumpService';
@@ -227,7 +237,30 @@ import { useAIHubStore } from '../src/stores/aiHubStore';
 
 const fsStore = (FileSystem as unknown as { __store: Map<string, string> }).__store;
 
+async function renderInitializedFloatingAIButton() {
+  const React = require('react');
+  const { FloatingAIButton } = require('../src/components/ai/FloatingAIButton');
+  const AsyncStorage = require('@react-native-async-storage/async-storage');
+  const { AccessibilityInfo } = require('react-native');
+  const rendered = render(React.createElement(FloatingAIButton));
+  const restoreResult: unknown = AsyncStorage.getItem.mock.results.at(-1)?.value;
+  const resolveRestore = mockPositionRestoreResolvers.shift();
+  if (resolveRestore === undefined) {
+    throw new RangeError('Expected position restore resolver');
+  }
+  const reduceMotionResult: unknown = (
+    AccessibilityInfo.isReduceMotionEnabled.mock.results.at(-1)?.value
+  );
+  await act(async () => {
+    resolveRestore(null);
+    if (restoreResult instanceof Promise) await restoreResult;
+    if (reduceMotionResult instanceof Promise) await reduceMotionResult;
+  });
+  return rendered;
+}
+
 beforeEach(async () => {
+  mockPositionRestoreResolvers.length = 0;
   fsStore.clear();
   jest.clearAllMocks();
   jest.restoreAllMocks();
@@ -251,16 +284,12 @@ beforeEach(async () => {
 });
 
 describe('e2e: FAB -> thought dump -> memory -> reset', () => {
-  it('long-press FAB opens hub menu with thought-dump item', () => {
-    const React = require('react');
-    const { render } = require('@testing-library/react-native');
-    const { FloatingAIButton } = require('../src/components/ai/FloatingAIButton');
-
+  it('long-press FAB opens hub menu with thought-dump item', async () => {
     const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() };
     const { useNavigation } = require('@react-navigation/native');
     (useNavigation as jest.Mock).mockReturnValue(mockNavigation);
 
-    const { getByTestId, queryByTestId } = render(React.createElement(FloatingAIButton));
+    const { getByTestId, queryByTestId } = await renderInitializedFloatingAIButton();
 
     const fab = getByTestId('floating-ai.button.navigate-chat');
     expect(fab).toBeTruthy();
@@ -275,16 +304,12 @@ describe('e2e: FAB -> thought dump -> memory -> reset', () => {
     expect(getByTestId('floating-ai.hub.ai-settings')).toBeTruthy();
   });
 
-  it('tapping thought-dump menu item calls goThoughtDump navigation', () => {
-    const React = require('react');
-    const { render } = require('@testing-library/react-native');
-    const { FloatingAIButton } = require('../src/components/ai/FloatingAIButton');
-
+  it('tapping thought-dump menu item calls goThoughtDump navigation', async () => {
     const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() };
     const { useNavigation } = require('@react-navigation/native');
     (useNavigation as jest.Mock).mockReturnValue(mockNavigation);
 
-    const { getByTestId } = render(React.createElement(FloatingAIButton));
+    const { getByTestId } = await renderInitializedFloatingAIButton();
 
     const fab = getByTestId('floating-ai.button.navigate-chat');
     fireEvent(fab, 'onLongPress');
@@ -382,13 +407,12 @@ describe('e2e: FAB -> thought dump -> memory -> reset', () => {
   it('full loop: long-press FAB -> thought dump item -> save -> index -> chat memory -> reset', async () => {
     const React = require('react');
     const { render } = require('@testing-library/react-native');
-    const { FloatingAIButton } = require('../src/components/ai/FloatingAIButton');
 
     const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() };
     const { useNavigation } = require('@react-navigation/native');
     (useNavigation as jest.Mock).mockReturnValue(mockNavigation);
 
-    const { getByTestId } = render(React.createElement(FloatingAIButton));
+    const { getByTestId } = await renderInitializedFloatingAIButton();
 
     const fab = getByTestId('floating-ai.button.navigate-chat');
     fireEvent(fab, 'onLongPress');

--- a/__tests__/floatingAIButtonGeometry.test.ts
+++ b/__tests__/floatingAIButtonGeometry.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  FLOATING_AI_BUTTON_SIZE,
+  FLOATING_AI_HUB_ITEMS,
+  FLOATING_AI_HUB_SATELLITE_SIZE,
+  getFloatingAIHubTriggerBounds,
+  resolveFloatingAIButtonPlacement,
+  type FloatingButtonGeometry,
+  type MenuDirection,
+} from '../src/components/ai/floatingAIButtonGeometry';
+
+const STANDARD_GEOMETRY: FloatingButtonGeometry = {
+  viewportWidth: 320,
+  viewportHeight: 480,
+  leftClearance: 16,
+  rightClearance: 16,
+  topBound: 60,
+  tabBarHeight: 0,
+  minimumBottomClearance: 100,
+};
+
+interface DirectionCase {
+  readonly horizontalDirection: MenuDirection;
+  readonly verticalDirection: MenuDirection;
+  readonly expectedBounds: {
+    readonly minX: number;
+    readonly maxX: number;
+    readonly minY: number;
+    readonly maxY: number;
+  };
+}
+
+const DIRECTION_CASES = [
+  {
+    horizontalDirection: 1,
+    verticalDirection: 1,
+    expectedBounds: { minX: 16, maxX: 162, minY: 97, maxY: 243 },
+  },
+  {
+    horizontalDirection: 1,
+    verticalDirection: -1,
+    expectedBounds: { minX: 16, maxX: 162, minY: 141, maxY: 287 },
+  },
+  {
+    horizontalDirection: -1,
+    verticalDirection: 1,
+    expectedBounds: { minX: 102, maxX: 248, minY: 97, maxY: 243 },
+  },
+  {
+    horizontalDirection: -1,
+    verticalDirection: -1,
+    expectedBounds: { minX: 102, maxX: 248, minY: 141, maxY: 287 },
+  },
+] as const satisfies readonly DirectionCase[];
+
+describe('floating AI hub geometry', () => {
+  it.each(DIRECTION_CASES)(
+    'returns exact trigger bounds for horizontal $horizontalDirection and vertical $verticalDirection',
+    ({ horizontalDirection, verticalDirection, expectedBounds }) => {
+      // Given
+      const directions = { horizontalDirection, verticalDirection };
+
+      // When
+      const bounds = getFloatingAIHubTriggerBounds(STANDARD_GEOMETRY, directions);
+
+      // Then
+      expect(bounds).toEqual(expectedBounds);
+    },
+  );
+
+  it.each(DIRECTION_CASES)(
+    'keeps every satellite inside safe clearances at horizontal $horizontalDirection and vertical $verticalDirection bounds',
+    ({ horizontalDirection, verticalDirection }) => {
+      // Given
+      const bounds = getFloatingAIHubTriggerBounds(STANDARD_GEOMETRY, {
+        horizontalDirection,
+        verticalDirection,
+      });
+      const safeRight = STANDARD_GEOMETRY.viewportWidth - STANDARD_GEOMETRY.rightClearance;
+      const safeBottom = STANDARD_GEOMETRY.viewportHeight
+        - Math.max(
+          STANDARD_GEOMETRY.tabBarHeight,
+          STANDARD_GEOMETRY.minimumBottomClearance,
+        );
+      const anchorInset = (
+        FLOATING_AI_BUTTON_SIZE - FLOATING_AI_HUB_SATELLITE_SIZE
+      ) / 2;
+      const boundaryPositions = [
+        { x: bounds.minX, y: bounds.minY },
+        { x: bounds.minX, y: bounds.maxY },
+        { x: bounds.maxX, y: bounds.minY },
+        { x: bounds.maxX, y: bounds.maxY },
+      ];
+
+      // When / Then
+      for (const position of boundaryPositions) {
+        for (const item of FLOATING_AI_HUB_ITEMS) {
+          const satelliteLeft = position.x + anchorInset + item.x * horizontalDirection;
+          const satelliteTop = position.y + anchorInset + item.y * verticalDirection;
+          expect(satelliteLeft).toBeGreaterThanOrEqual(STANDARD_GEOMETRY.leftClearance);
+          expect(satelliteLeft + FLOATING_AI_HUB_SATELLITE_SIZE).toBeLessThanOrEqual(
+            safeRight,
+          );
+          expect(satelliteTop).toBeGreaterThanOrEqual(STANDARD_GEOMETRY.topBound);
+          expect(satelliteTop + FLOATING_AI_HUB_SATELLITE_SIZE).toBeLessThanOrEqual(
+            safeBottom,
+          );
+        }
+      }
+    },
+  );
+
+  it.each([
+    {
+      position: { x: 131, y: 211 },
+      expectedDirections: { horizontalDirection: 1, verticalDirection: 1 },
+    },
+    {
+      position: { x: 132, y: 212 },
+      expectedDirections: { horizontalDirection: -1, verticalDirection: -1 },
+    },
+  ] as const)(
+    'uses the normalized trigger center to resolve direction at $position',
+    ({ position, expectedDirections }) => {
+      // Given / When
+      const placement = resolveFloatingAIButtonPlacement(position, STANDARD_GEOMETRY);
+
+      // Then
+      expect(placement).toMatchObject(expectedDirections);
+    },
+  );
+
+  it('preserves the snapped edge and flips expansion when the center preference cannot fit', () => {
+    // Given
+    const asymmetricGeometry: FloatingButtonGeometry = {
+      ...STANDARD_GEOMETRY,
+      leftClearance: 150,
+    };
+
+    // When
+    const placement = resolveFloatingAIButtonPlacement(
+      { x: 0, y: 211 },
+      asymmetricGeometry,
+    );
+
+    // Then
+    expect(placement.position.x).toBe(150);
+    expect(placement.horizontalDirection).toBe(1);
+  });
+
+  it.each([
+    { x: -500, y: -500 },
+    { x: 131, y: 211 },
+    { x: 132, y: 212 },
+    { x: 900, y: 1200 },
+  ])('returns an idempotent placement for $x,$y', (position) => {
+    // Given
+    const firstPlacement = resolveFloatingAIButtonPlacement(position, STANDARD_GEOMETRY);
+
+    // When
+    const repeatedPlacement = resolveFloatingAIButtonPlacement(
+      firstPlacement.position,
+      STANDARD_GEOMETRY,
+    );
+
+    // Then
+    expect(repeatedPlacement).toEqual(firstPlacement);
+  });
+
+  it('exposes impossible viewport bounds instead of fabricating a valid range', () => {
+    // Given
+    const impossibleGeometry: FloatingButtonGeometry = {
+      ...STANDARD_GEOMETRY,
+      viewportWidth: 120,
+    };
+
+    // When
+    const bounds = getFloatingAIHubTriggerBounds(impossibleGeometry, {
+      horizontalDirection: 1,
+      verticalDirection: 1,
+    });
+
+    // Then
+    expect(bounds.minX).toBeGreaterThan(bounds.maxX);
+  });
+});

--- a/__tests__/offline-banner-todos-explore.test.tsx
+++ b/__tests__/offline-banner-todos-explore.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 // Mock netinfo at the source so any indirect import resolves.
 jest.mock('@react-native-community/netinfo', () => {
@@ -207,6 +208,45 @@ describe('OfflineBanner mounted on TodoListScreen and ExploreScreen', () => {
   });
 
   describe('ExploreScreen', () => {
+    it('positions the repo-list search after one header reservation and local spacing', () => {
+      // Given
+      setOffline();
+
+      // When
+      const { UNSAFE_getAllByType } = render(<ExploreScreen />);
+      const headerReservation = UNSAFE_getAllByType(View).find(
+        (node) => StyleSheet.flatten(node.props.style)?.paddingTop === 60,
+      );
+      const searchWrapper = UNSAFE_getAllByType(View).find(
+        (node) => node.props.className?.includes('px-4') && node.props.className?.includes('pb-3'),
+      );
+
+      // Then
+      expect(headerReservation?.findAllByType(Text).some((node) => node.props.children === BANNER_TEXT)).toBe(true);
+      expect(StyleSheet.flatten(searchWrapper?.props.style)?.paddingTop).toBeUndefined();
+      expect(searchWrapper?.props.className).toContain('pt-2');
+    });
+
+    it('positions the repo-detail card after one header reservation without internal header padding', () => {
+      // Given
+      setOffline();
+      const { getByTestId, UNSAFE_getAllByType } = render(<ExploreScreen />);
+
+      // When
+      fireEvent.press(getByTestId('explore.button.select-repo'));
+      const headerReservation = UNSAFE_getAllByType(View).find(
+        (node) => StyleSheet.flatten(node.props.style)?.paddingTop === 60,
+      );
+      const repoCard = UNSAFE_getAllByType(View).find(
+        (node) => node.props.className?.includes('mx-4 mt-4 rounded-sm border p-4'),
+      );
+
+      // Then
+      expect(headerReservation?.findAllByType(Text).some((node) => node.props.children === BANNER_TEXT)).toBe(true);
+      expect(repoCard?.props.className).toContain('p-4');
+      expect(StyleSheet.flatten(repoCard?.props.style)).not.toHaveProperty('paddingTop');
+    });
+
     it('renders banner when offline', () => {
       setOffline();
       const { getByText } = render(<ExploreScreen />);

--- a/__tests__/stores/repoStore.test.ts
+++ b/__tests__/stores/repoStore.test.ts
@@ -4,7 +4,7 @@ import { getActiveGitHost } from '../../src/services/git/activeHost';
 import { gitHubHostService } from '../../src/services/git/gitHostFactory';
 import { checkGitHubRepoAccess } from '../../src/services/git/repoAccessPreflight';
 import { useRepoStore } from '../../src/stores/repoStore';
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 
 jest.mock('../../src/services/GitService', () => ({
   GitService: { addRepository: jest.fn() },

--- a/__tests__/ui/SafeAreaView.test.tsx
+++ b/__tests__/ui/SafeAreaView.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { useCssElement } from 'react-native-css';
+import { SafeAreaView as NativeSafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView } from '../../src/components/ui/SafeAreaView';
+
+jest.mock('react-native-css', () => {
+  const React = require('react');
+
+  return {
+    styled: <Component,>(component: Component): Component => component,
+    useCssElement: jest.fn(
+      (component: React.ElementType, props: Record<string, unknown>) =>
+        React.createElement(component, props),
+    ),
+  };
+});
+
+describe('SafeAreaView', () => {
+  it('maps className to style while preserving native props and children', () => {
+    const style = { backgroundColor: 'tomato' } as const;
+    const child = <Text>Safe content</Text>;
+
+    render(
+      <SafeAreaView
+        className="flex-1"
+        edges={['top', 'bottom']}
+        style={style}
+        testID="safe-area"
+      >
+        {child}
+      </SafeAreaView>,
+    );
+
+    expect(useCssElement).toHaveBeenCalledTimes(1);
+    expect(useCssElement).toHaveBeenCalledWith(
+      NativeSafeAreaView,
+      expect.objectContaining({
+        children: child,
+        className: 'flex-1',
+        edges: ['top', 'bottom'],
+        style,
+        testID: 'safe-area',
+      }),
+      { className: 'style' },
+    );
+  });
+});

--- a/__tests__/ui/__snapshots__/Toggle.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Toggle.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Toggle snapshots both states: toggle-off 1`] = `
   }
 >
   <View
-    className="bg-surface rounded-full"
+    className="justify-center bg-surface rounded-full"
     style={
       [
         {
@@ -178,7 +178,7 @@ exports[`Toggle snapshots both states: toggle-on 1`] = `
   }
 >
   <View
-    className="bg-surface rounded-full"
+    className="justify-center bg-surface rounded-full"
     style={
       [
         {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -5,10 +5,23 @@ jest.mock('nativewind', () => ({
   NativeWindStyleSheet: { setDimensions: jest.fn(), setDirection: jest.fn(), setAppearance: jest.fn() },
 }));
 
-jest.mock('react-native-css', () => ({
-  cssInterop: () => {},
-  useUnstableNativeVariable: (name: string) => undefined,
-}));
+jest.mock('react-native-css', () => {
+  const React = require('react');
+
+  return {
+    cssInterop: () => {},
+    styled: <Component>(component: Component): Component => component,
+    useCssElement: (
+      Component: React.ElementType,
+      props: Record<string, unknown>,
+      mapping: Readonly<Record<string, unknown>>,
+    ) => {
+      void mapping;
+      return React.createElement(Component, props);
+    },
+    useUnstableNativeVariable: (name: string) => undefined,
+  };
+});
 
 jest.mock('@rn-primitives/slot', () => {
   const React = require('react');
@@ -290,9 +303,11 @@ jest.mock('react-native-gesture-handler', () => {
     activeOffsetX: () => mockGesture(),
     activeOffsetY: () => mockGesture(),
     failOffsetY: () => mockGesture(),
+    onBegin: () => mockGesture(),
     onStart: () => mockGesture(),
     onUpdate: () => mockGesture(),
     onEnd: () => mockGesture(),
+    onFinalize: () => mockGesture(),
     runOnJS: () => mockGesture(),
   });
   return {

--- a/src/components/ai/FloatingAIButton.tsx
+++ b/src/components/ai/FloatingAIButton.tsx
@@ -1,16 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
-import { AccessibilityInfo, Dimensions, Pressable, StyleSheet } from 'react-native';
+import { AccessibilityInfo, Pressable, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import { GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
-  useSharedValue,
   useAnimatedStyle,
+  useSharedValue,
   withSpring,
-  runOnJS,
 } from 'react-native-reanimated';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAIStore } from '../../stores/aiStore';
 import { useAIHubStore } from '../../stores/aiHubStore';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -18,19 +16,20 @@ import { HapticService } from '../../utils/haptics';
 import { Surface } from '../ui/Surface';
 import type { RootStackParamList } from '../../navigation/types';
 import {
-  FloatingAIHubMenu,
-  MENU_SPRING,
+  FLOATING_AI_BUTTON_SIZE,
+  resolveFloatingAIButtonPlacement,
   type HubItemId,
   type MenuDirection,
+} from './floatingAIButtonGeometry';
+import {
+  FloatingAIHubMenu,
+  MENU_SPRING,
 } from './FloatingAIHubMenu';
-
-const BUTTON_SIZE = 56;
-const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
-
-const STORAGE_KEY = 'ai-button-position';
+import { useFloatingAIButtonPosition } from './useFloatingAIButtonPosition';
+import { useFloatingAIButtonPanGesture } from './useFloatingAIButtonPanGesture';
 
 interface FloatingAIButtonProps {
-  currentRouteName?: string;
+  readonly currentRouteName?: string;
 }
 
 export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
@@ -41,15 +40,16 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
   const [horizontalDirection, setHorizontalDirection] = useState<MenuDirection>(-1);
   const [verticalDirection, setVerticalDirection] = useState<MenuDirection>(-1);
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-
-  const initialX = SCREEN_WIDTH - BUTTON_SIZE - 24;
-  const initialY = SCREEN_HEIGHT - BUTTON_SIZE - 100;
-
-  const translateX = useSharedValue(initialX);
-  const translateY = useSharedValue(initialY);
-  
-  const savedTranslateX = useSharedValue(initialX);
-  const savedTranslateY = useSharedValue(initialY);
+  const position = useFloatingAIButtonPosition();
+  const {
+    geometry,
+    translateX,
+    translateY,
+    savedTranslateX,
+    savedTranslateY,
+    markPositionInteractionStarted,
+    savePosition,
+  } = position;
   const menuProgress = useSharedValue(0);
 
   useEffect(() => {
@@ -69,50 +69,62 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
   }, []);
 
   useEffect(() => {
-    AsyncStorage.getItem(STORAGE_KEY).then((pos) => {
-      if (pos) {
-        try {
-          const { x, y } = JSON.parse(pos);
-          translateX.value = x;
-          translateY.value = y;
-          savedTranslateX.value = x;
-          savedTranslateY.value = y;
-        } catch (e) {
-          console.warn('Failed to restore FAB position:', e);
-        }
-      }
-    });
-  }, [translateX, translateY, savedTranslateX, savedTranslateY]);
-
-  useEffect(() => {
     menuProgress.value = reduceMotionEnabled
       ? menuOpen ? 1 : 0
       : withSpring(menuOpen ? 1 : 0, MENU_SPRING);
   }, [menuOpen, menuProgress, reduceMotionEnabled]);
 
-  const savePosition = (x: number, y: number) => {
-    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ x, y })).catch(() => { return; });
-  };
-
   const closeMenu = useCallback(() => setMenuOpen(false), []);
 
+  useEffect(() => {
+    closeMenu();
+  }, [closeMenu, geometry]);
+
   const handleTap = useCallback(() => {
+    if (menuOpen) {
+      closeMenu();
+      return;
+    }
+
     closeMenu();
     HapticService.success();
     useAIHubStore.getState().goNewChat(navigation);
-  }, [closeMenu, navigation]);
+  }, [closeMenu, menuOpen, navigation]);
 
   const handleLongPress = useCallback(() => {
+    markPositionInteractionStarted();
     HapticService.selection();
     if (menuOpen) {
       closeMenu();
       return;
     }
 
-    setHorizontalDirection(translateX.value < SCREEN_WIDTH / 2 ? 1 : -1);
-    setVerticalDirection(translateY.value < SCREEN_HEIGHT / 2 ? 1 : -1);
+    const currentPosition = { x: translateX.value, y: translateY.value };
+    const placement = resolveFloatingAIButtonPlacement(currentPosition, geometry);
+    translateX.value = placement.position.x;
+    translateY.value = placement.position.y;
+    savedTranslateX.value = placement.position.x;
+    savedTranslateY.value = placement.position.y;
+    if (
+      placement.position.x !== currentPosition.x
+      || placement.position.y !== currentPosition.y
+    ) {
+      savePosition(placement.position);
+    }
+    setHorizontalDirection(placement.horizontalDirection);
+    setVerticalDirection(placement.verticalDirection);
     setMenuOpen(true);
-  }, [closeMenu, menuOpen, translateX, translateY]);
+  }, [
+    closeMenu,
+    geometry,
+    markPositionInteractionStarted,
+    menuOpen,
+    savedTranslateX,
+    savedTranslateY,
+    savePosition,
+    translateX,
+    translateY,
+  ]);
 
   const handleMenuItemPress = useCallback((itemId: HubItemId) => {
     setMenuOpen(false);
@@ -136,40 +148,11 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
     }
   }, [navigation]);
 
-  const panGesture = Gesture.Pan()
-    .onStart(() => {
-      runOnJS(closeMenu)();
-    })
-    .onUpdate((event) => {
-      translateX.value = savedTranslateX.value + event.translationX;
-      translateY.value = savedTranslateY.value + event.translationY;
-    })
-    .onEnd(() => {
-      const distanceToLeft = translateX.value;
-      const distanceToRight = SCREEN_WIDTH - BUTTON_SIZE - translateX.value;
-      
-      const snapX = distanceToLeft < distanceToRight ? 16 : SCREEN_WIDTH - BUTTON_SIZE - 16;
-      
-      const minY = 60;
-      const maxY = SCREEN_HEIGHT - BUTTON_SIZE - 100;
-      const snapY = Math.min(Math.max(translateY.value, minY), maxY);
-
-      translateX.value = withSpring(snapX, {
-        mass: 1,
-        damping: 15,
-        stiffness: 120,
-      });
-      translateY.value = withSpring(snapY, {
-        mass: 1,
-        damping: 15,
-        stiffness: 120,
-      });
-
-      savedTranslateX.value = snapX;
-      savedTranslateY.value = snapY;
-
-      runOnJS(savePosition)(snapX, snapY);
-    });
+  const panGesture = useFloatingAIButtonPanGesture(position, {
+    closeMenu,
+    setHorizontalDirection,
+    setVerticalDirection,
+  });
 
   const animatedStyle = useAnimatedStyle(() => {
     return {
@@ -241,8 +224,8 @@ const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     zIndex: 9999,
-    width: BUTTON_SIZE,
-    height: BUTTON_SIZE,
+    width: FLOATING_AI_BUTTON_SIZE,
+    height: FLOATING_AI_BUTTON_SIZE,
   },
   backdrop: {
     ...StyleSheet.absoluteFill,
@@ -250,8 +233,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.18)',
   },
   button: {
-    width: BUTTON_SIZE,
-    height: BUTTON_SIZE,
+    width: FLOATING_AI_BUTTON_SIZE,
+    height: FLOATING_AI_BUTTON_SIZE,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/src/components/ai/FloatingAIHubMenu.tsx
+++ b/src/components/ai/FloatingAIHubMenu.tsx
@@ -14,12 +14,20 @@ import Animated, {
   type SharedValue,
 } from 'react-native-reanimated';
 import { RADII } from '../../theme/tokens';
+import {
+  FLOATING_AI_BUTTON_SIZE,
+  FLOATING_AI_HUB_ITEMS,
+  FLOATING_AI_HUB_SATELLITE_SIZE,
+  type FloatingAIHubItem,
+  type HubItemId,
+  type MenuDirection,
+} from './floatingAIButtonGeometry';
 
-const BUTTON_SIZE = 56;
 const LIQUID_CANVAS_SIZE = 296;
-const LIQUID_CANVAS_INSET = (LIQUID_CANVAS_SIZE - BUTTON_SIZE) / 2;
+const LIQUID_CANVAS_INSET = (
+  LIQUID_CANVAS_SIZE - FLOATING_AI_BUTTON_SIZE
+) / 2;
 const LIQUID_CENTER = LIQUID_CANVAS_SIZE / 2;
-const SATELLITE_SIZE = 48;
 const GOOEY_ALPHA_MATRIX = [
   1, 0, 0, 0, 0,
   0, 1, 0, 0, 0,
@@ -27,27 +35,27 @@ const GOOEY_ALPHA_MATRIX = [
   0, 0, 0, 18, -7,
 ];
 
-export const MENU_SPRING = { mass: 0.72, damping: 18, stiffness: 210 } as const;
-export type HubItemId = 'new-chat' | 'chat-history' | 'ai-settings' | 'thought-dump';
-export type MenuDirection = -1 | 1;
+export const MENU_SPRING = {
+  mass: 0.72,
+  damping: 18,
+  stiffness: 210,
+  overshootClamping: true,
+} as const;
 
-interface HubItem {
-  readonly id: HubItemId;
+interface HubItemContent {
   readonly label: string;
   readonly icon: keyof typeof Ionicons.glyphMap;
-  readonly x: number;
-  readonly y: number;
 }
 
-const HUB_ITEMS = [
-  { id: 'new-chat', label: 'New chat', icon: 'add', x: 58, y: 85 },
-  { id: 'chat-history', label: 'Chat history', icon: 'chatbubbles-outline', x: 80, y: 43 },
-  { id: 'ai-settings', label: 'AI settings', icon: 'options-outline', x: 90, y: 1 },
-  { id: 'thought-dump', label: 'Thought dump', icon: 'bulb-outline', x: 80, y: -41 },
-] as const satisfies readonly HubItem[];
+const HUB_ITEM_CONTENT = {
+  'new-chat': { label: 'New chat', icon: 'add' },
+  'chat-history': { label: 'Chat history', icon: 'chatbubbles-outline' },
+  'ai-settings': { label: 'AI settings', icon: 'options-outline' },
+  'thought-dump': { label: 'Thought dump', icon: 'bulb-outline' },
+} as const satisfies Record<HubItemId, HubItemContent>;
 
 interface MenuGeometryProps {
-  readonly item: HubItem;
+  readonly item: FloatingAIHubItem;
   readonly horizontalDirection: MenuDirection;
   readonly verticalDirection: MenuDirection;
   readonly progress: SharedValue<number>;
@@ -83,6 +91,7 @@ function HubMenuItem({
   iconColor,
   onPress,
 }: HubMenuItemProps) {
+  const content = HUB_ITEM_CONTENT[item.id];
   const animatedStyle = useAnimatedStyle(() => ({
     opacity: progress.value,
     transform: [
@@ -97,11 +106,11 @@ function HubMenuItem({
       <Pressable
         testID={`floating-ai.hub.${item.id}`}
         accessibilityRole="button"
-        accessibilityLabel={item.label}
+        accessibilityLabel={content.label}
         onPress={() => onPress(item.id)}
         style={styles.satelliteButton}
       >
-        <Ionicons name={item.icon} size={22} color={iconColor} />
+        <Ionicons name={content.icon} size={22} color={iconColor} />
       </Pressable>
     </Animated.View>
   );
@@ -147,8 +156,12 @@ export function FloatingAIHubMenu({
               </Paint>
             }
           >
-            <Circle cx={LIQUID_CENTER} cy={LIQUID_CENTER} r={BUTTON_SIZE / 2} />
-            {HUB_ITEMS.map((item) => (
+            <Circle
+              cx={LIQUID_CENTER}
+              cy={LIQUID_CENTER}
+              r={FLOATING_AI_BUTTON_SIZE / 2}
+            />
+            {FLOATING_AI_HUB_ITEMS.map((item) => (
               <LiquidSatellite
                 key={item.id}
                 item={item}
@@ -161,7 +174,7 @@ export function FloatingAIHubMenu({
         </Canvas>
       )}
 
-      {menuOpen && HUB_ITEMS.map((item) => (
+      {menuOpen && FLOATING_AI_HUB_ITEMS.map((item) => (
         <HubMenuItem
           key={item.id}
           item={item}
@@ -186,15 +199,15 @@ const styles = StyleSheet.create({
   },
   satelliteAnchor: {
     position: 'absolute',
-    left: (BUTTON_SIZE - SATELLITE_SIZE) / 2,
-    top: (BUTTON_SIZE - SATELLITE_SIZE) / 2,
-    width: SATELLITE_SIZE,
-    height: SATELLITE_SIZE,
+    left: (FLOATING_AI_BUTTON_SIZE - FLOATING_AI_HUB_SATELLITE_SIZE) / 2,
+    top: (FLOATING_AI_BUTTON_SIZE - FLOATING_AI_HUB_SATELLITE_SIZE) / 2,
+    width: FLOATING_AI_HUB_SATELLITE_SIZE,
+    height: FLOATING_AI_HUB_SATELLITE_SIZE,
     zIndex: 2,
   },
   satelliteButton: {
-    width: SATELLITE_SIZE,
-    height: SATELLITE_SIZE,
+    width: FLOATING_AI_HUB_SATELLITE_SIZE,
+    height: FLOATING_AI_HUB_SATELLITE_SIZE,
     borderRadius: RADII.pill,
     alignItems: 'center',
     justifyContent: 'center',

--- a/src/components/ai/floatingAIButtonGeometry.ts
+++ b/src/components/ai/floatingAIButtonGeometry.ts
@@ -1,0 +1,169 @@
+export const FLOATING_AI_BUTTON_SIZE = 56;
+export const FLOATING_AI_HUB_SATELLITE_SIZE = 48;
+
+export type HubItemId = 'new-chat' | 'chat-history' | 'ai-settings' | 'thought-dump';
+export type MenuDirection = -1 | 1;
+
+export interface FloatingAIHubItem {
+  readonly id: HubItemId;
+  readonly x: number;
+  readonly y: number;
+}
+
+export const FLOATING_AI_HUB_ITEMS = [
+  { id: 'new-chat', x: 58, y: 85 },
+  { id: 'chat-history', x: 80, y: 43 },
+  { id: 'ai-settings', x: 90, y: 1 },
+  { id: 'thought-dump', x: 80, y: -41 },
+] as const satisfies readonly FloatingAIHubItem[];
+
+export interface FloatingButtonPosition {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface FloatingButtonGeometry {
+  readonly viewportWidth: number;
+  readonly viewportHeight: number;
+  readonly leftClearance: number;
+  readonly rightClearance: number;
+  readonly topBound: number;
+  readonly tabBarHeight: number;
+  readonly minimumBottomClearance: number;
+}
+
+export interface MenuDirections {
+  readonly horizontalDirection: MenuDirection;
+  readonly verticalDirection: MenuDirection;
+}
+
+export interface FloatingButtonBounds {
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minY: number;
+  readonly maxY: number;
+}
+
+export interface FloatingButtonPlacement extends MenuDirections {
+  readonly position: FloatingButtonPosition;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  'worklet';
+
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+function oppositeDirection(direction: MenuDirection): MenuDirection {
+  'worklet';
+
+  return direction === 1 ? -1 : 1;
+}
+
+export function getFloatingAIHubTriggerBounds(
+  geometry: FloatingButtonGeometry,
+  directions: MenuDirections,
+): FloatingButtonBounds {
+  'worklet';
+
+  const anchorInset = (
+    FLOATING_AI_BUTTON_SIZE - FLOATING_AI_HUB_SATELLITE_SIZE
+  ) / 2;
+  let minimumRelativeX = 0;
+  let maximumRelativeX = FLOATING_AI_BUTTON_SIZE;
+  let minimumRelativeY = 0;
+  let maximumRelativeY = FLOATING_AI_BUTTON_SIZE;
+
+  for (const item of FLOATING_AI_HUB_ITEMS) {
+    const satelliteLeft = anchorInset + item.x * directions.horizontalDirection;
+    const satelliteTop = anchorInset + item.y * directions.verticalDirection;
+    minimumRelativeX = Math.min(minimumRelativeX, satelliteLeft);
+    maximumRelativeX = Math.max(
+      maximumRelativeX,
+      satelliteLeft + FLOATING_AI_HUB_SATELLITE_SIZE,
+    );
+    minimumRelativeY = Math.min(minimumRelativeY, satelliteTop);
+    maximumRelativeY = Math.max(
+      maximumRelativeY,
+      satelliteTop + FLOATING_AI_HUB_SATELLITE_SIZE,
+    );
+  }
+
+  const safeRight = geometry.viewportWidth - geometry.rightClearance;
+  const safeBottom = geometry.viewportHeight - Math.max(
+    geometry.tabBarHeight,
+    geometry.minimumBottomClearance,
+  );
+
+  return {
+    minX: geometry.leftClearance - minimumRelativeX,
+    maxX: safeRight - maximumRelativeX,
+    minY: geometry.topBound - minimumRelativeY,
+    maxY: safeBottom - maximumRelativeY,
+  };
+}
+
+export function resolveFloatingAIButtonPlacement(
+  position: FloatingButtonPosition,
+  geometry: FloatingButtonGeometry,
+): FloatingButtonPlacement {
+  'worklet';
+
+  const leftX = geometry.leftClearance;
+  const rightX = geometry.viewportWidth
+    - FLOATING_AI_BUTTON_SIZE
+    - geometry.rightClearance;
+  const x = Math.abs(position.x - leftX) < Math.abs(position.x - rightX)
+    ? leftX
+    : rightX;
+  const safeBottom = geometry.viewportHeight - Math.max(
+    geometry.tabBarHeight,
+    geometry.minimumBottomClearance,
+  );
+  const triggerBottomBound = safeBottom - FLOATING_AI_BUTTON_SIZE;
+  const normalizedY = clamp(position.y, geometry.topBound, triggerBottomBound);
+
+  let horizontalDirection: MenuDirection = (
+    x + FLOATING_AI_BUTTON_SIZE / 2 < geometry.viewportWidth / 2
+  ) ? 1 : -1;
+  let verticalDirection: MenuDirection = (
+    normalizedY + FLOATING_AI_BUTTON_SIZE / 2 < geometry.viewportHeight / 2
+  ) ? 1 : -1;
+
+  let bounds = getFloatingAIHubTriggerBounds(geometry, {
+    horizontalDirection,
+    verticalDirection,
+  });
+  if (x < bounds.minX || x > bounds.maxX) {
+    const alternateHorizontalDirection = oppositeDirection(horizontalDirection);
+    const alternateBounds = getFloatingAIHubTriggerBounds(geometry, {
+      horizontalDirection: alternateHorizontalDirection,
+      verticalDirection,
+    });
+    if (x >= alternateBounds.minX && x <= alternateBounds.maxX) {
+      horizontalDirection = alternateHorizontalDirection;
+      bounds = alternateBounds;
+    }
+  }
+
+  let y = clamp(normalizedY, bounds.minY, bounds.maxY);
+  const resolvedVerticalDirection: MenuDirection = (
+    y + FLOATING_AI_BUTTON_SIZE / 2 < geometry.viewportHeight / 2
+  ) ? 1 : -1;
+  if (resolvedVerticalDirection !== verticalDirection) {
+    const alternateBounds = getFloatingAIHubTriggerBounds(geometry, {
+      horizontalDirection,
+      verticalDirection: resolvedVerticalDirection,
+    });
+    if (alternateBounds.minY <= alternateBounds.maxY) {
+      verticalDirection = resolvedVerticalDirection;
+      y = clamp(y, alternateBounds.minY, alternateBounds.maxY);
+    }
+  }
+
+  return {
+    position: { x, y },
+    horizontalDirection,
+    verticalDirection,
+  };
+}

--- a/src/components/ai/useFloatingAIButtonPanGesture.ts
+++ b/src/components/ai/useFloatingAIButtonPanGesture.ts
@@ -1,0 +1,91 @@
+import { Gesture } from 'react-native-gesture-handler';
+import { runOnJS, withSpring } from 'react-native-reanimated';
+import type { FloatingAIButtonPositionState } from './useFloatingAIButtonPosition';
+import {
+  resolveFloatingAIButtonPlacement,
+  type MenuDirection,
+} from './floatingAIButtonGeometry';
+
+const POSITION_SPRING = {
+  mass: 1,
+  damping: 15,
+  stiffness: 120,
+  overshootClamping: true,
+} as const;
+
+interface FloatingAIButtonPanActions {
+  readonly closeMenu: () => void;
+  readonly setHorizontalDirection: (direction: MenuDirection) => void;
+  readonly setVerticalDirection: (direction: MenuDirection) => void;
+}
+
+export function useFloatingAIButtonPanGesture(
+  position: FloatingAIButtonPositionState,
+  actions: FloatingAIButtonPanActions,
+) {
+  const {
+    translateX,
+    translateY,
+    savedTranslateX,
+    savedTranslateY,
+    latestGeometry,
+    dragActive,
+    markPositionInteractionStarted,
+    savePosition,
+  } = position;
+
+  return Gesture.Pan()
+    .onBegin(() => {
+      dragActive.value = true;
+      runOnJS(markPositionInteractionStarted)();
+    })
+    .onStart(() => {
+      runOnJS(actions.closeMenu)();
+    })
+    .onUpdate((event) => {
+      translateX.value = savedTranslateX.value + event.translationX;
+      translateY.value = savedTranslateY.value + event.translationY;
+    })
+    .onEnd((_event, successful) => {
+      if (!successful) return;
+
+      const placement = resolveFloatingAIButtonPlacement(
+        { x: translateX.value, y: translateY.value },
+        latestGeometry.value,
+      );
+      const normalizedPosition = placement.position;
+
+      translateX.value = withSpring(normalizedPosition.x, POSITION_SPRING);
+      translateY.value = withSpring(normalizedPosition.y, POSITION_SPRING);
+      savedTranslateX.value = normalizedPosition.x;
+      savedTranslateY.value = normalizedPosition.y;
+
+      runOnJS(actions.setHorizontalDirection)(placement.horizontalDirection);
+      runOnJS(actions.setVerticalDirection)(placement.verticalDirection);
+      runOnJS(savePosition)(normalizedPosition);
+    })
+    .onFinalize((_event, successful) => {
+      dragActive.value = false;
+      if (successful) return;
+
+      const savedPosition = {
+        x: savedTranslateX.value,
+        y: savedTranslateY.value,
+      };
+      const normalizedPosition = resolveFloatingAIButtonPlacement(
+        savedPosition,
+        latestGeometry.value,
+      ).position;
+      translateX.value = withSpring(normalizedPosition.x, POSITION_SPRING);
+      translateY.value = withSpring(normalizedPosition.y, POSITION_SPRING);
+      savedTranslateX.value = normalizedPosition.x;
+      savedTranslateY.value = normalizedPosition.y;
+
+      if (
+        normalizedPosition.x !== savedPosition.x
+        || normalizedPosition.y !== savedPosition.y
+      ) {
+        runOnJS(savePosition)(normalizedPosition);
+      }
+    });
+}

--- a/src/components/ai/useFloatingAIButtonPosition.ts
+++ b/src/components/ai/useFloatingAIButtonPosition.ts
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useWindowDimensions } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSharedValue, type SharedValue } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTabBarHeight } from '../ui/TabBar';
+import {
+  resolveFloatingAIButtonPlacement,
+  type FloatingButtonGeometry,
+  type FloatingButtonPosition,
+} from './floatingAIButtonGeometry';
+
+const EDGE_INSET = 16;
+const MINIMUM_TOP_BOUND = 60;
+const MINIMUM_BOTTOM_CLEARANCE = 100;
+const STORAGE_KEY = 'ai-button-position';
+
+export interface FloatingAIButtonPositionState {
+  readonly geometry: FloatingButtonGeometry;
+  readonly translateX: SharedValue<number>;
+  readonly translateY: SharedValue<number>;
+  readonly savedTranslateX: SharedValue<number>;
+  readonly savedTranslateY: SharedValue<number>;
+  readonly latestGeometry: SharedValue<FloatingButtonGeometry>;
+  readonly dragActive: SharedValue<boolean>;
+  readonly markPositionInteractionStarted: () => void;
+  readonly savePosition: (position: FloatingButtonPosition) => void;
+}
+
+function isFloatingButtonPosition(value: unknown): value is FloatingButtonPosition {
+  if (typeof value !== 'object' || value === null || !('x' in value) || !('y' in value)) {
+    return false;
+  }
+
+  return typeof value.x === 'number'
+    && Number.isFinite(value.x)
+    && typeof value.y === 'number'
+    && Number.isFinite(value.y);
+}
+
+export function useFloatingAIButtonPosition(): FloatingAIButtonPositionState {
+  const { width: viewportWidth, height: viewportHeight } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  const tabBarHeight = useTabBarHeight();
+  const geometry = useMemo<FloatingButtonGeometry>(() => ({
+    viewportWidth,
+    viewportHeight,
+    leftClearance: insets.left + EDGE_INSET,
+    rightClearance: insets.right + EDGE_INSET,
+    topBound: Math.max(MINIMUM_TOP_BOUND, insets.top + EDGE_INSET),
+    tabBarHeight,
+    minimumBottomClearance: Math.max(
+      MINIMUM_BOTTOM_CLEARANCE,
+      insets.bottom + EDGE_INSET,
+    ),
+  }), [
+    insets.bottom,
+    insets.left,
+    insets.right,
+    insets.top,
+    tabBarHeight,
+    viewportHeight,
+    viewportWidth,
+  ]);
+  const geometryRef = useRef(geometry);
+  const positionInteractionStartedRef = useRef(false);
+  const [positionRestored, setPositionRestored] = useState(false);
+  geometryRef.current = geometry;
+  const initialPosition = resolveFloatingAIButtonPlacement(
+    { x: viewportWidth, y: viewportHeight },
+    geometry,
+  ).position;
+  const translateX = useSharedValue(initialPosition.x);
+  const translateY = useSharedValue(initialPosition.y);
+  const savedTranslateX = useSharedValue(initialPosition.x);
+  const savedTranslateY = useSharedValue(initialPosition.y);
+  const latestGeometry = useSharedValue(geometry);
+  const dragActive = useSharedValue(false);
+
+  const applyPosition = useCallback((position: FloatingButtonPosition) => {
+    translateX.value = position.x;
+    translateY.value = position.y;
+    savedTranslateX.value = position.x;
+    savedTranslateY.value = position.y;
+  }, [savedTranslateX, savedTranslateY, translateX, translateY]);
+
+  const savePosition = useCallback((position: FloatingButtonPosition) => {
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(position)).catch((error: unknown) => {
+      console.warn('Failed to save FAB position:', error);
+    });
+  }, []);
+
+  const markPositionInteractionStarted = useCallback(() => {
+    positionInteractionStartedRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    AsyncStorage.getItem(STORAGE_KEY).then((storedPosition) => {
+      if (!isMounted) return;
+
+      if (
+        storedPosition !== null
+        && !positionInteractionStartedRef.current
+        && !dragActive.value
+      ) {
+        try {
+          const parsedPosition: unknown = JSON.parse(storedPosition);
+          if (isFloatingButtonPosition(parsedPosition)) {
+            const normalizedPosition = resolveFloatingAIButtonPlacement(
+              parsedPosition,
+              geometryRef.current,
+            ).position;
+            applyPosition(normalizedPosition);
+            if (
+              normalizedPosition.x !== parsedPosition.x
+              || normalizedPosition.y !== parsedPosition.y
+            ) {
+              savePosition(normalizedPosition);
+            }
+          }
+        } catch (error: unknown) {
+          console.warn('Failed to restore FAB position:', error);
+        }
+      }
+      setPositionRestored(true);
+    }).catch((error: unknown) => {
+      if (!isMounted) return;
+      console.warn('Failed to restore FAB position:', error);
+      setPositionRestored(true);
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [applyPosition, dragActive, savePosition]);
+
+  useEffect(() => {
+    latestGeometry.value = geometry;
+  }, [geometry, latestGeometry]);
+
+  useEffect(() => {
+    if (!positionRestored || dragActive.value) return;
+
+    const currentPosition = {
+      x: savedTranslateX.value,
+      y: savedTranslateY.value,
+    };
+    const normalizedPosition = resolveFloatingAIButtonPlacement(
+      currentPosition,
+      geometry,
+    ).position;
+    if (
+      normalizedPosition.x === currentPosition.x
+      && normalizedPosition.y === currentPosition.y
+    ) {
+      return;
+    }
+
+    applyPosition(normalizedPosition);
+    savePosition(normalizedPosition);
+  }, [
+    applyPosition,
+    dragActive,
+    geometry,
+    positionRestored,
+    savedTranslateX,
+    savedTranslateY,
+    savePosition,
+  ]);
+
+  return {
+    geometry,
+    translateX,
+    translateY,
+    savedTranslateX,
+    savedTranslateY,
+    latestGeometry,
+    dragActive,
+    markPositionInteractionStarted,
+    savePosition,
+  };
+}

--- a/src/components/ui/SafeAreaView.tsx
+++ b/src/components/ui/SafeAreaView.tsx
@@ -1,0 +1,19 @@
+import {
+  useCssElement,
+  type StyledConfiguration,
+  type StyledProps,
+} from 'react-native-css';
+import {
+  SafeAreaView as BaseSafeAreaView,
+  type SafeAreaViewProps,
+} from 'react-native-safe-area-context';
+
+const mapping = {
+  className: 'style',
+} as const satisfies StyledConfiguration<typeof BaseSafeAreaView>;
+
+export function SafeAreaView(
+  props: StyledProps<SafeAreaViewProps, typeof mapping>,
+) {
+  return useCssElement(BaseSafeAreaView, props, mapping);
+}

--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -8,7 +8,6 @@ import {
   Modal,
   TextInput,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
@@ -20,6 +19,7 @@ import { RootStackParamList } from '../navigation/types';
 import { Canvas } from '../models/Canvas';
 import SearchBar from '../components/SearchBar';
 import { ScreenHeader, IconButton, useScreenHeaderHeight } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { EntityFilterModal } from '../components/EntityFilterModal';
 import { ActiveFilterStrip } from '../components/ActiveFilterStrip';
 import { useEntityFilter } from '../hooks/useEntityFilter';
@@ -334,5 +334,4 @@ export default function CanvasListScreen() {
     </SafeAreaView>
   );
 }
-
 

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, KeyboardAvoidingView, Platform, Text, View } from 'react-native';
 import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { ChatMessageBubble } from '../components/ai/ChatMessageBubble';
@@ -10,6 +9,7 @@ import { ChatLoadingStrip } from '../components/ai/ChatLoadingStrip';
 import ContextPickerModal from '../components/ai/ContextPickerModal';
 import VoiceInputModal from '../components/VoiceInputModal';
 import { ScreenHeader, useScreenHeaderHeight } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { useTokens } from '../contexts/ThemeContext';
 import type { ChatMessage } from '../models/Chat';
 import type { RootStackParamList } from '../navigation/types';

--- a/src/screens/ChatThreadListScreen.tsx
+++ b/src/screens/ChatThreadListScreen.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { View, ActivityIndicator, Alert, FlatList, RefreshControl } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
@@ -13,6 +12,7 @@ import { useTokens } from '../contexts/ThemeContext';
 import { RootStackParamList } from '../navigation/types';
 import { ChatThreadSummary } from '../models/Chat';
 import { ScreenHeader, Button, EmptyState, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { SwipeableListItem } from '../components/list/SwipeableListItem';
 import { BulkActionBar } from '../components/list/BulkActionBar';
 import { ChatThreadCard } from '../components/chat/ChatThreadCard';

--- a/src/screens/ConflictResolverScreen.tsx
+++ b/src/screens/ConflictResolverScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { View, Text, TouchableOpacity, ScrollView, SafeAreaView, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView, Alert } from 'react-native';
 import type { RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation, useRoute } from '@react-navigation/native';
@@ -12,6 +12,7 @@ import { AuthService } from '../services/AuthService';
 import type { FileConflict } from '../services/conflict/types';
 import type { RootStackParamList } from '../navigation/types';
 import { ScreenHeader } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { cn } from '../lib/utils';
 
 type Tab = 'merged' | 'local' | 'remote';

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -9,7 +9,6 @@ import {
   ScrollView,
   RefreshControl,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
@@ -21,6 +20,7 @@ import { parseRepoPath } from '../utils/gitPathParser';
 import RepoFileTree, { TreeNode } from '../components/RepoFileTree';
 import { RootStackParamList } from '../navigation/types';
 import { EmptyState, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import SearchBar from '../components/SearchBar';
 import { useTranslation } from 'react-i18next';
@@ -160,7 +160,7 @@ export default function ExploreScreen() {
         <View style={{ paddingTop: headerHeight }}>
           <OfflineBanner />
         </View>
-        <View className="px-4 pb-3" style={{ paddingTop: headerHeight + 8 }}>
+        <View className="px-4 pt-2 pb-3">
           <SearchBar
             testID="explore.search-bar.repo-search"
             value={repoSearch}
@@ -204,7 +204,7 @@ export default function ExploreScreen() {
           <OfflineBanner />
         </View>
 
-        <View className="mx-4 mt-4 rounded-sm border p-4" style={{ paddingTop: headerHeight + 16, backgroundColor: colors.surface, borderColor: colors.border + '30' }}>
+        <View className="mx-4 mt-4 rounded-sm border p-4" style={{ backgroundColor: colors.surface, borderColor: colors.border + '30' }}>
           <View className="flex-row items-center gap-3.5">
             <View className="w-13 h-13 rounded-sm items-center justify-center" style={{ backgroundColor: colors.primary + '15', width: 52, height: 52, borderRadius: 14 }}>
               <Ionicons name="git-branch" size={28} color={colors.primary} />
@@ -305,5 +305,3 @@ export default function ExploreScreen() {
 
   return null;
 }
-
-

--- a/src/screens/FileViewerScreen.tsx
+++ b/src/screens/FileViewerScreen.tsx
@@ -6,7 +6,6 @@ import {
   ActivityIndicator,
   ScrollView,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
@@ -18,6 +17,7 @@ import { GitHubService } from '../services/GitHubService';
 import { NeorgContentParser } from '../services/NeorgContentParser';
 import { OrgContentParser } from '../services/OrgContentParser';
 import StructuredRenderer from '../components/StructuredRenderer';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { JsonRenderer } from '../components/JsonRenderer';
 import { HapticService } from '../utils/haptics';
 import { getMarkdownStyles, stripTopMetadata } from '../utils/preview';

--- a/src/screens/GraphViewScreen.tsx
+++ b/src/screens/GraphViewScreen.tsx
@@ -16,8 +16,8 @@ import { Note } from '../models/Note';
 import { buildBacklinkIndex } from '../services/BacklinksService';
 import { parseWikiLinks } from '../utils/wikiLinksParser';
 import { RootStackParamList } from '../navigation/types';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import SearchBar from '../components/SearchBar';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, Pressable, Alert } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
@@ -15,6 +14,7 @@ import { NoteFormat, NoteColor, Note } from '../models/Note';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { HapticService } from '../utils/haptics';
 import TemplateSelector from '../components/TemplateSelector';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { NoteTemplate } from '../services/TemplateService';
 import { NoteFormatPreferenceService } from '../services/NoteFormatPreferenceService';
 import {
@@ -410,5 +410,4 @@ export default function HomeScreen() {
     </SafeAreaView>
   );
 }
-
 

--- a/src/screens/ImageViewerScreen.tsx
+++ b/src/screens/ImageViewerScreen.tsx
@@ -7,7 +7,6 @@ import {
   ScrollView,
 } from 'react-native';
 import { Image, ImageLoadEventData } from 'expo-image';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import * as FileSystem from 'expo-file-system/legacy';
@@ -16,6 +15,7 @@ import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAuth } from '../contexts/AuthContext';
 import { HapticService } from '../utils/haptics';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 
 function encodeRepoPath(path: string): string {
   return path.split('/').map((seg) => encodeURIComponent(seg)).join('/');

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -3,7 +3,6 @@ import { View, Text, Pressable, KeyboardAvoidingView, Platform } from 'react-nat
 
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useNotes } from '../contexts/NoteContext';
 import { useCanvases } from '../contexts/CanvasContext';
@@ -19,6 +18,7 @@ import { useResponsive } from '../hooks/useResponsive';
 import { getMarkdownStyles } from '../utils/preview';
 import { useRenderStyle } from '../stores/renderStyleStore';
 import { GitHubActivityIndicator } from '../components/GitHubActivityIndicator';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { CanvasPickerModal } from '../components/editor/CanvasPickerModal';
 import { EditorHeader } from '../components/editor/EditorHeader';
 import { EditorToolbar } from '../components/editor/EditorToolbar';
@@ -318,5 +318,3 @@ function NoteEditorScreenInner() {
     </SafeAreaView>
   );
 }
-
-

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -11,7 +11,6 @@ import { useAuth } from '../contexts/AuthContext';
 import { useRepos } from '../contexts/RepoContext';
 import { RootStackParamList } from '../navigation/types';
 import { Note } from '../models/Note';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { GitHubService } from '../services/GitHubService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
 import { pullAllFromRepos } from '../services/RepoPullService';
@@ -19,6 +18,7 @@ import ColorPicker from '../components/ColorPicker';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import { ConflictBanner } from '../components/ui/ConflictBanner';
 import { IconButton, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { requireRepo } from '../utils/requireRepo';
 import { HapticService } from '../utils/haptics';
 import { useNetworkStatus } from '../hooks/useNetworkStatus';
@@ -639,5 +639,4 @@ export default function NotesListScreen() {
     </SafeAreaView>
   );
 }
-
 

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -10,7 +10,6 @@ import {
   TouchableOpacity,
   Clipboard,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import { OnboardingService } from '../services/OnboardingService';
@@ -18,6 +17,7 @@ import { AuthService } from '../services/AuthService';
 import { GitHubService } from '../services/GitHubService';
 import { useAIStore } from '../stores/aiStore';
 import { Button, Input, Surface } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 
 interface OnboardingScreenProps {
   onComplete: () => void;

--- a/src/screens/PdfViewerScreen.tsx
+++ b/src/screens/PdfViewerScreen.tsx
@@ -6,7 +6,6 @@ import {
   ActivityIndicator,
   Linking,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import { WebView, WebViewMessageEvent } from 'react-native-webview';
@@ -18,6 +17,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useAuth } from '../contexts/AuthContext';
 import { HapticService } from '../utils/haptics';
 import { PositionMemoryService } from '../services/PositionMemoryService';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 
 function encodeRepoPath(path: string): string {
   return path
@@ -304,5 +304,3 @@ export default function PdfViewerScreen() {
     </SafeAreaView>
   );
 }
-
-

--- a/src/screens/RenderStyleEditorScreen.tsx
+++ b/src/screens/RenderStyleEditorScreen.tsx
@@ -9,7 +9,6 @@ import {
   Alert,
   Pressable,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -18,6 +17,7 @@ import type { RouteProp } from '@react-navigation/native';
 import { useTheme } from '../contexts/ThemeContext';
 import { useRenderStyleStore } from '../stores/renderStyleStore';
 import StructuredRenderer from '../components/StructuredRenderer';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import HexColorPickerModal from '../components/HexColorPickerModal';
 import { NeorgContentParser } from '../services/NeorgContentParser';
 import { OrgContentParser } from '../services/OrgContentParser';

--- a/src/screens/RenderStyleSettingsScreen.tsx
+++ b/src/screens/RenderStyleSettingsScreen.tsx
@@ -7,7 +7,6 @@ import {
   ActivityIndicator,
   Alert,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -19,6 +18,7 @@ import { RenderStyleService, DiscoveredBinding } from '../services/RenderStyleSe
 import { RENDER_FORMATS, formatLabel } from '../types/RenderStyle';
 import { GitHubService } from '../services/GitHubService';
 import { Chip } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import type { RootStackParamList } from '../navigation/types';
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'RenderStyleSettings'>;

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { useTheme } from '../contexts/ThemeContext';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { useNotes } from '../contexts/NoteContext';
 import { useAuth } from '../contexts/AuthContext';
 import { useRepos } from '../contexts/RepoContext';

--- a/src/screens/SyncStatusScreen.tsx
+++ b/src/screens/SyncStatusScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { View, Text, FlatList, TouchableOpacity, SafeAreaView } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity } from 'react-native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTheme } from '../contexts/ThemeContext';
 import { useNavigation } from '@react-navigation/native';
@@ -7,6 +7,7 @@ import { useConflictStore } from '../stores/conflictStore';
 import type { FileConflict } from '../services/conflict/types';
 import type { RootStackParamList } from '../navigation/types';
 import { ScreenHeader } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 
 function formatChip(format: string): string {
   switch (format) {

--- a/src/screens/TemplateManagerScreen.tsx
+++ b/src/screens/TemplateManagerScreen.tsx
@@ -6,12 +6,12 @@ import {
   Alert,
   RefreshControl,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 
 import { useTheme } from '../contexts/ThemeContext';
 import { ScreenHeader, IconButton, useScreenHeaderHeight } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { useTemplateStore } from '../stores/templateStore';
 import { NoteTemplate, NoteTemplateIcon } from '../services/TemplateService';
 import { HapticService } from '../utils/haptics';

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 import { View, Alert, Platform, RefreshControl } from 'react-native';
 import { FlatList } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
 
 import { requireRepo } from '../utils/requireRepo';
@@ -15,6 +14,7 @@ import { HapticService } from '../utils/haptics';
 import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
 import { pullAllFromRepos } from '../services/RepoPullService';
 import { IconButton, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import { ConflictBanner } from '../components/ui/ConflictBanner';
 import { EntityFilterModal } from '../components/EntityFilterModal';
@@ -582,4 +582,3 @@ export default function TodoListScreen() {
     </SafeAreaView>
   );
 }
-

--- a/src/screens/VideoViewerScreen.tsx
+++ b/src/screens/VideoViewerScreen.tsx
@@ -5,7 +5,6 @@ import {
   TouchableOpacity,
   ActivityIndicator,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import { WebView } from 'react-native-webview';
@@ -15,6 +14,7 @@ import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAuth } from '../contexts/AuthContext';
 import { HapticService } from '../utils/haptics';
+import { SafeAreaView } from '../components/ui/SafeAreaView';
 
 function encodeRepoPath(path: string): string {
   return path.split('/').map((seg) => encodeURIComponent(seg)).join('/');

--- a/src/screens/__dev__/NativeWindSmokeScreen.tsx
+++ b/src/screens/__dev__/NativeWindSmokeScreen.tsx
@@ -1,12 +1,12 @@
 import '../../../global.css';
 import { useState } from 'react';
 import { View, Text, ScrollView } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button } from './ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from './ui/card';
 import { Input } from './ui/input';
 import { NativeWindThemeProvider } from '../../theme/nativewind';
 import { useTokens } from '../../contexts/ThemeContext';
+import { SafeAreaView } from '../../components/ui/SafeAreaView';
 
 export default function NativeWindSmokeScreen() {
   const [text, setText] = useState('');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["jest", "node"],
     "paths": {
       "@/*": ["./src/*"],
       "@components/*": ["./src/components/*"],


### PR DESCRIPTION
## Summary
- add a typed CSS-aware SafeAreaView adapter and migrate every className consumer
- remove duplicate Explore header reservations while preserving local spacing
- harden floating AI button restore, resize, drag, persistence, safe-area, menu-bound, and accessibility behavior
- serialize gesture success/cancellation, clamp animation overshoot, and align open/closed central-button actions

## Verification
- five-lane post-implementation review: all lanes passed
- 7 focused Jest suites: 59/59 tests passed, warning-clean
- focused ESLint: zero errors
- Prettier and git diff --check passed
- source-connected iOS QA verified repaired screen bodies, FAB persistence, bounded four-action hub, second-long-press collapse, open-state central close, and closed-state chat navigation

## Baseline observations
- repository-wide TypeScript checking still reports pre-existing Jest namespace errors in jest.setup.ts and __mocks__/expo-file-system-legacy.ts
- existing theme-parity, Toggle snapshot, and repoStore Jest-global failures reproduce unchanged on main