### PR TITLE
Followup: wire GitHub tools state param / i18n parity / gating test

### DIFF
--- a/__tests__/ai/GitHubTools.test.ts
+++ b/__tests__/ai/GitHubTools.test.ts
@@ -145,6 +145,89 @@ describe('GitHubService agent-tool methods', () => {
     });
   });
 
+  describe('getIssues', () => {
+    test('defaults to state=open in the request URL when state is omitted', async () => {
+      mockHttpRequest.mockResolvedValueOnce({ data: [] });
+
+      const issues = await GitHubService.getIssues('octo', 'notes');
+
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://api.github.com/repos/octo/notes/issues?state=open&per_page=50',
+        }),
+      );
+      expect(issues).toEqual([]);
+    });
+
+    test('passes the requested state into the request URL', async () => {
+      mockHttpRequest.mockResolvedValueOnce({
+        data: [
+          {
+            id: 5,
+            number: 5,
+            title: 'Fixed crash',
+            body: '',
+            state: 'closed',
+            html_url: 'https://github.com/octo/notes/issues/5',
+            milestone: null,
+            labels: [],
+            assignees: [],
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const issues = await GitHubService.getIssues('octo', 'notes', 'closed');
+
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://api.github.com/repos/octo/notes/issues?state=closed&per_page=50',
+        }),
+      );
+      expect(issues).toHaveLength(1);
+      expect(issues[0]?.state).toBe('closed');
+    });
+
+    test('passes state=all into the request URL', async () => {
+      mockHttpRequest.mockResolvedValueOnce({ data: [] });
+
+      await GitHubService.getIssues('octo', 'notes', 'all');
+
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining('state=all'),
+        }),
+      );
+    });
+  });
+
+  describe('getPullRequests', () => {
+    test('defaults to state=open in the request URL when state is omitted', async () => {
+      mockHttpRequest.mockResolvedValueOnce({ data: [] });
+
+      await GitHubService.getPullRequests('octo', 'notes');
+
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://api.github.com/repos/octo/notes/pulls?state=open&per_page=50',
+        }),
+      );
+    });
+
+    test('passes the requested state into the request URL', async () => {
+      mockHttpRequest.mockResolvedValueOnce({ data: [] });
+
+      await GitHubService.getPullRequests('octo', 'notes', 'closed');
+
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://api.github.com/repos/octo/notes/pulls?state=closed&per_page=50',
+        }),
+      );
+    });
+  });
+
   describe('getPullRequestDiff', () => {
     test('maps the files endpoint response into a diff shape', async () => {
       mockHttpRequest.mockResolvedValueOnce({
@@ -379,6 +462,76 @@ describe('executeToolCall - GitHub tools enabled', () => {
         url: 'https://github.com/a/b',
       },
     ]);
+  });
+
+  test('list_issues passes a valid state through to the service', async () => {
+    const getIssuesSpy = jest.spyOn(GitHubService, 'getIssues').mockResolvedValue([]);
+
+    const result = await executeToolCall(
+      'list_issues',
+      { owner: 'octo', repo: 'notes', state: 'closed' },
+      'auto',
+    );
+
+    expect(getIssuesSpy).toHaveBeenCalledWith('octo', 'notes', 'closed');
+    expect(result.success).toBe(true);
+    expect(result.requiresConfirmation).toBe(false);
+    expect(result.data).toEqual([]);
+  });
+
+  test('list_issues defaults to open when state is omitted', async () => {
+    const getIssuesSpy = jest.spyOn(GitHubService, 'getIssues').mockResolvedValue([]);
+
+    const result = await executeToolCall('list_issues', { owner: 'octo', repo: 'notes' }, 'auto');
+
+    expect(getIssuesSpy).toHaveBeenCalledWith('octo', 'notes', 'open');
+    expect(result.success).toBe(true);
+  });
+
+  test('list_issues rejects an invalid state without calling the service', async () => {
+    const getIssuesSpy = jest.spyOn(GitHubService, 'getIssues');
+
+    const result = await executeToolCall(
+      'list_issues',
+      { owner: 'octo', repo: 'notes', state: 'bogus' },
+      'auto',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.requiresConfirmation).toBe(false);
+    expect(result.error).toMatch(/Invalid 'state'/);
+    expect(getIssuesSpy).not.toHaveBeenCalled();
+  });
+
+  test('list_pull_requests passes a valid state through to the service', async () => {
+    const getPullRequestsSpy = jest
+      .spyOn(GitHubService, 'getPullRequests')
+      .mockResolvedValue([]);
+
+    const result = await executeToolCall(
+      'list_pull_requests',
+      { owner: 'octo', repo: 'notes', state: 'all' },
+      'auto',
+    );
+
+    expect(getPullRequestsSpy).toHaveBeenCalledWith('octo', 'notes', 'all');
+    expect(result.success).toBe(true);
+    expect(result.requiresConfirmation).toBe(false);
+  });
+
+  test('list_pull_requests rejects an invalid state without calling the service', async () => {
+    const getPullRequestsSpy = jest.spyOn(GitHubService, 'getPullRequests');
+
+    const result = await executeToolCall(
+      'list_pull_requests',
+      { owner: 'octo', repo: 'notes', state: 'merged' },
+      'auto',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.requiresConfirmation).toBe(false);
+    expect(result.error).toMatch(/Invalid 'state'/);
+    expect(getPullRequestsSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/useChatScreenController.githubTools.test.ts
+++ b/__tests__/useChatScreenController.githubTools.test.ts
@@ -1,0 +1,178 @@
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (value: string) => value }),
+}));
+
+jest.mock('../src/services/AIService', () => ({
+  initializeModel: jest.fn(async () => ({})),
+  streamChatResponse: jest.fn(),
+}));
+
+jest.mock('../src/services/ContextService', () => ({
+  buildContextString: jest.fn(async () => ''),
+}));
+
+jest.mock('../src/services/ChatStorageService', () => ({
+  loadThreadSummaries: jest.fn(async () => []),
+  loadThread: jest.fn(async () => null),
+  saveThread: jest.fn(async () => undefined),
+  deleteThread: jest.fn(async () => true),
+  setChatRepoAccount: jest.fn(),
+}));
+
+jest.mock('../src/services/ai/systemPrompt', () => ({
+  buildSystemPrompt: jest.fn(() => 'system prompt'),
+}));
+
+jest.mock('../src/services/ai/modelLimits', () => ({
+  checkContextBudget: jest.fn(() => ({ warningLevel: 'none', message: '' })),
+}));
+
+jest.mock('../src/services/ai/actionExecutor', () => ({
+  executeToolCall: jest.fn(async () => ({ success: true, requiresConfirmation: false })),
+}));
+
+jest.mock('../src/services/ai/tools', () => ({
+  chatTools: {
+    create_note: { description: 'Create a note' },
+    edit_note: { description: 'Edit a note' },
+    delete_note: { description: 'Delete a note' },
+    search_notes: { description: 'Search notes' },
+    get_note: { description: 'Get a note' },
+    create_todo: { description: 'Create a todo' },
+    edit_todo: { description: 'Edit a todo' },
+    delete_todo: { description: 'Delete a todo' },
+    search_todos: { description: 'Search todos' },
+    get_todos: { description: 'Get todos' },
+  },
+  githubTools: {
+    list_repos: { description: 'List repositories' },
+    list_issues: { description: 'List issues' },
+    create_issue: { description: 'Create an issue' },
+    list_pull_requests: { description: 'List pull requests' },
+    create_pull_request: { description: 'Create a pull request' },
+    get_pull_request_diff: { description: 'Get a pull request diff' },
+    review_pull_request: { description: 'Review a pull request' },
+  },
+}));
+
+import {
+  buildChatToolsMap,
+  sanitizeToolName,
+} from '../src/components/chat/useChatScreenController';
+import { useAIStore } from '../src/stores/aiStore';
+
+const CHAT_TOOL_NAMES = [
+  'create_note',
+  'edit_note',
+  'delete_note',
+  'search_notes',
+  'get_note',
+  'create_todo',
+  'edit_todo',
+  'delete_todo',
+  'search_todos',
+  'get_todos',
+];
+
+const GITHUB_TOOL_NAMES = [
+  'list_repos',
+  'list_issues',
+  'create_issue',
+  'list_pull_requests',
+  'create_pull_request',
+  'get_pull_request_diff',
+  'review_pull_request',
+];
+
+describe('useChatScreenController github tools gating', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('buildChatToolsMap', () => {
+    test('includes all chat and github tools when githubToolsEnabled is true', () => {
+      useAIStore.setState({ githubToolsEnabled: true });
+
+      const toolsMap = buildChatToolsMap(true);
+      const keys = Object.keys(toolsMap);
+
+      expect(keys).toHaveLength(CHAT_TOOL_NAMES.length + GITHUB_TOOL_NAMES.length);
+      for (const name of CHAT_TOOL_NAMES) {
+        expect(toolsMap).toHaveProperty(name);
+      }
+      for (const name of GITHUB_TOOL_NAMES) {
+        expect(toolsMap).toHaveProperty(name);
+      }
+    });
+
+    test('includes only chat tools when githubToolsEnabled is false', () => {
+      useAIStore.setState({ githubToolsEnabled: false });
+
+      const toolsMap = buildChatToolsMap(false);
+      const keys = Object.keys(toolsMap);
+
+      expect(keys).toHaveLength(CHAT_TOOL_NAMES.length);
+      for (const name of CHAT_TOOL_NAMES) {
+        expect(toolsMap).toHaveProperty(name);
+      }
+      for (const name of GITHUB_TOOL_NAMES) {
+        expect(toolsMap).not.toHaveProperty(name);
+      }
+      expect(toolsMap).not.toHaveProperty('list_repos');
+    });
+
+    test('defaults to the store flag when called with no argument', () => {
+      useAIStore.setState({ githubToolsEnabled: true });
+
+      const toolsMap = buildChatToolsMap();
+
+      for (const name of GITHUB_TOOL_NAMES) {
+        expect(toolsMap).toHaveProperty(name);
+      }
+      for (const name of CHAT_TOOL_NAMES) {
+        expect(toolsMap).toHaveProperty(name);
+      }
+    });
+
+    test('explicit false wins over a true store flag', () => {
+      useAIStore.setState({ githubToolsEnabled: true });
+
+      const toolsMap = buildChatToolsMap(false);
+
+      expect(Object.keys(toolsMap)).toHaveLength(CHAT_TOOL_NAMES.length);
+      for (const name of GITHUB_TOOL_NAMES) {
+        expect(toolsMap).not.toHaveProperty(name);
+      }
+    });
+  });
+
+  describe('sanitizeToolName', () => {
+    const enabledNames = new Set<string>([...CHAT_TOOL_NAMES, ...GITHUB_TOOL_NAMES]);
+
+    test('returns the name when it is known', () => {
+      expect(sanitizeToolName('list_repos', enabledNames)).toBe('list_repos');
+    });
+
+    test('returns the tool name from a colon-prefixed variant', () => {
+      expect(sanitizeToolName('list_repos:xyz', enabledNames)).toBe('list_repos');
+    });
+
+    test('returns null for an unknown name', () => {
+      expect(sanitizeToolName('drop_table', enabledNames)).toBeNull();
+    });
+
+    test('returns null for empty or missing input', () => {
+      expect(sanitizeToolName('', enabledNames)).toBeNull();
+      expect(sanitizeToolName('   ', enabledNames)).toBeNull();
+      expect(sanitizeToolName(undefined, enabledNames)).toBeNull();
+    });
+
+    test('rejects github tools when the known set is built with gating off', () => {
+      useAIStore.setState({ githubToolsEnabled: false });
+      const gatedNames = new Set<string>(Object.keys(buildChatToolsMap(false)));
+
+      expect(sanitizeToolName('list_repos', gatedNames)).toBeNull();
+      expect(sanitizeToolName('create_note', gatedNames)).toBe('create_note');
+    });
+  });
+});

