### PR TITLE
fix(daily-quote): stabilize useDailyQuote to prevent infinite re-render loop

### DIFF
--- a/src/hooks/useDailyQuote.ts
+++ b/src/hooks/useDailyQuote.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNotes } from '../contexts/NoteContext';
 import { dailyQuoteService, type DailyQuote } from '../services/DailyQuoteService';
 
@@ -15,12 +15,16 @@ export function useDailyQuote(): UseDailyQuoteReturn {
   const [error, setError] = useState<string | null>(null);
   const { notes } = useNotes();
 
+  const notesRef = useRef(notes); // ref so callbacks don't depend on unstable notes array
+  notesRef.current = notes;
+
   const loadQuote = useCallback(async () => {
     try {
       setIsLoading(true);
       setError(null);
-      const journals = notes.filter((n) => n.tags.includes('journal'));
-      const result = await dailyQuoteService.getDailyQuote(journals, notes);
+      const currentNotes = notesRef.current;
+      const journals = currentNotes.filter((n) => n.tags.includes('journal'));
+      const result = await dailyQuoteService.getDailyQuote(journals, currentNotes);
       setQuote(result);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to load daily quote';
@@ -29,14 +33,16 @@ export function useDailyQuote(): UseDailyQuoteReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [notes]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- notes read via ref
+  }, []);
 
   const refresh = useCallback(async () => {
     try {
       setIsLoading(true);
       setError(null);
-      const journals = notes.filter((n) => n.tags.includes('journal'));
-      const result = await dailyQuoteService.regenerate(journals, notes);
+      const currentNotes = notesRef.current;
+      const journals = currentNotes.filter((n) => n.tags.includes('journal'));
+      const result = await dailyQuoteService.regenerate(journals, currentNotes);
       setQuote(result);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to refresh daily quote';
@@ -45,7 +51,8 @@ export function useDailyQuote(): UseDailyQuoteReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [notes]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- notes read via ref
+  }, []);
 
   useEffect(() => {
     loadQuote();


### PR DESCRIPTION
## Problem

`Maximum update depth exceeded` error crashing the app on HomeScreen load (seen in simulator logs alongside ForegroundSync pulls).

Root cause: `useNotes()` returns a **new array reference on every render**. The `useDailyQuote` hook depended on `notes` inside `useCallback` and `useEffect`:

```ts
const loadQuote = useCallback(async () => { ... }, [notes]);  // ← recreates every render
useEffect(() => { loadQuote(); }, [loadQuote]);                // ← fires every render
```

Each render → new `loadQuote` → effect fires → `setIsLoading(true)` → re-render → infinite loop.

## Fix

Replace the `notes` dependency with a `useRef` so callbacks read the latest notes without subscribing to array identity changes. `loadQuote` now runs exactly once on mount; manual `refresh` remains available.

```ts
const notesRef = useRef(notes);
notesRef.current = notes;

const loadQuote = useCallback(async () => {
  const currentNotes = notesRef.current;
  ...
}, []);  // stable — no dep on notes identity
```

## Notes on the logs

- **`makeFallback` doesn't exist`** — already fixed in commit `2150151`; the simulator was running a stale Metro bundle. Rebuild picks up the rename.
- **`[UIKitCore] RCTScrollViewComponentView implements focusItemsInRect:`** — benign React Native iOS warning, not actionable per upstream.

## Tests

- TypeScript compile: clean.
- Jest (ForegroundSyncService + recentItems): 17/17 pass.
