### PR TITLE
feat(ai): add explicit API type selector to Add Provider modal

### DIFF
--- a/__tests__/ai/providerConfigModal.test.tsx
+++ b/__tests__/ai/providerConfigModal.test.tsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import type { AIProviderConfig } from '../../src/models/AIProvider';
+
+function getBgColor(element: any): string | undefined {
+  const style = element.props.style;
+  if (!style) return undefined;
+  if (Array.isArray(style)) {
+    for (const s of style) {
+      if (s && typeof s === 'object' && s.backgroundColor !== undefined) return s.backgroundColor;
+    }
+    return undefined;
+  }
+  return style?.backgroundColor;
+}
+
+const stableColors = {
+  background: '#fff',
+  surface: '#f4f4f4',
+  primary: '#2563eb',
+  text: '#111',
+  textSecondary: '#666',
+  border: '#ddd',
+  error: '#dc2626',
+};
+
+jest.mock('../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: stableColors, isDark: false }),
+  useTokens: () => ({ spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 } }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: unknown) => {
+    const { View } = require('react-native');
+    return <View />;
+  },
+}));
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+}));
+
+const mockAddProvider = jest.fn(async () => undefined);
+const mockUpdateProvider = jest.fn(async () => undefined);
+
+jest.mock('../../src/stores/aiStore', () => ({
+  useAIStore: { getState: () => ({ addProvider: mockAddProvider, updateProvider: mockUpdateProvider }) },
+}));
+
+jest.mock('../../src/services/ai/openrouterPreflight', () => ({
+  checkOpenRouterKey: jest.fn(),
+  isOpenRouterBaseURL: jest.fn(() => false),
+}));
+
+jest.mock('../../src/services/ai/anthropicDefaults', () => ({
+  isAnthropicBaseURL: (v: string) => /api\.anthropic\.com/i.test(v) || /anthropic/i.test(v),
+}));
+
+jest.mock('../../src/services/ai/providerFactory', () => ({
+  getFactory: (type: string) => ({
+    testConnection: jest.fn(async () => ({
+      models: [{ id: 'test-model', name: 'Test', providerId: 'test', providerType: type, requiresDownload: false }],
+      message: 'Connected',
+    })),
+    requiresBaseURL: type !== 'anthropic',
+    requiresApiKey: true,
+    defaultBaseURL: type === 'anthropic' ? 'https://api.anthropic.com/v1' : undefined,
+  }),
+}));
+
+jest.mock('../../src/components/ui', () => {
+  const { View } = require('react-native');
+  return {
+    Group: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+    GroupRow: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+  };
+});
+
+import { ProviderConfigModal } from '../../src/components/ai/ProviderConfigModal';
+
+describe('ProviderConfigModal API Type Selector', () => {
+  beforeEach(() => {
+    mockAddProvider.mockClear();
+    mockUpdateProvider.mockClear();
+  });
+
+  test('renders API type toggle for non-built-in providers', () => {
+    const { getByTestId } = render(
+      <ProviderConfigModal visible onClose={jest.fn()} />,
+    );
+    expect(getByTestId('provider-config.button.api-type-openai')).toBeTruthy();
+    expect(getByTestId('provider-config.button.api-type-anthropic')).toBeTruthy();
+  });
+
+  test('does NOT render API type toggle for built-in apple provider', () => {
+    const appleProvider: AIProviderConfig = {
+      id: 'apple-default',
+      type: 'apple',
+      name: 'Apple Intelligence',
+      isEnabled: true,
+      addedAt: 0,
+      models: [],
+    };
+    const { queryByTestId } = render(
+      <ProviderConfigModal visible onClose={jest.fn()} provider={appleProvider} />,
+    );
+    expect(queryByTestId('provider-config.button.api-type-openai')).toBeNull();
+    expect(queryByTestId('provider-config.button.api-type-anthropic')).toBeNull();
+  });
+
+  test('tapping Anthropic toggles the selection', async () => {
+    const { getByTestId } = render(
+      <ProviderConfigModal visible onClose={jest.fn()} />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('provider-config.button.api-type-anthropic'));
+    });
+
+    // After tapping, the Anthropic button should be selected
+    const anthropicBtn = getByTestId('provider-config.button.api-type-anthropic');
+    const openaiBtn = getByTestId('provider-config.button.api-type-openai');
+    expect(getBgColor(anthropicBtn)).toBe(stableColors.primary);
+    expect(getBgColor(openaiBtn)).toBe(stableColors.surface);
+  });
+
+  test('auto-detects Anthropic from base URL', async () => {
+    const { getByTestId } = render(
+      <ProviderConfigModal visible onClose={jest.fn()} />,
+    );
+
+    const urlInput = getByTestId('provider-config.input.base-url');
+    await act(async () => {
+      fireEvent.changeText(urlInput, 'https://api.anthropic.com/v1');
+    });
+
+    // After auto-detect, Anthropic button should be highlighted
+    await waitFor(() => {
+      const anthropicBtn = getByTestId('provider-config.button.api-type-anthropic');
+      expect(getBgColor(anthropicBtn)).toBe(stableColors.primary);
+    });
+  });
+
+  test('user tap override prevents auto-detect from changing selection', async () => {
+    const { getByTestId } = render(
+      <ProviderConfigModal visible onClose={jest.fn()} />,
+    );
+
+    // User explicitly taps OpenAI-compatible first
+    await act(async () => {
+      fireEvent.press(getByTestId('provider-config.button.api-type-openai'));
+    });
+
+    // Then types an Anthropic URL
+    const urlInput = getByTestId('provider-config.input.base-url');
+    await act(async () => {
+      fireEvent.changeText(urlInput, 'https://api.anthropic.com/v1');
+    });
+
+    // OpenAI-compatible should still be selected (user override respected)
+    const openaiBtn = getByTestId('provider-config.button.api-type-openai');
+    expect(getBgColor(openaiBtn)).toBe(stableColors.primary);
+  });
+
+  test('editing existing anthropic provider initializes toggle correctly', () => {
+    const anthropicConfig: AIProviderConfig = {
+      id: 'my-anthropic',
+      type: 'anthropic',
+      name: 'My Claude',
+      isEnabled: true,
+      addedAt: Date.now(),
+      models: [],
+    };
+    const { getByTestId } = render(
+      <ProviderConfigModal visible onClose={jest.fn()} provider={anthropicConfig} />,
+    );
+
+    // Anthropic should be pre-selected
+    const anthropicBtn = getByTestId('provider-config.button.api-type-anthropic');
+    expect(getBgColor(anthropicBtn)).toBe(stableColors.primary);
+  });
+
+  test('handleSave uses explicit apiType for provider type', async () => {
+    const { getByTestId } = render(
+      <ProviderConfigModal visible onClose={() => {}} />
+    );
+
+    const nameInput = getByTestId('provider-config.input.name');
+    const urlInput = getByTestId('provider-config.input.base-url');
+
+    await act(async () => {
+      fireEvent.changeText(nameInput, 'My Provider');
+      fireEvent.changeText(urlInput, 'https://api.anthropic.com/v1');
+    });
+
+    // Tap Anthropic explicitly
+    await act(async () => {
+      fireEvent.press(getByTestId('provider-config.button.api-type-anthropic'));
+    });
+
+    // Save
+    await act(async () => {
+      fireEvent.press(getByTestId('provider-config-modal.button.save'));
+    });
+
+    await waitFor(() => {
+      expect(mockAddProvider).toHaveBeenCalledTimes(1);
+    });
+
+    const savedProvider = mockAddProvider.mock.calls[0][0];
+    expect(savedProvider.type).toBe('anthropic');
+  });
+
+  test('handleSave respects openai-compatible when URL looks anthropic but user chose openai', async () => {
+    const { getByTestId } = render(
+      <ProviderConfigModal visible onClose={() => {}} />
+    );
+
+    const nameInput = getByTestId('provider-config.input.name');
+    const urlInput = getByTestId('provider-config.input.base-url');
+
+    await act(async () => {
+      fireEvent.changeText(nameInput, 'My Proxy');
+      fireEvent.changeText(urlInput, 'https://anthropic-proxy.example.com/v1');
+    });
+
+    // Auto-detect will try to set Anthropic, but user explicitly taps OpenAI
+    await act(async () => {
+      fireEvent.press(getByTestId('provider-config.button.api-type-openai'));
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('provider-config-modal.button.save'));
+    });
+
+    await waitFor(() => {
+      expect(mockAddProvider).toHaveBeenCalledTimes(1);
+    });
+
+    const savedProvider = mockAddProvider.mock.calls[0][0];
+    expect(savedProvider.type).toBe('openai-compatible');
+  });
+});

