### PR TITLE
fix(editor): replace full-screen saving overlay with inline Save button indicator

### DIFF
--- a/src/components/editor/EditorHeader.tsx
+++ b/src/components/editor/EditorHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 
 import { useTheme } from '../../contexts/ThemeContext';
 import { Button } from '../ui';
@@ -13,6 +13,9 @@ interface EditorHeaderProps {
 
 export function EditorHeader({ noteId, isSaving, onCancel, onSave }: EditorHeaderProps) {
   const { colors } = useTheme();
+  const saveTrailingIcon = isSaving ? (
+    <ActivityIndicator testID="note-editor.button.save-spinner" size="small" color={colors.textSecondary} />
+  ) : null;
 
   return (
     <View style={[styles.header, { borderBottomColor: colors.border, backgroundColor: colors.surface }]}>
@@ -27,6 +30,8 @@ export function EditorHeader({ noteId, isSaving, onCancel, onSave }: EditorHeade
           testID="note-editor.button.save"
           onPress={onSave}
           disabled={isSaving}
+          trailingIcon={saveTrailingIcon}
+          style={isSaving ? styles.saveButtonBusy : undefined}
           textStyle={[styles.headerButtonText, styles.saveButtonText, isSaving && styles.disabledButton]}
         />
       </View>
@@ -66,5 +71,10 @@ const styles = StyleSheet.create({
   },
   disabledButton: {
     opacity: 0.5,
+  },
+  saveButtonBusy: {
+    backgroundColor: 'rgba(120, 120, 120, 0.12)',
+    borderRadius: 6,
+    paddingHorizontal: 4,
   },
 });

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -16,7 +16,6 @@ import { useRepos } from '../contexts/RepoContext';
 import { useResponsive } from '../hooks/useResponsive';
 import { getMarkdownStyles } from '../utils/preview';
 import { useRenderStyle } from '../stores/renderStyleStore';
-import { SavingOverlay } from '../components/ui/SavingOverlay';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { CanvasPickerModal } from '../components/editor/CanvasPickerModal';
 import { EditorHeader } from '../components/editor/EditorHeader';
@@ -160,8 +159,7 @@ function NoteEditorScreenInner() {
   }
 
   return (
-    <SafeAreaView edges={['top', 'bottom']} className="flex-1" style={{ backgroundColor: colors.surface }}> 
-      {document.isSaving ? <SavingOverlay visible label={t('editor.saving')} /> : null}
+    <SafeAreaView edges={['top', 'bottom']} className="flex-1" style={{ backgroundColor: colors.surface }}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} className="flex-1">
         <EditorHeader noteId={noteId} isSaving={document.isSaving} onCancel={document.handleCancelEdit} onSave={document.handleSave} />
 


### PR DESCRIPTION
## Summary

Replaces the full-screen `SavingOverlay` (blur + scrim + large spinner + 'Saving…' label) on the note editor with a **localized inline indicator** on the Save button itself:

- Save button label remains **"Save"** — no text swap that disrupts the header layout.
- A small `ActivityIndicator` appears as a trailing icon on the Save button while `isSaving` is true.
- The Save button gets a subtle gray background (`rgba(120,120,120,0.12)` + rounded corners + horizontal padding) while busy, so the state change is visible without obscuring the editor form the user is working in.
- Cancel button remains disabled during save (unchanged).

## Why

The previous `SavingOverlay` covered the entire editor viewport during save — a heavy-handed UX that made it feel like the app had locked up, hid the note content the user was just editing, and blocked any visual feedback about which specific action was in flight.

## Changes

- **`src/screens/NoteEditorScreen.tsx`**: removed the `{document.isSaving ? <SavingOverlay …/> : null}` line and its import. Editor form stays fully visible during save.
- **`src/components/editor/EditorHeader.tsx`**: added an `ActivityIndicator` trailing icon and `saveButtonBusy` style that applies when `isSaving` is true. Save button still uses `disabled={isSaving}`.

The `SavingOverlay` component itself is **not deleted** — it is still consumed by `RenderStyleEditorScreen`. The `editor.saving` i18n key remains (still used by that other screen).

## Verification

- `yarn ts:check`: clean
- `lsp_diagnostics` on both changed files: clean
- `yarn jest` targeted suites (`NoteEditorScreen`, `editor-scaffold`, `editor-modes`, `SavingOverlay`, `editor-search`, `editor-undo-redo`): **31/31 passed**

No new tests added — the existing NoteEditorScreen test mocks EditorHeader outright, and the SavingOverlay unit test suite still verifies the component's API surface (component is preserved).

## Risk

Low. This is purely a UX polish change — no data flow, no persistence, no sync path touched.