### PR TITLE
feat(ai): expand chat tools — 8 new capabilities + 5 note-focused hint chips

### DIFF
--- a/__tests__/ChatHintChips.test.tsx
+++ b/__tests__/ChatHintChips.test.tsx
@@ -8,6 +8,11 @@ jest.mock('react-i18next', () => {
     'chat.hints.showRepos': 'Show my repos',
     'chat.hints.createIssue': 'Create an issue',
     'chat.hints.listPRs': 'List open PRs',
+    'chat.hints.askAboutNotes': 'Ask about my notes',
+    'chat.hints.createQuiz': 'Create a quiz',
+    'chat.hints.gradeAnswers': 'Grade my answers',
+    'chat.hints.searchEverything': 'Search everything',
+    'chat.hints.summarizeTopic': 'Summarize a topic',
   };
   return {
     useTranslation: () => ({
@@ -58,15 +63,47 @@ const HINT_CASES = [
     label: 'List open PRs',
     prompt: 'List my open pull requests across all repos',
   },
+  {
+    testID: 'chat.hint.ask-about-notes',
+    label: 'Ask about my notes',
+    prompt: 'What notes have I written about [topic]?',
+  },
+  {
+    testID: 'chat.hint.create-quiz',
+    label: 'Create a quiz',
+    prompt: 'Make me a questioner note on: my recent reading notes',
+  },
+  {
+    testID: 'chat.hint.grade-answers',
+    label: 'Grade my answers',
+    prompt: 'Grade my most recent questioner note',
+  },
+  {
+    testID: 'chat.hint.search-everything',
+    label: 'Search everything',
+    prompt: 'Find notes and todos mentioning [X] across my repo',
+  },
+  {
+    testID: 'chat.hint.summarize-topic',
+    label: 'Summarize a topic',
+    prompt: 'Summarize all my notes on [topic] into one note',
+  },
 ] as const;
 
 describe('ChatHintChips', () => {
-  test('renders all four hint chips with their translated labels', () => {
-    const { getByText } = render(<ChatHintChips onPressHint={jest.fn()} />);
+  test('renders 9 hint chips total with their translated labels', () => {
+    const { getByText, getAllByTestId } = render(<ChatHintChips onPressHint={jest.fn()} />);
 
+    expect(getAllByTestId(/^chat\.hint\./)).toHaveLength(9);
     for (const hint of HINT_CASES) {
       expect(getByText(hint.label)).toBeTruthy();
     }
+  });
+
+  test('lays chips out in a horizontal ScrollView', () => {
+    const { getByTestId } = render(<ChatHintChips onPressHint={jest.fn()} />);
+
+    expect(getByTestId('chat-hints-scroller')).toHaveProp('horizontal', true);
   });
 
   test.each(HINT_CASES.map(({ label, prompt }) => ({ label, prompt })))(

--- a/__tests__/ai-chat-tools-expansion.test.ts
+++ b/__tests__/ai-chat-tools-expansion.test.ts
@@ -1,0 +1,518 @@
+jest.mock('../src/stores/noteStore', () => {
+  const state = {
+    notes: [] as Array<Record<string, unknown>>,
+    getNoteById: jest.fn((id: string) => state.notes.find((note) => note.id === id)),
+    createNote: jest.fn(async (input: Record<string, unknown>) => ({
+      id: 'created-note',
+      createdAt: 100,
+      updatedAt: 100,
+      ...input,
+    })),
+    updateNote: jest.fn(async (input: Record<string, unknown>) => {
+      const existing = state.notes.find((note) => note.id === input.id);
+      return existing ? { ...existing, ...input } : null;
+    }),
+    deleteNote: jest.fn(async () => true),
+  };
+  return {
+    useNoteStore: { getState: () => state, __state: state },
+  };
+});
+
+jest.mock('../src/stores/todoStore', () => {
+  const state = {
+    todos: [] as Array<Record<string, unknown>>,
+  };
+  return {
+    useTodoStore: { getState: () => state, __state: state },
+  };
+});
+
+jest.mock('../src/stores/aiStore', () => {
+  const state = {
+    githubToolsEnabled: true,
+    chatRepoOwner: null as string | null,
+    chatRepoName: null as string | null,
+    chatRepoBranch: 'main',
+  };
+  return {
+    useAIStore: { getState: () => state, __state: state },
+  };
+});
+
+jest.mock('../src/services/ScheduledLearningService', () => ({
+  ScheduledLearningService: {
+    gradeQuestionerNote: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    enqueueNoteUpsert: jest.fn(async () => undefined),
+    drain: jest.fn(),
+  },
+}));
+
+import { executeToolCall } from '../src/services/ai/actionExecutor';
+import {
+  chatTools,
+  createQuestionerNoteParameters,
+  distillThoughtDumpParameters,
+  findNotesParameters,
+  findTodosParameters,
+  generateDailyBriefParameters,
+  gradeQuestionerNoteParameters,
+  linkNotesParameters,
+  summarizeNotesParameters,
+} from '../src/services/ai/tools';
+import { useNoteStore } from '../src/stores/noteStore';
+import { useTodoStore } from '../src/stores/todoStore';
+import { useAIStore } from '../src/stores/aiStore';
+import { ScheduledLearningService } from '../src/services/ScheduledLearningService';
+import { NoteSyncQueueService } from '../src/services/NoteSyncQueueService';
+
+type StoreMock<T> = { getState: () => T; __state: T };
+
+const noteState = (useNoteStore as unknown as StoreMock<{
+  notes: Array<Record<string, unknown>>;
+  getNoteById: jest.Mock;
+  createNote: jest.Mock;
+  updateNote: jest.Mock;
+}>).__state;
+const todoState = (useTodoStore as unknown as StoreMock<{
+  todos: Array<Record<string, unknown>>;
+}>).__state;
+const aiState = (useAIStore as unknown as StoreMock<{
+  githubToolsEnabled: boolean;
+  chatRepoOwner: string | null;
+  chatRepoName: string | null;
+  chatRepoBranch: string;
+}>).__state;
+
+const gradeQuestionerNote = ScheduledLearningService.gradeQuestionerNote as jest.Mock;
+
+function makeNote(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: `note-${noteState.notes.length}`,
+    title: 'Untitled',
+    content: '',
+    tags: [],
+    createdAt: 100,
+    updatedAt: 100,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  noteState.notes = [];
+  todoState.todos = [];
+  aiState.githubToolsEnabled = true;
+  aiState.chatRepoOwner = null;
+  aiState.chatRepoName = null;
+  aiState.chatRepoBranch = 'main';
+  noteState.createNote.mockClear();
+  noteState.updateNote.mockClear();
+  (NoteSyncQueueService.enqueueNoteUpsert as jest.Mock).mockClear();
+  (NoteSyncQueueService.drain as jest.Mock).mockClear();
+  gradeQuestionerNote.mockReset();
+});
+
+describe('chat-tools expansion — schema validation', () => {
+  interface SchemaCase {
+    label: string;
+    schema: { parse: (value: unknown) => unknown };
+    valid: Record<string, unknown>;
+    invalid: Record<string, unknown>;
+  }
+
+  const cases: SchemaCase[] = [
+    {
+      label: 'createQuestionerNoteParameters',
+      schema: createQuestionerNoteParameters,
+      valid: { topic: 'Type theory', content: 'Q1? Q2?', sourceNotes: ['n1'], tags: ['study'] },
+      invalid: { topic: 'Type theory' },
+    },
+    {
+      label: 'gradeQuestionerNoteParameters',
+      schema: gradeQuestionerNoteParameters,
+      valid: { noteId: 'n1' },
+      invalid: { noteId: 42 },
+    },
+    {
+      label: 'findNotesParameters',
+      schema: findNotesParameters,
+      valid: { query: 'react', tags: ['web'], sortBy: 'alphabetical', limit: 5 },
+      invalid: { query: 'react', limit: 0 },
+    },
+    {
+      label: 'findTodosParameters',
+      schema: findTodosParameters,
+      valid: { query: 'review', status: 'pending', priority: 'high', sortBy: 'due' },
+      invalid: { status: 'archived' },
+    },
+    {
+      label: 'summarizeNotesParameters',
+      schema: summarizeNotesParameters,
+      valid: { noteIds: ['n1', 'n2'], content: 'Combined summary', outputTitle: 'Sum' },
+      invalid: { noteIds: 'n1', content: 'body' },
+    },
+    {
+      label: 'distillThoughtDumpParameters',
+      schema: distillThoughtDumpParameters,
+      valid: { sourceNoteIds: ['n1'], content: 'Distilled body', outputTitle: 'Clean note' },
+      invalid: { sourceNoteIds: ['n1'], content: 'Distilled body' },
+    },
+    {
+      label: 'linkNotesParameters',
+      schema: linkNotesParameters,
+      valid: { noteIds: ['n1', 'n2'], relationship: 'contradicts' },
+      invalid: { noteIds: ['only-one'] },
+    },
+    {
+      label: 'generateDailyBriefParameters',
+      schema: generateDailyBriefParameters,
+      valid: { content: 'Brief body', topics: ['work'], outputTags: ['daily'] },
+      invalid: { topics: ['work'] },
+    },
+  ];
+
+  test.each(cases)('$label accepts valid args', ({ schema, valid }) => {
+    expect(() => schema.parse(valid)).not.toThrow();
+  });
+
+  test.each(cases)('$label rejects invalid args', ({ schema, invalid }) => {
+    expect(() => schema.parse(invalid)).toThrow();
+  });
+
+  test('chatTools exposes all 8 new tools alongside the original 10', () => {
+    expect(Object.keys(chatTools).sort()).toEqual(
+      [
+        'create_note',
+        'edit_note',
+        'delete_note',
+        'search_notes',
+        'get_note',
+        'create_todo',
+        'edit_todo',
+        'delete_todo',
+        'search_todos',
+        'get_todos',
+        'create_questioner_note',
+        'grade_questioner_answers',
+        'find_notes',
+        'find_todos',
+        'summarize_notes',
+        'distill_thought_dump',
+        'link_notes',
+        'generate_daily_brief',
+      ].sort(),
+    );
+  });
+});
+
+describe('chat-tools expansion — read tools return data', () => {
+  test('find_notes returns matches and total for all matching notes', async () => {
+    noteState.notes = [
+      makeNote({ id: 'n1', title: 'Review notes', content: 'review hooks', tags: ['web'], updatedAt: 5 }),
+      makeNote({ id: 'n2', title: 'Rust ownership', content: 'review borrow', tags: ['lang'], updatedAt: 4 }),
+      makeNote({ id: 'n3', title: 'React testing', content: 'review jest', tags: ['web', 'test'], updatedAt: 3 }),
+      makeNote({ id: 'n4', title: 'Cooking', content: 'review pasta', tags: ['home'], updatedAt: 2 }),
+      makeNote({ id: 'n5', title: 'React internals', content: 'review fiber', tags: ['web'], updatedAt: 1 }),
+    ];
+
+    const result = await executeToolCall('find_notes', { query: 'review' }, 'auto');
+
+    expect(result.success).toBe(true);
+    expect(result.requiresConfirmation).toBe(false);
+    const data = result.data as {
+      matches: Array<{ id: string; excerpt: string; updatedAt: number | null }>;
+      total: number;
+    };
+    expect(data.total).toBe(5);
+    expect(data.matches.map((note) => note.id)).toEqual(['n1', 'n2', 'n3', 'n4', 'n5']);
+    expect(data.matches[0].excerpt).toBe('review hooks');
+    expect(data.matches[0].updatedAt).toBe(5);
+  });
+
+  test('find_notes applies tag exclusion, alphabetical sort and limit', async () => {
+    noteState.notes = [
+      makeNote({ id: 'n1', title: 'Beta', tags: ['web'], updatedAt: 5 }),
+      makeNote({ id: 'n2', title: 'Alpha', tags: ['web'], updatedAt: 4 }),
+      makeNote({ id: 'n3', title: 'Gamma', tags: ['web', 'skip'], updatedAt: 3 }),
+    ];
+
+    const result = await executeToolCall(
+      'find_notes',
+      { query: '', tags: ['web'], excludeTags: ['skip'], sortBy: 'alphabetical', limit: 1 },
+      'auto',
+    );
+
+    const data = result.data as { matches: Array<{ id: string; title: string }>; total: number };
+    expect(data.total).toBe(2);
+    expect(data.matches.map((note) => ({ id: note.id, title: note.title }))).toEqual([
+      { id: 'n2', title: 'Alpha' },
+    ]);
+  });
+
+  test('find_todos filters by status and priority and returns filterApplied', async () => {
+    todoState.todos = [
+      { id: 't1', text: 'open high', completed: false, priority: 'high', createdAt: 30, tags: ['work'] },
+      { id: 't2', text: 'open low', completed: false, priority: 'low', createdAt: 20 },
+      { id: 't3', text: 'done high', completed: true, priority: 'high', createdAt: 10 },
+    ];
+
+    const result = await executeToolCall(
+      'find_todos',
+      { status: 'pending', priority: 'high', sortBy: 'priority' },
+      'auto',
+    );
+
+    const data = result.data as {
+      matches: Array<{ id: string }>;
+      total: number;
+      filterApplied: { status: string; priority: string | null; query: string };
+    };
+    expect(data.total).toBe(1);
+    expect(data.matches.map((todo) => todo.id)).toEqual(['t1']);
+    expect(data.filterApplied).toEqual({ status: 'pending', priority: 'high', query: '' });
+  });
+
+  test('find_todos dueBefore drops todos without or beyond the due date', async () => {
+    const cutoff = Date.parse('2026-08-01T00:00:00Z');
+    todoState.todos = [
+      { id: 't1', text: 'due before', completed: false, dueDate: cutoff - 1000, createdAt: 2 },
+      { id: 't2', text: 'due after', completed: false, dueDate: cutoff + 1000, createdAt: 1 },
+      { id: 't3', text: 'no due date', completed: false, createdAt: 3 },
+    ];
+
+    const result = await executeToolCall(
+      'find_todos',
+      { dueBefore: '2026-08-01T00:00:00Z' },
+      'auto',
+    );
+
+    const data = result.data as { matches: Array<{ id: string }>; total: number };
+    expect(data.matches.map((todo) => todo.id)).toEqual(['t1']);
+    expect(data.total).toBe(1);
+  });
+});
+
+describe('chat-tools expansion — write tools respect confirm mode', () => {
+  test.each([
+    {
+      tool: 'create_questioner_note',
+      args: { topic: 'Topic', content: 'Question?' },
+      expectedType: 'create_questioner_note',
+    },
+    {
+      tool: 'summarize_notes',
+      args: { noteIds: ['n1', 'n2'], content: 'The summary body' },
+      expectedType: 'summarize_notes',
+      seedNotes: [makeNote({ id: 'n1', title: 'One' }), makeNote({ id: 'n2', title: 'Two' })],
+    },
+    {
+      tool: 'distill_thought_dump',
+      args: { sourceNoteIds: ['n1'], content: 'Clean body', outputTitle: 'Clean' },
+      expectedType: 'distill_thought_dump',
+    },
+    {
+      tool: 'link_notes',
+      args: { noteIds: ['n1', 'n2'] },
+      expectedType: 'link_notes',
+      seedNotes: [makeNote({ id: 'n1', title: 'One' }), makeNote({ id: 'n2', title: 'Two' })],
+    },
+    {
+      tool: 'generate_daily_brief',
+      args: { content: 'Today in review' },
+      expectedType: 'generate_daily_brief',
+    },
+  ] as Array<{ tool: string; args: Record<string, unknown>; expectedType: string; seedNotes?: Array<Record<string, unknown>> }>)(
+    '$tool in confirm mode returns proposedChanges without touching the store',
+    async ({ tool, args, expectedType, seedNotes }) => {
+      if (seedNotes) {
+        noteState.notes = seedNotes;
+      }
+
+      const result = await executeToolCall(tool, args, 'confirm');
+
+      expect(result.success).toBe(true);
+      expect(result.requiresConfirmation).toBe(true);
+      expect(result.proposedChanges?.type).toBe(expectedType);
+      expect(noteState.createNote).not.toHaveBeenCalled();
+      expect(noteState.updateNote).not.toHaveBeenCalled();
+    },
+  );
+
+  test('grade_questioner_answers in confirm mode targets the questioner note', async () => {
+    noteState.notes = [makeNote({ id: 'q1', title: 'Quiz', tags: ['questioner'] })];
+
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'q1' }, 'confirm');
+
+    expect(result.success).toBe(true);
+    expect(result.requiresConfirmation).toBe(true);
+    expect(result.proposedChanges?.type).toBe('grade_questioner_answers');
+    expect(result.proposedChanges?.targetId).toBe('q1');
+    expect(gradeQuestionerNote).not.toHaveBeenCalled();
+  });
+
+  test('grade_questioner_answers rejects notes without the questioner tag', async () => {
+    noteState.notes = [makeNote({ id: 'p1', title: 'Plain', tags: [] })];
+
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'p1' }, 'auto');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/questioner/);
+    expect(gradeQuestionerNote).not.toHaveBeenCalled();
+  });
+});
+
+describe('chat-tools expansion — create_questioner_note forces the questioner tag', () => {
+  test('merge user tags with the forced questioner tag', async () => {
+    const result = await executeToolCall(
+      'create_questioner_note',
+      { topic: 'Type theory', content: 'What is a monad?', tags: ['study'] },
+      'auto',
+    );
+
+    expect(result.success).toBe(true);
+    const input = noteState.createNote.mock.calls[0][0] as { tags: string[]; content: string };
+    expect(input.tags).toEqual(['study', 'questioner']);
+    expect(input.content).toContain('<!-- sl-item-id: chat-gen-');
+    const data = result.data as { tag: string; questionCount: number };
+    expect(data.tag).toBe('questioner');
+    expect(data.questionCount).toBe(1);
+  });
+
+  test('does not duplicate the questioner tag when the user already supplies it', async () => {
+    await executeToolCall(
+      'create_questioner_note',
+      { topic: 'Topic', content: 'Q?', tags: ['questioner'] },
+      'auto',
+    );
+
+    const input = noteState.createNote.mock.calls[0][0] as { tags: string[] };
+    expect(input.tags).toEqual(['questioner']);
+  });
+});
+
+describe('chat-tools expansion — grade_questioner_answers delegation', () => {
+  test('delegates to ScheduledLearningService and reports appended content length', async () => {
+    const questioner = makeNote({ id: 'q1', title: 'Quiz', tags: ['questioner'], content: 'Q?' });
+    noteState.notes = [questioner];
+    const appended = '\n## Grading & Corrections\nWell done.';
+    gradeQuestionerNote.mockImplementation(async (noteId: string) => {
+      questioner.content = `${questioner.content}${appended}`;
+      void noteId;
+      return true;
+    });
+
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'q1' }, 'auto');
+
+    expect(gradeQuestionerNote).toHaveBeenCalledWith('q1');
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      noteId: 'q1',
+      graded: true,
+      gradingAppended: appended.length,
+    });
+  });
+
+  test('surfaces an error when the grading service returns false', async () => {
+    noteState.notes = [makeNote({ id: 'q2', title: 'Quiz', tags: ['questioner'], content: 'Q?' })];
+    gradeQuestionerNote.mockResolvedValue(false);
+
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'q2' }, 'auto');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Grading failed/);
+  });
+
+  test('errors when the note does not exist', async () => {
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'missing' }, 'auto');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Note not found.');
+    expect(gradeQuestionerNote).not.toHaveBeenCalled();
+  });
+});
+
+describe('chat-tools expansion — chatRepoSync behavior', () => {
+  test('write tools enqueue sync and drain when a chat repo is selected', async () => {
+    aiState.chatRepoOwner = 'me';
+    aiState.chatRepoName = 'notes-repo';
+    aiState.chatRepoBranch = 'dev';
+
+    await executeToolCall(
+      'generate_daily_brief',
+      { content: 'Open items: 3', outputTags: ['morning'] },
+      'auto',
+    );
+
+    const createInput = noteState.createNote.mock.calls[0][0] as { repo?: string; branch?: string };
+    expect(createInput.repo).toBe('me/notes-repo');
+    expect(createInput.branch).toBe('dev');
+    expect(NoteSyncQueueService.enqueueNoteUpsert).toHaveBeenCalledTimes(1);
+    expect(NoteSyncQueueService.drain).toHaveBeenCalled();
+  });
+
+  test('write tools skip the sync queue when no chat repo is selected', async () => {
+    await executeToolCall('generate_daily_brief', { content: 'Body' }, 'auto');
+
+    expect(noteState.createNote).toHaveBeenCalledWith(
+      expect.objectContaining({ format: 'markdown', tags: ['daily-brief'] }),
+    );
+    expect(NoteSyncQueueService.enqueueNoteUpsert).not.toHaveBeenCalled();
+    expect(NoteSyncQueueService.drain).not.toHaveBeenCalled();
+  });
+
+  test('link_notes appends link sections and enqueues an upsert per updated note', async () => {
+    aiState.chatRepoOwner = 'me';
+    aiState.chatRepoName = 'notes-repo';
+    noteState.notes = [
+      makeNote({ id: 'n1', title: 'First', content: 'aaa' }),
+      makeNote({ id: 'n2', title: 'Second', content: 'bbb' }),
+    ];
+
+    const result = await executeToolCall(
+      'link_notes',
+      { noteIds: ['n1', 'n2'], relationship: 'sequence' },
+      'auto',
+    );
+
+    expect(result.success).toBe(true);
+    expect(noteState.updateNote).toHaveBeenCalledTimes(2);
+    const firstUpdate = noteState.updateNote.mock.calls[0][0] as { id: string; content: string };
+    expect(firstUpdate.content).toContain('## Sequence');
+    expect(firstUpdate.content).toContain('[[Second]]');
+    expect(NoteSyncQueueService.enqueueNoteUpsert).toHaveBeenCalledTimes(2);
+    expect(NoteSyncQueueService.drain).toHaveBeenCalled();
+    expect((result.data as { linked: number }).linked).toBe(2);
+  });
+});
+
+describe('chat-tools expansion — regression guards', () => {
+  test('GitHub gate still fires for GitHub tools when disabled', async () => {
+    aiState.githubToolsEnabled = false;
+
+    const result = await executeToolCall('list_repos', {}, 'auto');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/GitHub tools are disabled/);
+  });
+
+  test('create_note still works unchanged after the enqueueNoteSync extraction', async () => {
+    const result = await executeToolCall('create_note', { title: 'T', content: 'C' }, 'auto');
+
+    expect(result.success).toBe(true);
+    expect(noteState.createNote).toHaveBeenCalledWith({
+      title: 'T',
+      content: 'C',
+      tags: undefined,
+      format: undefined,
+    });
+    expect(NoteSyncQueueService.enqueueNoteUpsert).not.toHaveBeenCalled();
+
+    const data = result.data as { synced: boolean };
+    expect(data.synced).toBe(false);
+  });
+});