--- a/src/components/chat/useChatScreenController.ts
+++ b/src/components/chat/useChatScreenController.ts
@@ -39,11 +39,11 @@ type ToolListItem = {
   completed?: boolean;
 };
 
-function buildChatToolsMap(enabled: boolean = useAIStore.getState().githubToolsEnabled) {
+export function buildChatToolsMap(enabled: boolean = useAIStore.getState().githubToolsEnabled) {
   return enabled ? { ...chatTools, ...githubTools } : chatTools;
 }
 
-function sanitizeToolName(raw: string | undefined, knownToolNames: ReadonlySet<string>): string | null {
+export function sanitizeToolName(raw: string | undefined, knownToolNames: ReadonlySet<string>): string | null {
   const trimmed = raw?.trim();
   if (!trimmed) return null;
   if (knownToolNames.has(trimmed)) return trimmed;

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -91,6 +91,10 @@
       "title": "KI mit meinen Notizen personalisieren"
     },
     "aiPersonalizationDescription": "Wenn aus, liest die KI keine Notizen oder Tagebücher zum Datenschutz",
+    "githubTools": {
+      "title": "GitHub-Tools",
+      "description": "Die KI kann Issues, PRs und Repositories über dein aktives GitHub-Konto verwalten."
+    },
     "security": "Sicherheit",
     "appearance": "Erscheinungsbild",
     "updatedUI": "Aktualisierte Oberfläche",
@@ -163,7 +167,13 @@
   "chat": {
     "askAI": "KI fragen",
     "typeMessage": "Nachricht eingeben...",
-    "thinking": "Denke nach..."
+    "thinking": "Denke nach...",
+    "hints": {
+      "summarizeIssues": "Fasse meine offenen Issues zusammen",
+      "showRepos": "Zeige meine Repositories",
+      "createIssue": "Issue erstellen",
+      "listPRs": "Offene PRs auflisten"
+    }
   },
   "errors": {
     "somethingWrong": "Etwas ist schiefgelaufen",
@@ -204,7 +214,8 @@
       "providers": "KI-Anbieter ermöglichen dir, verschiedene KI-Dienste zu verbinden. Apple Intelligence nutzt On-Device-Verarbeitung für Datenschutz.",
       "scheduledLearning": "KI-Anbieter ermöglichen dir, verschiedene KI-Dienste zu verbinden. Apple Intelligence nutzt On-Device-Verarbeitung für Datenschutz.",
       "dailyQuote": "Zeigt ein tägliches Philosophenzitat auf deinem Startbildschirm, personalisiert basierend auf deinen letzten Tagebuch-Reflexionen.",
-      "aiPersonalization": "Wenn aktiviert, liest die KI deine Notizen und Tagebücher, um personalisierte Antworten zu liefern. Deaktivieren für Datenschutz — KI verwendet nur den aktuellen Chat-Kontext."
+      "aiPersonalization": "Wenn aktiviert, liest die KI deine Notizen und Tagebücher, um personalisierte Antworten zu liefern. Deaktivieren für Datenschutz — KI verwendet nur den aktuellen Chat-Kontext.",
+      "githubTools": "Wenn aktiviert, kann dein KI-Agent deine Repositories auflisten, Issues erstellen, Pull Requests öffnen, Diff-Änderungen prüfen und Reviews posten – über dein verbundenes GitHub-Konto. Verwendet denselben Token, den du bereits eingerichtet hast."
     },
     "title": "Hint"
   },
@@ -332,6 +343,12 @@
     "aiDescription": "Chat over your notes, todos, and canvases. AI can read context and apply edits when you allow it.",
     "aiHelper": "You can turn this on or off anytime in Settings → AI.",
     "aiEnable": "Enable AI",
+    "githubTools": {
+      "title": "GitHub-Agent-Tools",
+      "body": "Deine KI kann jetzt Repositories auflisten, Issues erstellen, Pull Requests öffnen, Änderungen prüfen und PR-Reviews posten – über dein verbundenes GitHub-Konto. Alle Schreibvorgänge beachten deine Aktionsmodus-Einstellung.",
+      "enable": "GitHub-Tools aktivieren",
+      "bodyReminder": "Du kannst dies jederzeit unter Einstellungen → KI → GitHub-Tools ein- oder ausschalten."
+    },
     "skipForNow": "Skip for Now"
   },
   "renderStyle": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -91,6 +91,10 @@
       "title": "Personalizar IA con mis notas"
     },
     "aiPersonalizationDescription": "Cuando está desactivado, la IA no lee tus notas ni diarios por seguridad",
