### PR TITLE
chore(release): bump app and package version to 1.5.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "GitNotēs",
     "slug": "gitnotes",
-    "version": "1.2.0",
+    "version": "1.5.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnotes",
-  "version": "1.2.0",
+  "version": "1.5.0",
   "license": "MPL-2.0",
   "main": "expo/AppEntry.js",
   "engines": {


### PR DESCRIPTION
Version bump 1.2.0 → 1.5.0 following the established release convention (commit 874e591 pattern).

## Changes
- `package.json`: `version` → `1.5.0`
- `app.json`: `expo.version` → `1.5.0`

Follows repo history exactly: prior bumps (1.1.1 → 1.1.2 → 1.2.0) touched only these two files. iOS `buildNumber` left at 8 per convention (only bumped once historically at 1.0.7). The `ios/` directory is gitignored (Expo prebuild artifact) — generated plists will pick up the new version on next `expo prebuild`.

## Verification
- `yarn ts:check` exits 0
- Diff is exactly 2 lines (2 files, +2/-2)
- `Constants.expoConfig?.version` in Settings renders this value dynamically — no other code references the version string.