--- a/__tests__/ai/tools.test.ts
+++ b/__tests__/ai/tools.test.ts
@@ -13,19 +13,27 @@ import {
 } from '../../src/services/ai/tools';
 
 describe('chatTools registry', () => {
-  test('exposes all 10 expected tools', () => {
+  test('exposes all 18 expected tools', () => {
     expect(Object.keys(chatTools).sort()).toEqual(
       [
         'create_note',
+        'create_questioner_note',
         'create_todo',
         'delete_note',
         'delete_todo',
+        'distill_thought_dump',
         'edit_note',
         'edit_todo',
+        'find_notes',
+        'find_todos',
+        'generate_daily_brief',
         'get_note',
         'get_todos',
+        'grade_questioner_answers',
+        'link_notes',
         'search_notes',
         'search_todos',
+        'summarize_notes',
       ].sort(),
     );
   });

--- a/src/components/ai/ChatHintChips.tsx
+++ b/src/components/ai/ChatHintChips.tsx
@@ -1,10 +1,19 @@
-import { TouchableOpacity, View, Text } from 'react-native';
+import { ScrollView, TouchableOpacity, View, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { useTokens } from '../../contexts/ThemeContext';
 
 type Hint = {
-  icon: 'search-outline' | 'globe-outline' | 'add-circle-outline' | 'git-branch-outline';
+  icon:
+    | 'search-outline'
+    | 'globe-outline'
+    | 'add-circle-outline'
+    | 'git-branch-outline'
+    | 'document-text-outline'
+    | 'help-circle-outline'
+    | 'checkmark-circle-outline'
+    | 'search-circle-outline'
+    | 'list-outline';
   labelKey: string;
   labelDefault: string;
   prompt: string;
@@ -40,6 +49,41 @@ const HINTS: Hint[] = [
     prompt: 'List my open pull requests across all repos',
     testID: 'chat.hint.list-prs',
   },
+  {
+    icon: 'document-text-outline',
+    labelKey: 'chat.hints.askAboutNotes',
+    labelDefault: 'Ask about my notes',
+    prompt: 'What notes have I written about [topic]?',
+    testID: 'chat.hint.ask-about-notes',
+  },
+  {
+    icon: 'help-circle-outline',
+    labelKey: 'chat.hints.createQuiz',
+    labelDefault: 'Create a quiz',
+    prompt: 'Make me a questioner note on: my recent reading notes',
+    testID: 'chat.hint.create-quiz',
+  },
+  {
+    icon: 'checkmark-circle-outline',
+    labelKey: 'chat.hints.gradeAnswers',
+    labelDefault: 'Grade my answers',
+    prompt: 'Grade my most recent questioner note',
+    testID: 'chat.hint.grade-answers',
+  },
+  {
+    icon: 'search-circle-outline',
+    labelKey: 'chat.hints.searchEverything',
+    labelDefault: 'Search everything',
+    prompt: 'Find notes and todos mentioning [X] across my repo',
+    testID: 'chat.hint.search-everything',
+  },
+  {
+    icon: 'list-outline',
+    labelKey: 'chat.hints.summarizeTopic',
+    labelDefault: 'Summarize a topic',
+    prompt: 'Summarize all my notes on [topic] into one note',
+    testID: 'chat.hint.summarize-topic',
+  },
 ];
 
 export interface ChatHintChipsProps {
@@ -53,39 +97,44 @@ export function ChatHintChips({ onPressHint }: ChatHintChipsProps) {
   return (
     <View
       style={{
-        flexDirection: 'row',
-        flexWrap: 'wrap',
-        gap: spacing[2],
         marginTop: spacing[4],
-        justifyContent: 'center',
+        paddingHorizontal: spacing[4],
+        alignSelf: 'stretch',
       }}
     >
-      {HINTS.map((hint) => (
-        <TouchableOpacity
-          key={hint.testID}
-          testID={hint.testID}
-          accessibilityLabel={hint.labelDefault}
-          accessibilityRole="button"
-          onPress={() => onPressHint(hint.prompt)}
-          activeOpacity={0.7}
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: spacing[1],
-            paddingHorizontal: spacing[3],
-            paddingVertical: spacing[2],
-            backgroundColor: colors.surface,
-            borderWidth: 1,
-            borderColor: colors.border,
-            borderRadius: radii.pill,
-          }}
-        >
-          <Ionicons name={hint.icon} size={14} color={colors.accent} />
-          <Text style={{ color: colors.text, fontSize: type.sm, fontWeight: '500' }}>
-            {t(hint.labelKey, { defaultValue: hint.labelDefault })}
-          </Text>
-        </TouchableOpacity>
-      ))}
+      <ScrollView
+        testID="chat-hints-scroller"
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ gap: spacing[2], paddingHorizontal: spacing[2] }}
+      >
+        {HINTS.map((hint) => (
+          <TouchableOpacity
+            key={hint.testID}
+            testID={hint.testID}
+            accessibilityLabel={hint.labelDefault}
+            accessibilityRole="button"
+            onPress={() => onPressHint(hint.prompt)}
+            activeOpacity={0.7}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: spacing[1],
+              paddingHorizontal: spacing[3],
+              paddingVertical: spacing[2],
+              backgroundColor: colors.surface,
+              borderWidth: 1,
+              borderColor: colors.border,
+              borderRadius: radii.pill,
+            }}
+          >
+            <Ionicons name={hint.icon} size={14} color={colors.accent} />
+            <Text style={{ color: colors.text, fontSize: type.sm, fontWeight: '500' }}>
+              {t(hint.labelKey, { defaultValue: hint.labelDefault })}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
     </View>
   );
 }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -172,7 +172,12 @@
       "summarizeIssues": "Fasse meine offenen Issues zusammen",
       "showRepos": "Zeige meine Repositories",
       "createIssue": "Issue erstellen",
-      "listPRs": "Offene PRs auflisten"
+      "listPRs": "Offene PRs auflisten",
+      "askAboutNotes": "Ask about my notes",
+      "createQuiz": "Create a quiz",
+      "gradeAnswers": "Grade my answers",
+      "searchEverything": "Search everything",
+      "summarizeTopic": "Summarize a topic"
     }
   },
   "errors": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -210,7 +210,12 @@
       "summarizeIssues": "Summarize my open issues",
       "showRepos": "Show my repos",
       "createIssue": "Create an issue",
-      "listPRs": "List open PRs"
+      "listPRs": "List open PRs",
+      "askAboutNotes": "Ask about my notes",
+      "createQuiz": "Create a quiz",
+      "gradeAnswers": "Grade my answers",
+      "searchEverything": "Search everything",
+      "summarizeTopic": "Summarize a topic"
     }
   },
   "explore": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -172,7 +172,12 @@
       "summarizeIssues": "Resume mis issues abiertos",
       "showRepos": "Muestra mis repositorios",
       "createIssue": "Crear un issue",