--- a/src/components/ai/ProviderConfigModal.tsx
+++ b/src/components/ai/ProviderConfigModal.tsx
@@ -20,7 +20,7 @@ import { Group, GroupRow } from '../ui';
 import { AIProviderConfig, AIModelConfig } from '../../models/AIProvider';
 import { useAIStore } from '../../stores/aiStore';
 import { checkOpenRouterKey, isOpenRouterBaseURL } from '../../services/ai/openrouterPreflight';
-import { isAnthropicBaseURL, isAnthropicProviderType } from '../../services/ai/anthropicDefaults';
+import { isAnthropicBaseURL } from '../../services/ai/anthropicDefaults';
 import { getFactory } from '../../services/ai/providerFactory';
 
 interface ProviderConfigModalProps {
@@ -61,6 +61,8 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
   const [apiKeyVisible, setApiKeyVisible] = useState(false);
   const [isTesting, setIsTesting] = useState(false);
   const [testedModels, setTestedModels] = useState<AIModelConfig[]>([]);
+  const [apiType, setApiType] = useState<'openai-compatible' | 'anthropic'>('openai-compatible');
+  const [userSetApiType, setUserSetApiType] = useState(false);
 
   useEffect(() => {
     if (visible) {
@@ -69,15 +71,26 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
         setBaseURL(provider.baseURL || '');
         setApiKey(provider.apiKey || '');
         setTestedModels(provider.models || []);
+        setApiType(provider.type === 'anthropic' ? 'anthropic' : 'openai-compatible');
+        setUserSetApiType(true);
       } else {
         setName('');
         setBaseURL('');
         setApiKey('');
         setTestedModels([]);
+        setApiType('openai-compatible');
+        setUserSetApiType(false);
       }
       setApiKeyVisible(false);
     }
   }, [visible, provider]);