+    "githubTools": {
+      "title": "Herramientas de GitHub",
+      "description": "Permite que la IA gestione issues, PRs y repositorios con tu cuenta activa de GitHub."
+    },
     "security": "Seguridad",
     "appearance": "Apariencia",
     "updatedUI": "IU actualizada",
@@ -163,7 +167,13 @@
   "chat": {
     "askAI": "Preguntar a IA",
     "typeMessage": "Escribe un mensaje...",
-    "thinking": "Pensando..."
+    "thinking": "Pensando...",
+    "hints": {
+      "summarizeIssues": "Resume mis issues abiertos",
+      "showRepos": "Muestra mis repositorios",
+      "createIssue": "Crear un issue",
+      "listPRs": "Lista los PR abiertos"
+    }
   },
   "errors": {
     "somethingWrong": "Algo salió mal",
@@ -204,7 +214,8 @@
       "providers": "Los proveedores IA te permiten conectar diferentes servicios de IA. Apple Intelligence usa procesamiento en el dispositivo para mayor privacidad.",
       "scheduledLearning": "Los proveedores IA te permiten conectar diferentes servicios de IA. Apple Intelligence usa procesamiento en el dispositivo para mayor privacidad.",
       "dailyQuote": "Muestra una cita filosófica diaria en tu pantalla de inicio, personalizada según tus reflexiones recientes de diario.",
-      "aiPersonalization": "Cuando está activada, la IA lee tus notas y diarios para ofrecer respuestas personalizadas. Desactiva para mayor privacidad — la IA solo usará el contexto del chat actual."
+      "aiPersonalization": "Cuando está activada, la IA lee tus notas y diarios para ofrecer respuestas personalizadas. Desactiva para mayor privacidad — la IA solo usará el contexto del chat actual.",
+      "githubTools": "Cuando está activado, tu agente de IA puede listar tus repositorios, crear issues, abrir pull requests, revisar cambios de diff y publicar reseñas usando tu cuenta de GitHub conectada. Usa el mismo token que ya configuraste."
     },
     "title": "Hint"
   },
