### PR TITLE
fix: add missing hint for daily quote and AI personalization toggle

### DIFF
--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -809,6 +809,7 @@ onSetSyncIntervalSeconds,
                 onValueChange={onToggleAiPersonalization}
                 disabled={!isAIEnabled}
               />
+              <HintIcon hintKey="hints.settings.aiPersonalization" testID="hint.ai-personalization" />
             </View>
           }
         >

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -202,7 +202,9 @@
       "actionModeConfirm": "KI fragt vor dem Ausführen von Schreiboperationen wie Erstellen oder Löschen von Notizen nach Bestätigung.",
       "chatStorage": "Wähle, in welchem Repository KI-Chat-Unterhaltungen gespeichert werden sollen.",
       "providers": "KI-Anbieter ermöglichen dir, verschiedene KI-Dienste zu verbinden. Apple Intelligence nutzt On-Device-Verarbeitung für Datenschutz.",
-      "scheduledLearning": "KI-Anbieter ermöglichen dir, verschiedene KI-Dienste zu verbinden. Apple Intelligence nutzt On-Device-Verarbeitung für Datenschutz."
+      "scheduledLearning": "KI-Anbieter ermöglichen dir, verschiedene KI-Dienste zu verbinden. Apple Intelligence nutzt On-Device-Verarbeitung für Datenschutz.",
+      "dailyQuote": "Zeigt ein tägliches Philosophenzitat auf deinem Startbildschirm, personalisiert basierend auf deinen letzten Tagebuch-Reflexionen.",
+      "aiPersonalization": "Wenn aktiviert, liest die KI deine Notizen und Tagebücher, um personalisierte Antworten zu liefern. Deaktivieren für Datenschutz — KI verwendet nur den aktuellen Chat-Kontext."
     },
     "title": "Hint"
   },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -721,7 +721,9 @@
       "actionModeConfirm": "AI asks for confirmation before performing write operations like creating or deleting notes.",
       "chatStorage": "Choose which repository to store AI chat conversations in.",
       "providers": "AI providers allow you to connect different AI services. Apple Intelligence uses on-device processing for privacy.",
-      "scheduledLearning": "Schedule daily reviews of notes with specific tags. The app sends reminders to help you learn and remember your notes."
+      "scheduledLearning": "Schedule daily reviews of notes with specific tags. The app sends reminders to help you learn and remember your notes.",
+      "dailyQuote": "Shows a daily philosopher quote on your Home screen, personalized based on your recent journal reflections.",
+      "aiPersonalization": "When enabled, AI reads your notes and journals to provide personalized responses. Turn off for data privacy — AI will only use the current chat context."
     },
     "title": "Hint"
   },

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -202,7 +202,9 @@
       "actionModeConfirm": "La IA pide confirmación antes de realizar operaciones de escritura como crear o eliminar notas.",
       "chatStorage": "Elige en qué repositorio almacenar las conversaciones de chat IA.",
       "providers": "Los proveedores IA te permiten conectar diferentes servicios de IA. Apple Intelligence usa procesamiento en el dispositivo para mayor privacidad.",
-      "scheduledLearning": "Los proveedores IA te permiten conectar diferentes servicios de IA. Apple Intelligence usa procesamiento en el dispositivo para mayor privacidad."
+      "scheduledLearning": "Los proveedores IA te permiten conectar diferentes servicios de IA. Apple Intelligence usa procesamiento en el dispositivo para mayor privacidad.",
+      "dailyQuote": "Muestra una cita filosófica diaria en tu pantalla de inicio, personalizada según tus reflexiones recientes de diario.",
+      "aiPersonalization": "Cuando está activada, la IA lee tus notas y diarios para ofrecer respuestas personalizadas. Desactiva para mayor privacidad — la IA solo usará el contexto del chat actual."
     },
     "title": "Hint"
   },

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -202,7 +202,9 @@
       "actionModeConfirm": "L'IA demande confirmation avant d'effectuer des opérations d'écriture comme créer ou supprimer des notes.",
       "chatStorage": "Choisissez dans quel dépôt stocker les conversations de chat IA.",
       "providers": "Les fournisseurs IA vous permettent de connecter différents services IA. Apple Intelligence utilise le traitement sur appareil pour la confidentialité.",
