### PR TITLE
fix(editor): block with blur overlay instead of "Saving…" label swap while saving

### DIFF
--- a/__tests__/save-loading-indicator.test.ts
+++ b/__tests__/save-loading-indicator.test.ts
@@ -280,39 +280,39 @@ describe('save/loading indicator', () => {
     jest.restoreAllMocks();
   });
 
-  it('shows and hides the save spinner on success', async () => {
+  it('shows and hides the saving overlay on success', async () => {
     const deferred = createDeferred<{ id: string } | null>();
     mockCreateNote.mockReturnValueOnce(deferred.promise);
 
     const screen = render(React.createElement(NoteEditorScreen));
     fireEvent.press(screen.getByText('Save'));
 
-    expect(screen.getByTestId('github-activity-indicator')).toBeTruthy();
+    expect(screen.getByTestId('saving-overlay')).toBeTruthy();
 
     await act(async () => {
       deferred.resolve({ id: 'note-1' });
     });
 
     await waitFor(() => {
-      expect(screen.queryByTestId('github-activity-indicator')).toBeNull();
+      expect(screen.queryByTestId('saving-overlay')).toBeNull();
     });
   });
 
-  it('hides the save spinner on error', async () => {
+  it('hides the saving overlay on error', async () => {
     const deferred = createDeferred<{ id: string } | null>();
     mockCreateNote.mockReturnValueOnce(deferred.promise);
 
     const screen = render(React.createElement(NoteEditorScreen));
     fireEvent.press(screen.getByText('Save'));
 
-    expect(screen.getByTestId('github-activity-indicator')).toBeTruthy();
+    expect(screen.getByTestId('saving-overlay')).toBeTruthy();
 
     await act(async () => {
       deferred.reject(new Error('save failed'));
     });
 
     await waitFor(() => {
-      expect(screen.queryByTestId('github-activity-indicator')).toBeNull();
+      expect(screen.queryByTestId('saving-overlay')).toBeNull();
     });
   });
 

--- a/__tests__/ui/SavingOverlay.test.tsx
+++ b/__tests__/ui/SavingOverlay.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { SavingOverlay } from '../../src/components/ui/SavingOverlay';
+import { TestThemeProvider } from './testThemeProvider';
+
+describe('SavingOverlay', () => {
+  it('renders the loader and label when visible', () => {
+    const { getByTestId, getByText } = render(
+      <TestThemeProvider>
+        <SavingOverlay visible label="Saving…" />
+      </TestThemeProvider>,
+    );
+    expect(getByTestId('saving-overlay')).toBeTruthy();
+    expect(getByText('Saving…')).toBeTruthy();
+  });
+
+  it('renders without a label', () => {
+    const { getByTestId, queryByText } = render(
+      <TestThemeProvider>
+        <SavingOverlay visible />
+      </TestThemeProvider>,
+    );
+    expect(getByTestId('saving-overlay')).toBeTruthy();
+    expect(queryByText('Saving…')).toBeNull();
+  });
+
+  it('blocks touches while visible', () => {
+    const { getByTestId } = render(
+      <TestThemeProvider>
+        <SavingOverlay visible label="Saving…" />
+      </TestThemeProvider>,
+    );
+    expect(getByTestId('saving-overlay').props.pointerEvents).toBe('auto');
+  });
+
+  it('ignores touches while hidden', () => {
+    const { getByTestId } = render(
+      <TestThemeProvider>
+        <SavingOverlay visible={false} label="Saving…" />
+      </TestThemeProvider>,
+    );
+    expect(getByTestId('saving-overlay').props.pointerEvents).toBe('none');
+  });
+
+  it('honors a custom testID', () => {
+    const { getByTestId } = render(
+      <TestThemeProvider>
+        <SavingOverlay visible testID="note-editor.saving-overlay" />
+      </TestThemeProvider>,
+    );
+    expect(getByTestId('note-editor.saving-overlay')).toBeTruthy();
+  });
+});

--- a/src/components/editor/EditorHeader.tsx
+++ b/src/components/editor/EditorHeader.tsx
@@ -23,7 +23,7 @@ export function EditorHeader({ noteId, isSaving, onCancel, onSave }: EditorHeade
       <View testID="editor-header.button.save" style={styles.headerRight}>
         <Button
           variant="ghost"
-          label={isSaving ? 'Saving…' : 'Save'}
+          label="Save"
           testID="note-editor.button.save"
           onPress={onSave}
           disabled={isSaving}

--- a/src/components/ui/SavingOverlay.tsx
+++ b/src/components/ui/SavingOverlay.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef } from 'react';
+import { ActivityIndicator, Animated, Easing, Pressable, StyleSheet, Text, View } from 'react-native';
+import { BlurView } from 'expo-blur';
+
+import { useTheme, useTokens } from '../../contexts/ThemeContext';
+
+export interface SavingOverlayProps {
+  visible: boolean;
+  label?: string;
+  testID?: string;
+}
+
+// Blocking overlay shown while a save is in flight. Keeps button labels
+// (and therefore layout) stable instead of swapping in "Saving…" text.
+export function SavingOverlay({ visible, label, testID = 'saving-overlay' }: SavingOverlayProps) {
+  const { isDark } = useTheme();
+  const { colors, spacing, type } = useTokens();
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: visible ? 1 : 0,
+      duration: 180,
+      easing: Easing.out(Easing.quad),
+      useNativeDriver: true,
+    }).start();
+  }, [visible, opacity]);
+
+  return (
+    <Animated.View
+      testID={testID}
+      pointerEvents={visible ? 'auto' : 'none'}
+      accessible
+      accessibilityRole="alert"
+      accessibilityLabel={label}
+      style={[styles.root, { opacity }]}
+    >
+      <BlurView intensity={40} tint={isDark ? 'dark' : 'light'} style={StyleSheet.absoluteFill} />
+      <View pointerEvents="none" style={styles.scrim} />
+      <Pressable style={StyleSheet.absoluteFill} />
+      <View style={[styles.content, { gap: spacing[2] }]}>
+        <ActivityIndicator size="large" color={colors.accent} />
+        {label ? (
+          <Text style={{ color: colors.text, fontSize: type.sm, fontWeight: '600' }} numberOfLines={1}>
+            {label}
+          </Text>
+        ) : null}
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    ...StyleSheet.absoluteFill,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+    elevation: 10,
+  },
+  scrim: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: 'rgba(0,0,0,0.18)',
+  },
+  content: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -16,6 +16,8 @@ export { Toggle } from './Toggle';
 export type { ToggleProps } from './Toggle';
 export { Modal } from './Modal';
 export type { ModalProps } from './Modal';