@@ -332,6 +343,12 @@
     "aiDescription": "Chat over your notes, todos, and canvases. AI can read context and apply edits when you allow it.",
     "aiHelper": "You can turn this on or off anytime in Settings → AI.",
     "aiEnable": "Enable AI",
+    "githubTools": {
+      "title": "Herramientas del agente de GitHub",
+      "body": "Tu IA ahora puede listar repositorios, crear issues, abrir pull requests, revisar cambios y publicar reseñas de PR usando tu cuenta de GitHub conectada. Todas las operaciones de escritura respetan tu configuración de modo de acción.",
+      "enable": "Activar herramientas de GitHub",
+      "bodyReminder": "Puedes activar o desactivar esto en cualquier momento en Configuración → IA → Herramientas de GitHub."
+    },
     "skipForNow": "Skip for Now"
   },
   "renderStyle": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -91,6 +91,10 @@
       "title": "Personnaliser l'IA avec mes notes"
     },
     "aiPersonalizationDescription": "Si désactivé, l'IA ne lit pas vos notes ni journaux pour votre sécurité",
+    "githubTools": {
+      "title": "Outils GitHub",
+      "description": "Laissez l'IA gérer les issues, PR et dépôts via votre compte GitHub actif."
+    },
     "security": "Sécurité",
     "appearance": "Apparence",
     "updatedUI": "Interface mise à jour",
