### PR TITLE
ui: replace DailyQuote card with borderless typographic strip

### DIFF
--- a/src/components/home/DailyQuoteCard.tsx
+++ b/src/components/home/DailyQuoteCard.tsx
@@ -13,6 +13,20 @@ interface DailyQuoteCardProps {
   isRefreshing?: boolean;
 }
 
+/**
+ * Daily Quote strip — a borderless, typographic element that integrates
+ * into the HomeScreen scroll content without feeling like a pasted-in widget.
+ * Replaces the original "card" design.
+ *
+ * Layout:
+ *   [“] Quote text in italics…                      [↻]
+ *       — Philosopher Name
+ *       Small AI-personalized description tied to your journals
+ *
+ * Parent ScrollView already provides horizontal padding (20px), so this
+ * component uses NO horizontal margin — avoiding the nested-box effect
+ * that made the card look like a bolted-on widget.
+ */
 export function DailyQuoteCard({
   quote,
   isLoading,
@@ -23,117 +37,121 @@ export function DailyQuoteCard({
   const { colors } = useTheme();
   const { t } = useTranslation();
 
+  // Feature disabled / no content / not loading → render nothing.
   if (!quote && !isLoading && !error) return null;
 
-  const showSkeleton = isLoading && !quote;
+  // Loading state — small spinner + subtle text.
+  if (isLoading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator color={colors.textSecondary} size="small" />
+        <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+          {t('home.dailyQuote.loading', { defaultValue: 'Finding your quote…' })}
+        </Text>
+      </View>
+    );
+  }
+
+  // Error-only state — muted, non-alarming.
+  if (error && !quote) {
+    return (
+      <View style={styles.container}>
+        <Text style={[styles.errorText, { color: colors.error }]}>{error}</Text>
+      </View>
+    );
+  }
+
+  if (!quote) return null;
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-      <View style={styles.headerRow}>
-        <Ionicons name="sparkles" size={18} color={colors.primary} />
-        <Text style={[styles.title, { color: colors.primary }]}>
-          {t('home.dailyQuote', { defaultValue: 'Daily Wisdom' })}
-        </Text>
-        <View style={styles.spacer} />
+    <View style={styles.container}>
+      <View style={styles.quoteRow}>
+        <View style={styles.quoteIconColumn}>
+          <Text style={[styles.quoteIcon, { color: colors.primary }]}>“</Text>
+        </View>
+        <Text style={[styles.quoteText, { color: colors.text }]}>{quote.text}</Text>
         {onRefresh ? (
           <TouchableOpacity
             onPress={onRefresh}
             disabled={isRefreshing}
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            style={styles.refreshButton}
             accessibilityLabel={t('common.refresh', { defaultValue: 'Refresh' })}
           >
             {isRefreshing ? (
               <ActivityIndicator size="small" color={colors.textSecondary} />
             ) : (
-              <Ionicons name="refresh-outline" size={18} color={colors.textSecondary} />
+              <Ionicons name="refresh-outline" size={14} color={colors.textSecondary} />
             )}
           </TouchableOpacity>
         ) : null}
       </View>
-
-      {showSkeleton ? (
-        <View style={styles.skeletonWrap}>
-          <View style={[styles.skeletonLineLong, { backgroundColor: colors.border }]} />
-          <View style={[styles.skeletonLineShort, { backgroundColor: colors.border }]} />
-          <View style={[styles.skeletonLineMedium, { backgroundColor: colors.border, marginTop: 12 }]} />
-        </View>
-      ) : error ? (
-        <Text style={[styles.errorText, { color: colors.error }]}>{error}</Text>
-      ) : quote ? (
-        <>
-          <Text style={[styles.quoteText, { color: colors.text }]}>
-            &ldquo;{quote.text}&rdquo;
-          </Text>
-          <Text style={[styles.author, { color: colors.primary }]}>— {quote.author}</Text>
-          <Text style={[styles.description, { color: colors.textSecondary }]}>
-            {quote.description}
-          </Text>
-        </>
+      <Text style={[styles.author, { color: colors.primary }]}>— {quote.author}</Text>
+      {quote.description ? (
+        <Text style={[styles.description, { color: colors.textSecondary }]}>
+          {quote.description}
+        </Text>
       ) : null}
     </View>
   );
 }
 
+const TYPOGRAPHY_LEFT = 20 + 6;
+
 const styles = StyleSheet.create({
   container: {
-    margin: 16,
-    marginBottom: 8,
-    borderRadius: 14,
-    padding: 16,
-    borderWidth: 1,
-  },
-  headerRow: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     alignItems: 'center',
-    marginBottom: 10,
+    gap: 8,
+    paddingVertical: 12,
+    marginBottom: 4,
   },
-  title: {
-    fontSize: 11,
+  quoteRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    width: '100%',
+  },
+  quoteIconColumn: {
+    width: 20,
+    marginRight: 6,
+  },
+  quoteIcon: {
+    marginTop: 4,
+    fontSize: 20,
+    lineHeight: 22,
     fontWeight: '700',
-    letterSpacing: 0.8,
-    textTransform: 'uppercase',
-    marginLeft: 6,
   },
-  spacer: { flex: 1 },
   quoteText: {
-    fontSize: 17,
+    flex: 1,
+    fontSize: 15,
     fontStyle: 'italic',
-    lineHeight: 24,
+    lineHeight: 22,
     fontWeight: '500',
   },
+  refreshButton: {
+    padding: 2,
+    marginLeft: 6,
+    marginTop: 2,
+  },
   author: {
-    fontSize: 13,
-    fontWeight: '700',
-    marginTop: 8,
+    fontSize: 12,
+    fontWeight: '600',
+    marginLeft: TYPOGRAPHY_LEFT,
   },
   description: {
-    fontSize: 14,
-    lineHeight: 20,
-    marginTop: 10,
+    fontSize: 13,
+    lineHeight: 18,
+    marginTop: 4,
+    marginLeft: TYPOGRAPHY_LEFT,
+    width: '100%',
+  },
+  loadingText: {
+    fontSize: 13,
+    fontStyle: 'italic',
   },
   errorText: {
     fontSize: 13,
     fontStyle: 'italic',
-  },
-  skeletonWrap: {
-    gap: 8,
-  },
-  skeletonLineLong: {
-    height: 10,
-    width: '95%',
-    borderRadius: 4,
-    opacity: 0.5,
-  },
-  skeletonLineShort: {
-    height: 10,
-    width: '55%',
-    borderRadius: 4,
-    opacity: 0.4,
-  },
-  skeletonLineMedium: {
-    height: 10,
-    width: '80%',
-    borderRadius: 4,
-    opacity: 0.3,
   },
 });

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -173,8 +173,7 @@
   "home": {
     "title": "Start",
     "dailyQuote": {
-      "title": "Tägliche Weisheit",
-      "loading": "Zitat wird gesucht..."
+      "loading": "Zitat wird gesucht…"
     }
   },
   "hints": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -51,8 +51,7 @@
   "home": {
     "title": "Home",
     "dailyQuote": {
-      "title": "Daily Wisdom",
-      "loading": "Finding your quote..."
+      "loading": "Finding your quote…"
     },
     "appTitle": "GitNotēs",
     "subtitle": "Your development notes, organized.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -173,8 +173,7 @@
   "home": {
     "title": "Inicio",
     "dailyQuote": {
-      "title": "Sabiduría Diaria",
-      "loading": "Buscando tu cita..."
+      "loading": "Buscando tu cita…"
     }
   },
   "hints": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -173,8 +173,7 @@
   "home": {
     "title": "Accueil",
     "dailyQuote": {
-      "title": "Sagesse du Jour",
-      "loading": "Recherche de votre citation..."
+      "loading": "Recherche de votre citation…"
     }
   },
   "hints": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -173,8 +173,7 @@
   "home": {
     "title": "ホーム",
     "dailyQuote": {
-      "title": "今日の名言",
-      "loading": "名言を検索中..."
+      "loading": "名言を検索中…"
     }
   },
   "hints": {

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -173,8 +173,7 @@
   "home": {
     "title": "홈",
     "dailyQuote": {
-      "title": "오늘의 지혜",
-      "loading": "명언을 찾는 중..."
+      "loading": "명언을 찾는 중…"
     }
   },
   "hints": {


### PR DESCRIPTION
## Problem

PR #823 introduced the daily quote feature as a bordered card at the top of Home.
After using it, the card feels like a bolted-on widget rather than part of the home screen.

**Specific UX issues:**

1. **Nested-box effect** — The card has  +  + , but
   the HomeScreen ScrollView already provides . This creates ugly double-padding
   and a boxed-in look.
2. **Bugged i18n** — The component used `t('home.dailyQuote')` which is an OBJECT in the
   i18n files (containing `title` & `loading`), not a string. Renders as
   `[object Object]` or blank.
3. **"DAILY WISDOM" caps label** — Dashboard-card aesthetic, too loud for the home page.
4. **Skeleton placeholders** — Overkill for what's essentially 2 lines of text.
5. **Sparkles icon** — Decorative chrome that doesn't aid scanning.
6. **Widget shape** — It's clearly a "card" rather than integrated typography.

## Solution

Replace the card with a **borderless typographic strip**:

```
\u201c Quote text in italics…                     [↻]
   — Philosopher Name
   Small AI-personalized description tied to your journals
```

**Design decisions:**

| Before (Card) | After (Strip) |
|---|---|
| Bordered box, background colored | Borderless, no background, no box |
| `margin: 16` + `padding: 16` | No extra margin — flows inside ScrollView's 20px padding |
| Sparkles icon + caps header | Typographic \u201c left-quote mark at text baseline |
| Skeleton placeholders on loading | Inline `ActivityIndicator` + muted italic text |
| Large refresh icon in header row | Small `refresh-outline` right-aligned, subtle |
| Author under quote | Author + description indented to align with text (not icon) |

**Alignment math:**
- Quote icon (Text \u201c) rendered at 20px fontSize inside a 20px-wide, 6px-margin column
- Author + description get `marginLeft: 26px` (`20 + 6`) so the typography line aligns
- Expressed as `const TYPOGRAPHY_LEFT = 20 + 6` rather than a magic number

## i18n Cleanup

Removed the orphaned `home.dailyQuote.title` key from all 6 language files
(the card had labeled "DAILY WISDOM" but the strip doesn't need a header label).

Only `home.dailyQuote.loading` remains, which the component actually uses for the
loading spinner. The settings keys (`settings.dailyQuote.title` and
`settings.dailyQuoteDescription`) are preserved, still used in SettingsScreen.

Also changed the ellipsis in loading strings from `...` to the proper typographic
ellipsis \u2026 (`\u2026`).

## Edge states handled

| State | Render |
|---|---|
| Feature disabled / AI off + no quote | Nothing (empty component) |
| Loading | Inline spinner + italic loading text |
| Error only (no quote) | Muted italic error text |
| Quote + no description | Quote + author only |
| Quote + description | Full stack: quote → author → description |

## Verification

- `yarn ts:check` passes
- All 6 i18n JSON files validated (node `JSON.parse`)
- `lint-staged` passes (eslint + prettier)

## Files changed

- `src/components/home/DailyQuoteCard.tsx` — rewrote as borderless strip (same export name for back-compat)
- `src/i18n/{en,es,fr,de,ja,ko}.json` — removed unused `home.dailyQuote.title`, kept `loading`

**Note:** Same component export name `DailyQuoteCard` kept intentionally so no
HomeScreen changes are needed — it just receives the same props. Renaming to
`DailyQuoteStrip` is a future cleanup if desired.