+
+  const handleBaseURLChange = (url: string) => {
+    setBaseURL(url);
+    if (!userSetApiType) {
+      setApiType(isAnthropicBaseURL(url) ? 'anthropic' : 'openai-compatible');
+    }
+  };
 
   const handleTestConnection = async () => {
     if (!baseURL.trim()) {
@@ -90,7 +103,7 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
       const normalizedBaseURL = normalizeMiniMaxBaseURL(baseURL);
       const headers: Record<string, string> = {};
       if (apiKey.trim()) {
-        if (isAnthropicBaseURL(normalizedBaseURL)) {
+        if (apiType === 'anthropic') {
           headers['x-api-key'] = apiKey.trim();
           headers['anthropic-version'] = '2023-06-01';
         } else {
@@ -98,7 +111,7 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
         }
       }
 
-      if (isAnthropicBaseURL(normalizedBaseURL)) {
+      if (apiType === 'anthropic') {
         const providerId = provider?.id || `custom-${Date.now()}`;
         const result = await getFactory('anthropic').testConnection(normalizedBaseURL, apiKey.trim(), providerId);
         setTestedModels(result.models);
@@ -183,7 +196,7 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
       return;
     }
 
-    if (!isBuiltIn && !baseURL.trim() && provider?.type !== 'anthropic') {
+    if (!isBuiltIn && !baseURL.trim() && apiType !== 'anthropic') {
       Alert.alert('Validation Error', 'Base URL is required.');
       return;
     }
@@ -224,7 +237,7 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
 
     const baseProvider: AIProviderConfig = {
       id: providerId,
-      type: isBuiltIn ? provider!.type : (isAnthropicBaseURL(normalizedBaseURL ?? '') ? 'anthropic' : 'openai-compatible'),
+      type: isBuiltIn ? provider!.type : apiType,
       name: name.trim(),
       isEnabled: provider?.isEnabled ?? true,
       addedAt: provider?.addedAt || Date.now(),
@@ -304,11 +317,46 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
                       placeholder="Base URL (e.g., http://localhost:11434/v1)"
                       placeholderTextColor={colors.textSecondary}
                       value={baseURL}
-                      onChangeText={setBaseURL}
+                      onChangeText={handleBaseURLChange}
                       autoCapitalize="none"
                       autoCorrect={false}
                       keyboardType="url"
                     />
+                  </GroupRow>
+                  <GroupRow>
+                    <Text style={[styles.apiTypeLabel, { color: colors.textSecondary }]}>API Format</Text>
+                    <View style={styles.apiTypeToggle}>
+                      <TouchableOpacity
+                        testID="provider-config.button.api-type-openai"
+                        style={[
+                          styles.apiTypeButton,
+                          {
+                            backgroundColor: apiType === 'openai-compatible' ? colors.primary : colors.surface,
+                            borderColor: apiType === 'openai-compatible' ? colors.primary : colors.border,
+                          },
+                        ]}
+                        onPress={() => { setApiType('openai-compatible'); setUserSetApiType(true); }}
+                      >
+                        <Text style={[styles.apiTypeButtonText, { color: apiType === 'openai-compatible' ? '#FFF' : colors.text }]}>
+                          OpenAI-compatible
+                        </Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        testID="provider-config.button.api-type-anthropic"
+                        style={[
+                          styles.apiTypeButton,
+                          {
+                            backgroundColor: apiType === 'anthropic' ? colors.primary : colors.surface,
+                            borderColor: apiType === 'anthropic' ? colors.primary : colors.border,
+                          },
+                        ]}
+                        onPress={() => { setApiType('anthropic'); setUserSetApiType(true); }}
+                      >
+                        <Text style={[styles.apiTypeButtonText, { color: apiType === 'anthropic' ? '#FFF' : colors.text }]}>
+                          Anthropic
+                        </Text>
+                      </TouchableOpacity>
+                    </View>
                   </GroupRow>
                   <GroupRow>
                     <View style={styles.apiKeyContainer}>
@@ -460,5 +508,25 @@ const styles = StyleSheet.create({
   actionBtnText: {
     fontSize: 16,
     fontWeight: '600',
+  },
+  apiTypeToggle: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  apiTypeButton: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+  },
+  apiTypeButtonText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  apiTypeLabel: {
+    fontSize: 12,
+    marginBottom: 6,
   },
 });

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -4,7 +4,6 @@ import { create } from 'zustand';
 import { AIActionMode, AIModelConfig, AIProviderConfig, AISettings } from '../models/AIProvider';
 import { setChatRepoAccount } from '../services/ChatStorageService';
 import { resolveProviderAvailability } from '../services/ai/providerAvailability';
-import { ANTHROPIC_DEFAULT_MODELS, ANTHROPIC_DEFAULT_PROVIDER_ID } from '../services/ai/anthropicDefaults';
 import { discoverModelsIfNeeded } from '../services/ai/modelDiscoveryService';
 
 const AI_SETTINGS_STORAGE_KEY = 'ai-settings';
@@ -82,20 +81,6 @@ const createDefaultProviders = (): AIProviderConfig[] => [
         isDownloaded: false,
       },
     ],
-  },
-  {
-    id: ANTHROPIC_DEFAULT_PROVIDER_ID,
-    type: 'anthropic',
-    name: 'Anthropic',
-    isEnabled: false,
-    addedAt: 0,
-    models: ANTHROPIC_DEFAULT_MODELS.map((m) => ({
-      id: m.id,
-      name: m.name,
-      providerId: ANTHROPIC_DEFAULT_PROVIDER_ID,
-      providerType: 'anthropic',
-      requiresDownload: false,
-    })),
   },
 ];
 


### PR DESCRIPTION
## Summary

Replaces fragile URL-regex-based API type inference with an explicit two-button toggle (OpenAI-compatible / Anthropic) in the Add Provider modal.

## Problem

The current code infers API type from a regex on the base URL (`/api\.anthropic\.com/i` or `/anthropic/i`). Any Anthropic-compatible proxy URL (e.g. `https://my-proxy.company.com/v1`) fails detection and gets misrouted to the OpenAI SDK with wrong auth headers (Bearer instead of x-api-key), silently breaking connections.

## Solution

- **Explicit API type toggle**: Two-button segmented control (OpenAI-compatible / Anthropic) rendered between the Base URL and API Key fields
- **URL-based auto-detect**: Typing a base URL containing `anthropic` pre-selects the Anthropic toggle — but user can override by tapping a button explicitly
- **Explicit save**: `handleSave()` and `handleTestConnection()` use the user-selected `apiType` instead of URL heuristics
- **Removed hardcoded preset**: `anthropic-default` removed from `createDefaultProviders()` — users add Anthropic-compatible providers via Add Provider with full control
- **New tests**: 8 tests covering toggle rendering, auto-detect, user override, and save behavior

## Files Changed

- `src/components/ai/ProviderConfigModal.tsx` — toggle UI + auto-detect + explicit apiType
- `src/stores/aiStore.ts` — removed anthropic-default preset
- `__tests__/ai/providerConfigModal.test.tsx` — 8 new tests

## Verification

- `yarn ts:check` — passes
- `yarn jest` — 1844 pass (2 pre-existing unrelated failures in HotspotGrid and save-loading-indicator)
- All 8 new ProviderConfigModal tests pass