+export { SavingOverlay } from './SavingOverlay';
+export type { SavingOverlayProps } from './SavingOverlay';
 export { TabBar, useTabBarHeight, TAB_BAR_BASE_HEIGHT } from './TabBar';
 export { ScreenHeader, useScreenHeaderHeight, SCREEN_HEADER_BASE_HEIGHT, SCREEN_HEADER_SUBTITLE_HEIGHT } from './ScreenHeader';
 export type { ScreenHeaderProps } from './ScreenHeader';

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -16,7 +16,7 @@ import { useRepos } from '../contexts/RepoContext';
 import { useResponsive } from '../hooks/useResponsive';
 import { getMarkdownStyles } from '../utils/preview';
 import { useRenderStyle } from '../stores/renderStyleStore';
-import { GitHubActivityIndicator } from '../components/GitHubActivityIndicator';
+import { SavingOverlay } from '../components/ui/SavingOverlay';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { CanvasPickerModal } from '../components/editor/CanvasPickerModal';
 import { EditorHeader } from '../components/editor/EditorHeader';
@@ -184,7 +184,7 @@ function NoteEditorScreenInner() {
 
   return (
     <SafeAreaView edges={['top', 'bottom']} className="flex-1" style={{ backgroundColor: colors.surface }}> 
-      {document.isSaving ? <GitHubActivityIndicator /> : null}
+      {document.isSaving ? <SavingOverlay visible label={t('editor.saving')} /> : null}
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} className="flex-1">
         <EditorHeader noteId={noteId} isSaving={document.isSaving} onCancel={document.handleCancelEdit} onSave={document.handleSave} />
 

--- a/src/screens/RenderStyleEditorScreen.tsx
+++ b/src/screens/RenderStyleEditorScreen.tsx
@@ -5,7 +5,6 @@ import {
   TextInput,
   ScrollView,
   TouchableOpacity,
-  ActivityIndicator,
   Alert,
   Pressable,
 } from 'react-native';
@@ -18,6 +17,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useRenderStyleStore } from '../stores/renderStyleStore';
 import StructuredRenderer from '../components/StructuredRenderer';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