@@ -163,7 +167,13 @@
   "chat": {
     "askAI": "Demander à l'IA",
     "typeMessage": "Écrire un message...",
-    "thinking": "Réflexion..."
+    "thinking": "Réflexion...",
+    "hints": {
+      "summarizeIssues": "Résume mes issues ouvertes",
+      "showRepos": "Affiche mes dépôts",
+      "createIssue": "Créer une issue",
+      "listPRs": "Liste les PR ouvertes"
+    }
   },
   "errors": {
     "somethingWrong": "Une erreur est survenue",
@@ -204,7 +214,8 @@
       "providers": "Les fournisseurs IA vous permettent de connecter différents services IA. Apple Intelligence utilise le traitement sur appareil pour la confidentialité.",
       "scheduledLearning": "Les fournisseurs IA vous permettent de connecter différents services IA. Apple Intelligence utilise le traitement sur appareil pour la confidentialité.",
       "dailyQuote": "Affiche une citation philosophique quotidienne sur votre écran d'accueil, personnalisée en fonction de vos réflexions récentes dans le journal.",
-      "aiPersonalization": "Lorsqu'activée, l'IA lit vos notes et journaux pour fournir des réponses personnalisées. Désactivez pour la confidentialité — l'IA utilisera uniquement le contexte du chat actuel."
+      "aiPersonalization": "Lorsqu'activée, l'IA lit vos notes et journaux pour fournir des réponses personnalisées. Désactivez pour la confidentialité — l'IA utilisera uniquement le contexte du chat actuel.",
+      "githubTools": "Lorsqu'ils sont activés, votre agent IA peut lister vos dépôts, créer des issues, ouvrir des pull requests, examiner les diffs et publier des revues via votre compte GitHub connecté. Utilise le même jeton que vous avez déjà configuré."
     },
     "title": "Hint"
   },