-      "listPRs": "Lista los PR abiertos"
+      "listPRs": "Lista los PR abiertos",
+      "askAboutNotes": "Ask about my notes",
+      "createQuiz": "Create a quiz",
+      "gradeAnswers": "Grade my answers",
+      "searchEverything": "Search everything",
+      "summarizeTopic": "Summarize a topic"
     }
   },
   "errors": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -172,7 +172,12 @@
       "summarizeIssues": "Résume mes issues ouvertes",
       "showRepos": "Affiche mes dépôts",
       "createIssue": "Créer une issue",
-      "listPRs": "Liste les PR ouvertes"
+      "listPRs": "Liste les PR ouvertes",
+      "askAboutNotes": "Ask about my notes",
+      "createQuiz": "Create a quiz",
+      "gradeAnswers": "Grade my answers",
+      "searchEverything": "Search everything",
+      "summarizeTopic": "Summarize a topic"
     }
   },
   "errors": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -172,7 +172,12 @@
       "summarizeIssues": "未完了のIssueをまとめて",
       "showRepos": "リポジトリを表示して",
       "createIssue": "Issueを作成して",
-      "listPRs": "オープンなPRを一覧表示して"
+      "listPRs": "オープンなPRを一覧表示して",
+      "askAboutNotes": "Ask about my notes",
+      "createQuiz": "Create a quiz",
+      "gradeAnswers": "Grade my answers",
+      "searchEverything": "Search everything",
+      "summarizeTopic": "Summarize a topic"
     }
   },
   "errors": {

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -172,7 +172,12 @@
       "summarizeIssues": "열린 이슈를 요약해 줘",
       "showRepos": "내 저장소를 보여 줘",
       "createIssue": "이슈를 만들어 줘",
-      "listPRs": "열린 PR 목록을 보여 줘"
+      "listPRs": "열린 PR 목록을 보여 줘",
+      "askAboutNotes": "Ask about my notes",
+      "createQuiz": "Create a quiz",
+      "gradeAnswers": "Grade my answers",
+      "searchEverything": "Search everything",
+      "summarizeTopic": "Summarize a topic"
     }
   },
   "errors": {

--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -1,10 +1,11 @@
-import { NoteCreateInput, NoteFormat, NoteUpdateInput } from '../../models/Note';
+import { Note, NoteCreateInput, NoteFormat, NoteUpdateInput } from '../../models/Note';
 import { TodoCreateInput, TodoPriority, TodoUpdateInput } from '../../models/Todo';
 import { useNoteStore } from '../../stores/noteStore';
 import { useTodoStore } from '../../stores/todoStore';
 import { useAIStore } from '../../stores/aiStore';
 import { GITHUB_ITEM_STATES, GitHubItemState, GitHubService } from '../GitHubService';
 import { NoteSyncQueueService } from '../NoteSyncQueueService';
+import { ScheduledLearningService } from '../ScheduledLearningService';
 
 export interface ProposedChange {
   type: string;
@@ -164,6 +165,45 @@ function buildExcerpt(content: string): string {
   return content.length > 100 ? `${content.slice(0, 100)}...` : content;
 }
 
+/**
+ * Enqueue a note upsert so it is pushed to GitHub on the next queue drain.
+ * Other app sessions pick it up via the foreground pull watcher (typically
+ * within the configured interval).
+ *
+ * Omit filePath so syncNoteToGitHub derives `notes/${slug}${ext}` and
+ * treats this as a brand-new file (#732). Pre-computing a bare
+ * `${slug}${ext}` here both pointed the file at repo root and tripped the
+ * updateFile "remote was deleted" guard, leaving the queue stuck with
+ * "GitHub API returned no result". The store-side Note record gets its
+ * filePath populated from the sync result on success (see
+ * applyPostSyncStorageUpdate), so mirror the manual-note path in
+ * useNoteEditorDocument.
+ */
+async function enqueueNoteSync(
+  createInput: NoteCreateInput,
+  noteId: string,
+  repoPath: string,
+  branch: string,
+): Promise<void> {
+  try {
+    await NoteSyncQueueService.enqueueNoteUpsert(
+      {
+        repo: repoPath,
+        branch,
+        title: createInput.title,
+        content: createInput.content,
+        format: createInput.format,
+        tags: createInput.tags ?? [],
+        color: null,
+      },
+      noteId,
+    );
+    void NoteSyncQueueService.drain();
+  } catch (error) {
+    console.warn('[actionExecutor] enqueueNoteUpsert failed:', error);
+  }
+}
+
 export async function executeToolCall(
   toolName: string,
   args: Record<string, unknown>,
@@ -180,14 +220,17 @@ export async function executeToolCall(
       };
     }
 
+    // Chat-thread repo context: attaching repo/branch to created notes
+    // keeps them visible under the same repo and lets the sync queue
+    // push them (see enqueueNoteSync).
+    const aiState = useAIStore.getState();
+    const repoOwner = aiState.chatRepoOwner ?? undefined;
+    const repoName = aiState.chatRepoName ?? undefined;
+    const repoPath = repoOwner && repoName ? `${repoOwner}/${repoName}` : undefined;
+    const branch = aiState.chatRepoBranch || 'main';
+
     switch (toolName) {
       case 'create_note': {
-        const aiState = useAIStore.getState();
-        const repoOwner = aiState.chatRepoOwner ?? undefined;
-        const repoName = aiState.chatRepoName ?? undefined;
-        const repoPath = repoOwner && repoName ? `${repoOwner}/${repoName}` : undefined;
-        const branch = aiState.chatRepoBranch || 'main';
-
         const input: NoteCreateInput = {
           title: getStringArg(args, 'title'),
           content: getStringArg(args, 'content'),
@@ -213,36 +256,8 @@ export async function executeToolCall(
           return { success: false, requiresConfirmation: false, error: 'Failed to create note.' };
         }
 
-        // Enqueue an upsert so the note is pushed to GitHub on the next
-        // queue drain. Other app sessions pick it up via the foreground
-        // pull watcher (typically within the configured interval).
-        //
-        // Omit filePath so syncNoteToGitHub derives `notes/${slug}${ext}`
-        // and treats this as a brand-new file (#732). Pre-computing a
-        // bare `${slug}${ext}` here both pointed the file at repo root
-        // and tripped the updateFile "remote was deleted" guard, leaving
-        // the queue stuck with "GitHub API returned no result". The
-        // store-side Note record gets its filePath populated from the
-        // sync result on success (see applyPostSyncStorageUpdate), so
-        // mirror the manual-note path in useNoteEditorDocument.
         if (repoPath) {
-          try {
-            await NoteSyncQueueService.enqueueNoteUpsert(
-              {
-                repo: repoPath,
-                branch,
-                title: input.title,
-                content: input.content,
-                format: input.format,
-                tags: input.tags ?? [],
-                color: null,
-              },
-              created.id,
-            );
-            void NoteSyncQueueService.drain();
-          } catch (error) {
-            console.warn('[actionExecutor] enqueueNoteUpsert failed:', error);
-          }
+          await enqueueNoteSync(input, created.id, repoPath, branch);
         }
 
         // Return a slim summary; the previous full-Note dump filled the
@@ -252,6 +267,443 @@ export async function executeToolCall(
           title: created.title,
           format: created.format,
           repo: created.repo,
+          synced: Boolean(repoPath),
+        });
+      }
+
+      case 'create_questioner_note': {
+        const topic = getStringArg(args, 'topic');
+        const content = getStringArg(args, 'content');
+        const sourceNotes = getOptionalStringArrayArg(args, 'sourceNotes') ?? [];
+        const userTags = getOptionalStringArrayArg(args, 'tags') ?? [];
+        // Force the 'questioner' tag — NoteEditorScreen shows the
+        // Grade Answers button only for notes carrying it.
+        const tags = Array.from(new Set([...userTags, 'questioner']));
+        const format = getOptionalNoteFormatArg(args, 'format');
+        const questionCount = (content.match(/\?/g) || []).length;
+
+        const sourceList = sourceNotes.length
+          ? `## Sources\n\n${sourceNotes.map((id) => `- ${id}`).join('\n')}\n\n`
+          : '';
+        const marker = `<!-- sl-item-id: chat-gen-${Date.now()} -->\n`;
+
+        const input: NoteCreateInput = {
+          title: topic,
+          content: `${marker}${sourceList}${content}`,
+          tags,
+          format: format ?? 'markdown',
+          ...(repoPath ? { repo: repoPath, branch } : {}),
+        };
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'create_questioner_note',
+            description: `Create questioner note on: ${topic}`,
+            details: { topic, tags, questionCount },
+          });
+        }
+
+        const created = await useNoteStore.getState().createNote(input);
+        if (!created) {
+          return { success: false, requiresConfirmation: false, error: 'Failed to create questioner note.' };
+        }
+        if (repoPath) {
+          await enqueueNoteSync(input, created.id, repoPath, branch);
+        }
+
+        return buildSuccessResult({
+          noteId: created.id,
+          title: created.title,
+          format: created.format,
+          repo: created.repo,
+          synced: Boolean(repoPath),
+          questionCount,
+          tag: 'questioner',
+        });
+      }
+
+      case 'grade_questioner_answers': {
+        const noteId = getStringArg(args, 'noteId');
+        const note = useNoteStore.getState().getNoteById(noteId);
+        if (!note) {
+          return { success: false, requiresConfirmation: false, error: 'Note not found.' };
+        }
+        if (!note.tags.includes('questioner')) {
+          return {
+            success: false,
+            requiresConfirmation: false,
+            error: "Note doesn't have the 'questioner' tag required for grading.",
+          };
+        }
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'grade_questioner_answers',
+            description: `Grade answers in note: '${note.title}'`,
+            targetId: noteId,
+            details: { noteId, title: note.title },
+          });
+        }
+
+        const contentLenBefore = (useNoteStore.getState().getNoteById(noteId)?.content ?? '').length;
+        const graded = await ScheduledLearningService.gradeQuestionerNote(noteId);
+        if (!graded) {
+          return {
+            success: false,
+            requiresConfirmation: false,
+            error: 'Grading failed. Check your AI model is configured.',
+          };
+        }
+        const contentLenAfter = (useNoteStore.getState().getNoteById(noteId)?.content ?? '').length;
+        return buildSuccessResult({
+          noteId,
+          graded: true,
+          gradingAppended: Math.max(0, contentLenAfter - contentLenBefore),
+        });
+      }
+
+      case 'find_notes': {
+        const query = getStringArg(args, 'query').trim().toLowerCase();
+        const requiredTags = getOptionalStringArrayArg(args, 'tags');
+        const excludeTags = getOptionalStringArrayArg(args, 'excludeTags');
+        const folderPath = getOptionalStringArg(args, 'folderPath');
+        const sortBy = getOptionalStringArg(args, 'sortBy') ?? 'recent';
+        if (!['recent', 'alphabetical'].includes(sortBy)) {
+          throw new Error("Invalid 'sortBy' — must be recent or alphabetical");
+        }
+        const limit =
+          args.limit === undefined ? 20 : Math.max(1, Math.min(100, getNumberArg(args, 'limit')));
+
+        const filtered = useNoteStore.getState().notes.filter((note) => {
+          if (
+            query &&
+            !(
+              note.title.toLowerCase().includes(query) ||
+              note.content.toLowerCase().includes(query) ||
+              note.tags.some((tag) => tag.toLowerCase().includes(query))
+            )
+          ) {
+            return false;
+          }
+          if (requiredTags && !requiredTags.every((tag) => note.tags.includes(tag))) {
+            return false;
+          }
+          if (excludeTags && excludeTags.some((tag) => note.tags.includes(tag))) {
+            return false;
+          }
+          if (folderPath && !(note.folderPath ?? '').startsWith(folderPath)) {
+            return false;
+          }
+          return true;
+        });
+
+        filtered.sort((a, b) => {
+          if (sortBy === 'alphabetical') {
+            return a.title.localeCompare(b.title);
+          }
+          return b.updatedAt - a.updatedAt;
+        });
+
+        return buildSuccessResult({
+          matches: filtered.slice(0, limit).map((note) => ({
+            id: note.id,
+            title: note.title,
+            tags: note.tags,
+            folderPath: note.folderPath ?? null,
+            excerpt: buildExcerpt(note.content),
+            updatedAt: note.updatedAt,
+          })),
+          total: filtered.length,
+        });
+      }
+
+      case 'find_todos': {
+        const query = getOptionalStringArg(args, 'query')?.trim().toLowerCase() ?? '';
+        const status = getOptionalStringArg(args, 'status') ?? 'all';
+        if (!['all', 'pending', 'completed'].includes(status)) {
+          throw new Error("Invalid 'status' — must be all, pending, or completed");
+        }
+        const priority = getOptionalTodoPriorityArg(args, 'priority');
+        const tags = getOptionalStringArrayArg(args, 'tags');
+        const dueBeforeRaw = getOptionalStringArg(args, 'dueBefore');
+        const dueBeforeMs = dueBeforeRaw ? Date.parse(dueBeforeRaw) : NaN;
+        if (dueBeforeRaw && Number.isNaN(dueBeforeMs)) {
+          throw new Error("Invalid 'dueBefore' — must be a parseable date string");
+        }
+        const sortBy = getOptionalStringArg(args, 'sortBy') ?? 'recent';
+        if (!['due', 'priority', 'recent'].includes(sortBy)) {
+          throw new Error("Invalid 'sortBy' — must be due, priority, or recent");
+        }
+
+        const priorityRank: Record<TodoPriority, number> = { high: 0, medium: 1, low: 2 };
+
+        const filtered = useTodoStore.getState().todos.filter((todo) => {
+          if (status === 'pending' && todo.completed) {
+            return false;
+          }
+          if (status === 'completed' && !todo.completed) {
+            return false;
+          }
+          if (priority && todo.priority !== priority) {
+            return false;
+          }
+          if (tags && !tags.every((tag) => (todo.tags ?? []).includes(tag))) {
+            return false;
+          }
+          if (dueBeforeRaw && (!todo.dueDate || todo.dueDate > dueBeforeMs)) {
+            return false;
+          }
+          if (
+            query &&
+            !(
+              todo.text.toLowerCase().includes(query) ||
+              (todo.notes?.toLowerCase().includes(query) ?? false) ||
+              (todo.tags?.some((tag) => tag.toLowerCase().includes(query)) ?? false)
+            )
+          ) {
+            return false;
+          }
+          return true;
+        });
+
+        filtered.sort((a, b) => {
+          if (sortBy === 'due') {
+            const aDue = a.dueDate ?? Number.MAX_SAFE_INTEGER;
+            const bDue = b.dueDate ?? Number.MAX_SAFE_INTEGER;
+            return aDue - bDue;
+          }
+          if (sortBy === 'priority') {
+            return priorityRank[a.priority ?? 'medium'] - priorityRank[b.priority ?? 'medium'];
+          }
+          return b.createdAt - a.createdAt;
+        });
+
+        return buildSuccessResult({
+          matches: filtered.map((todo) => ({
+            id: todo.id,
+            text: todo.text,
+            completed: todo.completed,
+            priority: todo.priority ?? null,
+            dueDate: todo.dueDate ?? null,
+            tags: todo.tags ?? [],
+          })),
+          total: filtered.length,
+          filterApplied: { status, priority: priority ?? null, query },
+        });
+      }
+
+      case 'summarize_notes': {
+        const noteIds = getOptionalStringArrayArg(args, 'noteIds') ?? [];
+        if (noteIds.length === 0) {
+          return { success: false, requiresConfirmation: false, error: 'noteIds must be non-empty' };
+        }
+        const content = getStringArg(args, 'content');
+        const outputTags = getOptionalStringArrayArg(args, 'outputTags') ?? [];
+        const format = getOptionalNoteFormatArg(args, 'format');
+
+        const noteStore = useNoteStore.getState();
+        const sources = noteIds
+          .map((id) => noteStore.getNoteById(id))
+          .filter((found): found is Note => found !== undefined);
+        if (sources.length === 0) {
+          return { success: false, requiresConfirmation: false, error: 'None of the source notes exist.' };
+        }
+
+        const title = getOptionalStringArg(args, 'outputTitle') ?? `Summary (${sources.length} notes)`;
+        const tags = Array.from(new Set([...outputTags, 'summary']));
+        const marker = `<!-- source-note-ids: ${noteIds.join(',')} -->\n`;
+        const sourceListMd = `## Sources\n\n${sources
+          .map((source) => `- ${source.title} (${source.id})`)
+          .join('\n')}\n\n`;
+
+        const input: NoteCreateInput = {
+          title,
+          content: `${marker}${sourceListMd}${content}`,
+          tags,
+          format: format ?? 'markdown',
+          ...(repoPath ? { repo: repoPath, branch } : {}),
+        };
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'summarize_notes',
+            description: `Summarize ${sources.length} notes into '${title}'`,
+            details: { sourceCount: sources.length, title, tags },
+          });
+        }
+
+        const created = await useNoteStore.getState().createNote(input);
+        if (!created) {
+          return { success: false, requiresConfirmation: false, error: 'Failed to create summary note.' };
+        }
+        if (repoPath) {
+          await enqueueNoteSync(input, created.id, repoPath, branch);
+        }
+
+        return buildSuccessResult({
+          noteId: created.id,
+          title: created.title,
+          sourceCount: sources.length,
+          synced: Boolean(repoPath),
+        });
+      }
+
+      case 'distill_thought_dump': {
+        const sourceIds = getOptionalStringArrayArg(args, 'sourceNoteIds') ?? [];
+        if (sourceIds.length === 0) {
+          return { success: false, requiresConfirmation: false, error: 'sourceNoteIds must be non-empty' };
+        }
+        const content = getStringArg(args, 'content');
+        const title = getStringArg(args, 'outputTitle');
+        const userTags = getOptionalStringArrayArg(args, 'outputTags') ?? [];
+        const tags = Array.from(new Set([...userTags, 'distilled']));
+        const marker = `<!-- distilled-from: ${sourceIds.join(',')} -->\n`;
+
+        const input: NoteCreateInput = {
+          title,
+          content: `${marker}${content}`,
+          tags,
+          format: 'markdown',
+          ...(repoPath ? { repo: repoPath, branch } : {}),
+        };
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'distill_thought_dump',
+            description: `Distill ${sourceIds.length} thought-dumps into '${title}'`,
+            details: { sourceIds, title, tags },
+          });
+        }
+
+        const created = await useNoteStore.getState().createNote(input);
+        if (!created) {
+          return { success: false, requiresConfirmation: false, error: 'Failed to create distilled note.' };
+        }
+        if (repoPath) {
+          await enqueueNoteSync(input, created.id, repoPath, branch);
+        }
+
+        return buildSuccessResult({
+          noteId: created.id,
+          title: created.title,
+          sourceIds,
+          synced: Boolean(repoPath),
+        });
+      }
+
+      case 'link_notes': {
+        const ids = getOptionalStringArrayArg(args, 'noteIds') ?? [];
+        if (ids.length < 2) {
+          return { success: false, requiresConfirmation: false, error: 'link_notes requires at least 2 noteIds' };
+        }
+        const relationship = getOptionalStringArg(args, 'relationship') ?? 'related';
+        if (!['related', 'sequence', 'contradicts'].includes(relationship)) {
+          throw new Error("Invalid 'relationship' — must be related, sequence, or contradicts");
+        }
+        const heading =
+          relationship === 'contradicts'
+            ? '## Contradicts'
+            : relationship === 'sequence'
+              ? '## Sequence'
+              : '## Related';
+
+        const noteStore = useNoteStore.getState();
+        const targets = ids
+          .map((id) => noteStore.getNoteById(id))
+          .filter((found): found is Note => found !== undefined);
+        if (targets.length < 2) {
+          return { success: false, requiresConfirmation: false, error: 'At least 2 of the given noteIds must exist' };
+        }
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'link_notes',
+            description: `Cross-link ${targets.length} notes with '${heading.replace('## ', '')}' references`,
+            details: { noteIds: targets.map((note) => note.id), relationship },
+          });
+        }
+
+        let linked = 0;
+        for (const self of targets) {
+          const siblings = targets.filter((note) => note.id !== self.id);
+          const linkBlock =
+            `\n\n<!-- linked-by-chat: ${new Date().toISOString().slice(0, 10)} -->\n` +
+            `${heading}\n\n${siblings.map((sibling) => `- [[${sibling.title}]]`).join('\n')}`;
+          const updated = await noteStore.updateNote({
+            id: self.id,
+            content: self.content + linkBlock,
+          });
+
+          if (repoPath && updated) {
+            try {
+              await NoteSyncQueueService.enqueueNoteUpsert(
+                {
+                  repo: repoPath,
+                  branch,
+                  title: updated.title,
+                  content: updated.content,
+                  format: updated.format ?? 'markdown',
+                  tags: updated.tags,
+                  color: null,
+                },
+                updated.id,
+              );
+            } catch (error) {
+              console.warn('[actionExecutor] link_notes sync enqueue failed:', error);
+            }
+          }
+          linked += 1;
+        }
+
+        if (repoPath) {
+          try {
+            void NoteSyncQueueService.drain();
+          } catch {
+            // Drain is best-effort — the queue retries on its next trigger.
+          }
+        }
+
+        return buildSuccessResult({
+          linked,
+          noteIds: targets.map((note) => note.id),
+        });
+      }
+
+      case 'generate_daily_brief': {
+        const content = getStringArg(args, 'content');
+        const userTags = getOptionalStringArrayArg(args, 'outputTags') ?? [];
+        const tags = Array.from(new Set([...userTags, 'daily-brief']));
+        const today = new Date().toISOString().slice(0, 10);
+        const title = `Daily Brief: ${today}`;
+        const marker = `<!-- daily-brief: ${today} -->\n`;
+
+        const input: NoteCreateInput = {
+          title,
+          content: `${marker}${content}`,
+          tags,
+          format: 'markdown',
+          ...(repoPath ? { repo: repoPath, branch } : {}),
+        };
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'generate_daily_brief',
+            description: `Create daily brief for ${today}`,
+            details: { date: today, tags },
+          });
+        }
+
+        const created = await useNoteStore.getState().createNote(input);
+        if (!created) {
+          return { success: false, requiresConfirmation: false, error: 'Failed to create daily brief.' };
+        }
+        if (repoPath) {
+          await enqueueNoteSync(input, created.id, repoPath, branch);
+        }
+
+        return buildSuccessResult({
+          noteId: created.id,
+          date: today,
           synced: Boolean(repoPath),
         });
       }

