### PR TITLE
feat(ai): GitHub Agent Tools with Settings toggle, Onboarding step, and Chat hints

### DIFF
--- a/__tests__/ChatHintChips.test.tsx
+++ b/__tests__/ChatHintChips.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { ChatHintChips } from '../src/components/ai/ChatHintChips';
+
+jest.mock('react-i18next', () => {
+  const translations: Record<string, string> = {
+    'chat.hints.summarizeIssues': 'Summarize my open issues',
+    'chat.hints.showRepos': 'Show my repos',
+    'chat.hints.createIssue': 'Create an issue',
+    'chat.hints.listPRs': 'List open PRs',
+  };
+  return {
+    useTranslation: () => ({
+      t: (key: string, options?: { defaultValue?: string }) =>
+        translations[key] ?? options?.defaultValue ?? key,
+      i18n: { changeLanguage: jest.fn() },
+    }),
+    initReactI18next: { type: '3rdParty', init: jest.fn() },
+  };
+});
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTokens: () => ({
+    colors: {
+      surface: '#f4f4f4',
+      border: '#dddddd',
+      accent: '#8b5cf6',
+      text: '#111111',
+    },
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+    radii: { pill: 999 },
+    type: { sm: 14 },
+  }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+const HINT_CASES = [
+  {
+    testID: 'chat.hint.summarize-issues',
+    label: 'Summarize my open issues',
+    prompt: 'Summarize my open GitHub issues across all repos',
+  },
+  {
+    testID: 'chat.hint.show-repos',
+    label: 'Show my repos',
+    prompt: 'List all my GitHub repositories',
+  },
+  {
+    testID: 'chat.hint.create-issue',
+    label: 'Create an issue',
+    prompt: 'Help me create a new GitHub issue',
+  },
+  {
+    testID: 'chat.hint.list-prs',
+    label: 'List open PRs',
+    prompt: 'List my open pull requests across all repos',
+  },
+] as const;
+
+describe('ChatHintChips', () => {
+  test('renders all four hint chips with their translated labels', () => {
+    const { getByText } = render(<ChatHintChips onPressHint={jest.fn()} />);
+
+    for (const hint of HINT_CASES) {
+      expect(getByText(hint.label)).toBeTruthy();
+    }
+  });
+
+  test.each(HINT_CASES.map(({ label, prompt }) => ({ label, prompt })))(
+    'tapping "$label" fires onPressHint once with the prompt "$prompt"',
+    ({ label, prompt }) => {
+      const onPressHint = jest.fn();
+      const { getByText } = render(<ChatHintChips onPressHint={onPressHint} />);
+
+      fireEvent.press(getByText(label));
+
+      expect(onPressHint).toHaveBeenCalledTimes(1);
+      expect(onPressHint).toHaveBeenCalledWith(prompt);
+    },
+  );
+});

--- a/__tests__/ai/GitHubTools.test.ts
+++ b/__tests__/ai/GitHubTools.test.ts
@@ -1,0 +1,407 @@
+jest.mock('../../src/services/http', () => ({
+  __esModule: true,
+  default: { request: jest.fn() },
+  setAuthToken: jest.fn(),
+  clearAuthToken: jest.fn(),
+}));
+
+jest.mock('../../src/services/AuthService', () => ({
+  __esModule: true,
+  default: {
+    getToken: jest.fn(async () => null),
+    setToken: jest.fn(async () => undefined),
+    clearToken: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock('../../src/stores/noteStore', () => ({
+  useNoteStore: {
+    getState: () => ({
+      notes: [],
+      createNote: jest.fn(),
+      updateNote: jest.fn(),
+      deleteNote: jest.fn(),
+      getNoteById: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock('../../src/stores/todoStore', () => ({
+  useTodoStore: {
+    getState: () => ({
+      todos: [],
+      createTodo: jest.fn(),
+      updateTodo: jest.fn(),
+      deleteTodo: jest.fn(),
+    }),
+  },
+}));
+
+// Only the slice of AI state that `executeToolCall` reads. Kept mutable via
+// `__state` so tests can flip the GitHub-tools gate per case.
+jest.mock('../../src/stores/aiStore', () => {
+  const state = {
+    githubToolsEnabled: false,
+    chatRepoOwner: null as string | null,
+    chatRepoName: null as string | null,
+    chatRepoBranch: 'main',
+    chatRepoAccountId: null as string | null,
+  };
+  return {
+    useAIStore: { getState: () => state, __state: state },
+  };
+});
+
+import { GitHubService, type GitHubRepository } from '../../src/services/GitHubService';
+import http from '../../src/services/http';
+import { executeToolCall } from '../../src/services/ai/actionExecutor';
+import { buildSystemPrompt } from '../../src/services/ai/systemPrompt';
+import {
+  createIssueParameters,
+  createPullRequestParameters,
+  getPullRequestDiffParameters,
+  listIssuesParameters,
+  listPullRequestsParameters,
+  listReposParameters,
+  reviewPullRequestParameters,
+} from '../../src/services/ai/tools';
+import { useAIStore } from '../../src/stores/aiStore';
+
+const mockHttpRequest = http.request as jest.Mock;
+
+type AISlice = {
+  githubToolsEnabled: boolean;
+  chatRepoOwner: string | null;
+  chatRepoName: string | null;
+  chatRepoBranch: string;
+  chatRepoAccountId: string | null;
+};
+type AIStoreMock = { getState: () => AISlice; __state: AISlice };
+const aiSlice = (useAIStore as unknown as AIStoreMock).__state;
+
+const testUser = {
+  login: 'octocat',
+  id: 1,
+  avatar_url: '',
+  html_url: '',
+  name: 'Octocat',
+  email: 'octocat@example.com',
+};
+
+const serverError = Object.assign(new Error('GitHub API error: 502'), { status: 502 });
+
+describe('GitHubService agent-tool methods', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    aiSlice.githubToolsEnabled = false;
+    await GitHubService.setToken('token', testUser);
+  });
+
+  afterEach(async () => {
+    await GitHubService.clearToken();
+    jest.restoreAllMocks();
+  });
+
+  describe('createIssue', () => {
+    test('POSTs to the issues endpoint with the title in the body', async () => {
+      mockHttpRequest.mockResolvedValueOnce({
+        data: {
+          id: 10,
+          number: 42,
+          title: 'Fix crash',
+          body: 'Details',
+          state: 'open',
+          html_url: 'https://github.com/octo/notes/issues/42',
+          milestone: null,
+          labels: [],
+          assignees: [],
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      });
+
+      const result = await GitHubService.createIssue({
+        owner: 'octo',
+        repo: 'notes',
+        title: 'Fix crash',
+        body: 'Details',
+      });
+
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://api.github.com/repos/octo/notes/issues',
+          method: 'POST',
+          data: expect.objectContaining({ title: 'Fix crash' }),
+        }),
+      );
+      expect(result?.number).toBe(42);
+      expect(result?.html_url).toContain('octo/notes/issues/42');
+    });
+
+    test('returns null on a 5xx response', async () => {
+      mockHttpRequest.mockRejectedValueOnce(serverError);
+      const result = await GitHubService.createIssue({ owner: 'octo', repo: 'notes', title: 'T' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getPullRequestDiff', () => {
+    test('maps the files endpoint response into a diff shape', async () => {
+      mockHttpRequest.mockResolvedValueOnce({
+        data: [
+          { filename: 'src/a.ts', status: 'modified', additions: 3, deletions: 1, patch: '@@' },
+          { filename: 'src/b.ts', status: 'added', additions: 10, deletions: 0 },
+        ],
+      });
+
+      const diff = await GitHubService.getPullRequestDiff('octo', 'notes', 42);
+
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://api.github.com/repos/octo/notes/pulls/42/files',
+        }),
+      );
+      expect(diff).toEqual({
+        files: [
+          { filename: 'src/a.ts', status: 'modified', additions: 3, deletions: 1, patch: '@@' },
+          { filename: 'src/b.ts', status: 'added', additions: 10, deletions: 0, patch: undefined },
+        ],
+      });
+    });
+
+    test('returns null when the files endpoint returns a non-array', async () => {
+      mockHttpRequest.mockResolvedValueOnce({ data: { message: 'Not Found' } });
+      const diff = await GitHubService.getPullRequestDiff('octo', 'notes', 42);
+      expect(diff).toBeNull();
+    });
+
+    test('returns null on a 5xx response', async () => {
+      mockHttpRequest.mockRejectedValueOnce(serverError);
+      const diff = await GitHubService.getPullRequestDiff('octo', 'notes', 42);
+      expect(diff).toBeNull();
+    });
+  });
+
+  describe('reviewPullRequest', () => {
+    test('POSTs body and event to the reviews endpoint', async () => {
+      mockHttpRequest.mockResolvedValueOnce({
+        data: {
+          id: 99,
+          user: { login: 'octocat' },
+          body: 'Looks good',
+          state: 'APPROVED',
+          submitted_at: '2026-01-01T00:00:00Z',
+          html_url: 'https://github.com/octo/notes/pull/42#review-99',
+        },
+      });
+
+      const review = await GitHubService.reviewPullRequest({
+        owner: 'octo',
+        repo: 'notes',
+        pull_number: 42,
+        body: 'Looks good',
+        event: 'APPROVE',
+      });
+
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://api.github.com/repos/octo/notes/pulls/42/reviews',
+          method: 'POST',
+          data: { body: 'Looks good', event: 'APPROVE' },
+        }),
+      );
+      expect(review?.id).toBe(99);
+      expect(review?.state).toBe('APPROVED');
+    });
+
+    test('returns null on a 5xx response', async () => {
+      mockHttpRequest.mockRejectedValueOnce(serverError);
+      const review = await GitHubService.reviewPullRequest({
+        owner: 'octo',
+        repo: 'notes',
+        pull_number: 42,
+        body: 'b',
+        event: 'COMMENT',
+      });
+      expect(review).toBeNull();
+    });
+  });
+});
+
+describe('GitHub tool Zod schemas', () => {
+  test('listReposParameters accepts an empty object and rejects non-object input', () => {
+    expect(listReposParameters.parse({})).toEqual({});
+    expect(() => listReposParameters.parse(null)).toThrow();
+  });
+
+  test('listIssuesParameters requires owner and repo and constrains state', () => {
+    expect(() =>
+      listIssuesParameters.parse({ owner: 'a', repo: 'b', state: 'open' }),
+    ).not.toThrow();
+    expect(() => listIssuesParameters.parse({ owner: 'a' })).toThrow();
+    expect(() =>
+      listIssuesParameters.parse({ owner: 'a', repo: 'b', state: 'bogus' }),
+    ).toThrow();
+  });
+
+  test('createIssueParameters requires owner, repo, title', () => {
+    expect(() =>
+      createIssueParameters.parse({ owner: 'a', repo: 'b', title: 'T' }),
+    ).not.toThrow();
+    expect(() => createIssueParameters.parse({ owner: 'a', repo: 'b' })).toThrow();
+  });
+
+  test('listPullRequestsParameters requires owner and repo and constrains state', () => {
+    expect(() =>
+      listPullRequestsParameters.parse({ owner: 'a', repo: 'b', state: 'closed' }),
+    ).not.toThrow();
+    expect(() => listPullRequestsParameters.parse({ owner: 'a' })).toThrow();
+    expect(() =>
+      listPullRequestsParameters.parse({ owner: 'a', repo: 'b', state: 'merged' }),
+    ).toThrow();
+  });
+
+  test('createPullRequestParameters requires owner, repo, title, head, base', () => {
+    expect(() =>
+      createPullRequestParameters.parse({ owner: 'a', repo: 'b', title: 'T', head: 'h', base: 'main' }),
+    ).not.toThrow();
+    expect(() =>
+      createPullRequestParameters.parse({ owner: 'a', repo: 'b', title: 'T', base: 'main' }),
+    ).toThrow();
+  });
+
+  test('getPullRequestDiffParameters requires a numeric pull_number', () => {
+    expect(() =>
+      getPullRequestDiffParameters.parse({ owner: 'a', repo: 'b', pull_number: 7 }),
+    ).not.toThrow();
+    expect(() =>
+      getPullRequestDiffParameters.parse({ owner: 'a', repo: 'b', pull_number: '7' }),
+    ).toThrow();
+  });
+
+  test('reviewPullRequestParameters requires body and a known event', () => {
+    expect(() =>
+      reviewPullRequestParameters.parse({
+        owner: 'a',
+        repo: 'b',
+        pull_number: 7,
+        body: 'ok',
+        event: 'APPROVE',
+      }),
+    ).not.toThrow();
+    expect(() =>
+      reviewPullRequestParameters.parse({ owner: 'a', repo: 'b', pull_number: 7, body: 'ok' }),
+    ).toThrow();
+    expect(() =>
+      reviewPullRequestParameters.parse({
+        owner: 'a',
+        repo: 'b',
+        pull_number: 7,
+        body: 'ok',
+        event: 'MERGE',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('executeToolCall - GitHub tools gate', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('rejects GitHub tools when githubToolsEnabled is false', async () => {
+    aiSlice.githubToolsEnabled = false;
+    const result = await executeToolCall('list_repos', {}, 'auto');
+    expect(result.success).toBe(false);
+    expect(result.requiresConfirmation).toBe(false);
+    expect(result.error).toMatch(/GitHub tools are disabled/);
+  });
+});
+
+describe('executeToolCall - GitHub tools enabled', () => {
+  beforeEach(() => {
+    aiSlice.githubToolsEnabled = true;
+  });
+
+  afterEach(() => {
+    aiSlice.githubToolsEnabled = false;
+    jest.restoreAllMocks();
+  });
+
+  test('create_issue in confirm mode returns proposed changes without calling the service', async () => {
+    const createIssueSpy = jest.spyOn(GitHubService, 'createIssue');
+
+    const result = await executeToolCall(
+      'create_issue',
+      { owner: 'octo', repo: 'notes', title: 'Ship feature', body: 'Details here' },
+      'confirm',
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.requiresConfirmation).toBe(true);
+    expect(result.proposedChanges).toEqual({
+      type: 'create_issue',
+      description: 'Create issue "Ship feature" in octo/notes',
+      details: { owner: 'octo', repo: 'notes', title: 'Ship feature', body: 'Details here' },
+    });
+    expect(createIssueSpy).not.toHaveBeenCalled();
+  });
+
+  test('list_repos maps repositories into the agent result shape', async () => {
+    // The GitHub API returns `description: null` for repos without one; the
+    // typed interface narrows it to `string`, so the fixture casts explicitly.
+    const repos = [
+      {
+        id: 1,
+        name: 'b',
+        full_name: 'a/b',
+        owner: { login: 'a' },
+        html_url: 'https://github.com/a/b',
+        description: null,
+        private: false,
+      },
+    ] as unknown as GitHubRepository[];
+    const getRepositoriesSpy = jest
+      .spyOn(GitHubService, 'getRepositories')
+      .mockResolvedValue(repos);
+
+    const result = await executeToolCall('list_repos', {}, 'auto');
+
+    expect(getRepositoriesSpy).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    expect(result.requiresConfirmation).toBe(false);
+    expect(result.data).toEqual([
+      {
+        id: 1,
+        name: 'a/b',
+        private: false,
+        description: null,
+        url: 'https://github.com/a/b',
+      },
+    ]);
+  });
+});
+
+describe('buildSystemPrompt - GitHub tools section', () => {
+  const baseContext = { noteCount: 0, todoCount: 0, actionMode: 'auto' as const };
+
+  test('includes the GitHub tool list and account login when enabled', () => {
+    const prompt = buildSystemPrompt({
+      ...baseContext,
+      githubToolsEnabled: true,
+      githubAccountLogin: 'octocat',
+    });
+
+    expect(prompt).toContain('list_repos');
+    expect(prompt).toContain('get_pull_request_diff');
+    expect(prompt).toContain('review_pull_request');
+    expect(prompt).toContain('@octocat');
+  });
+
+  test('omits the GitHub tool list when disabled', () => {
+    const prompt = buildSystemPrompt({ ...baseContext, githubToolsEnabled: false });
+
+    expect(prompt).not.toContain('list_repos');
+    expect(prompt).not.toContain('GitHub Tools');
+  });
+});

--- a/__tests__/aiStore.githubTools.test.ts
+++ b/__tests__/aiStore.githubTools.test.ts
@@ -1,0 +1,103 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  let store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (key: string) => store[key] ?? null),
+      setItem: jest.fn(async (key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: jest.fn(async (key: string) => {
+        delete store[key];
+      }),
+      clear: jest.fn(async () => {
+        store = {};
+      }),
+      __reset: () => {
+        store = {};
+      },
+    },
+  };
+});
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => undefined),
+  deleteItemAsync: jest.fn(async () => undefined),
+}));
+
+jest.mock('../src/services/ChatStorageService', () => ({
+  setChatRepoAccount: jest.fn(),
+}));
+
+jest.mock('../src/services/ai/providerAvailability', () => ({
+  resolveProviderAvailability: jest.fn(async () => ({ kind: 'available' })),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useAIStore } from '../src/stores/aiStore';
+
+const AI_SETTINGS_KEY = 'ai-settings';
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage> & {
+  __reset: () => void;
+};
+
+describe('useAIStore - githubToolsEnabled', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockAsyncStorage.__reset();
+    await useAIStore.getState().loadSettings();
+    useAIStore.setState({ githubToolsEnabled: false });
+  });
+
+  test('defaults to false when nothing is stored', () => {
+    expect(useAIStore.getState().githubToolsEnabled).toBe(false);
+  });
+
+  test('toggleGithubTools flips false → true → false', async () => {
+    await useAIStore.getState().toggleGithubTools();
+    expect(useAIStore.getState().githubToolsEnabled).toBe(true);
+
+    await useAIStore.getState().toggleGithubTools();
+    expect(useAIStore.getState().githubToolsEnabled).toBe(false);
+  });
+
+  test('persists githubToolsEnabled in the ai-settings blob', async () => {
+    await useAIStore.getState().toggleGithubTools();
+
+    const settingsCalls = mockAsyncStorage.setItem.mock.calls.filter(
+      ([key]) => key === AI_SETTINGS_KEY,
+    );
+    expect(settingsCalls.length).toBeGreaterThan(0);
+
+    const lastCall = settingsCalls[settingsCalls.length - 1];
+    expect(lastCall).toBeDefined();
+    const [, serialized] = lastCall;
+    expect(serialized).toContain('"githubToolsEnabled":true');
+
+    const parsed = JSON.parse(serialized) as { githubToolsEnabled?: boolean };
+    expect(parsed.githubToolsEnabled).toBe(true);
+  });
+
+  test('loading a persisted blob without githubToolsEnabled falls back to false', async () => {
+    const legacyBlob = {
+      isEnabled: true,
+      selectedModelId: null,
+      actionMode: 'auto',
+      chatRepoOwner: null,
+      chatRepoName: null,
+      chatRepoBranch: 'main',
+      chatRepoAccountId: null,
+      providers: [],
+      dailyQuoteEnabled: true,
+      aiPersonalizationEnabled: true,
+      // githubToolsEnabled intentionally absent — simulates a blob written
+      // before the GitHub tools feature shipped.
+    };
+    await mockAsyncStorage.setItem(AI_SETTINGS_KEY, JSON.stringify(legacyBlob));
+
+    await useAIStore.getState().loadSettings();
+
+    expect(useAIStore.getState().githubToolsEnabled).toBe(false);
+  });
+});

--- a/src/components/ai/ChatHintChips.tsx
+++ b/src/components/ai/ChatHintChips.tsx
@@ -1,0 +1,91 @@
+import { TouchableOpacity, View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { useTokens } from '../../contexts/ThemeContext';
+
+type Hint = {
+  icon: 'search-outline' | 'globe-outline' | 'add-circle-outline' | 'git-branch-outline';
+  labelKey: string;
+  labelDefault: string;
+  prompt: string;
+  testID: string;
+};
+
+const HINTS: Hint[] = [
+  {
+    icon: 'search-outline',
+    labelKey: 'chat.hints.summarizeIssues',
+    labelDefault: 'Summarize my open issues',
+    prompt: 'Summarize my open GitHub issues across all repos',
+    testID: 'chat.hint.summarize-issues',
+  },
+  {
+    icon: 'globe-outline',
+    labelKey: 'chat.hints.showRepos',
+    labelDefault: 'Show my repos',
+    prompt: 'List all my GitHub repositories',
+    testID: 'chat.hint.show-repos',
+  },
+  {
+    icon: 'add-circle-outline',
+    labelKey: 'chat.hints.createIssue',
+    labelDefault: 'Create an issue',
+    prompt: 'Help me create a new GitHub issue',
+    testID: 'chat.hint.create-issue',
+  },
+  {
+    icon: 'git-branch-outline',
+    labelKey: 'chat.hints.listPRs',
+    labelDefault: 'List open PRs',
+    prompt: 'List my open pull requests across all repos',
+    testID: 'chat.hint.list-prs',
+  },
+];
+
+export interface ChatHintChipsProps {
+  onPressHint: (text: string) => void;
+}
+
+export function ChatHintChips({ onPressHint }: ChatHintChipsProps) {
+  const { t } = useTranslation();
+  const { colors, spacing, radii, type } = useTokens();
+
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        gap: spacing[2],
+        marginTop: spacing[4],
+        justifyContent: 'center',
+      }}
+    >
+      {HINTS.map((hint) => (
+        <TouchableOpacity
+          key={hint.testID}
+          testID={hint.testID}
+          accessibilityLabel={hint.labelDefault}
+          accessibilityRole="button"
+          onPress={() => onPressHint(hint.prompt)}
+          activeOpacity={0.7}
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: spacing[1],
+            paddingHorizontal: spacing[3],
+            paddingVertical: spacing[2],
+            backgroundColor: colors.surface,
+            borderWidth: 1,
+            borderColor: colors.border,
+            borderRadius: radii.pill,
+          }}
+        >
+          <Ionicons name={hint.icon} size={14} color={colors.accent} />
+          <Text style={{ color: colors.text, fontSize: type.sm, fontWeight: '500' }}>
+            {t(hint.labelKey, { defaultValue: hint.labelDefault })}
+          </Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}

--- a/src/components/chat/useChatScreenController.ts
+++ b/src/components/chat/useChatScreenController.ts
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert } from 'react-native';
 import type { AIContextItem, AIModelConfig, AIProviderConfig } from '../../models/AIProvider';
 import type { ChatMessage } from '../../models/Chat';
 import * as AIService from '../../services/AIService';
+import { AuthService } from '../../services/AuthService';
 import * as ChatStorageService from '../../services/ChatStorageService';
 import { executeToolCall } from '../../services/ai/actionExecutor';
-import { chatTools } from '../../services/ai/tools';
+import { chatTools, githubTools } from '../../services/ai/tools';
 import { buildSystemPrompt } from '../../services/ai/systemPrompt';
 import { checkContextBudget, getModelContextLimit } from '../../services/ai/modelLimits';
 import { buildContextString } from '../../services/ContextService';
@@ -38,16 +39,18 @@ type ToolListItem = {
   completed?: boolean;
 };
 
-const KNOWN_TOOL_NAMES = new Set(Object.keys(chatTools));
+function buildChatToolsMap(enabled: boolean = useAIStore.getState().githubToolsEnabled) {
+  return enabled ? { ...chatTools, ...githubTools } : chatTools;
+}
 
-function sanitizeToolName(raw: string | undefined): string | null {
+function sanitizeToolName(raw: string | undefined, knownToolNames: ReadonlySet<string>): string | null {
   const trimmed = raw?.trim();
   if (!trimmed) return null;
-  if (KNOWN_TOOL_NAMES.has(trimmed)) return trimmed;
+  if (knownToolNames.has(trimmed)) return trimmed;
   const colonIdx = trimmed.indexOf(':');
   if (colonIdx > 0) {
     const prefix = trimmed.slice(0, colonIdx).trim();
-    if (KNOWN_TOOL_NAMES.has(prefix)) return prefix;
+    if (knownToolNames.has(prefix)) return prefix;
   }
   return null;
 }
@@ -197,6 +200,11 @@ function mergeAssistantWithToolFallback(
 export function useChatScreenController(threadId: string) {
   const noteCount = useNoteStore((state) => state.notes.length);
   const todoCount = useTodoStore((state) => state.todos.length);
+  const githubToolsEnabled = useAIStore((state) => state.githubToolsEnabled);
+  const knownToolNames = useMemo(
+    () => new Set(Object.keys(buildChatToolsMap(githubToolsEnabled))),
+    [githubToolsEnabled],
+  );
   const activeThread = useChatStore((state) => state.activeThread);
   const isLoading = useChatStore((state) => state.isLoading);
   const storeError = useChatStore((state) => state.error);
@@ -327,6 +335,9 @@ export function useChatScreenController(threadId: string) {
 
     try {
       const aiState = useAIStore.getState();
+      const githubAccountLogin = githubToolsEnabled
+        ? (await AuthService.checkAuthState()).user?.login
+        : undefined;
       const { model, provider } = getSelectedModelConfig();
       const runtimeThread = useChatStore.getState().activeThread;
       if (!runtimeThread) throw new Error('Chat thread is not available.');
@@ -334,15 +345,15 @@ export function useChatScreenController(threadId: string) {
       const aggregatedContexts = dedupeContexts([...runtimeThread.messages.flatMap((message) => message.attachedContexts ?? []), ...contexts]);
       const contextString = aggregatedContexts.length ? await buildContextString(aggregatedContexts) : undefined;
       const history = runtimeThread.messages.filter((message) => message.id !== assistantMessageId).map(formatHistoryMessage);
-      const basePrompt = buildSystemPrompt({ attachedContexts: contextString, noteCount, todoCount, actionMode: aiState.actionMode });
+      const basePrompt = buildSystemPrompt({ attachedContexts: contextString, noteCount, todoCount, actionMode: aiState.actionMode, githubToolsEnabled, githubAccountLogin });
       const memoryBlock = await buildMemoryBlockForQuery(trimmedText, model, basePrompt.length);
       const prompt = memoryBlock
-        ? buildSystemPrompt({ attachedContexts: contextString, noteCount, todoCount, actionMode: aiState.actionMode, memoryBlock })
+        ? buildSystemPrompt({ attachedContexts: contextString, noteCount, todoCount, actionMode: aiState.actionMode, memoryBlock, githubToolsEnabled, githubAccountLogin })
         : basePrompt;
       const modelInstance = await AIService.initializeModel(model, provider as AIProviderConfig | undefined);
       const requestMessages: Parameters<typeof AIService.streamChatResponse>[1] = [{ role: 'system', content: prompt }, ...history];
 
-      for await (const chunk of AIService.streamChatResponse(modelInstance, requestMessages, chatTools, abortController.signal)) {
+      for await (const chunk of AIService.streamChatResponse(modelInstance, requestMessages, buildChatToolsMap(), abortController.signal)) {
         if (abortController.signal.aborted) break;
         const toolEvent = parseToolEvent(chunk);
         if (!toolEvent) {
@@ -359,7 +370,7 @@ export function useChatScreenController(threadId: string) {
           // model finishes streaming the args and the tool actually runs.
           toolArgsBufferRef.current[toolCallId] = existingArgs;
           if (!toolMessageIdsRef.current[toolCallId]) {
-            const streamingToolName = sanitizeToolName(toolEvent.toolName);
+            const streamingToolName = sanitizeToolName(toolEvent.toolName, knownToolNames);
             if (!streamingToolName) continue;
             const streamingMessageId = generateId();
             toolMessageIdsRef.current[toolCallId] = streamingMessageId;
@@ -389,7 +400,7 @@ export function useChatScreenController(threadId: string) {
           const streamedResultText = formatToolResult(toolEvent.result);
           const existingToolMessageId = toolMessageIdsRef.current[toolCallId];
           if (existingToolMessageId) {
-            const eventToolName = sanitizeToolName(toolEvent.toolName);
+            const eventToolName = sanitizeToolName(toolEvent.toolName, knownToolNames);
             updateMessage(existingToolMessageId, {
               ...(eventToolName ? { toolCallName: eventToolName } : null),
               toolCallResult: streamedResultText,
@@ -402,7 +413,7 @@ export function useChatScreenController(threadId: string) {
           continue;
         }
 
-        const resolvedToolName = sanitizeToolName(toolEvent.toolName);
+        const resolvedToolName = sanitizeToolName(toolEvent.toolName, knownToolNames);
         if (!resolvedToolName) continue;
 
         const args = parseToolArgs(toolEvent.input, toolArgsBufferRef.current[toolCallId]);
@@ -494,7 +505,7 @@ export function useChatScreenController(threadId: string) {
       setStreaming(false);
       setStreamStartedAt(0);
     }
-  }, [addMessage, clearError, getSelectedModelConfig, noteCount, persistPrimedThread, removeMessage, runToolCall, saveActiveThread, setStreaming, t, todoCount, updateMessage]);
+  }, [addMessage, clearError, getSelectedModelConfig, githubToolsEnabled, knownToolNames, noteCount, persistPrimedThread, removeMessage, runToolCall, saveActiveThread, setStreaming, t, todoCount, updateMessage]);
 
   const stopStreaming = useCallback(() => abortRef.current?.abort(), []);
 

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -124,6 +124,8 @@ onRemoveAccount: (id: string, login: string) => void;
   onToggleDailyQuote: () => void;
   aiPersonalizationEnabled: boolean;
   onToggleAiPersonalization: () => void;
+  githubToolsEnabled: boolean;
+  onToggleGithubTools: () => void;
   isBiometricLockEnabled: boolean;
   isBiometricAvailable: boolean;
   biometricKind: BiometricKind;
@@ -202,6 +204,8 @@ export function SettingsContent(props: SettingsContentProps) {
     onToggleDailyQuote,
     aiPersonalizationEnabled,
     onToggleAiPersonalization,
+    githubToolsEnabled,
+    onToggleGithubTools,
     isBiometricLockEnabled,
     isBiometricAvailable,
     biometricKind,
@@ -819,6 +823,29 @@ onSetSyncIntervalSeconds,
             </Text>
             <Text style={[styles.settingValue, { color: colors.textSecondary, fontSize: 12, marginTop: 2 }]}>
               {t('settings.aiPersonalizationDescription', { defaultValue: "When off, AI won't read your notes or journals for data safety" })}
+            </Text>
+          </View>
+        </GroupRow>
+        <GroupRow
+          testID="settings.row.github-tools"
+          trailing={
+            <View className="flex-row items-center gap-2">
+              <Toggle
+                testID="settings.toggle.github-tools"
+                value={isAIEnabled ? githubToolsEnabled : false}
+                onValueChange={onToggleGithubTools}
+                disabled={!isAIEnabled}
+              />
+              <HintIcon hintKey="hints.settings.githubTools" testID="hint.github-tools" />
+            </View>
+          }
+        >
+          <View>
+            <Text style={[styles.settingLabel, { color: colors.text }]}>
+              {t('settings.githubTools.title', { defaultValue: 'GitHub Tools' })}
+            </Text>
+            <Text style={[styles.settingValue, { color: colors.textSecondary, fontSize: 12, marginTop: 2 }]}>
+              {t('settings.githubTools.description', { defaultValue: "Let AI manage issues, PRs, and repos via your active GitHub account." })}
             </Text>
           </View>
         </GroupRow>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -205,7 +205,13 @@
     "chat": "chat",
     "chats": "chats",
     "stopGeneration": "Stop generation",
-    "cancelResponse": "Cancel AI response"
+    "cancelResponse": "Cancel AI response",
+    "hints": {
+      "summarizeIssues": "Summarize my open issues",
+      "showRepos": "Show my repos",
+      "createIssue": "Create an issue",
+      "listPRs": "List open PRs"
+    }
   },
   "explore": {
     "title": "Explore",
@@ -227,6 +233,10 @@
       "title": "Personalize AI with my notes"
     },
     "aiPersonalizationDescription": "When off, AI won't read your notes or journals for data safety",
+    "githubTools": {
+      "title": "GitHub Tools",
+      "description": "Let AI manage issues, PRs, and repos via your active GitHub account."
+    },
     "security": "Security",
     "appearance": "Appearance",
     "updatedUI": "Updated UI",
@@ -479,6 +489,12 @@
     "aiDescription": "Chat over your notes, todos, and canvases. AI can read context and apply edits when you allow it.",
     "aiHelper": "You can turn this on or off anytime in Settings → AI.",
     "aiEnable": "Enable AI",
+    "githubTools": {
+      "title": "GitHub Agent Tools",
+      "body": "Your AI can now list repos, create issues, open pull requests, review changes, and post PR reviews using your connected GitHub account. All write operations respect your Action Mode setting.",
+      "enable": "Enable GitHub Tools",
+      "bodyReminder": "You can turn this on or off anytime in Settings → AI → GitHub Tools."
+    },
     "skipForNow": "Skip for Now"
   },
   "renderStyle": {
@@ -723,7 +739,8 @@
       "providers": "AI providers allow you to connect different AI services. Apple Intelligence uses on-device processing for privacy.",
       "scheduledLearning": "Schedule daily reviews of notes with specific tags. The app sends reminders to help you learn and remember your notes.",
       "dailyQuote": "Shows a daily philosopher quote on your Home screen, personalized based on your recent journal reflections.",
-      "aiPersonalization": "When enabled, AI reads your notes and journals to provide personalized responses. Turn off for data privacy — AI will only use the current chat context."
+      "aiPersonalization": "When enabled, AI reads your notes and journals to provide personalized responses. Turn off for data privacy — AI will only use the current chat context.",
+      "githubTools": "When enabled, your AI agent can list your repos, create issues, open pull requests, review diff changes, and post reviews using your connected GitHub account. Uses the same token you already set up."
     },
     "title": "Hint"
   },

--- a/src/models/AIProvider.ts
+++ b/src/models/AIProvider.ts
@@ -42,6 +42,8 @@ export interface AISettings {
   providers: AIProviderConfig[];
   dailyQuoteEnabled: boolean;
   aiPersonalizationEnabled: boolean;
+  /** Expose seven GitHub tools to the AI agent. Defaults to false (opt-in). */
+  githubToolsEnabled: boolean;
 }
 
 export interface AIContextItem {

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -4,6 +4,7 @@ import { useNavigation, useRoute, type RouteProp } from '@react-navigation/nativ
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { ChatMessageBubble } from '../components/ai/ChatMessageBubble';
+import { ChatHintChips } from '../components/ai/ChatHintChips';
 import { ChatInputBar } from '../components/ai/ChatInputBar';
 import { ChatLoadingStrip } from '../components/ai/ChatLoadingStrip';
 import ContextPickerModal from '../components/ai/ContextPickerModal';
@@ -60,6 +61,13 @@ export default function ChatScreen() {
 
   const [voiceModalVisible, setVoiceModalVisible] = useState(false);
   const [chatText, setChatText] = useState('');
+
+  const handleHintPress = useCallback(
+    (text: string) => {
+      setChatText(text);
+    },
+    [],
+  );
 
   const handleVoiceDone = useCallback((text: string) => {
     setVoiceModalVisible(false);
@@ -139,6 +147,7 @@ export default function ChatScreen() {
                 <Text className="text-md text-center text-text-secondary">
                   {t('chat.emptyStateBody')}
                 </Text>
+                <ChatHintChips onPressHint={handleHintPress} />
               </View>
             }
           />

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -11,6 +11,7 @@ import {
   Clipboard,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
 import { useTheme } from '../contexts/ThemeContext';
 import { OnboardingService } from '../services/OnboardingService';
 import { AuthService } from '../services/AuthService';
@@ -59,9 +60,11 @@ const INFO_STEPS = [
 
 const TOKEN_STEP = INFO_STEPS.length;
 const AI_STEP = TOKEN_STEP + 1;
-const TOTAL_STEPS = INFO_STEPS.length + 2;
+const GITHUB_TOOLS_STEP = AI_STEP + 1;
+const TOTAL_STEPS = INFO_STEPS.length + 3;
 
 export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScreenProps) {
+  const { t } = useTranslation();
   const { colors } = useTheme();
   const [currentStep, setCurrentStep] = useState(0);
   const [token, setToken] = useState('');
@@ -92,16 +95,30 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
       } else {
         setCurrentStep(AI_STEP);
       }
+    } else if (currentStep === AI_STEP) {
+      setCurrentStep(GITHUB_TOOLS_STEP);
+    } else if (currentStep === GITHUB_TOOLS_STEP) {
+      await finish();
     }
-  }, [currentStep, token]);
+  }, [currentStep, token, finish]);
 
   const handleEnableAI = useCallback(async () => {
     await useAIStore.getState().setEnabled(true);
-    await finish();
-  }, [finish]);
+    setCurrentStep(GITHUB_TOOLS_STEP);
+  }, []);
 
   const handleSkipAI = useCallback(async () => {
     await useAIStore.getState().setEnabled(false);
+    await finish();
+  }, [finish]);
+
+  const handleEnableGithubTools = useCallback(async () => {
+    await useAIStore.getState().toggleGithubTools();
+    await finish();
+  }, [finish]);
+
+  const handleSkipGithubTools = useCallback(async () => {
+    // Skipping leaves githubToolsEnabled at its default (false), so no toggle call
     await finish();
   }, [finish]);
 
@@ -112,6 +129,7 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
 
   const isTokenStep = currentStep === TOKEN_STEP;
   const isAIStep = currentStep === AI_STEP;
+  const isGithubToolsStep = currentStep === GITHUB_TOOLS_STEP;
 
   return (
     <SafeAreaView className="flex-1" style={{ backgroundColor: colors.background }} edges={['top', 'bottom']}>
@@ -192,6 +210,21 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
               You can turn this on or off anytime in Settings → AI.
             </Text>
           </View>
+        ) : isGithubToolsStep ? (
+          <View className="flex-1 px-10 items-center">
+            <Surface elevation="raised" radius="pill" className="w-[140px] h-[140px] items-center justify-center mb-6">
+              <Ionicons name="git-branch-outline" size={72} color={colors.accent} />
+            </Surface>
+            <Text className="text-[28px] font-bold text-center" style={{ color: colors.text }}>
+              {t('onboarding.githubTools.title', { defaultValue: 'GitHub Agent Tools' })}
+            </Text>
+            <Text className="text-base text-center leading-6" style={{ color: colors.textSecondary }}>
+              {t('onboarding.githubTools.body', { defaultValue: 'Your AI can now list repos, create issues, open pull requests, review changes, and post PR reviews using your connected GitHub account. All write operations respect your Action Mode setting.' })}
+            </Text>
+            <Text className="text-[13px] text-center leading-[18px] mt-2 opacity-80" style={{ color: colors.textSecondary }}>
+              {t('onboarding.githubTools.bodyReminder', { defaultValue: 'You can turn this on or off anytime in Settings → AI → GitHub Tools.' })}
+            </Text>
+          </View>
         ) : (
           <View className="flex-1 px-10 items-center">
             <Surface elevation="raised" radius="pill" className="w-[140px] h-[140px] items-center justify-center mb-6">
@@ -224,7 +257,26 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
             ))}
           </View>
 
-          {isAIStep ? (
+          {isGithubToolsStep ? (
+            <View className="w-full">
+              <Button
+                variant="primary"
+                fullWidth
+                testID="onboarding.button.enable-github-tools"
+                onPress={handleEnableGithubTools}
+                label={t('onboarding.githubTools.enable', { defaultValue: 'Enable GitHub Tools' })}
+                trailingIcon={<Ionicons name="git-branch-outline" size={20} color={colors.accent} />}
+              />
+              <Button
+                variant="ghost"
+                fullWidth
+                testID="onboarding.button.skip-github-tools"
+                onPress={handleSkipGithubTools}
+                label="Skip for Now"
+                style={{ marginTop: 8 }}
+              />
+            </View>
+          ) : isAIStep ? (
             <View className="w-full">
               <Button
                 variant="primary"

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -91,6 +91,8 @@ export default function SettingsScreen() {
   const toggleDailyQuote = useAIStore((state) => state.toggleDailyQuote);
   const aiPersonalizationEnabled = useAIStore((state) => state.aiPersonalizationEnabled);
   const toggleAiPersonalization = useAIStore((state) => state.toggleAiPersonalization);
+  const githubToolsEnabled = useAIStore((state) => state.githubToolsEnabled);
+  const toggleGithubTools = useAIStore((state) => state.toggleGithubTools);
   const setActionMode = useAIStore((state) => state.setActionMode);
 
   const [showRepoPickerModal, setShowRepoPickerModal] = useState(false);
@@ -722,6 +724,8 @@ export default function SettingsScreen() {
         onToggleDailyQuote={() => { void toggleDailyQuote(); }}
         aiPersonalizationEnabled={aiPersonalizationEnabled}
         onToggleAiPersonalization={() => { void toggleAiPersonalization(); }}
+        githubToolsEnabled={githubToolsEnabled}
+        onToggleGithubTools={() => { void toggleGithubTools(); }}
         onOpenModelSelector={() => setShowModelSelector(true)}
         onToggleActionMode={() => { void setActionMode(actionMode === 'auto' ? 'confirm' : 'auto'); }}
         onOpenChatRepoPicker={() => { setShowTemplatesRepoPicker(false); setShowChatRepoPicker(true); }}

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -167,6 +167,42 @@ export interface GitHubContent {
   sha?: string;
 }
 
+export interface GitHubCreateIssueInput {
+  owner: string;
+  repo: string;
+  title: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+}
+
+export interface GitHubPullRequestDiff {
+  files: Array<{
+    filename: string;
+    status: string;
+    additions: number;
+    deletions: number;
+    patch?: string;
+  }>;
+}
+
+export interface GitHubReviewInput {
+  owner: string;
+  repo: string;
+  pull_number: number;
+  body: string;
+  event: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
+}
+
+export interface GitHubReview {
+  id: number;
+  user: { login: string };
+  body: string;
+  state: string;
+  submitted_at: string;
+  html_url?: string;
+}
+
 export interface GitHubFileCommit {
   content: { sha: string } | null;
   commit: { sha: string };
@@ -401,6 +437,67 @@ class GitHubServiceClass {
       return data as GitHubPullRequest;
     } catch (error) {
       console.warn('[GitHubService] Failed to create pull request:', error);
+      return null;
+    }
+  }
+
+  async createIssue(input: GitHubCreateIssueInput): Promise<GitHubIssue | null> {
+    try {
+      const data = await this.request(
+        `https://api.github.com/repos/${input.owner}/${input.repo}/issues`,
+        'POST',
+        {
+          title: input.title,
+          body: input.body,
+          labels: input.labels,
+          assignees: input.assignees,
+        }
+      );
+      return data as GitHubIssue;
+    } catch (error) {
+      console.warn('[GitHubService] Failed to create issue:', error);
+      return null;
+    }
+  }
+
+  async getPullRequestDiff(
+    owner: string,
+    repo: string,
+    pull_number: number,
+  ): Promise<GitHubPullRequestDiff | null> {
+    try {
+      const data = await this.request<
+        Array<{ filename: string; status: string; additions: number; deletions: number; patch?: string }>
+      >(`https://api.github.com/repos/${owner}/${repo}/pulls/${pull_number}/files`);
+      if (!Array.isArray(data)) return null;
+      return {
+        files: data.map((f) => ({
+          filename: f.filename,
+          status: f.status,
+          additions: f.additions,
+          deletions: f.deletions,
+          patch: f.patch,
+        })),
+      };
+    } catch (error) {
+      console.warn('[GitHubService] Failed to get pull request diff:', error);
+      return null;
+    }
+  }
+
+  async reviewPullRequest(input: GitHubReviewInput): Promise<GitHubReview | null> {
+    try {
+      const data = await this.request(
+        `https://api.github.com/repos/${input.owner}/${input.repo}/pulls/${input.pull_number}/reviews`,
+        'POST',
+        {
+          body: input.body,
+          event: input.event,
+        }
+      );
+      return data as GitHubReview;
+    } catch (error) {
+      console.warn('[GitHubService] Failed to review pull request:', error);
       return null;
     }
   }

--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -3,6 +3,7 @@ import { TodoCreateInput, TodoPriority, TodoUpdateInput } from '../../models/Tod
 import { useNoteStore } from '../../stores/noteStore';
 import { useTodoStore } from '../../stores/todoStore';
 import { useAIStore } from '../../stores/aiStore';
+import { GitHubService } from '../GitHubService';
 import { NoteSyncQueueService } from '../NoteSyncQueueService';
 
 export interface ProposedChange {
@@ -25,9 +26,27 @@ type ActionMode = 'auto' | 'confirm';
 const NOTE_FORMATS: NoteFormat[] = ['markdown', 'neorg', 'org', 'pdf'];
 const TODO_PRIORITIES: TodoPriority[] = ['low', 'medium', 'high'];
 
+const GITHUB_TOOL_NAMES = new Set<string>([
+  'list_repos',
+  'list_issues',
+  'create_issue',
+  'list_pull_requests',
+  'create_pull_request',
+  'get_pull_request_diff',
+  'review_pull_request',
+]);
+
 function getStringArg(args: Record<string, unknown>, key: string): string {
   const value = args[key];
   if (typeof value !== 'string') {
+    throw new Error(`Missing or invalid '${key}'`);
+  }
+  return value;
+}
+
+function getNumberArg(args: Record<string, unknown>, key: string): number {
+  const value = args[key];
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
     throw new Error(`Missing or invalid '${key}'`);
   }
   return value;
@@ -140,6 +159,16 @@ export async function executeToolCall(
   mode: ActionMode,
 ): Promise<ActionExecutorResult> {
   try {
+    // GitHub tools gate — checked here as defence-in-depth
+    // (the chat controller also gates registration)
+    if (GITHUB_TOOL_NAMES.has(toolName) && !useAIStore.getState().githubToolsEnabled) {
+      return {
+        success: false,
+        requiresConfirmation: false,
+        error: 'GitHub tools are disabled. Enable them in Settings → AI → GitHub Tools.',
+      };
+    }
+
     switch (toolName) {
       case 'create_note': {
         const aiState = useAIStore.getState();
@@ -384,6 +413,142 @@ export async function executeToolCall(
         });
 
         return buildSuccessResult(todos);
+      }
+
+      case 'list_repos': {
+        const repos = await GitHubService.getRepositories();
+        return buildSuccessResult(
+          repos.map((r) => ({
+            id: r.id,
+            name: r.full_name,
+            private: r.private,
+            description: r.description,
+            url: r.html_url,
+          })),
+        );
+      }
+
+      case 'list_issues': {
+        const owner = getStringArg(args, 'owner');
+        const repo = getStringArg(args, 'repo');
+        const issues = await GitHubService.getIssues(owner, repo);
+        return buildSuccessResult(
+          issues.map((i) => ({
+            number: i.number,
+            title: i.title,
+            state: i.state,
+            html_url: i.html_url,
+            created_at: i.created_at,
+          })),
+        );
+      }
+
+      case 'create_issue': {
+        const owner = getStringArg(args, 'owner');
+        const repo = getStringArg(args, 'repo');
+        const title = getStringArg(args, 'title');
+        const body = getOptionalStringArg(args, 'body');
+        const labels = getOptionalStringArrayArg(args, 'labels');
+        const assignees = getOptionalStringArrayArg(args, 'assignees');
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'create_issue',
+            description: `Create issue "${title}" in ${owner}/${repo}`,
+            details: toDetails({ owner, repo, title, body, labels, assignees }),
+          });
+        }
+
+        const created = await GitHubService.createIssue({ owner, repo, title, body, labels, assignees });
+        if (!created) {
+          return {
+            success: false,
+            requiresConfirmation: false,
+            error: 'Failed to create issue. Check token permissions for Issues: Read and write.',
+          };
+        }
+        return buildSuccessResult({ number: created.number, title: created.title, html_url: created.html_url });
+      }
+
+      case 'list_pull_requests': {
+        const owner = getStringArg(args, 'owner');
+        const repo = getStringArg(args, 'repo');
+        const prs = await GitHubService.getPullRequests(owner, repo);
+        return buildSuccessResult(
+          prs.map((p) => ({
+            number: p.number,
+            title: p.title,
+            state: p.state,
+            html_url: p.html_url,
+            draft: p.draft,
+          })),
+        );
+      }
+
+      case 'create_pull_request': {
+        const owner = getStringArg(args, 'owner');
+        const repo = getStringArg(args, 'repo');
+        const title = getStringArg(args, 'title');
+        const body = getOptionalStringArg(args, 'body');
+        const head = getStringArg(args, 'head');
+        const base = getStringArg(args, 'base');
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'create_pull_request',
+            description: `Create PR "${title}" (${head} → ${base}) in ${owner}/${repo}`,
+            details: toDetails({ owner, repo, title, body, head, base }),
+          });
+        }
+
+        const pr = await GitHubService.createPullRequest({ owner, repo, title, body: body ?? '', head, base });
+        if (!pr) {
+          return { success: false, requiresConfirmation: false, error: 'Failed to create pull request.' };
+        }
+        return buildSuccessResult({ number: pr.number, title: pr.title, html_url: pr.html_url, draft: pr.draft });
+      }
+
+      case 'get_pull_request_diff': {
+        const owner = getStringArg(args, 'owner');
+        const repo = getStringArg(args, 'repo');
+        const pull_number = getNumberArg(args, 'pull_number');
+        const diff = await GitHubService.getPullRequestDiff(owner, repo, pull_number);
+        if (!diff) {
+          return { success: false, requiresConfirmation: false, error: 'Could not fetch PR diff.' };
+        }
+        return buildSuccessResult({
+          files: diff.files.map((f) => ({
+            filename: f.filename,
+            status: f.status,
+            additions: f.additions,
+            deletions: f.deletions,
+          })),
+        });
+      }
+
+      case 'review_pull_request': {
+        const owner = getStringArg(args, 'owner');
+        const repo = getStringArg(args, 'repo');
+        const pull_number = getNumberArg(args, 'pull_number');
+        const body = getStringArg(args, 'body');
+        const event = getStringArg(args, 'event') as 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
+        if (!['APPROVE', 'REQUEST_CHANGES', 'COMMENT'].includes(event)) {
+          throw new Error("Invalid 'event' — must be APPROVE, REQUEST_CHANGES, or COMMENT");
+        }
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'review_pull_request',
+            description: `Post ${event} review on PR #${pull_number} in ${owner}/${repo}`,
+            details: toDetails({ owner, repo, pull_number, body, event }),
+          });
+        }
+
+        const review = await GitHubService.reviewPullRequest({ owner, repo, pull_number, body, event });
+        if (!review) {
+          return { success: false, requiresConfirmation: false, error: 'Failed to post review.' };
+        }
+        return buildSuccessResult({ id: review.id, state: review.state, html_url: review.html_url });
       }
 
       default:

--- a/src/services/ai/systemPrompt.ts
+++ b/src/services/ai/systemPrompt.ts
@@ -4,6 +4,8 @@ type SystemPromptContext = {
   todoCount: number;
   actionMode: 'auto' | 'confirm';
   memoryBlock?: string;
+  githubToolsEnabled?: boolean;
+  githubAccountLogin?: string;
 };
 
 const BASE_PROMPT =
@@ -27,6 +29,23 @@ export function buildSystemPrompt(context: SystemPromptContext): string {
   if (context.memoryBlock) {
     sections.push(
       `=== User memory (thought dumps) ===\n${context.memoryBlock}\n=== End memory ===`
+    );
+  }
+
+  if (context.githubToolsEnabled) {
+    const loginLine = context.githubAccountLogin
+      ? ` for the account @${context.githubAccountLogin}`
+      : '';
+    sections.push(
+      `=== GitHub Tools${loginLine} ===
+You have access to GitHub tools:
+- list_repos: list repositories the user has access to
+- list_issues / create_issue: view and create issues in any repository
+- list_pull_requests / create_pull_request: view and open pull requests
+- get_pull_request_diff: fetch the file-level diff for review
+- review_pull_request: post an APPROVE, REQUEST_CHANGES, or COMMENT review on a PR
+Use these tools when the user asks about their repos, issues, PRs, or reviews. Always confirm before write operations if the user has actionMode=confirm.
+=== End GitHub Tools ===`
     );
   }
 

--- a/src/services/ai/tools.ts
+++ b/src/services/ai/tools.ts
@@ -127,3 +127,101 @@ export const chatTools = {
   search_todos,
   get_todos,
 };
+
+export const listReposParameters = z.object({});
+
+export const list_repos = tool({
+  description: 'List the repositories accessible with the linked account.',
+  inputSchema: listReposParameters,
+  execute: async (params) => params,
+});
+
+export const listIssuesParameters = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  state: z.enum(['open', 'closed', 'all']).optional(),
+});
+
+export const list_issues = tool({
+  description: 'List issues in a repository with an optional state filter.',
+  inputSchema: listIssuesParameters,
+  execute: async (params) => params,
+});
+
+export const createIssueParameters = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  title: z.string(),
+  body: z.string().optional(),
+  labels: z.array(z.string()).optional(),
+  assignees: z.array(z.string()).optional(),
+});
+
+export const create_issue = tool({
+  description: 'Create a new issue in a repository.',
+  inputSchema: createIssueParameters,
+  execute: async (params) => params,
+});
+
+export const listPullRequestsParameters = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  state: z.enum(['open', 'closed', 'all']).optional(),
+});
+
+export const list_pull_requests = tool({
+  description: 'List pull requests in a repository with an optional state filter.',
+  inputSchema: listPullRequestsParameters,
+  execute: async (params) => params,
+});
+
+export const createPullRequestParameters = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  title: z.string(),
+  body: z.string().optional(),
+  head: z.string(),
+  base: z.string(),
+});
+
+export const create_pull_request = tool({
+  description: 'Create a new pull request from a head branch into a base branch.',
+  inputSchema: createPullRequestParameters,
+  execute: async (params) => params,
+});
+
+export const getPullRequestDiffParameters = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  pull_number: z.number(),
+});
+
+export const get_pull_request_diff = tool({
+  description: 'Fetch the diff of a pull request by number.',
+  inputSchema: getPullRequestDiffParameters,
+  execute: async (params) => params,
+});
+
+export const reviewPullRequestParameters = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  pull_number: z.number(),
+  body: z.string(),
+  event: z.enum(['APPROVE', 'REQUEST_CHANGES', 'COMMENT']),
+});
+
+export const review_pull_request = tool({
+  description: 'Submit a review on a pull request.',
+  inputSchema: reviewPullRequestParameters,
+  execute: async (params) => params,
+});
+
+export const githubTools = {
+  list_repos,
+  list_issues,
+  create_issue,
+  list_pull_requests,
+  create_pull_request,
+  get_pull_request_diff,
+  review_pull_request,
+};

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -22,6 +22,7 @@ interface AIState {
   error: string | null;
   dailyQuoteEnabled: boolean;
   aiPersonalizationEnabled: boolean;
+  githubToolsEnabled: boolean;
 }
 
 interface AIActions {
@@ -40,6 +41,7 @@ interface AIActions {
   loadSettings: () => Promise<void>;
   toggleDailyQuote: () => Promise<void>;
   toggleAiPersonalization: () => Promise<void>;
+  toggleGithubTools: () => Promise<void>;
 }
 
 const createDefaultProviders = (): AIProviderConfig[] => [
@@ -95,6 +97,7 @@ const createDefaultSettings = (): AISettings => ({
   providers: createDefaultProviders(),
   dailyQuoteEnabled: true,
   aiPersonalizationEnabled: true,
+  githubToolsEnabled: false,
 });
 
 const getProviderApiKeyStorageKey = (providerId: string) => `${AI_PROVIDER_KEY_PREFIX}${providerId}`;
@@ -338,6 +341,11 @@ export const useAIStore = create<AIState & AIActions>()((set, get) => ({
     await get().persistSettings();
   },
 
+  toggleGithubTools: async () => {
+    set((state) => ({ githubToolsEnabled: !state.githubToolsEnabled, error: null }));
+    await get().persistSettings();
+  },
+
   getAvailableModels: () =>
     get()
       .providers.filter((provider) => provider.isEnabled)
@@ -374,6 +382,7 @@ export const useAIStore = create<AIState & AIActions>()((set, get) => ({
         providers,
         dailyQuoteEnabled,
         aiPersonalizationEnabled,
+        githubToolsEnabled,
       } = get();
 
       await Promise.all(
@@ -400,6 +409,7 @@ export const useAIStore = create<AIState & AIActions>()((set, get) => ({
         providers: providers.map(stripProviderApiKey),
         dailyQuoteEnabled,
         aiPersonalizationEnabled,
+        githubToolsEnabled,
       };
 
       await AsyncStorage.setItem(AI_SETTINGS_STORAGE_KEY, JSON.stringify(settingsToPersist));


### PR DESCRIPTION
## What

Gives the AI agent seven new GitHub tools (list repos, list issues, create issue, list PRs, create PR, get PR diff, post PR review) behind a single opt-in toggle (`githubToolsEnabled`, default **false**) — plus a new onboarding step explaining capabilities, and interactive hint chips on empty-chat states.

## Changes

- **Backend (GitHubService.ts)**: 3 new methods — `createIssue`, `getPullRequestDiff`, `reviewPullRequest`
- **Tool schemas (tools.ts)**: 7 new Zod + AI-SDK tool definitions, exported in separate `githubTools` map
- **Action executor (actionExecutor.ts)**: 7 switch cases honoring `confirm` mode on writes; gated by `githubToolsEnabled`
- **Store (aiStore.ts + AISettings)**: `githubToolsEnabled: boolean` persisted via AsyncStorage (default false)
- **System prompt (systemPrompt.ts)**: conditional GitHub section when enabled
- **Controller (useChatScreenController.ts)**: reactively merges GitHub tools into schema based on toggle
- **Settings (SettingsContent.tsx + SettingsScreen.tsx)**: new toggle in AI section with HintIcon tooltip
- **Onboarding (OnboardingScreen.tsx)**: new GitHub Agent Tools step between AI and finish
- **Chat (ChatScreen.tsx)**: new `<ChatHintChips />` component in empty state with 4 tappable suggestion chips
- **i18n (en.json)**: keys under `chat.hints.*`, `settings.githubTools.*`, `onboarding.githubTools.*`, `hints.settings.githubTools`
- **Tests**: 3 new test files — `GitHubTools.test.ts`, `aiStore.githubTools.test.ts`, `ChatHintChips.test.tsx` (28 tests, all pass)

## Verification

- `yarn ts:check` exits 0
- `yarn eslint . --ext .ts,.tsx` exits 0 (0 errors)
- `yarn jest` — 28 new tests + 1896 total tests pass, 3 skipped, 0 failed
- Default: `githubToolsEnabled = false` — existing behavior 100% preserved until explicit opt-in

## Plan

`.omo/plans/github-agent-tools.md`

## Not included (out of scope)

- No GitHub Actions/Workflows/Discussions/Webhooks
- No new OAuth / PAT permissions
- No merge-PR tool
- No multi-language i18n (en only, defaultValue fallbacks)