@@ -332,6 +343,12 @@
     "aiDescription": "Chat over your notes, todos, and canvases. AI can read context and apply edits when you allow it.",
     "aiHelper": "You can turn this on or off anytime in Settings → AI.",
     "aiEnable": "Enable AI",
+    "githubTools": {
+      "title": "Outils d'agent GitHub",
+      "body": "Votre IA peut désormais lister les dépôts, créer des issues, ouvrir des pull requests, examiner les changements et publier des revues de PR via votre compte GitHub connecté. Toutes les opérations d'écriture respectent votre réglage de mode d'action.",
+      "enable": "Activer les outils GitHub",
+      "bodyReminder": "Vous pouvez activer ou désactiver ceci à tout moment dans Paramètres → IA → Outils GitHub."
+    },
     "skipForNow": "Skip for Now"
   },
   "renderStyle": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -91,6 +91,10 @@
       "title": "ノートでAIをパーソナライズ"
     },
     "aiPersonalizationDescription": "オフにするとAIはノートや日記を読みません（データ保護）",
+    "githubTools": {
+      "title": "GitHubツール",
+      "description": "アクティブなGitHubアカウントを使って、AIにIssue・PR・リポジトリを管理させます。"
+    },
     "security": "セキュリティ",
     "appearance": "外観",
     "updatedUI": "新しいUI",
@@ -163,7 +167,13 @@
   "chat": {
     "askAI": "AIに質問",
     "typeMessage": "メッセージを入力...",
-    "thinking": "思考中..."
+    "thinking": "思考中...",
+    "hints": {
+      "summarizeIssues": "未完了のIssueをまとめて",
+      "showRepos": "リポジトリを表示して",
+      "createIssue": "Issueを作成して",
+      "listPRs": "オープンなPRを一覧表示して"
+    }
   },
   "errors": {
     "somethingWrong": "問題が発生しました",
@@ -204,7 +214,8 @@
       "providers": "AIプロバイダーはさまざまなAIサービスを接続できます。Apple Intelligenceはプライバシーのためオンデバイス処理を使用します。",
       "scheduledLearning": "AIプロバイダーはさまざまなAIサービスを接続できます。Apple Intelligenceはプライバシーのためオンデバイス処理を使用します。",
       "dailyQuote": "ホーム画面に日替わりの哲学的な名言を表示します。最近の日記の振り返りに基づいてパーソナライズされます。",
-      "aiPersonalization": "有効にすると、AIはノートと日記を読んでパーソナライズされた応答を提供します。プライバシーのためにオフにすると、AIは現在のチャットコンテキストのみを使用します。"
+      "aiPersonalization": "有効にすると、AIはノートと日記を読んでパーソナライズされた応答を提供します。プライバシーのためにオフにすると、AIは現在のチャットコンテキストのみを使用します。",
+      "githubTools": "有効にすると、AIエージェントが接続済みのGitHubアカウントを使って、リポジトリの一覧表示、Issueの作成、プルリクエストの作成、差分の変更レビュー、レビューの投稿を行えます。設定済みの同じトークンを使用します。"
     },
     "title": "Hint"
   },
@@ -332,6 +343,12 @@
     "aiDescription": "Chat over your notes, todos, and canvases. AI can read context and apply edits when you allow it.",
     "aiHelper": "You can turn this on or off anytime in Settings → AI.",
     "aiEnable": "Enable AI",
+    "githubTools": {
+      "title": "GitHubエージェントツール",
+      "body": "接続済みのGitHubアカウントを使って、AIがリポジトリの一覧表示、Issueの作成、プルリクエストの作成、変更のレビュー、PRレビューの投稿を行えるようになりました。すべての書き込み操作はアクションモードの設定に従います。",
+      "enable": "GitHubツールを有効にする",
+      "bodyReminder": "設定 → AI → GitHubツールから、いつでもオン・オフを切り替えられます。"
+    },
     "skipForNow": "Skip for Now"
   },
   "renderStyle": {

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -91,6 +91,10 @@
       "title": "내 노트로 AI 맞춤화"
     },
     "aiPersonalizationDescription": "끄면 AI가 데이터 보호를 위해 노트나 일지를 읽지 않습니다",
