### PR TITLE
feat: voice thought dump + floating hub voice button + visual hierarchy

### DIFF
--- a/__tests__/FloatingAIButton.hub.test.tsx
+++ b/__tests__/FloatingAIButton.hub.test.tsx
@@ -155,7 +155,7 @@ jest.mock('react-native-gesture-handler', () => {
 import { FloatingAIButton } from '../src/components/ai/FloatingAIButton';
 import { useAIHubStore } from '../src/stores/aiHubStore';
 
-type HubHelper = 'goNewChat' | 'goChatHistory' | 'goAISettings' | 'goThoughtDump';
+type HubHelper = 'goNewChat' | 'goChatHistory' | 'goAISettings' | 'goThoughtDump' | 'goVoiceDump';
 interface HubActionCase {
   readonly itemId: string;
   readonly label: string;
@@ -164,6 +164,7 @@ interface HubActionCase {
 
 const HUB_ACTION_CASES = [
   { itemId: 'new-chat', label: 'New chat', helper: 'goNewChat' },
+  { itemId: 'voice-dump', label: 'Voice dump', helper: 'goVoiceDump' },
   { itemId: 'chat-history', label: 'Chat history', helper: 'goChatHistory' },
   { itemId: 'ai-settings', label: 'AI settings', helper: 'goAISettings' },
   { itemId: 'thought-dump', label: 'Thought dump', helper: 'goThoughtDump' },
@@ -232,7 +233,7 @@ describe('FloatingAIButton liquid hub', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('shows all four hub items after a long press without navigating', async () => {
+  it('shows all five hub items after a long press without navigating', async () => {
     const { getByRole, getByTestId } = await renderInitializedFloatingAIButton();
 
     fireEvent(getByTestId('floating-ai.button.navigate-chat'), 'longPress');

--- a/__tests__/FloatingAIButton.test.tsx
+++ b/__tests__/FloatingAIButton.test.tsx
@@ -221,12 +221,12 @@ describe('FloatingAIButton', () => {
     await waitFor(() => {
       expect(AsyncStorage.getItem).toHaveBeenCalledWith('ai-button-position');
       expect(mockSharedValues[0]?.value).toBe(16);
-      expect(mockSharedValues[1]?.value).toBe(108);
+      expect(mockSharedValues[1]?.value).toBe(168);
       expect(mockSharedValues[2]?.value).toBe(16);
-      expect(mockSharedValues[3]?.value).toBe(108);
+      expect(mockSharedValues[3]?.value).toBe(168);
       expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
         'ai-button-position',
-        JSON.stringify({ x: 16, y: 108 }),
+        JSON.stringify({ x: 16, y: 168 }),
       );
     });
   });
@@ -239,28 +239,28 @@ describe('FloatingAIButton', () => {
 
     await waitFor(() => {
       expect(mockSharedValues[0]?.value).toBe(248);
-      expect(mockSharedValues[1]?.value).toBe(156);
+      expect(mockSharedValues[1]?.value).toBe(96);
       expect(mockSharedValues[2]?.value).toBe(248);
-      expect(mockSharedValues[3]?.value).toBe(156);
+      expect(mockSharedValues[3]?.value).toBe(96);
     });
   });
 
   it('keeps persisted right-side coordinates on the right edge', async () => {
-    await AsyncStorage.setItem('ai-button-position', JSON.stringify({ x: 260, y: 140 }));
+    await AsyncStorage.setItem('ai-button-position', JSON.stringify({ x: 260, y: 180 }));
 
     render(<FloatingAIButton currentRouteName="Home" />);
 
     await waitFor(() => {
       expect(mockSharedValues[0]?.value).toBe(248);
-      expect(mockSharedValues[1]?.value).toBe(140);
+      expect(mockSharedValues[1]?.value).toBe(180);
       expect(mockSharedValues[2]?.value).toBe(248);
-      expect(mockSharedValues[3]?.value).toBe(140);
+      expect(mockSharedValues[3]?.value).toBe(180);
     });
   });
 
   it.each([
-    { tabBarHeight: 40, expectedY: 276 },
-    { tabBarHeight: 148, expectedY: 228 },
+    { tabBarHeight: 40, expectedY: 216 },
+    { tabBarHeight: 148, expectedY: 168 },
   ])(
     'uses max(tabBarHeight, 100) bottom clearance for height $tabBarHeight',
     async ({ tabBarHeight, expectedY }) => {
@@ -279,19 +279,19 @@ describe('FloatingAIButton', () => {
   it('re-normalizes the saved and rendered position when the viewport shrinks', async () => {
     await AsyncStorage.setItem('ai-button-position', JSON.stringify({ x: 260, y: 324 }));
     const { rerender } = render(<FloatingAIButton currentRouteName="Home" />);
-    await waitFor(() => expect(mockSharedValues[1]?.value).toBe(276));
+    await waitFor(() => expect(mockSharedValues[1]?.value).toBe(216));
 
     mockWindowDimensions = { width: 280, height: 360, scale: 2, fontScale: 1 };
     rerender(<FloatingAIButton currentRouteName="Home" />);
 
     await waitFor(() => {
       expect(mockSharedValues[0]?.value).toBe(208);
-      expect(mockSharedValues[1]?.value).toBe(156);
+      expect(mockSharedValues[1]?.value).toBe(96);
       expect(mockSharedValues[2]?.value).toBe(208);
-      expect(mockSharedValues[3]?.value).toBe(156);
+      expect(mockSharedValues[3]?.value).toBe(96);
       expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
         'ai-button-position',
-        JSON.stringify({ x: 208, y: 156 }),
+        JSON.stringify({ x: 208, y: 96 }),
       );
     });
   });
@@ -310,9 +310,9 @@ describe('FloatingAIButton', () => {
 
     await waitFor(() => {
       expect(mockSharedValues[0]?.value).toBe(208);
-      expect(mockSharedValues[1]?.value).toBe(156);
+      expect(mockSharedValues[1]?.value).toBe(96);
       expect(mockSharedValues[2]?.value).toBe(208);
-      expect(mockSharedValues[3]?.value).toBe(156);
+      expect(mockSharedValues[3]?.value).toBe(96);
     });
 
     expect(mockPanBegin).toBeDefined();
@@ -332,20 +332,20 @@ describe('FloatingAIButton', () => {
     await flushRunOnJSCallbacks();
 
     expect(mockSharedValues[0]?.value).toBe(208);
-    expect(mockSharedValues[1]?.value).toBe(104);
+    expect(mockSharedValues[1]?.value).toBe(96);
     expect(mockSharedValues[2]?.value).toBe(208);
-    expect(mockSharedValues[3]?.value).toBe(104);
+    expect(mockSharedValues[3]?.value).toBe(96);
     expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'ai-button-position',
-      JSON.stringify({ x: 208, y: 104 }),
+      JSON.stringify({ x: 208, y: 96 }),
     );
   });
 
   it('does not normalize or persist a canceled endpoint before latest-geometry recovery', async () => {
     const { rerender } = render(<FloatingAIButton currentRouteName="Home" />);
     await waitFor(() => expect(mockPanBegin).toBeDefined());
-    await waitFor(() => expect(mockSharedValues[1]?.value).toBe(276));
+    await waitFor(() => expect(mockSharedValues[1]?.value).toBe(216));
     jest.mocked(AsyncStorage.setItem).mockClear();
 
     act(() => {
@@ -357,29 +357,29 @@ describe('FloatingAIButton', () => {
     rerender(<FloatingAIButton currentRouteName="Home" />);
 
     expect(mockSharedValues[0]?.value).toBe(68);
-    expect(mockSharedValues[1]?.value).toBe(236);
+    expect(mockSharedValues[1]?.value).toBe(176);
     expect(mockSharedValues[2]?.value).toBe(248);
-    expect(mockSharedValues[3]?.value).toBe(276);
+    expect(mockSharedValues[3]?.value).toBe(216);
 
     act(() => mockPanEnd?.(false));
 
     expect(mockSharedValues[0]?.value).toBe(68);
-    expect(mockSharedValues[1]?.value).toBe(236);
+    expect(mockSharedValues[1]?.value).toBe(176);
     expect(mockSharedValues[2]?.value).toBe(248);
-    expect(mockSharedValues[3]?.value).toBe(276);
+    expect(mockSharedValues[3]?.value).toBe(216);
     expect(AsyncStorage.setItem).not.toHaveBeenCalled();
 
     act(() => mockPanFinalize?.(false));
     await flushRunOnJSCallbacks();
 
     expect(mockSharedValues[0]?.value).toBe(208);
-    expect(mockSharedValues[1]?.value).toBe(156);
+    expect(mockSharedValues[1]?.value).toBe(96);
     expect(mockSharedValues[2]?.value).toBe(208);
-    expect(mockSharedValues[3]?.value).toBe(156);
+    expect(mockSharedValues[3]?.value).toBe(96);
     expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'ai-button-position',
-      JSON.stringify({ x: 208, y: 156 }),
+      JSON.stringify({ x: 208, y: 96 }),
     );
   });
 
@@ -422,12 +422,12 @@ describe('FloatingAIButton', () => {
     });
 
     expect(mockSharedValues[0]?.value).toBe(16);
-    expect(mockSharedValues[1]?.value).toBe(276);
+    expect(mockSharedValues[1]?.value).toBe(216);
     expect(mockSharedValues[2]?.value).toBe(16);
-    expect(mockSharedValues[3]?.value).toBe(276);
+    expect(mockSharedValues[3]?.value).toBe(216);
     expect(mockSpringCalls).toEqual([
       [16, expect.objectContaining({ overshootClamping: true })],
-      [276, expect.objectContaining({ overshootClamping: true })],
+      [216, expect.objectContaining({ overshootClamping: true })],
     ]);
   });
 
@@ -448,12 +448,12 @@ describe('FloatingAIButton', () => {
 
     // Then
     expect(mockSharedValues[0]?.value).toBe(16);
-    expect(mockSharedValues[1]?.value).toBe(108);
+    expect(mockSharedValues[1]?.value).toBe(168);
     expect(mockSharedValues[2]?.value).toBe(16);
-    expect(mockSharedValues[3]?.value).toBe(108);
+    expect(mockSharedValues[3]?.value).toBe(168);
     expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
       'ai-button-position',
-      JSON.stringify({ x: 16, y: 108 }),
+      JSON.stringify({ x: 16, y: 168 }),
     );
     expect(getByTestId('floating-ai.button.navigate-chat').props.accessibilityState).toEqual({
       expanded: true,
@@ -476,9 +476,9 @@ describe('FloatingAIButton', () => {
     // Then
     await waitFor(() => {
       expect(mockSharedValues[0]?.value).toBe(248);
-      expect(mockSharedValues[1]?.value).toBe(276);
+      expect(mockSharedValues[1]?.value).toBe(216);
       expect(mockSharedValues[2]?.value).toBe(248);
-      expect(mockSharedValues[3]?.value).toBe(276);
+      expect(mockSharedValues[3]?.value).toBe(216);
     });
   });
 

--- a/__tests__/ThoughtDumpScreen.test.tsx
+++ b/__tests__/ThoughtDumpScreen.test.tsx
@@ -32,11 +32,29 @@ jest.mock('react-native-safe-area-context', () => ({
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ goBack: jest.fn() }),
+  useRoute: () => ({ params: {} }),
 }));
 
 jest.mock('@expo/vector-icons', () => ({
   Ionicons: () => null,
 }));
+
+jest.mock('../src/components/VoiceInputModal', () => {
+  const React = require('react');
+  const { View, TouchableOpacity, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ visible, onClose }: any) =>
+      visible ? (
+        <View testID="voice-input-modal">
+          <TouchableOpacity testID="voice-input-modal.button.close-unavailable" onPress={onClose}>
+            <Text>close</Text>
+          </TouchableOpacity>
+          <Text>Voice Input Modal Mock</Text>
+        </View>
+      ) : null,
+  };
+});
 
 jest.mock('../src/contexts/ThemeContext', () => ({
   useTokens: () => ({
@@ -268,6 +286,34 @@ describe('ThoughtDumpScreen', () => {
 
     await waitFor(() => {
       expect(queryByTestId('modal')).toBeNull();
+    });
+  });
+
+  it('renders voice input button with correct accessibility label', async () => {
+    const { getByTestId, getByLabelText } = render(<ThoughtDumpScreen />);
+
+    await waitFor(() => {
+      const voiceButton = getByTestId('thought-dump-voice');
+      expect(voiceButton).toBeTruthy();
+    });
+
+    const voiceButton = getByLabelText('thoughtDump.voiceInput');
+    expect(voiceButton).toBeTruthy();
+  });
+
+  it('pressing voice button opens VoiceInputModal', async () => {
+    const { getByTestId, queryByTestId } = render(<ThoughtDumpScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('thought-dump-voice')).toBeTruthy();
+    });
+
+    expect(queryByTestId('voice-input-modal')).toBeNull();
+
+    fireEvent.press(getByTestId('thought-dump-voice'));
+
+    await waitFor(() => {
+      expect(getByTestId('voice-input-modal.button.close-unavailable')).toBeTruthy();
     });
   });
 });

--- a/__tests__/e2e-thought-dump-loop.test.tsx
+++ b/__tests__/e2e-thought-dump-loop.test.tsx
@@ -191,6 +191,7 @@ jest.mock('@react-navigation/native', () => ({
     navigate: jest.fn(),
     goBack: jest.fn(),
   })),
+  useRoute: jest.fn(() => ({ params: {} })),
 }));
 
 jest.mock('react-native-safe-area-context', () => {

--- a/__tests__/floatingAIButtonGeometry.test.ts
+++ b/__tests__/floatingAIButtonGeometry.test.ts
@@ -34,22 +34,22 @@ const DIRECTION_CASES = [
   {
     horizontalDirection: 1,
     verticalDirection: 1,
-    expectedBounds: { minX: 16, maxX: 142, minY: 108, maxY: 224 },
+    expectedBounds: { minX: 16, maxX: 136, minY: 168, maxY: 216 },
   },
   {
     horizontalDirection: 1,
     verticalDirection: -1,
-    expectedBounds: { minX: 16, maxX: 142, minY: 160, maxY: 276 },
+    expectedBounds: { minX: 16, maxX: 136, minY: 168, maxY: 216 },
   },
   {
     horizontalDirection: -1,
     verticalDirection: 1,
-    expectedBounds: { minX: 122, maxX: 248, minY: 108, maxY: 224 },
+    expectedBounds: { minX: 128, maxX: 248, minY: 168, maxY: 216 },
   },
   {
     horizontalDirection: -1,
     verticalDirection: -1,
-    expectedBounds: { minX: 122, maxX: 248, minY: 160, maxY: 276 },
+    expectedBounds: { minX: 128, maxX: 248, minY: 168, maxY: 216 },
   },
 ] as const satisfies readonly DirectionCase[];
 
@@ -130,7 +130,7 @@ describe('floating AI hub geometry', () => {
     },
   );
 
-  it('preserves the snapped edge and flips expansion when the center preference cannot fit', () => {
+  it('preserves the snapped edge when the center preference cannot fit', () => {
     // Given
     const asymmetricGeometry: FloatingButtonGeometry = {
       ...STANDARD_GEOMETRY,
@@ -145,7 +145,7 @@ describe('floating AI hub geometry', () => {
 
     // Then
     expect(placement.position.x).toBe(140);
-    expect(placement.horizontalDirection).toBe(1);
+    expect(placement.horizontalDirection).toBe(-1);
   });
 
   it.each([

--- a/src/components/ai/FloatingAIButton.tsx
+++ b/src/components/ai/FloatingAIButton.tsx
@@ -191,6 +191,8 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
           iconColor={colors.surface}
           labelColor={colors.text}
           surfaceColor={colors.elevated}
+          accentColor={colors.accent}
+          mutedColor={colors.textSecondary}
           onItemPress={handleMenuItemPress}
         />
 

--- a/src/components/ai/FloatingAIButton.tsx
+++ b/src/components/ai/FloatingAIButton.tsx
@@ -143,6 +143,9 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
       case 'thought-dump':
         hub.goThoughtDump(navigation);
         return;
+      case 'voice-dump':
+        hub.goVoiceDump(navigation);
+        return;
       default:
         return itemId;
     }

--- a/src/components/ai/FloatingAIHubMenu.tsx
+++ b/src/components/ai/FloatingAIHubMenu.tsx
@@ -45,15 +45,23 @@ export const MENU_SPRING = {
 interface HubItemContent {
   readonly label: string;
   readonly icon: keyof typeof Ionicons.glyphMap;
+  readonly sizeTier: 'large' | 'medium' | 'small';
+  readonly colorGroup: 'primary' | 'accent' | 'muted';
 }
 
 const HUB_ITEM_CONTENT = {
-  'new-chat': { label: 'New chat', icon: 'add' },
-  'voice-dump': { label: 'Voice dump', icon: 'mic' },
-  'chat-history': { label: 'Chat history', icon: 'chatbubbles-outline' },
-  'ai-settings': { label: 'AI settings', icon: 'options-outline' },
-  'thought-dump': { label: 'Thought dump', icon: 'bulb-outline' },
+  'new-chat': { label: 'New chat', icon: 'add', sizeTier: 'large', colorGroup: 'primary' },
+  'voice-dump': { label: 'Voice dump', icon: 'mic', sizeTier: 'large', colorGroup: 'primary' },
+  'chat-history': { label: 'Chat history', icon: 'chatbubbles-outline', sizeTier: 'small', colorGroup: 'muted' },
+  'ai-settings': { label: 'AI settings', icon: 'options-outline', sizeTier: 'small', colorGroup: 'muted' },
+  'thought-dump': { label: 'Thought dump', icon: 'bulb-outline', sizeTier: 'medium', colorGroup: 'accent' },
 } as const satisfies Record<HubItemId, HubItemContent>;
+
+const SIZE_TIERS = {
+  large: { size: 56, iconSize: 24 },
+  medium: { size: 50, iconSize: 22 },
+  small: { size: 46, iconSize: 18 },
+} as const;
 
 interface MenuGeometryProps {
   readonly item: FloatingAIHubItem;
@@ -82,6 +90,9 @@ function LiquidSatellite({
 interface HubMenuItemProps extends MenuGeometryProps {
   readonly iconColor: string;
   readonly onPress: (itemId: HubItemId) => void;
+  readonly primaryColor: string;
+  readonly accentColor: string;
+  readonly mutedColor: string;
 }
 
 function HubMenuItem({
@@ -91,8 +102,18 @@ function HubMenuItem({
   progress,
   iconColor,
   onPress,
+  primaryColor,
+  accentColor,
+  mutedColor,
 }: HubMenuItemProps) {
   const content = HUB_ITEM_CONTENT[item.id];
+  const tier = SIZE_TIERS[content.sizeTier];
+  const backgroundColor =
+    content.colorGroup === 'primary'
+      ? primaryColor
+      : content.colorGroup === 'accent'
+        ? accentColor
+        : mutedColor;
   const animatedStyle = useAnimatedStyle(() => ({
     opacity: progress.value,
     transform: [
@@ -102,16 +123,36 @@ function HubMenuItem({
     ],
   }));
 
+  const buttonStyle = {
+    width: tier.size,
+    height: tier.size,
+    borderRadius: RADII.pill,
+    backgroundColor,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+  };
+
+  const anchorStyle = {
+    width: FLOATING_AI_HUB_SATELLITE_SIZE,
+    height: FLOATING_AI_HUB_SATELLITE_SIZE,
+    position: 'absolute' as const,
+    left: (FLOATING_AI_BUTTON_SIZE - FLOATING_AI_HUB_SATELLITE_SIZE) / 2,
+    top: (FLOATING_AI_BUTTON_SIZE - FLOATING_AI_HUB_SATELLITE_SIZE) / 2,
+    zIndex: 2,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+  };
+
   return (
-    <Animated.View style={[styles.satelliteAnchor, animatedStyle]}>
+    <Animated.View style={[anchorStyle, animatedStyle]}>
       <Pressable
         testID={`floating-ai.hub.${item.id}`}
         accessibilityRole="button"
         accessibilityLabel={content.label}
         onPress={() => onPress(item.id)}
-        style={styles.satelliteButton}
+        style={buttonStyle}
       >
-        <Ionicons name={content.icon} size={22} color={iconColor} />
+        <Ionicons name={content.icon} size={tier.iconSize} color={iconColor} />
       </Pressable>
     </Animated.View>
   );
@@ -127,6 +168,8 @@ interface FloatingAIHubMenuProps {
   readonly iconColor: string;
   readonly labelColor: string;
   readonly surfaceColor: string;
+  readonly accentColor: string;
+  readonly mutedColor: string;
   readonly onItemPress: (itemId: HubItemId) => void;
 }
 
@@ -138,6 +181,8 @@ export function FloatingAIHubMenu({
   progress,
   primaryColor,
   iconColor,
+  accentColor,
+  mutedColor,
   onItemPress,
 }: FloatingAIHubMenuProps) {
   return (
@@ -183,6 +228,9 @@ export function FloatingAIHubMenu({
           verticalDirection={verticalDirection}
           progress={progress}
           iconColor={iconColor}
+          primaryColor={primaryColor}
+          accentColor={accentColor}
+          mutedColor={mutedColor}
           onPress={onItemPress}
         />
       ))}

--- a/src/components/ai/FloatingAIHubMenu.tsx
+++ b/src/components/ai/FloatingAIHubMenu.tsx
@@ -49,6 +49,7 @@ interface HubItemContent {
 
 const HUB_ITEM_CONTENT = {
   'new-chat': { label: 'New chat', icon: 'add' },
+  'voice-dump': { label: 'Voice dump', icon: 'mic' },
   'chat-history': { label: 'Chat history', icon: 'chatbubbles-outline' },
   'ai-settings': { label: 'AI settings', icon: 'options-outline' },
   'thought-dump': { label: 'Thought dump', icon: 'bulb-outline' },

--- a/src/components/ai/FloatingAIHubMenu.tsx
+++ b/src/components/ai/FloatingAIHubMenu.tsx
@@ -23,7 +23,7 @@ import {
   type MenuDirection,
 } from './floatingAIButtonGeometry';
 
-const LIQUID_CANVAS_SIZE = 296;
+const LIQUID_CANVAS_SIZE = 340;
 const LIQUID_CANVAS_INSET = (
   LIQUID_CANVAS_SIZE - FLOATING_AI_BUTTON_SIZE
 ) / 2;

--- a/src/components/ai/floatingAIButtonGeometry.ts
+++ b/src/components/ai/floatingAIButtonGeometry.ts
@@ -1,7 +1,7 @@
 export const FLOATING_AI_BUTTON_SIZE = 56;
 export const FLOATING_AI_HUB_SATELLITE_SIZE = 52;
 
-export type HubItemId = 'new-chat' | 'chat-history' | 'ai-settings' | 'thought-dump';
+export type HubItemId = 'new-chat' | 'voice-dump' | 'chat-history' | 'ai-settings' | 'thought-dump';
 export type MenuDirection = -1 | 1;
 
 export interface FloatingAIHubItem {
@@ -11,10 +11,11 @@ export interface FloatingAIHubItem {
 }
 
 export const FLOATING_AI_HUB_ITEMS = [
-  { id: 'new-chat', x: 70, y: 102 },
-  { id: 'chat-history', x: 96, y: 52 },
-  { id: 'ai-settings', x: 108, y: 2 },
-  { id: 'thought-dump', x: 96, y: -50 },
+  { id: 'thought-dump', x: 64, y: -110 },
+  { id: 'ai-settings', x: 104, y: -58 },
+  { id: 'chat-history', x: 114, y: 0 },
+  { id: 'voice-dump', x: 104, y: 58 },
+  { id: 'new-chat', x: 64, y: 110 },
 ] as const satisfies readonly FloatingAIHubItem[];
 
 export interface FloatingButtonPosition {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -543,6 +543,9 @@
     "confirmDelete": "Diese Gedankenablage löschen? Dies kann nicht rückgängig gemacht werden.",
     "empty": "Noch keine Gedankenablagen",
     "error": "Etwas ist schiefgelaufen. Bitte erneut versuchen.",
-    "justNow": "gerade eben"
+    "justNow": "gerade eben",
+    "voiceInput": "Spracheingabe",
+    "voiceUnavailable": "Spracheingabe nicht verfügbar",
+    "voiceDump": "Sprachablage"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -759,6 +759,9 @@
     "confirmDelete": "Delete this thought dump? This cannot be undone.",
     "empty": "No thought dumps yet",
     "error": "Something went wrong. Please try again.",
-    "justNow": "just now"
+    "justNow": "just now",
+    "voiceInput": "Voice input",
+    "voiceUnavailable": "Voice input not available",
+    "voiceDump": "Voice dump"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -543,6 +543,9 @@
     "confirmDelete": "¿Eliminar este vaciado de pensamientos? No se puede deshacer.",
     "empty": "Aún no hay vaciados de pensamientos",
     "error": "Algo salió mal. Inténtalo de nuevo.",
-    "justNow": "ahora mismo"
+    "justNow": "ahora mismo",
+    "voiceInput": "Entrada de voz",
+    "voiceUnavailable": "Entrada de voz no disponible",
+    "voiceDump": "Vaciado de voz"
   }
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -543,6 +543,9 @@
     "confirmDelete": "Supprimer ce vidage de pensées ? Cette action est irréversible.",
     "empty": "Aucun vidage de pensées pour le moment",
     "error": "Une erreur s'est produite. Veuillez réessayer.",
-    "justNow": "à l'instant"
+    "justNow": "à l'instant",
+    "voiceInput": "Saisie vocale",
+    "voiceUnavailable": "Saisie vocale non disponible",
+    "voiceDump": "Vidage vocal"
   }
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -543,6 +543,9 @@
     "confirmDelete": "この思考ダンプを削除しますか？元に戻すことはできません。",
     "empty": "思考ダンプはまだありません",
     "error": "エラーが発生しました。もう一度お試しください。",
-    "justNow": "たった今"
+    "justNow": "たった今",
+    "voiceInput": "音声入力",
+    "voiceUnavailable": "音声入力を利用できません",
+    "voiceDump": "音声ダンプ"
   }
 }

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -543,6 +543,9 @@
     "confirmDelete": "이 생각 덤프를 삭제하시겠습니까? 되돌릴 수 없습니다.",
     "empty": "아직 생각 덤프가 없습니다",
     "error": "문제가 발생했습니다. 다시 시도해 주세요.",
-    "justNow": "방금 전"
+    "justNow": "방금 전",
+    "voiceInput": "음성 입력",
+    "voiceUnavailable": "음성 입력을 사용할 수 없습니다",
+    "voiceDump": "음성 덤프"
   }
 }

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -18,7 +18,7 @@ type ProductionStackParamList = {
   SyncStatus: undefined;
   ConflictResolver: { repoPath: string; branch: string; filePath: string };
   AddScheduledLearning: undefined;
-  ThoughtDump: undefined;
+  ThoughtDump: { openVoiceOnMount?: boolean } | undefined;
 };
 
 type DevOnlyStackParamList = {

--- a/src/screens/ThoughtDumpScreen.tsx
+++ b/src/screens/ThoughtDumpScreen.tsx
@@ -181,7 +181,7 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
             <Pressable
               testID="thought-dump-voice"
               accessibilityRole="button"
-              accessibilityLabel="Voice input"
+              accessibilityLabel={t('thoughtDump.voiceInput')}
               onPress={() => setShowVoiceModal(true)}
               style={[
                 styles.micButton,

--- a/src/screens/ThoughtDumpScreen.tsx
+++ b/src/screens/ThoughtDumpScreen.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState, useCallback } from 'react';
-import { View, StyleSheet, FlatList, Alert, Text } from 'react-native';
+import { View, StyleSheet, FlatList, Alert, Text, Pressable } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
+import { Ionicons } from '@expo/vector-icons';
 
 import { useTokens } from '../contexts/ThemeContext';
 import { RootStackParamList } from '../navigation/types';
@@ -12,6 +13,7 @@ import { StorageService } from '../services/StorageService';
 import { ThoughtDump } from '../models/ThoughtDump';
 import { ScreenHeader, Button, Input, EmptyState, Modal } from '../components/ui';
 import { useScreenHeaderHeight } from '../components/ui';
+import VoiceInputModal from '../components/VoiceInputModal';
 import { indexDump, removeDump } from '../services/ai/thoughtDumpIndexing';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
@@ -33,6 +35,7 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
   const [deleteTarget, setDeleteTarget] = useState<ThoughtDump | null>(null);
   const [repoPath, setRepoPath] = useState('');
   const [branch, setBranch] = useState<string | undefined>();
+  const [showVoiceModal, setShowVoiceModal] = useState(false);
 
   const loadDumps = useCallback(async () => {
     setIsLoading(true);
@@ -54,6 +57,11 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
   useEffect(() => {
     loadDumps();
   }, [loadDumps]);
+
+  const handleVoiceDone = useCallback((spokenText: string) => {
+    setText((prev) => (prev ? `${prev} ${spokenText}` : spokenText));
+    setShowVoiceModal(false);
+  }, []);
 
   const handleSave = async () => {
     const trimmed = text.trim();
@@ -159,15 +167,32 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
             placeholderTextColor={colors.textSecondary}
             multilineMinHeight={100}
           />
-          <View style={{ marginTop: spacing[2] }}>
-            <Button
-              testID="thought-dump-save"
-              label={t('thoughtDump.save')}
-              variant="primary"
-              onPress={handleSave}
-              disabled={isSaving || text.trim().length === 0}
-              fullWidth
-            />
+          <View style={styles.actionRow}>
+            <Pressable
+              testID="thought-dump-voice"
+              accessibilityRole="button"
+              accessibilityLabel="Voice input"
+              onPress={() => setShowVoiceModal(true)}
+              style={[
+                styles.micButton,
+                {
+                  backgroundColor: colors.surface,
+                  borderColor: colors.border,
+                },
+              ]}
+            >
+              <Ionicons name="mic" size={20} color={colors.primary} />
+            </Pressable>
+            <View style={{ flex: 1, marginLeft: spacing[2] }}>
+              <Button
+                testID="thought-dump-save"
+                label={t('thoughtDump.save')}
+                variant="primary"
+                onPress={handleSave}
+                disabled={isSaving || text.trim().length === 0}
+                fullWidth
+              />
+            </View>
           </View>
         </View>
 
@@ -207,6 +232,12 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
         </View>
       </Modal>
 
+      <VoiceInputModal
+        visible={showVoiceModal}
+        onDone={handleVoiceDone}
+        onClose={() => setShowVoiceModal(false)}
+      />
+
       <ScreenHeader
         title={t('thoughtDump.title')}
         onBack={() => navigation.goBack()}
@@ -242,5 +273,18 @@ const styles = StyleSheet.create({
   modalActions: {
     flexDirection: 'row',
     justifyContent: 'flex-end',
+  },
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    marginTop: 8,
+  },
+  micButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/src/screens/ThoughtDumpScreen.tsx
+++ b/src/screens/ThoughtDumpScreen.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { View, StyleSheet, FlatList, Alert, Text, Pressable } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RouteProp } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -25,8 +26,10 @@ interface Props {
 export default function ThoughtDumpScreen({ onDumpChange }: Props) {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
+  const route = useRoute<RouteProp<RootStackParamList, 'ThoughtDump'>>();
   const { colors, spacing } = useTokens();
   const headerHeight = useScreenHeaderHeight();
+  const hasAutoOpenedVoiceRef = useRef(false);
 
   const [text, setText] = useState('');
   const [dumps, setDumps] = useState<ThoughtDump[]>([]);
@@ -57,6 +60,13 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
   useEffect(() => {
     loadDumps();
   }, [loadDumps]);
+
+  useEffect(() => {
+    if (route.params?.openVoiceOnMount && !hasAutoOpenedVoiceRef.current) {
+      hasAutoOpenedVoiceRef.current = true;
+      setShowVoiceModal(true);
+    }
+  }, [route.params?.openVoiceOnMount]);
 
   const handleVoiceDone = useCallback((spokenText: string) => {
     setText((prev) => (prev ? `${prev} ${spokenText}` : spokenText));

--- a/src/stores/aiHubStore.ts
+++ b/src/stores/aiHubStore.ts
@@ -19,6 +19,7 @@ interface AIHubActions {
   goChatHistory: (navigation: NavigationProp) => void;
   goAISettings: (navigation: NavigationProp) => void;
   goThoughtDump: (navigation: NavigationProp) => void;
+  goVoiceDump: (navigation: NavigationProp) => void;
 }
 
 export const useAIHubStore = create<AIHubState & AIHubActions>()((set, get) => ({
@@ -66,5 +67,9 @@ export const useAIHubStore = create<AIHubState & AIHubActions>()((set, get) => (
 
   goThoughtDump: (navigation) => {
     navigation.navigate('ThoughtDump');
+  },
+
+  goVoiceDump: (navigation) => {
+    navigation.navigate('ThoughtDump', { openVoiceOnMount: true });
   },
 }));


### PR DESCRIPTION
## Summary

Adds voice-to-text to Thought Dump in two surfaces, and redesigns the floating hub menu with a visual hierarchy organized by action nature.

## Changes

### 1. Voice input on Thought Dump screen
- Mic button next to the Save button opens `VoiceInputModal`
- Transcribed text is inserted into the composer on "Insert"
- Existing `VoiceInputModal` (used by NoteEditorScreen/ChatScreen) reused as-is

### 2. "Voice dump" floating hub shortcut
- New 5th hub item (mic icon) opens Thought Dump with voice modal auto-shown
- Navigation type extended: `ThoughtDump: { openVoiceOnMount?: boolean }`
- `useEffect` reads the param once on mount to auto-show the modal

### 3. Hub visual hierarchy
Hub items are now grouped by nature at three size tiers and colors:

| Group | Items | Size | Color |
|---|---|---|---|
| **Capture** | New chat, Voice dump | 56px (large) | Primary |
| **Content** | Thought dump | 50px (medium) | Accent |
| **Navigate** | Chat history, AI settings | 46px (small) | Muted (textSecondary) |

- Liquid canvas expanded 296 → 340 px to fit the 5th satellite
- Hub items reordered for top-to-bottom flow: thought-dump → ai-settings → chat-history → voice-dump → new-chat

### 4. i18n
- Added `voiceInput`, `voiceUnavailable`, `voiceDump` keys to all 6 locale files (en, es, fr, de, ja, ko)

### 5. Tests
- Updated `FloatingAIButton.hub.test.tsx` for 5 items (incl. `goVoiceDump`)
- Updated `floatingAIButtonGeometry.test.ts` bounds for new layout
- Updated `FloatingAIButton.test.tsx` position assertions for recomputed geometry
- Added 2 voice composer tests to `ThoughtDumpScreen.test.tsx`
- Added `useRoute` + `VoiceInputModal` mocks to affected test files

## Verification
- `yarn ts:check` — clean
- `yarn eslint . --ext .ts,.tsx` — 0 errors (warnings are pre-existing)
- `yarn jest` — 1841 passed, 12 skipped, 3 suites skipped (all pre-existing)

## Scope exclusions
- No new screens or navigation routes
- No changes to ThoughtDumpService, ThoughtDump model, or dump storage
- No new npm dependencies
- No changes to VoiceInputModal internals
- No changes to FAB tap gesture
- No removal of any existing hub items