-      "scheduledLearning": "Les fournisseurs IA vous permettent de connecter différents services IA. Apple Intelligence utilise le traitement sur appareil pour la confidentialité."
+      "scheduledLearning": "Les fournisseurs IA vous permettent de connecter différents services IA. Apple Intelligence utilise le traitement sur appareil pour la confidentialité.",
+      "dailyQuote": "Affiche une citation philosophique quotidienne sur votre écran d'accueil, personnalisée en fonction de vos réflexions récentes dans le journal.",
+      "aiPersonalization": "Lorsqu'activée, l'IA lit vos notes et journaux pour fournir des réponses personnalisées. Désactivez pour la confidentialité — l'IA utilisera uniquement le contexte du chat actuel."
     },
     "title": "Hint"
   },

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -202,7 +202,9 @@
       "actionModeConfirm": "AIはノートを作成や削除などの書き込み操作の前に確認を求めます。",
       "chatStorage": "AIチャット会話を保存するリポジトリを選びます。",
       "providers": "AIプロバイダーはさまざまなAIサービスを接続できます。Apple Intelligenceはプライバシーのためオンデバイス処理を使用します。",
-      "scheduledLearning": "AIプロバイダーはさまざまなAIサービスを接続できます。Apple Intelligenceはプライバシーのためオンデバイス処理を使用します。"
+      "scheduledLearning": "AIプロバイダーはさまざまなAIサービスを接続できます。Apple Intelligenceはプライバシーのためオンデバイス処理を使用します。",
+      "dailyQuote": "ホーム画面に日替わりの哲学的な名言を表示します。最近の日記の振り返りに基づいてパーソナライズされます。",
+      "aiPersonalization": "有効にすると、AIはノートと日記を読んでパーソナライズされた応答を提供します。プライバシーのためにオフにすると、AIは現在のチャットコンテキストのみを使用します。"
     },
     "title": "Hint"
   },

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -202,7 +202,9 @@
       "actionModeConfirm": "AI는 노트 생성 또는 삭제와 같은 쓰기 작업을 수행하기 전에 확인을 요청합니다.",
       "chatStorage": "AI 채팅 대화를 저장할 리포지토리를 선택하세요.",
       "providers": "AI 공급자를 사용하면 다양한 AI 서비스를 연결할 수 있습니다. Apple Intelligence는 개인정보 보호를 위해 온디바이스 처리를 사용합니다.",
-      "scheduledLearning": "AI 공급자를 사용하면 다양한 AI 서비스를 연결할 수 있습니다. Apple Intelligence는 개인정보 보호를 위해 온디바이스 처리를 사용합니다."
+      "scheduledLearning": "AI 공급자를 사용하면 다양한 AI 서비스를 연결할 수 있습니다. Apple Intelligence는 개인정보 보호를 위해 온디바이스 처리를 사용합니다.",
+      "dailyQuote": "홈 화면에 일일 철학자 명언을 표시합니다. 최근 일기 성찰을 기반으로 맞춤화됩니다.",
+      "aiPersonalization": "활성화하면 AI가 노트와 일기를 읽어 맞춤화된 응답을 제공합니다. 데이터 프라이버시를 위해 끄면 AI는 현재 채팅 컨텍스트만 사용합니다."
     },
     "title": "Hint"
   },


### PR DESCRIPTION
## Summary

Two hint bugs in Settings → AI section:

### Bug 1: Daily Quote hint showing raw key
The `HintIcon` on the Daily Quote toggle referenced `hints.settings.dailyQuote` — a key that didn't exist in any of the 6 i18n files. i18next falls back to showing the raw key string (`hints.settings.dailyQuote`) instead of a human-readable explanation.

### Bug 2: AI Personalization toggle missing hint entirely
The "Personalize AI with my notes" toggle had no `HintIcon` at all, leaving users without any in-app explanation of what the toggle does and its data safety implications.

## Changes

| File | Change |
|------|--------|
| `src/i18n/{en,es,de,ja,ko,fr}.json` | Added `hints.settings.dailyQuote` and `hints.settings.aiPersonalization` keys |
| `src/components/settings/SettingsContent.tsx` | Added `<HintIcon hintKey="hints.settings.aiPersonalization" />` to AI personalization trailing slot |

## Verification
- [x] `yarn ts:check` passes
- [x] JSON valid in all 6 language files (verified via Node script)
- [x] Hint pattern matches existing HintIcon usage (e.g. daily quote, dark mode, biometric lock)