+    "githubTools": {
+      "title": "GitHub 도구",
+      "description": "활성 GitHub 계정으로 AI가 이슈, PR, 저장소를 관리하도록 합니다."
+    },
     "security": "보안",
     "appearance": "모양",
     "updatedUI": "업데이트된 UI",
@@ -163,7 +167,13 @@
   "chat": {
     "askAI": "AI에게 묻기",
     "typeMessage": "메시지 입력...",
-    "thinking": "생각 중..."
+    "thinking": "생각 중...",
+    "hints": {
+      "summarizeIssues": "열린 이슈를 요약해 줘",
+      "showRepos": "내 저장소를 보여 줘",
+      "createIssue": "이슈를 만들어 줘",
+      "listPRs": "열린 PR 목록을 보여 줘"
+    }
   },
   "errors": {
     "somethingWrong": "문제가 발생했습니다",
@@ -204,7 +214,8 @@
       "providers": "AI 공급자를 사용하면 다양한 AI 서비스를 연결할 수 있습니다. Apple Intelligence는 개인정보 보호를 위해 온디바이스 처리를 사용합니다.",
       "scheduledLearning": "AI 공급자를 사용하면 다양한 AI 서비스를 연결할 수 있습니다. Apple Intelligence는 개인정보 보호를 위해 온디바이스 처리를 사용합니다.",
       "dailyQuote": "홈 화면에 일일 철학자 명언을 표시합니다. 최근 일기 성찰을 기반으로 맞춤화됩니다.",
-      "aiPersonalization": "활성화하면 AI가 노트와 일기를 읽어 맞춤화된 응답을 제공합니다. 데이터 프라이버시를 위해 끄면 AI는 현재 채팅 컨텍스트만 사용합니다."
+      "aiPersonalization": "활성화하면 AI가 노트와 일기를 읽어 맞춤화된 응답을 제공합니다. 데이터 프라이버시를 위해 끄면 AI는 현재 채팅 컨텍스트만 사용합니다.",
+      "githubTools": "활성화하면 AI 에이전트가 연결된 GitHub 계정으로 저장소 목록 보기, 이슈 생성, 풀 리퀘스트 열기, diff 변경 검토, 리뷰 게시를 할 수 있습니다. 이미 설정한 동일한 토큰을 사용합니다."
     },
     "title": "Hint"
   },
@@ -332,6 +343,12 @@
     "aiDescription": "Chat over your notes, todos, and canvases. AI can read context and apply edits when you allow it.",
     "aiHelper": "You can turn this on or off anytime in Settings → AI.",
     "aiEnable": "Enable AI",