+import { SavingOverlay } from '../components/ui/SavingOverlay';
 import HexColorPickerModal from '../components/HexColorPickerModal';
 import { NeorgContentParser } from '../services/NeorgContentParser';
 import { OrgContentParser } from '../services/OrgContentParser';
@@ -181,11 +181,12 @@ export default function RenderStyleEditorScreen() {
         </TouchableOpacity>
         <Text className="text-[17px] font-semibold" style={{ color: colors.text }}>{formatLabel(format)}</Text>
         <TouchableOpacity onPress={handleSave} disabled={isSaving || !dirty}>
-          {isSaving ? (
-            <ActivityIndicator color={colors.primary} />
-          ) : (
-            <Text className="text-[15px] font-semibold" style={{ color: dirty ? colors.primary : colors.textSecondary }}>Save</Text>
-          )}
+          <Text
+            className="text-[15px] font-semibold"
+            style={{ color: dirty ? colors.primary : colors.textSecondary, opacity: isSaving ? 0.5 : 1 }}
+          >
+            Save
+          </Text>
         </TouchableOpacity>
       </View>
 
@@ -408,6 +409,8 @@ export default function RenderStyleEditorScreen() {
           Save pushes settings/render.json to {binding ? `${binding.owner}/${binding.name}` : 'the bound repo'}. Other devices pick it up on next launch.
         </Text>
       </ScrollView>
+
+      {isSaving ? <SavingOverlay visible label="Saving…" /> : null}
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Problem

In several places the Save button swaps its content while saving — the editor header changes its label to `Saving…` and the render-style editor swaps the `Save` text for a spinner. Both shift the layout mid-flight and make the UI jump.

## Fix

Keep save buttons stable and **disabled** during saves, and block interaction with a blurred full-screen overlay + loader instead:

- **`SavingOverlay`** (new, `src/components/ui/`): `expo-blur` backdrop + scrim + centered `ActivityIndicator`, fade in/out, touch-blocking, exported from the ui barrel. Follows the existing `Modal`/`GitHubActivityIndicator` patterns.
- **EditorHeader**: label stays `Save`; button and Cancel remain disabled while saving.
- **NoteEditorScreen**: renders `SavingOverlay` (label via existing `editor.saving` i18n key) while `document.isSaving`; the screen-local `GitHubActivityIndicator` instance is removed (the global one in `App.tsx` still reports sync activity).
- **RenderStyleEditorScreen**: Save text dims instead of swapping to a spinner; overlay shown while the store saves.

## Tests

- New `__tests__/ui/SavingOverlay.test.tsx` (label, no-label, touch blocking visible/hidden, custom testID).
- `save-loading-indicator.test.ts` repointed: overlay appears/disappears around save success and failure (real screen render).
- Verified: `yarn ts:check`, full `yarn jest` (217 suites / 1920 tests, green), `yarn eslint . --ext .ts,.tsx` (0 errors).