### PR TITLE
feat: Thought Dump home card + daily quote fixes

### DIFF
--- a/src/components/home/DailyQuoteCard.tsx
+++ b/src/components/home/DailyQuoteCard.tsx
@@ -144,7 +144,7 @@ const styles = StyleSheet.create({
     lineHeight: 18,
     marginTop: 4,
     marginLeft: TYPOGRAPHY_LEFT,
-    width: '100%',
+    marginRight: 0,
   },
   loadingText: {
     fontSize: 13,

--- a/src/hooks/useDailyQuote.ts
+++ b/src/hooks/useDailyQuote.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNotes } from '../contexts/NoteContext';
 import { dailyQuoteService, type DailyQuote } from '../services/DailyQuoteService';
+import { useAIStore } from '../stores/aiStore';
 
 interface UseDailyQuoteReturn {
   quote: DailyQuote | null;
@@ -14,6 +15,8 @@ export function useDailyQuote(): UseDailyQuoteReturn {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { notes } = useNotes();
+  const aiIsLoading = useAIStore((s) => s.isLoading);
+  const selectedModelId = useAIStore((s) => s.selectedModelId);
 
   const notesRef = useRef(notes); // ref so callbacks don't depend on unstable notes array
   notesRef.current = notes;
@@ -33,8 +36,8 @@ export function useDailyQuote(): UseDailyQuoteReturn {
     } finally {
       setIsLoading(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- notes read via ref
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- notes read via ref, aiIsLoading intentional dep
+  }, [aiIsLoading, selectedModelId]);
 
   const refresh = useCallback(async () => {
     try {
@@ -55,8 +58,9 @@ export function useDailyQuote(): UseDailyQuoteReturn {
   }, []);
 
   useEffect(() => {
+    if (aiIsLoading) return; // Wait for AI store hydration
     loadQuote();
-  }, [loadQuote]);
+  }, [aiIsLoading, loadQuote]);
 
   return { quote, isLoading, error, refresh };
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -10,6 +10,7 @@
   },
   "common": {
     "beta": "BETA",
+    "new": "NEW",
     "untitled": "Untitled",
     "cannotBeUndone": "This cannot be undone.",
     "later": "Later",
@@ -68,7 +69,8 @@
       "newJournal": "New Journal",
       "fromTemplate": "From Template",
       "fromTemplateSub": "Quick start",
-      "canvasesSub": "Visual notes"
+      "canvasesSub": "Visual notes",
+      "thoughtDumpSub": "Capture fleeting thoughts, raw ideas, and stream-of-consciousness dumps. They stay as searchable Markdown files in your repo and feed AI context."
     }
   },
   "notes": {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -345,6 +345,35 @@ export default function HomeScreen() {
             </View>
           </Pressable>
         </View>
+
+        <Pressable
+          testID="home.button.open-thought-dump"
+          onPress={() => {
+            HapticService.medium();
+            navigation.navigate('ThoughtDump');
+          }}
+          style={({ pressed }) => [
+            { width: '100%', height: 120, borderRadius: 20, padding: 16, overflow: 'hidden', justifyContent: 'flex-end', backgroundColor: colors.accent, opacity: pressed ? 0.92 : 1, transform: [{ scale: pressed ? 0.985 : 1 }] },
+          ]}
+        >
+          <View className="absolute top-4 left-4 w-9 h-9 rounded-full bg-white items-center justify-center">
+            <Ionicons name="bulb-outline" size={18} color={colors.accent} />
+          </View>
+          <View className="absolute" style={{ top: -50, right: -50, opacity: 0.3 }}>
+            <Ionicons name="bulb-outline" size={120} color="#FFFFFF" />
+          </View>
+          <View className="absolute top-4 right-4 bg-emerald-500 px-1.5 py-0.5 rounded">
+            <Text className="text-white font-extrabold" style={{ fontSize: 9, letterSpacing: 0.5 }}>{t('common.new')}</Text>
+          </View>
+          <View className="gap-1">
+            <Text className="text-xl font-bold text-white" style={{ letterSpacing: -0.3 }} numberOfLines={1}>
+              {t('thoughtDump.title')}
+            </Text>
+            <Text className="text-xs font-medium text-white opacity-80" numberOfLines={2}>
+              {t('home.bento.thoughtDumpSub')}
+            </Text>
+          </View>
+        </Pressable>
       </View>
 
       <QuickAccessShelf items={pinnedItems} onOpen={handleOpenRecentItem} onLongPress={handleLongPressRecentItem} />

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -46,6 +46,11 @@ const INFO_STEPS = [
     icon: 'rocket-outline' as const,
   },
   {
+    title: 'Dump Your Thoughts',
+    description: "Thought Dump lets you capture fleeting ideas, half-formed questions, and stream-of-consciousness reflections as Markdown files in your repo. They're indexed for smart search and feed context into your AI chats.",
+    icon: 'bulb-outline' as const,
+  },
+  {
     title: 'Scheduled Learning',
     description: 'Let AI generate daily or weekly learning notes on your topics. You can also get Questioner notes with questions you answer and get graded — perfect for active recall and spaced repetition.',
     icon: 'help-circle-outline' as const,


### PR DESCRIPTION
## Summary
Four targeted improvements to the home screen and daily quote experience.

### Changes

**1. Thought Dump Card on Home Screen** 🆕
- Full-width accent-colored card placed below the existing Template/Canvas rows
- `NEW` badge draws attention to the feature
- Explanation subtitle teaches users what Thought Dump is (since it's a new feature)
- Navigates to the ThoughtDump screen on press

**2. Fix: Quote `no AI model selected` false positive on cold start** 🐛
- Root cause: `useDailyQuote` fetched before `aiStore.loadSettings()` finished hydration
- Fix: subscribe to `aiStore.isLoading` and `selectedModelId`; only fetch when hydration completes; re-fetch when model selection resolves after hydration

**3. Fix: Quote description text margin overflow** 📐  
- Root cause: `description` style had `width: '100%'` combined with `marginLeft: 26px`, causing the description to overflow past the right edge of the container
- Fix: remove `width: '100%'`, add `marginRight: 0` for clarity — lets flex layout constrain width naturally

**4. Onboarding: Thought Dump step added** 📖
- New info step inserted before `Scheduled Learning` in the onboarding flow
- Explains that Thought Dump captures fleeting ideas as Markdown, indexed for smart search and AI context
- `TOTAL_STEPS` auto-adjusts (computed from array length)

### Files Changed
- `src/screens/HomeScreen.tsx` — Thought Dump card
- `src/hooks/useDailyQuote.ts` — AI store hydration guard
- `src/components/home/DailyQuoteCard.tsx` — description margin fix  
- `src/screens/OnboardingScreen.tsx` — Thought Dump onboarding step
- `src/i18n/en.json` — `common.new` and `home.bento.thoughtDumpSub` keys

### Testing
- ✅ `yarn ts:check` (no new TS errors — pre-existing Skia/NativeWind errors unchanged)
- ✅ ThoughtDumpScreen 7/7 tests pass
- ✅ FloatingAIButton hub 10/10 tests pass
- ✅ e2e thought dump loop tests pass
