### PR TITLE
fix(home): improve thought dump card layout (no icon text overlap, no cropped subtitle)

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -378,23 +378,20 @@ export default function HomeScreen() {
             navigation.navigate('ThoughtDump');
           }}
           style={({ pressed }) => [
-            { width: '100%', height: 120, borderRadius: 20, padding: 16, overflow: 'hidden', justifyContent: 'flex-end', backgroundColor: colors.accent, opacity: pressed ? 0.92 : 1, transform: [{ scale: pressed ? 0.985 : 1 }] },
+            { width: '100%', height: 130, borderRadius: 20, paddingLeft: 16, paddingRight: 16, paddingBottom: 16, paddingTop: 20, justifyContent: 'space-between', overflow: 'hidden', backgroundColor: colors.accent, opacity: pressed ? 0.92 : 1, transform: [{ scale: pressed ? 0.985 : 1 }] },
           ]}
         >
-          <View className="absolute top-4 left-4 w-9 h-9 rounded-full bg-white items-center justify-center">
-            <Ionicons name="bulb-outline" size={18} color={colors.accent} />
+          <View className="w-10 h-10 rounded-md items-center justify-center" style={{ backgroundColor: 'rgba(255,255,255,0.2)' }}>
+            <Ionicons name="bulb-outline" size={22} color="#FFFFFF" />
           </View>
-          <View className="absolute" style={{ top: -50, right: -50, opacity: 0.3 }}>
-            <Ionicons name="bulb-outline" size={120} color="#FFFFFF" />
-          </View>
-          <View className="absolute top-4 right-4 bg-emerald-500 px-1.5 py-0.5 rounded">
-            <Text className="text-white font-extrabold" style={{ fontSize: 9, letterSpacing: 0.5 }}>{t('common.new')}</Text>
-          </View>
-          <View className="gap-1">
-            <Text className="text-xl font-bold text-white" style={{ letterSpacing: -0.3 }} numberOfLines={1}>
-              {t('thoughtDump.title')}
-            </Text>
-            <Text className="text-xs font-medium text-white opacity-80" numberOfLines={2}>
+          <View className="gap-0.5">
+            <View className="flex-row items-center gap-1.5">
+              <Text className="text-base font-bold" style={{ color: '#FFFFFF', letterSpacing: -0.2 }}>{t('thoughtDump.title')}</Text>
+              <View className="bg-emerald-500 px-1.5 py-0.5 rounded">
+                <Text className="text-white font-extrabold" style={{ fontSize: 9, letterSpacing: 0.5 }}>{t('common.new')}</Text>
+              </View>
+            </View>
+            <Text className="text-xs font-medium" style={{ color: 'rgba(255,255,255,0.85)' }} numberOfLines={2}>
               {t('home.bento.thoughtDumpSub')}
             </Text>
           </View>


### PR DESCRIPTION
## Summary

Fixes the Thought Dump home-screen card layout where:
1. The Record (bulb) icon was overlapping the title text
2. The 2-line subtitle was cropped/truncated

## Changes (src/screens/HomeScreen.tsx)

Restructured the Thought Dump card to match the existing template/canvases card pattern:

- **Removed** absolute-positioned icon + decorative background bulb + floating NEW badge
- **Added** structured flex layout: icon in rounded-md container at top, text section below
- Changed `justifyContent` from `flex-end` to `space-between` (icon at top, text at bottom)
- Split padding: `paddingLeft: 16, paddingRight: 16, paddingBottom: 16, paddingTop: 20`
- Increased height from 120 to 130 (matches template card)
- NEW badge is now inline with the title (flex-row, gap-1.5)
- Subtitle has full horizontal width so `numberOfLines={2}` renders completely
- Title size adjusted from xl to base for better vertical proportions

## Visual

Before:
```
┌──────────────────────────────────┐
│ 🡲  (icon, absolute)     [NEW]   │
│                                  │
│           (decorative bulb, 120px│
│            clipped behind)       │
│                                  │
│ Thought Dump [cropped here]      │
│ Capture fleeting... [cut off]    │
└──────────────────────────────────┘
```

After:
```
┌──────────────────────────────────┐
│ ┌──────┐                         │
│ │  🡲   │                         │
│ └──────┘                         │
│                                  │
│ Thought Dump  [NEW]              │
│ Capture fleeting thoughts, raw   │
│ ideas, and stream-of-conscious.. │
└──────────────────────────────────┘
```

## Verification

- `yarn ts:check` — 0 errors ✓
- `lint-staged` (eslint + prettier) — passed on pre-commit hook ✓
- Icon in rounded container matches template card aesthetic
- Subtitle renders full 2 lines without cropping
- No icon/text overlap (icon is in flow, not absolute)