--- a/src/services/ai/tools.ts
+++ b/src/services/ai/tools.ts
@@ -115,6 +115,115 @@ export const get_todos = tool({
   execute: async (params) => params,
 });
 
+export const createQuestionerNoteParameters = z.object({
+  topic: z.string(),
+  content: z.string(),
+  sourceNotes: z.array(z.string()).optional(),
+  tags: z.array(z.string()).optional(),
+  format: z.enum(['markdown', 'neorg', 'org']).optional(),
+});
+
+export const create_questioner_note = tool({
+  description:
+    "Create a quiz-style note with open questions on a topic for the user to answer then have graded. The result is automatically tagged 'questioner' so the Grade Answers button appears in the editor.",
+  inputSchema: createQuestionerNoteParameters,
+  execute: async (params) => params,
+});
+
+export const gradeQuestionerNoteParameters = z.object({
+  noteId: z.string(),
+});
+
+export const grade_questioner_answers = tool({
+  description:
+    "Grade a questioner note by appending '## Grading & Corrections' with the AI evaluation to the same note. Uses the chat-selected AI model.",
+  inputSchema: gradeQuestionerNoteParameters,
+  execute: async (params) => params,
+});
+
+export const findNotesParameters = z.object({
+  query: z.string(),
+  tags: z.array(z.string()).optional(),
+  excludeTags: z.array(z.string()).optional(),
+  folderPath: z.string().optional(),
+  sortBy: z.enum(['recent', 'alphabetical']).optional(),
+  limit: z.number().int().positive().optional(),
+});
+
+export const find_notes = tool({
+  description: 'Richer note search with full-text + tag inclusion/exclusion + folder scope + sort + limit.',
+  inputSchema: findNotesParameters,
+  execute: async (params) => params,
+});
+
+export const findTodosParameters = z.object({
+  query: z.string().optional(),
+  status: z.enum(['all', 'pending', 'completed']).optional(),
+  priority: z.enum(['low', 'medium', 'high']).optional(),
+  tags: z.array(z.string()).optional(),
+  dueBefore: z.string().optional(),
+  sortBy: z.enum(['due', 'priority', 'recent']).optional(),
+});
+
+export const find_todos = tool({
+  description: 'Richer todo search with status/priority/tags/due-before + sort.',
+  inputSchema: findTodosParameters,
+  execute: async (params) => params,
+});
+
+export const summarizeNotesParameters = z.object({
+  noteIds: z.array(z.string()),
+  content: z.string(),
+  outputTitle: z.string().optional(),
+  outputTags: z.array(z.string()).optional(),
+  format: z.enum(['markdown', 'neorg', 'org']).optional(),
+});
+
+export const summarize_notes = tool({
+  description:
+    'Persist a summary note composed from multiple source notes. The agent synthesizes the summary in its response; this tool saves it with a source-note-ids marker.',
+  inputSchema: summarizeNotesParameters,
+  execute: async (params) => params,
+});
+
+export const distillThoughtDumpParameters = z.object({
+  sourceNoteIds: z.array(z.string()),
+  content: z.string(),
+  outputTitle: z.string(),
+  outputTags: z.array(z.string()).optional(),
+});
+
+export const distill_thought_dump = tool({
+  description:
+    'Distill raw thought-dump content into a clean, themed note. Creates one distilled note per call — loop for multiple.',
+  inputSchema: distillThoughtDumpParameters,
+  execute: async (params) => params,
+});
+
+export const linkNotesParameters = z.object({
+  noteIds: z.array(z.string()).min(2),
+  relationship: z.enum(['related', 'sequence', 'contradicts']).optional(),
+});
+
+export const link_notes = tool({
+  description:
+    "Add wiki-link cross-references between 2+ notes. Appends a '## Related' section with [[name]] links to each targeted note.",
+  inputSchema: linkNotesParameters,
+  execute: async (params) => params,
+});
+
+export const generateDailyBriefParameters = z.object({
+  content: z.string(),
+  topics: z.array(z.string()).optional(),
+  outputTags: z.array(z.string()).optional(),
+});
+
+export const generate_daily_brief = tool({
+  description: "Create a dated daily brief note aggregating today's open todos and recent notes.",
+  inputSchema: generateDailyBriefParameters,
+  execute: async (params) => params,
+});
+
 export const chatTools = {
   create_note,
   edit_note,
@@ -126,6 +235,14 @@ export const chatTools = {
   delete_todo,
   search_todos,
   get_todos,
+  create_questioner_note,
+  grade_questioner_answers,
+  find_notes,
+  find_todos,
+  summarize_notes,
+  distill_thought_dump,
+  link_notes,
+  generate_daily_brief,
 };
 
 export const listReposParameters = z.object({});


### PR DESCRIPTION
## Summary

Extends the AI chat/agent with **8 new tools** across questioner integration, richer discovery, and content helpers — so the AI can do more than CRUD + GitHub. Also adds **5 note-focused hint chips** on the empty-thread screen, converted to a horizontal ScrollView to handle 9 total chips cleanly on mobile.

## New Tools

### 🧠 Questioner integration
- **`create_questioner_note`** — composes quiz-style notes. Forces the `'questioner'` tag so the Grade Answers button auto-appears in the editor. Synthesizes the question body as markdown, prefixes an `sl-item-id: chat-gen-...` marker, and writes through the same repo + sync queue pipeline as `create_note`.
- **`grade_questioner_answers`** — delegates entirely to `ScheduledLearningService.gradeQuestionerNote`, using the currently selected chat model via the service's existing fallback resolution. Returns `{noteId, graded, gradingAppended}` (length of the appended grading block).

### 🔍 Discovery (richer than the existing 1-arg tools)
- **`find_notes`** — full-text search + tag inclusion/exclusion + folder scope + sort (recent/alphabetical) + limit (1–100). Returns ranked snippets with total count.
- **`find_todos`** — status / priority / tags / due-before filters with sort (due / priority / recent). Returns filtered matches with `filterApplied` summary.

### ✍️ Content helpers
- **`summarize_notes`** — persists a synthesis note composed from N source notes. Adds an `<!-- source-note-ids: ... -->` marker + `## Sources` list, forced `'summary'` tag.
- **`distill_thought_dump`** — distills raw thought-dump content into a clean themed note. `<!-- distilled-from: ... -->` marker + forced `'distilled'` tag.
- **`link_notes`** — cross-links 2+ notes with `[[wiki-links]]` under a `## Related` / `## Sequence` / `## Contradicts` heading. Enqueues a sync upsert per updated note, drains once after the loop.
- **`generate_daily_brief`** — creates a `Daily Brief: YYYY-MM-DD` note tagged `'daily-brief'` with a daily-brief marker.

## Hint Chips

- Converted the outer `<View style={{ flexWrap: 'wrap' }}>` into a horizontal `<ScrollView>` so 9 total chips don't eat two rows on mobile.
- **Layout fix**: added `alignSelf: 'stretch'` to the outer View to counter ChatScreen's `items-center` parent — without it the ScrollView would shrink-wrap to content width and clip the 9 chips.
- **5 new hints**: Ask about my notes · Create a quiz · Grade my answers · Search everything · Summarize a topic
- **Icon union extended** with 5 new Ionicons names (all verified against the glyph map).

## Refactor

- Extracted `enqueueNoteSync()` helper in `actionExecutor.ts` to eliminate duplication across the 6 write-note cases. The existing `create_note` case now delegates to this helper — verified unchanged by a regression guard test.

## Other changes

- **i18n**: 5 new `chat.hints.*` keys added to all 6 language files (en/es/fr/de/ja/ko). Non-English files use English strings as placeholders (translation follow-up is separate).
- **System prompt**: intentionally unchanged (lean approach — tool `description` field is enough).

## Tests

- **`__tests__/ai-chat-tools-expansion.test.ts`** (new) — **38 tests** covering:
  - Schema validation (valid + invalid) for each of the 8 new tools
  - chatTools registry exposes all 18 keys
  - Read tools (`find_notes`, `find_todos`) return matches/total, respect tag exclusion and sort
  - All 6 write tools respect confirm mode
  - `create_questioner_note` forces the `'questioner'` tag + dedupes when supplied by the user
  - `grade_questioner_answers` delegates to `ScheduledLearningService` and surfaces errors correctly
  - chatRepoSync: write tools enqueue sync when a repo is selected, skip when not
  - `link_notes` appends a link section per note + enqueues one upsert per updated note
  - GitHub-tools gate regression guard (fires even after refactor)
  - `create_note` unchanged after `enqueueNoteSync` extraction
- **`__tests__/ai/tools.test.ts`** — updated registry-count assertion 10 → 18 (required; otherwise the exact-match assertion would fail).
- **`__tests__/ChatHintChips.test.tsx`** — asserts 9 chips total, horizontal ScrollView prop, tap behaviour for all 9 hints.

## Verification

- `yarn ts:check`: clean
- `lsp_diagnostics` on `tools.ts` + `actionExecutor.ts` + `ChatHintChips.tsx`: clean
- `yarn jest __tests__/ai-chat-tools-expansion`: **38/38 pass**
- `yarn jest __tests__/ai` (17 suites): **215/215 pass**
- `yarn jest __tests__/live-questioner + ScheduledLearningService`: 17/22 pass (5 pre-existing skips, no regressions)
- `yarn jest` full suite: **218 suites, 1964 tests pass, 0 fail**

Plan artifact: `.omo/plans/ai-chat-tools-expansion.md` (git-ignored).