+    "githubTools": {
+      "title": "GitHub 에이전트 도구",
+      "body": "연결된 GitHub 계정으로 AI가 저장소 목록 보기, 이슈 생성, 풀 리퀘스트 열기, 변경 사항 검토, PR 리뷰 게시를 할 수 있습니다. 모든 쓰기 작업은 액션 모드 설정을 따릅니다.",
+      "enable": "GitHub 도구 활성화",
+      "bodyReminder": "설정 → AI → GitHub 도구에서 언제든지 켜거나 끌 수 있습니다."
+    },
     "skipForNow": "Skip for Now"
   },
   "renderStyle": {

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -213,6 +213,10 @@ export interface GitHubPathCommitDates {
   createdAt?: number;
 }
 
+export type GitHubItemState = 'open' | 'closed' | 'all';
+
+export const GITHUB_ITEM_STATES: GitHubItemState[] = ['open', 'closed', 'all'];
+
 /**
  * Tristate result of a sha lookup so callers can distinguish
  * "definitely gone" from "couldn't tell". Critical for delete paths —
@@ -391,10 +395,14 @@ class GitHubServiceClass {
     }
   }
 
-  async getIssues(owner: string, repo: string): Promise<GitHubIssue[]> {
+  async getIssues(
+    owner: string,
+    repo: string,
+    state: GitHubItemState = 'open',
+  ): Promise<GitHubIssue[]> {
     try {
       const data = await this.request(
-        `https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=50`
+        `https://api.github.com/repos/${owner}/${repo}/issues?state=${state}&per_page=50`
       );
       return Array.isArray(data) ? data : [];
     } catch (error) {
@@ -403,10 +411,14 @@ class GitHubServiceClass {
     }
   }
 
-  async getPullRequests(owner: string, repo: string): Promise<GitHubPullRequest[]> {
+  async getPullRequests(
+    owner: string,
+    repo: string,
+    state: GitHubItemState = 'open',
+  ): Promise<GitHubPullRequest[]> {
     try {
       const data = await this.request(
-        `https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=50`
+        `https://api.github.com/repos/${owner}/${repo}/pulls?state=${state}&per_page=50`
       );
       return Array.isArray(data) ? data : [];
     } catch (error) {

--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -3,7 +3,7 @@ import { TodoCreateInput, TodoPriority, TodoUpdateInput } from '../../models/Tod
 import { useNoteStore } from '../../stores/noteStore';
 import { useTodoStore } from '../../stores/todoStore';
 import { useAIStore } from '../../stores/aiStore';
-import { GitHubService } from '../GitHubService';
+import { GITHUB_ITEM_STATES, GitHubItemState, GitHubService } from '../GitHubService';
 import { NoteSyncQueueService } from '../NoteSyncQueueService';
 
 export interface ProposedChange {
@@ -105,6 +105,17 @@ function getOptionalTodoPriorityArg(args: Record<string, unknown>, key: string):
     throw new Error(`Invalid '${key}'`);
   }
   return value as TodoPriority;
+}
+
+function getOptionalItemStateArg(args: Record<string, unknown>, key: string): GitHubItemState | undefined {
+  const value = getOptionalStringArg(args, key);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!GITHUB_ITEM_STATES.includes(value as GitHubItemState)) {
+    throw new Error(`Invalid '${key}' — must be open, closed, or all`);
+  }
+  return value as GitHubItemState;
 }
 
 function getOptionalDueDateArg(args: Record<string, unknown>, key: string): number | undefined {
@@ -431,7 +442,8 @@ export async function executeToolCall(
       case 'list_issues': {
         const owner = getStringArg(args, 'owner');
         const repo = getStringArg(args, 'repo');
-        const issues = await GitHubService.getIssues(owner, repo);
+        const state = getOptionalItemStateArg(args, 'state') ?? 'open';
+        const issues = await GitHubService.getIssues(owner, repo, state);
         return buildSuccessResult(
           issues.map((i) => ({
             number: i.number,
@@ -473,7 +485,8 @@ export async function executeToolCall(
       case 'list_pull_requests': {
         const owner = getStringArg(args, 'owner');
         const repo = getStringArg(args, 'repo');
-        const prs = await GitHubService.getPullRequests(owner, repo);
+        const state = getOptionalItemStateArg(args, 'state') ?? 'open';
+        const prs = await GitHubService.getPullRequests(owner, repo, state);
         return buildSuccessResult(
           prs.map((p) => ({
             number: p.number,


### PR DESCRIPTION
## Summary
Addresses findings from Final Wave review of #840 (GitHub Agent Tools feature).

## Changes

**1. Wire `state` parameter through `list_issues` and `list_pull_requests`** (`87b6f5d`)
- `GitHubService.getIssues`/`getPullRequests` now accept optional `state='open' | 'closed' | 'all'` param
- `actionExecutor.ts` validates and threads the param through to the service
- 8 new tests covering URL pass-through, default value, and rejection of invalid states

**2. Add GitHub Tools i18n keys to 5 locale files** (`8889b23`)
- Mirrors en.json positions for `chat.hints`, `settings.githubTools`, `onboarding.githubTools`, `hints.settings.githubTools`
- Adds keys to de.json, es.json, fr.json, ja.json, ko.json (95 insertions, 10 deletions)

**3. Add controller-gating test** (`2e620a7`)
- Exports `buildChatToolsMap` and `sanitizeToolName` from `useChatScreenController.ts`
- New test file covers map on/off, store read path, explicit override, and tool name sanitization with both enabled and disabled states

## Verification
- `yarn ts:check` exits 0
- Targeted `yarn jest` on changed files: all green
- Full regression: 3 pre-existing flaky tests (HotspotGrid, TilePersistenceService, save-loading-indicator) that pass when run in isolation