### PR TITLE
fix(editor): wire hard-wrap toggle into save path

### DIFF
--- a/src/components/editor/useNoteEditorDocument.ts
+++ b/src/components/editor/useNoteEditorDocument.ts
@@ -17,6 +17,7 @@ import { classifyGitHubSyncError, isRetryableFailure, syncStatusForError } from 
 import { githubActivity } from '../../stores/githubActivityStore';
 import { canvasToLink } from '../../models/Canvas';
 import { getExtensionForFormat, extractCanvasJsonRefs, slugifyLocal } from './editorShared';
+import { useHardWrap, applyHardWrap } from '../../hooks/useHardWrap';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'NoteEditor'>;
 
@@ -96,6 +97,7 @@ export function useNoteEditorDocument({
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [repoFolders, setRepoFolders] = useState<Folder[]>([]);
   const [notFound, setNotFound] = useState(false);
+  const { hardWrapEnabled } = useHardWrap();
 
   useEffect(() => {
     if (noteId) return;
@@ -262,6 +264,8 @@ export function useNoteEditorDocument({
       return;
     }
 
+    const finalContent = applyHardWrap(content.trim(), hardWrapEnabled && noteFormat === 'markdown');
+
     setIsSaving(true);
     try {
       let savedNoteId = noteId;
@@ -270,7 +274,7 @@ export function useNoteEditorDocument({
         const updated = await updateNote({
           id: noteId,
           title: title.trim(),
-          content: content.trim(),
+          content: finalContent,
           tags,
           repo,
           branch,
@@ -291,7 +295,7 @@ export function useNoteEditorDocument({
       } else {
         const newNote = await createNote({
           title: title.trim(),
-          content: content.trim(),
+          content: finalContent,
           tags,
           repo,
           branch,
@@ -319,7 +323,7 @@ export function useNoteEditorDocument({
             branch,
             filePath: existingFilePath ?? (folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : undefined),
             title: title.trim(),
-            content: content.trim(),
+            content: finalContent,
             format: noteFormat,
             accountId,
             tags,
@@ -333,7 +337,7 @@ export function useNoteEditorDocument({
             const updated = await updateNote({
               id: savedNoteId,
               filePath: syncResult.filePath,
-              ...(syncResult.finalContent != null && syncResult.finalContent !== content.trim()
+              ...(syncResult.finalContent != null && syncResult.finalContent !== finalContent
                 ? { content: syncResult.finalContent }
                 : {}),
             });
@@ -377,7 +381,7 @@ export function useNoteEditorDocument({
             branch,
             filePath: existingFilePath ?? (folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : undefined),
             title: title.trim(),
-            content: content.trim(),
+            content: finalContent,
             format: noteFormat,
             accountId,
             tags,
@@ -420,7 +424,7 @@ export function useNoteEditorDocument({
     } finally {
       setIsSaving(false);
     }
-  }, [title, content, repo, noteId, updateNote, tags, branch, commit, folderPath, noteFormat, attachments, accountId, createNote, navigation]);
+  }, [title, content, repo, noteId, updateNote, tags, branch, commit, folderPath, noteFormat, attachments, accountId, createNote, navigation, hardWrapEnabled]);
 
   const handleCancelEdit = useCallback(() => {
     if (hasChanges && (title.trim() || content.trim())) {


### PR DESCRIPTION
## Summary

The **Wrap** button in the note editor header toggled and persisted the `hardWrapEnabled` preference, but the `applyHardWrap` transformation was never actually invoked — flipping the button had no effect on the file that got written to the repo.

## Changes

- Import `useHardWrap` + `applyHardWrap` in `useNoteEditorDocument` and call the hook at hook scope.
- Compute `finalContent = applyHardWrap(content.trim(), hardWrapEnabled && noteFormat === 'markdown')` at the top of `handleSave`.
- Route `finalContent` through:
  - `updateNote` (existing-note save)
  - `createNote` (new-note save)
  - Both `syncNoteToGitHub` payload paths
  - The `syncResult.finalContent` comparison
- Non-markdown formats (neorg / org / json / pdf) pass through unmodified via the `noteFormat === 'markdown'` guard.

## Behavior

- **While editing:** the in-memory text stays exactly as typed — no cursor jumps, no live reflow during typing.
- **On Save:** if Wrap is ON and the format is Markdown, single newlines inside text segments become paragraph breaks (`\n` → `\n\n`), so each typed line becomes its own paragraph in the committed `*.md` file. Fenced code blocks (``` / \~\~\~) are preserved verbatim by `applyHardWrap`'s fence parser.
- **Wrap OFF / non-markdown:** text persists exactly as typed.

This matches [GitJournal](https://gitjournal.io/)'s hard-wrap convention (the reference app this feature came from in PR #527).

## Test

- `yarn ts:check` ✅
- `yarn jest __tests__/editor __tests__/useHardWrap.test.ts __tests__/components` ✅ 102/102
- `lsp_diagnostics` on the changed file ✅ clean
- Pre-existing `__tests__/useHardWrap.test.ts` covers the `applyHardWrap` transform semantics — no new tests needed since this change only wires an existing, already-tested util into the save pipeline.