### PR TITLE
feat(ai): affordance animations for the floating AI button (tap/hold/peek)

### DIFF
--- a/__tests__/FloatingAIButton.global-gesture.test.tsx
+++ b/__tests__/FloatingAIButton.global-gesture.test.tsx
@@ -33,6 +33,7 @@ jest.mock('@shopify/react-native-skia', () => {
     Paint: ({ children }: { children: ReactNode }) => children,
     Blur: MockView,
     ColorMatrix: MockView,
+    DashPathEffect: ({ children }: { children?: ReactNode }) => children ?? null,
   };
 });
 

--- a/__tests__/FloatingAIButton.hub.test.tsx
+++ b/__tests__/FloatingAIButton.hub.test.tsx
@@ -353,4 +353,14 @@ describe('FloatingAIButton liquid hub', () => {
       })).toBe(true);
     });
   });
+
+  it('marks the hub discovered after a long press', async () => {
+    const { getByTestId } = await renderInitializedFloatingAIButton();
+
+    fireEvent(getByTestId('floating-ai.button.navigate-chat'), 'longPress');
+
+    await waitFor(() => {
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith('ai-hub-discovered', 'true');
+    });
+  });
 });

--- a/__tests__/FloatingAIButton.hub.test.tsx
+++ b/__tests__/FloatingAIButton.hub.test.tsx
@@ -7,6 +7,8 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 const mockNavigate = jest.fn();
 const mockCreateThread = jest.fn(() => ({ id: 'thread-from-fab' }));
 const mockRunOnJSCallbacks: Array<() => void> = [];
+const mockDashIntervals: unknown[] = [];
+const mockTimingCalls: Array<[unknown, unknown]> = [];
 let mockAIState = {
   isEnabled: true,
   chatRepoOwner: 'owner',
@@ -93,6 +95,10 @@ jest.mock('@shopify/react-native-skia', () => {
     Paint: ({ children }: { children: ReactNode }) => children,
     Blur: MockView,
     ColorMatrix: MockView,
+    DashPathEffect: (props: { intervals?: unknown; children?: ReactNode }) => {
+      mockDashIntervals.push(props.intervals);
+      return props.children ?? null;
+    },
   };
 });
 
@@ -106,6 +112,14 @@ jest.mock('react-native-reanimated', () => {
     useDerivedValue: (callback: () => unknown) => ({ value: callback() }),
     useAnimatedStyle: (callback: () => Record<string, unknown>) => callback(),
     withSpring: (value: unknown) => value,
+    withTiming: (value: unknown, config: unknown) => {
+      mockTimingCalls.push([value, config]);
+      return value;
+    },
+    withDelay: (_delay: unknown, animation: unknown) => animation,
+    withSequence: (...animations: unknown[]) => animations[animations.length - 1],
+    withRepeat: (animation: unknown) => animation,
+    cancelAnimation: () => {},
     runOnJS: (callback: (...args: readonly unknown[]) => unknown) => (
       (...args: readonly unknown[]) => {
         mockRunOnJSCallbacks.push(() => callback(...args));
@@ -153,6 +167,7 @@ jest.mock('react-native-gesture-handler', () => {
 });
 
 import { FloatingAIButton } from '../src/components/ai/FloatingAIButton';
+import { HOLD_RING_CIRCUMFERENCE } from '../src/components/ai/FloatingAIHubMenu';
 import { useAIHubStore } from '../src/stores/aiHubStore';
 
 type HubHelper = 'goNewChat' | 'goChatHistory' | 'goAISettings' | 'goThoughtDump' | 'goVoiceDump';
@@ -186,6 +201,8 @@ describe('FloatingAIButton liquid hub', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     mockRunOnJSCallbacks.length = 0;
+    mockDashIntervals.length = 0;
+    mockTimingCalls.length = 0;
     mockPanCallbacks.begin = undefined;
     mockPanCallbacks.start = undefined;
     mockPanCallbacks.update = undefined;
@@ -319,5 +336,21 @@ describe('FloatingAIButton liquid hub', () => {
 
     await waitFor(() => expect(queryByTestId('floating-ai.hub.new-chat')).toBeNull());
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('draws the hold ring with the full circumference as dash cycle', async () => {
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(false);
+
+    await renderInitializedFloatingAIButton();
+
+    await waitFor(() => {
+      expect(mockDashIntervals.some((entry) => {
+        const intervals = entry as { value: number[] };
+        return (
+          intervals.value[0] === 0
+          && intervals.value[1] === HOLD_RING_CIRCUMFERENCE
+        );
+      })).toBe(true);
+    });
   });
 });

--- a/__tests__/FloatingAIButton.test.tsx
+++ b/__tests__/FloatingAIButton.test.tsx
@@ -164,6 +164,7 @@ jest.mock('@shopify/react-native-skia', () => {
     Paint: ({ children }: { children: ReactNode }) => children,
     Blur: MockView,
     ColorMatrix: MockView,
+    DashPathEffect: ({ children }: { children?: ReactNode }) => children ?? null,
   };
 });
 

--- a/__tests__/FloatingAIButton.test.tsx
+++ b/__tests__/FloatingAIButton.test.tsx
@@ -7,6 +7,8 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 const mockNavigate = jest.fn();
 const mockSharedValues: Array<{ value: unknown }> = [];
 const mockSpringCalls: Array<readonly [unknown, unknown]> = [];
+const mockTimingCalls: Array<readonly [unknown, unknown]> = [];
+const mockCancelled: Array<{ value: unknown }> = [];
 const mockRunOnJSCallbacks: Array<() => void> = [];
 let mockPanBegin: (() => void) | undefined;
 let mockPanStart: (() => void) | undefined;
@@ -50,6 +52,15 @@ async function flushRunOnJSCallbacks(): Promise<void> {
   await act(async () => {
     for (const callback of callbacks) callback();
     await Promise.resolve();
+  });
+}
+
+async function waitForEntranceSpring(): Promise<void> {
+  await waitFor(() => {
+    expect(mockSpringCalls).toContainEqual([
+      1,
+      expect.objectContaining({ stiffness: 240 }),
+    ]);
   });
 }
 
@@ -108,6 +119,16 @@ jest.mock('react-native-reanimated', () => {
     withSpring: (value: unknown, config: unknown) => {
       mockSpringCalls.push([value, config]);
       return value;
+    },
+    withTiming: (value: unknown, config: unknown) => {
+      mockTimingCalls.push([value, config]);
+      return value;
+    },
+    withDelay: (_delay: unknown, animation: unknown) => animation,
+    withSequence: (...animations: unknown[]) => animations[animations.length - 1],
+    withRepeat: (animation: unknown) => animation,
+    cancelAnimation: (sharedValue: { value: unknown }) => {
+      mockCancelled.push(sharedValue);
     },
     runOnJS: (callback: (...args: unknown[]) => unknown) => (
       (...args: unknown[]) => {
@@ -175,6 +196,8 @@ describe('FloatingAIButton', () => {
     jest.clearAllMocks();
     mockSharedValues.length = 0;
     mockSpringCalls.length = 0;
+    mockTimingCalls.length = 0;
+    mockCancelled.length = 0;
     mockRunOnJSCallbacks.length = 0;
     mockPanBegin = undefined;
     mockPanStart = undefined;
@@ -452,7 +475,7 @@ describe('FloatingAIButton', () => {
     expect(mockSharedValues[1]?.value).toBe(168);
     expect(mockSharedValues[2]?.value).toBe(16);
     expect(mockSharedValues[3]?.value).toBe(168);
-    expect(AsyncStorage.setItem).toHaveBeenLastCalledWith(
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'ai-button-position',
       JSON.stringify({ x: 16, y: 168 }),
     );
@@ -512,5 +535,80 @@ describe('FloatingAIButton', () => {
       expect(getByTestId('floating-ai.button.navigate-chat')).toBeTruthy();
       expect(queryByTestId('floating-ai.button.liquid')).toBeNull();
     });
+  });
+
+  it('advertises tap-and-hold affordances via the accessibility hint', async () => {
+    const { getByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+    await waitFor(() => {
+      expect(AccessibilityInfo.isReduceMotionEnabled).toHaveBeenCalledTimes(1);
+    });
+    const trigger = getByTestId('floating-ai.button.navigate-chat');
+
+    expect(trigger.props.accessibilityHint).toContain('Press and hold');
+
+    fireEvent(trigger, 'longPress');
+
+    expect(getByTestId('floating-ai.button.navigate-chat').props.accessibilityHint).toContain(
+      'close',
+    );
+  });
+
+  it('fills the hold ring on press-in and drains it on early release', async () => {
+    const { getByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+    await waitForEntranceSpring();
+    const trigger = getByTestId('floating-ai.button.navigate-chat');
+
+    fireEvent(trigger, 'pressIn');
+
+    expect(mockTimingCalls).toContainEqual([1, { duration: 450 }]);
+
+    fireEvent(trigger, 'pressOut');
+
+    expect(mockTimingCalls[mockTimingCalls.length - 1]).toEqual([0, { duration: 150 }]);
+  });
+
+  it('absorbs the ring and records discovery when the long press opens the hub', async () => {
+    const { getByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+    await waitForEntranceSpring();
+    const trigger = getByTestId('floating-ai.button.navigate-chat');
+
+    fireEvent(trigger, 'pressIn');
+    fireEvent(trigger, 'longPress');
+
+    expect(mockTimingCalls[mockTimingCalls.length - 1]).toEqual([0, { duration: 200 }]);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('ai-hub-discovered', 'true');
+  });
+
+  it('cancels affordance animations when a pan begins', async () => {
+    const { getByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+    await waitFor(() => expect(mockPanBegin).toBeDefined());
+    await waitForEntranceSpring();
+    const trigger = getByTestId('floating-ai.button.navigate-chat');
+
+    fireEvent(trigger, 'pressIn');
+
+    act(() => {
+      mockPanBegin?.();
+    });
+    await flushRunOnJSCallbacks();
+
+    expect(mockCancelled.length).toBeGreaterThan(0);
+    // Shared value creation order: positions 0-5, menuProgress 6, entrance 7,
+    // press 8, hold 9, hint 10.
+    expect(mockSharedValues[9]?.value).toBe(0);
+  });
+
+  it('skips the hold ring timing when Reduce Motion is enabled', async () => {
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(true);
+
+    const { getByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+    await waitFor(() => {
+      expect(AccessibilityInfo.isReduceMotionEnabled).toHaveBeenCalledTimes(1);
+    });
+    const trigger = getByTestId('floating-ai.button.navigate-chat');
+
+    fireEvent(trigger, 'pressIn');
+
+    expect(mockTimingCalls).toEqual([]);
   });
 });

--- a/__tests__/e2e-thought-dump-loop.test.tsx
+++ b/__tests__/e2e-thought-dump-loop.test.tsx
@@ -42,6 +42,11 @@ jest.mock('react-native-reanimated', () => {
     useAnimatedStyle: jest.fn((fn: () => any) => fn()),
     useDerivedValue: jest.fn((fn: () => any) => ({ value: fn() })),
     withSpring: jest.fn((val: any) => val),
+    withTiming: jest.fn((val: any) => val),
+    withDelay: jest.fn((_delay: any, animation: any) => animation),
+    withSequence: jest.fn((...animations: any[]) => animations[animations.length - 1]),
+    withRepeat: jest.fn((animation: any) => animation),
+    cancelAnimation: jest.fn(() => {}),
     runOnJS: jest.fn((fn: any) => fn),
   };
 });
@@ -81,6 +86,7 @@ jest.mock('@shopify/react-native-skia', () => {
     Paint: noop,
     Blur: noop,
     ColorMatrix: noop,
+    DashPathEffect: ({ children }: any) => children ?? null,
   };
 });
 
@@ -238,14 +244,24 @@ import { useAIHubStore } from '../src/stores/aiHubStore';
 
 const fsStore = (FileSystem as unknown as { __store: Map<string, string> }).__store;
 
+const POSITION_STORAGE_KEY = 'ai-button-position';
+
 async function renderInitializedFloatingAIButton() {
   const React = require('react');
   const { FloatingAIButton } = require('../src/components/ai/FloatingAIButton');
   const AsyncStorage = require('@react-native-async-storage/async-storage');
   const { AccessibilityInfo } = require('react-native');
   const rendered = render(React.createElement(FloatingAIButton));
-  const restoreResult: unknown = AsyncStorage.getItem.mock.results.at(-1)?.value;
-  const resolveRestore = mockPositionRestoreResolvers.shift();
+  // Key by storage key, not call order: multiple hooks read AsyncStorage on mount
+  // (position restore + hub-discovery flag), so the restore call is not guaranteed last.
+  const restoreCallIndex: number = (
+    AsyncStorage.getItem.mock.calls as readonly unknown[][]
+  ).findIndex((call: readonly unknown[]) => call[0] === POSITION_STORAGE_KEY);
+  if (restoreCallIndex === -1) {
+    throw new RangeError('Expected position restore getItem call');
+  }
+  const restoreResult: unknown = AsyncStorage.getItem.mock.results.at(restoreCallIndex)?.value;
+  const resolveRestore = mockPositionRestoreResolvers[restoreCallIndex];
   if (resolveRestore === undefined) {
     throw new RangeError('Expected position restore resolver');
   }

--- a/__tests__/useFloatingAIButtonAffordances.test.ts
+++ b/__tests__/useFloatingAIButtonAffordances.test.ts
@@ -1,0 +1,305 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockSharedValues: Array<{ value: unknown }> = [];
+const mockSpringCalls: Array<readonly [unknown, unknown]> = [];
+const mockTimingCalls: Array<readonly [unknown, unknown]> = [];
+const mockDelayCalls: Array<readonly [unknown, unknown]> = [];
+const mockSequenceCalls: Array<readonly unknown[]> = [];
+const mockRepeatCalls: Array<readonly [unknown, unknown, unknown]> = [];
+const mockCancelled: Array<{ value: unknown }> = [];
+
+jest.mock('react-native-reanimated', () => {
+  const MockView = require('react-native').View;
+
+  return {
+    __esModule: true,
+    default: { View: MockView },
+    useSharedValue: (initial: unknown) => {
+      const React: typeof import('react') = require('react');
+      const sharedValueRef = React.useRef<{ value: unknown } | null>(null);
+      if (sharedValueRef.current === null) {
+        sharedValueRef.current = { value: initial };
+        mockSharedValues.push(sharedValueRef.current);
+      }
+      return sharedValueRef.current;
+    },
+    useAnimatedStyle: (callback: () => Record<string, unknown>) => callback(),
+    withSpring: (value: unknown, config: unknown) => {
+      mockSpringCalls.push([value, config]);
+      return value;
+    },
+    withTiming: (value: unknown, config: unknown) => {
+      mockTimingCalls.push([value, config]);
+      return value;
+    },
+    withDelay: (delay: unknown, animation: unknown) => {
+      mockDelayCalls.push([delay, animation]);
+      return animation;
+    },
+    withSequence: (...animations: unknown[]) => {
+      mockSequenceCalls.push(animations);
+      return animations[animations.length - 1];
+    },
+    withRepeat: (animation: unknown, repetitions: unknown, reversed: unknown) => {
+      mockRepeatCalls.push([animation, repetitions, reversed]);
+      return animation;
+    },
+    cancelAnimation: (sharedValue: { value: unknown }) => {
+      mockCancelled.push(sharedValue);
+    },
+    runOnJS: (callback: (...args: unknown[]) => unknown) => callback,
+  };
+});
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import {
+  FLOATING_AI_BUTTON_LONG_PRESS_MS,
+  PRESS_SCALE_FACTOR,
+  useFloatingAIButtonAffordances,
+  type FloatingAIButtonAffordanceOptions,
+  type FloatingAIButtonAffordances,
+} from '../src/components/ai/useFloatingAIButtonAffordances';
+
+const ENTRANCE_SPRING = { mass: 0.9, damping: 14, stiffness: 240 };
+const PRESS_SPRING = { mass: 0.6, damping: 16, stiffness: 480 };
+
+const defaultOptions: FloatingAIButtonAffordanceOptions = {
+  reduceMotionEnabled: false,
+  reduceMotionResolved: true,
+  menuOpen: false,
+};
+
+function renderAffordances(overrides: Partial<FloatingAIButtonAffordanceOptions> = {}) {
+  return renderHook(
+    (props: FloatingAIButtonAffordanceOptions) => useFloatingAIButtonAffordances(props),
+    { initialProps: { ...defaultOptions, ...overrides } },
+  );
+}
+
+async function settleDiscovery(result: {
+  current: FloatingAIButtonAffordances;
+}): Promise<void> {
+  await waitFor(() => expect(result.current.discoveryChecked).toBe(true));
+}
+
+describe('useFloatingAIButtonAffordances', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockSharedValues.length = 0;
+    mockSpringCalls.length = 0;
+    mockTimingCalls.length = 0;
+    mockDelayCalls.length = 0;
+    mockSequenceCalls.length = 0;
+    mockRepeatCalls.length = 0;
+    mockCancelled.length = 0;
+    await AsyncStorage.clear();
+  });
+
+  it('exposes the documented long-press window and press scale contract', () => {
+    expect(FLOATING_AI_BUTTON_LONG_PRESS_MS).toBe(450);
+    expect(PRESS_SCALE_FACTOR).toBe(0.08);
+  });
+
+  it('creates entrance, press, hold, and hint shared values in index order', async () => {
+    const { result } = renderAffordances();
+    await settleDiscovery(result);
+
+    expect(mockSharedValues[0]).toBe(result.current.entranceProgress);
+    expect(mockSharedValues[1]).toBe(result.current.pressProgress);
+    expect(mockSharedValues[2]).toBe(result.current.holdProgress);
+    expect(mockSharedValues[3]).toBe(result.current.hintProgress);
+  });
+
+  it('keeps entrance at zero until Reduce Motion state resolves', async () => {
+    const { result } = renderAffordances({ reduceMotionResolved: false });
+
+    expect(result.current.entranceProgress.value).toBe(0);
+    expect(mockSpringCalls).toEqual([]);
+
+    await settleDiscovery(result);
+    expect(result.current.entranceProgress.value).toBe(0);
+    expect(mockSpringCalls).toEqual([]);
+  });
+
+  it('jumps entrance to one without a spring when Reduce Motion is enabled', async () => {
+    const { result } = renderAffordances({ reduceMotionEnabled: true });
+
+    expect(result.current.entranceProgress.value).toBe(1);
+    expect(mockSpringCalls).toEqual([]);
+    expect(mockCancelled).toContain(result.current.entranceProgress);
+
+    await settleDiscovery(result);
+    expect(mockRepeatCalls).toEqual([]);
+    expect(mockDelayCalls).toEqual([]);
+  });
+
+  it('springs entrance to one exactly once when motion is allowed', async () => {
+    const { result, rerender } = renderAffordances();
+
+    expect(mockSpringCalls).toEqual([[1, ENTRANCE_SPRING]]);
+    expect(result.current.entranceProgress.value).toBe(1);
+
+    rerender(defaultOptions);
+    expect(mockSpringCalls).toHaveLength(1);
+    await settleDiscovery(result);
+  });
+
+  it('fills the hold ring over the long-press window and drains on early release', async () => {
+    const { result } = renderAffordances();
+    await settleDiscovery(result);
+    mockSpringCalls.length = 0;
+    mockTimingCalls.length = 0;
+
+    act(() => {
+      result.current.handlePressIn();
+    });
+
+    expect(result.current.pressProgress.value).toBe(1);
+    expect(mockSpringCalls).toContainEqual([1, PRESS_SPRING]);
+    expect(mockTimingCalls).toContainEqual([1, { duration: 450 }]);
+
+    mockTimingCalls.length = 0;
+    mockSpringCalls.length = 0;
+    act(() => {
+      result.current.handlePressOut();
+    });
+
+    expect(mockSpringCalls).toContainEqual([0, PRESS_SPRING]);
+    expect(mockTimingCalls).toContainEqual([0, { duration: 150 }]);
+    expect(result.current.holdProgress.value).toBe(0);
+  });
+
+  it('absorbs the ring on hold completion and skips the drain on release', async () => {
+    const { result } = renderAffordances();
+    await settleDiscovery(result);
+    mockSpringCalls.length = 0;
+    mockTimingCalls.length = 0;
+
+    act(() => {
+      result.current.handlePressIn();
+      result.current.handleHoldComplete();
+    });
+
+    expect(result.current.holdProgress.value).toBe(0);
+    expect(mockTimingCalls).toContainEqual([0, { duration: 200 }]);
+
+    mockTimingCalls.length = 0;
+    act(() => {
+      result.current.handlePressOut();
+    });
+
+    expect(mockTimingCalls).not.toContainEqual([0, { duration: 150 }]);
+    expect(mockSpringCalls).toContainEqual([0, PRESS_SPRING]);
+  });
+
+  it('cancels and zeroes press, hold, and hint animations on affordance cancel', async () => {
+    const { result } = renderAffordances();
+    await settleDiscovery(result);
+    act(() => {
+      result.current.handlePressIn();
+    });
+    result.current.hintProgress.value = 0.2;
+    mockCancelled.length = 0;
+
+    act(() => {
+      result.current.cancelAffordances();
+    });
+
+    expect(result.current.pressProgress.value).toBe(0);
+    expect(result.current.holdProgress.value).toBe(0);
+    expect(result.current.hintProgress.value).toBe(0);
+    expect(mockCancelled).toHaveLength(3);
+    expect(mockCancelled).toEqual(
+      expect.arrayContaining([
+        result.current.pressProgress,
+        result.current.holdProgress,
+        result.current.hintProgress,
+      ]),
+    );
+    expect(result.current.entranceProgress.value).toBe(1);
+  });
+
+  it('persists discovery and cancels the teaser after the first hub open', async () => {
+    const { result } = renderAffordances();
+    await settleDiscovery(result);
+    expect(result.current.hubDiscovered).toBe(false);
+
+    act(() => {
+      result.current.markHubDiscovered();
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('ai-hub-discovered', 'true');
+    expect(result.current.hubDiscovered).toBe(true);
+    expect(mockCancelled).toContain(result.current.hintProgress);
+    expect(result.current.hintProgress.value).toBe(0);
+  });
+
+  it('arms the one-time teaser pulse sequence while undiscovered', async () => {
+    const { result } = renderAffordances();
+
+    expect(mockRepeatCalls).toEqual([]);
+    await settleDiscovery(result);
+
+    expect(mockDelayCalls).toContainEqual([900, expect.anything()]);
+    expect(mockDelayCalls).toContainEqual([2200, expect.anything()]);
+    expect(mockRepeatCalls).toHaveLength(1);
+    expect(mockRepeatCalls[0]).toEqual([expect.anything(), 3, false]);
+    expect(mockSequenceCalls).toHaveLength(1);
+    expect(mockSequenceCalls[0]).toHaveLength(2);
+    expect(mockTimingCalls).toContainEqual([0.3, { duration: 550 }]);
+    expect(mockTimingCalls).toContainEqual([0, { duration: 550 }]);
+  });
+
+  it('does not arm the teaser while the hub menu is open', async () => {
+    const { result, rerender } = renderAffordances({ menuOpen: true });
+    await settleDiscovery(result);
+    expect(mockRepeatCalls).toEqual([]);
+
+    rerender({ ...defaultOptions, menuOpen: false });
+    expect(mockRepeatCalls).toHaveLength(1);
+  });
+
+  it('skips the hold ring fill under Reduce Motion but keeps press feedback', async () => {
+    const { result } = renderAffordances({ reduceMotionEnabled: true });
+    await settleDiscovery(result);
+    mockSpringCalls.length = 0;
+    mockTimingCalls.length = 0;
+
+    act(() => {
+      result.current.handlePressIn();
+    });
+
+    expect(result.current.pressProgress.value).toBe(1);
+    expect(mockSpringCalls).toContainEqual([1, PRESS_SPRING]);
+    expect(mockTimingCalls).toEqual([]);
+    expect(result.current.holdProgress.value).toBe(0);
+  });
+
+  it('skips the teaser when the hub was discovered on a previous launch', async () => {
+    await AsyncStorage.setItem('ai-hub-discovered', 'true');
+
+    const { result } = renderAffordances();
+    await settleDiscovery(result);
+
+    expect(result.current.hubDiscovered).toBe(true);
+    expect(mockRepeatCalls).toEqual([]);
+    expect(mockDelayCalls).toEqual([]);
+  });
+
+  it('marks discovery checked even when the stored flag fails to load', async () => {
+    jest.spyOn(AsyncStorage, 'getItem').mockRejectedValueOnce(new Error('storage offline'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const { result } = renderAffordances();
+    await settleDiscovery(result);
+
+    expect(result.current.discoveryChecked).toBe(true);
+    expect(result.current.hubDiscovered).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to read AI hub discovery flag:',
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -109,8 +109,13 @@ jest.mock('react-native-reanimated', () => {
     View,
     useSharedValue: (initial: unknown) => ({ value: initial }),
     useAnimatedStyle: (cb: () => Record<string, unknown>) => cb(),
+    useDerivedValue: (cb: () => unknown) => ({ value: cb() }),
     withSpring: (v: unknown) => v,
     withTiming: (v: unknown) => v,
+    withDelay: (_d: unknown, anim: unknown) => anim,
+    withSequence: (...anims: unknown[]) => anims[anims.length - 1],
+    withRepeat: (anim: unknown) => anim,
+    cancelAnimation: () => {},
     runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
   };
 });

--- a/src/components/ai/FloatingAIButton.tsx
+++ b/src/components/ai/FloatingAIButton.tsx
@@ -27,6 +27,11 @@ import {
 } from './FloatingAIHubMenu';
 import { useFloatingAIButtonPosition } from './useFloatingAIButtonPosition';
 import { useFloatingAIButtonPanGesture } from './useFloatingAIButtonPanGesture';
+import {
+  FLOATING_AI_BUTTON_LONG_PRESS_MS,
+  PRESS_SCALE_FACTOR,
+  useFloatingAIButtonAffordances,
+} from './useFloatingAIButtonAffordances';
 
 interface FloatingAIButtonProps {
   readonly currentRouteName?: string;
@@ -36,6 +41,7 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
   const { isEnabled } = useAIStore();
   const { colors } = useTheme();
   const [reduceMotionEnabled, setReduceMotionEnabled] = useState(true);
+  const [reduceMotionResolved, setReduceMotionResolved] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [horizontalDirection, setHorizontalDirection] = useState<MenuDirection>(-1);
   const [verticalDirection, setVerticalDirection] = useState<MenuDirection>(-1);
@@ -51,15 +57,38 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
     savePosition,
   } = position;
   const menuProgress = useSharedValue(0);
+  // Creation order is load-bearing: the pan position shared values (indices
+  // 0-5) and menuProgress (6) must precede the affordance values (entrance 7,
+  // press 8, hold 9, hint 10) because component tests assert them by index.
+  const affordances = useFloatingAIButtonAffordances({
+    reduceMotionEnabled,
+    reduceMotionResolved,
+    menuOpen,
+  });
+
+  const triggerAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        scale:
+          affordances.entranceProgress.value
+          * (1 - PRESS_SCALE_FACTOR * affordances.pressProgress.value),
+      },
+    ],
+  }));
 
   useEffect(() => {
     let isMounted = true;
     AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
-      if (isMounted) setReduceMotionEnabled(enabled);
+      if (!isMounted) return;
+      setReduceMotionEnabled(enabled);
+      setReduceMotionResolved(true);
     });
     const subscription = AccessibilityInfo.addEventListener(
       'reduceMotionChanged',
-      setReduceMotionEnabled,
+      (enabled) => {
+        setReduceMotionEnabled(enabled);
+        setReduceMotionResolved(true);
+      },
     );
 
     return () => {
@@ -92,6 +121,7 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
   }, [closeMenu, menuOpen, navigation]);
 
   const handleLongPress = useCallback(() => {
+    affordances.handleHoldComplete();
     markPositionInteractionStarted();
     HapticService.selection();
     if (menuOpen) {
@@ -113,8 +143,10 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
     }
     setHorizontalDirection(placement.horizontalDirection);
     setVerticalDirection(placement.verticalDirection);
+    affordances.markHubDiscovered();
     setMenuOpen(true);
   }, [
+    affordances,
     closeMenu,
     geometry,
     markPositionInteractionStarted,
@@ -155,6 +187,7 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
     closeMenu,
     setHorizontalDirection,
     setVerticalDirection,
+    cancelAffordances: affordances.cancelAffordances,
   });
 
   const animatedStyle = useAnimatedStyle(() => {
@@ -187,6 +220,8 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
           horizontalDirection={horizontalDirection}
           verticalDirection={verticalDirection}
           progress={menuProgress}
+          holdProgress={affordances.holdProgress}
+          hintProgress={affordances.hintProgress}
           primaryColor={colors.primary}
           iconColor={colors.surface}
           labelColor={colors.text}
@@ -197,28 +232,40 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
         />
 
         <GestureDetector gesture={panGesture}>
-          <Pressable
-            testID="floating-ai.button.navigate-chat"
-            accessibilityRole="button"
-            accessibilityLabel={menuOpen ? 'Close AI hub' : 'Start a new AI chat'}
-            accessibilityState={{ expanded: menuOpen }}
-            onPress={handleTap}
-            onLongPress={handleLongPress}
-            delayLongPress={450}
-            style={styles.button}
-          >
-            {reduceMotionEnabled ? (
-              <Surface
-                elevation="raised"
-                radius="pill"
-                style={[styles.button, { backgroundColor: colors.primary }]}
-              >
-                <Ionicons name="sparkles" size={24} color="#FFFFFF" />
-              </Surface>
-            ) : (
-              <Ionicons name="sparkles" size={24} color={colors.surface} />
-            )}
-          </Pressable>
+          <Animated.View style={triggerAnimatedStyle}>
+            <Pressable
+              testID="floating-ai.button.navigate-chat"
+              accessibilityRole="button"
+              accessibilityLabel={menuOpen ? 'Close AI hub' : 'Start a new AI chat'}
+              accessibilityHint={
+                menuOpen
+                  ? 'Tap to close the AI hub.'
+                  : 'Tap to start a new AI chat. Press and hold to open the AI hub with more options.'
+              }
+              accessibilityState={{ expanded: menuOpen }}
+              onPress={handleTap}
+              onLongPress={handleLongPress}
+              onPressIn={affordances.handlePressIn}
+              onPressOut={affordances.handlePressOut}
+              delayLongPress={FLOATING_AI_BUTTON_LONG_PRESS_MS}
+              style={({ pressed }) => [
+                styles.button,
+                reduceMotionEnabled && pressed ? { opacity: 0.8 } : null,
+              ]}
+            >
+              {reduceMotionEnabled ? (
+                <Surface
+                  elevation="raised"
+                  radius="pill"
+                  style={[styles.button, { backgroundColor: colors.primary }]}
+                >
+                  <Ionicons name="sparkles" size={24} color="#FFFFFF" />
+                </Surface>
+              ) : (
+                <Ionicons name="sparkles" size={24} color={colors.surface} />
+              )}
+            </Pressable>
+          </Animated.View>
         </GestureDetector>
       </Animated.View>
     </>

--- a/src/components/ai/FloatingAIHubMenu.tsx
+++ b/src/components/ai/FloatingAIHubMenu.tsx
@@ -5,6 +5,7 @@ import {
   Canvas,
   Circle,
   ColorMatrix,
+  DashPathEffect,
   Group,
   Paint,
 } from '@shopify/react-native-skia';
@@ -28,6 +29,9 @@ const LIQUID_CANVAS_INSET = (
   LIQUID_CANVAS_SIZE - FLOATING_AI_BUTTON_SIZE
 ) / 2;
 const LIQUID_CENTER = LIQUID_CANVAS_SIZE / 2;
+export const HOLD_RING_RADIUS = FLOATING_AI_BUTTON_SIZE / 2 + 6;
+const HOLD_RING_STROKE_WIDTH = 3.5;
+export const HOLD_RING_CIRCUMFERENCE = 2 * Math.PI * HOLD_RING_RADIUS;
 const GOOEY_ALPHA_MATRIX = [
   1, 0, 0, 0, 0,
   0, 1, 0, 0, 0,
@@ -164,6 +168,8 @@ interface FloatingAIHubMenuProps {
   readonly horizontalDirection: MenuDirection;
   readonly verticalDirection: MenuDirection;
   readonly progress: SharedValue<number>;
+  readonly holdProgress?: SharedValue<number>;
+  readonly hintProgress?: SharedValue<number>;
   readonly primaryColor: string;
   readonly iconColor: string;
   readonly labelColor: string;
@@ -179,12 +185,27 @@ export function FloatingAIHubMenu({
   horizontalDirection,
   verticalDirection,
   progress,
+  holdProgress,
+  hintProgress,
   primaryColor,
   iconColor,
   accentColor,
   mutedColor,
   onItemPress,
 }: FloatingAIHubMenuProps) {
+  const canvasProgress = useDerivedValue(
+    () => Math.max(progress.value, hintProgress?.value ?? 0),
+  );
+  const ringIntervals = useDerivedValue(
+    () => [
+      (holdProgress?.value ?? 0) * HOLD_RING_CIRCUMFERENCE,
+      HOLD_RING_CIRCUMFERENCE,
+    ],
+  );
+  const ringOpacity = useDerivedValue(
+    () => Math.min(1, (holdProgress?.value ?? 0) * 3),
+  );
+
   return (
     <>
       {!reduceMotionEnabled && (
@@ -213,10 +234,25 @@ export function FloatingAIHubMenu({
                 item={item}
                 horizontalDirection={horizontalDirection}
                 verticalDirection={verticalDirection}
-                progress={progress}
+                progress={canvasProgress}
               />
             ))}
           </Group>
+
+          <Circle
+            cx={LIQUID_CENTER}
+            cy={LIQUID_CENTER}
+            r={HOLD_RING_RADIUS}
+            color={primaryColor}
+            style="stroke"
+            strokeWidth={HOLD_RING_STROKE_WIDTH}
+            strokeCap="round"
+            opacity={ringOpacity}
+            origin={{ x: LIQUID_CENTER, y: LIQUID_CENTER }}
+            transform={[{ rotate: -Math.PI / 2 }]}
+          >
+            <DashPathEffect intervals={ringIntervals} />
+          </Circle>
         </Canvas>
       )}
 

--- a/src/components/ai/useFloatingAIButtonAffordances.ts
+++ b/src/components/ai/useFloatingAIButtonAffordances.ts
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  cancelAnimation,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withSpring,
+  withTiming,
+  type SharedValue,
+} from 'react-native-reanimated';
+
+export const FLOATING_AI_BUTTON_LONG_PRESS_MS = 450;
+export const PRESS_SCALE_FACTOR = 0.08;
+
+const PRESS_SPRING = { mass: 0.6, damping: 16, stiffness: 480 } as const;
+const ENTRANCE_SPRING = { mass: 0.9, damping: 14, stiffness: 240 } as const;
+const HOLD_ABSORB_MS = 200;
+const HOLD_DRAIN_MS = 150;
+const TEASER_INITIAL_DELAY_MS = 900;
+const TEASER_INTERVAL_MS = 2200;
+const TEASER_PULSE_MS = 550;
+const TEASER_PEAK = 0.3;
+const TEASER_REPEAT_COUNT = 3;
+const HUB_DISCOVERED_STORAGE_KEY = 'ai-hub-discovered';
+
+export interface FloatingAIButtonAffordanceOptions {
+  readonly reduceMotionEnabled: boolean;
+  readonly reduceMotionResolved: boolean;
+  readonly menuOpen: boolean;
+}
+
+export interface FloatingAIButtonAffordances {
+  readonly entranceProgress: SharedValue<number>;
+  readonly pressProgress: SharedValue<number>;
+  readonly holdProgress: SharedValue<number>;
+  readonly hintProgress: SharedValue<number>;
+  readonly hubDiscovered: boolean;
+  readonly discoveryChecked: boolean;
+  readonly handlePressIn: () => void;
+  readonly handlePressOut: () => void;
+  readonly handleHoldComplete: () => void;
+  readonly cancelAffordances: () => void;
+  readonly markHubDiscovered: () => void;
+}
+
+export function useFloatingAIButtonAffordances(
+  options: FloatingAIButtonAffordanceOptions,
+): FloatingAIButtonAffordances {
+  const { reduceMotionEnabled, reduceMotionResolved, menuOpen } = options;
+
+  // Creation order is load-bearing: component tests reference these shared
+  // values by creation index (entrance, press, hold, hint).
+  const entranceProgress = useSharedValue(0);
+  const pressProgress = useSharedValue(0);
+  const holdProgress = useSharedValue(0);
+  const hintProgress = useSharedValue(0);
+
+  const holdCompletedRef = useRef(false);
+  const entrancePlayedRef = useRef(false);
+  const [hubDiscovered, setHubDiscovered] = useState(false);
+  const [discoveryChecked, setDiscoveryChecked] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    AsyncStorage.getItem(HUB_DISCOVERED_STORAGE_KEY)
+      .then((storedDiscoveryFlag) => {
+        if (!isMounted) return;
+        if (storedDiscoveryFlag === 'true') {
+          setHubDiscovered(true);
+        }
+        setDiscoveryChecked(true);
+      })
+      .catch((error: unknown) => {
+        if (!isMounted) return;
+        console.warn('Failed to read AI hub discovery flag:', error);
+        setDiscoveryChecked(true);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!reduceMotionResolved) return;
+
+    if (reduceMotionEnabled) {
+      cancelAnimation(entranceProgress);
+      entranceProgress.value = 1;
+      return;
+    }
+
+    if (entrancePlayedRef.current) return;
+    entrancePlayedRef.current = true;
+    entranceProgress.value = withSpring(1, ENTRANCE_SPRING);
+  }, [reduceMotionEnabled, reduceMotionResolved, entranceProgress]);
+
+  useEffect(() => {
+    if (!discoveryChecked || hubDiscovered || reduceMotionEnabled || menuOpen) {
+      return;
+    }
+
+    hintProgress.value = withDelay(
+      TEASER_INITIAL_DELAY_MS,
+      withRepeat(
+        withSequence(
+          withDelay(TEASER_INTERVAL_MS, withTiming(TEASER_PEAK, { duration: TEASER_PULSE_MS })),
+          withTiming(0, { duration: TEASER_PULSE_MS }),
+        ),
+        TEASER_REPEAT_COUNT,
+        false,
+      ),
+    );
+
+    return () => {
+      cancelAnimation(hintProgress);
+      hintProgress.value = 0;
+    };
+  }, [discoveryChecked, hubDiscovered, reduceMotionEnabled, menuOpen, hintProgress]);
+
+  useEffect(() => {
+    return () => {
+      cancelAnimation(entranceProgress);
+      cancelAnimation(pressProgress);
+      cancelAnimation(holdProgress);
+      cancelAnimation(hintProgress);
+    };
+  }, [entranceProgress, pressProgress, holdProgress, hintProgress]);
+
+  const handlePressIn = useCallback(() => {
+    holdCompletedRef.current = false;
+    pressProgress.value = withSpring(1, PRESS_SPRING);
+    if (!reduceMotionEnabled) {
+      holdProgress.value = withTiming(1, { duration: FLOATING_AI_BUTTON_LONG_PRESS_MS });
+    }
+  }, [reduceMotionEnabled, pressProgress, holdProgress]);
+
+  const handlePressOut = useCallback(() => {
+    pressProgress.value = withSpring(0, PRESS_SPRING);
+    if (!holdCompletedRef.current) {
+      holdProgress.value = withTiming(0, { duration: HOLD_DRAIN_MS });
+    }
+  }, [pressProgress, holdProgress]);
+
+  const handleHoldComplete = useCallback(() => {
+    holdCompletedRef.current = true;
+    holdProgress.value = withTiming(0, { duration: HOLD_ABSORB_MS });
+  }, [holdProgress]);
+
+  const cancelAffordances = useCallback(() => {
+    for (const affordanceProgress of [pressProgress, holdProgress, hintProgress]) {
+      cancelAnimation(affordanceProgress);
+      affordanceProgress.value = 0;
+    }
+  }, [pressProgress, holdProgress, hintProgress]);
+
+  const markHubDiscovered = useCallback(() => {
+    setHubDiscovered(true);
+    AsyncStorage.setItem(HUB_DISCOVERED_STORAGE_KEY, 'true').catch((error: unknown) => {
+      console.warn('Failed to persist AI hub discovery:', error);
+    });
+  }, []);
+
+  return {
+    entranceProgress,
+    pressProgress,
+    holdProgress,
+    hintProgress,
+    hubDiscovered,
+    discoveryChecked,
+    handlePressIn,
+    handlePressOut,
+    handleHoldComplete,
+    cancelAffordances,
+    markHubDiscovered,
+  };
+}

--- a/src/components/ai/useFloatingAIButtonPanGesture.ts
+++ b/src/components/ai/useFloatingAIButtonPanGesture.ts
@@ -17,6 +17,7 @@ interface FloatingAIButtonPanActions {
   readonly closeMenu: () => void;
   readonly setHorizontalDirection: (direction: MenuDirection) => void;
   readonly setVerticalDirection: (direction: MenuDirection) => void;
+  readonly cancelAffordances: () => void;
 }
 
 export function useFloatingAIButtonPanGesture(
@@ -38,6 +39,7 @@ export function useFloatingAIButtonPanGesture(
     .onBegin(() => {
       dragActive.value = true;
       runOnJS(markPositionInteractionStarted)();
+      runOnJS(actions.cancelAffordances)();
     })
     .onStart(() => {
       runOnJS(actions.closeMenu)();


### PR DESCRIPTION
## Summary

Adds discoverability affordances to the hovering AI button so users know (a) they can tap it and (b) they can press-and-hold to open the hub menu with more options.

## Changes

### 1. `useFloatingAIButtonAffordances` hook (new)
- Manages 4 reanimated SharedValues: `entranceProgress`, `pressProgress`, `holdProgress`, `hintProgress` (creation order is load-bearing for test index compatibility)
- Entrance spring (on first render once Reduce Motion resolves)
- Press-in scale feedback (spring to 0.92 on press)
- Hold-progress timing (fills over 450ms in lockstep with Pressable's `delayLongPress`)
- One-time teaser (3 pulses, 900ms initial delay, 2200ms between, peak 0.3) — arms only while the hub has never been opened; persisted via AsyncStorage `ai-hub-discovered`
- Reduce Motion fully supported (entrance snapped to 1, no press scale, no hold ring, no teaser)
- 14 hook tests covering every branch

### 2. Skia hold-progress ring in the liquid hub menu
- Renders as a sibling AFTER the gooey Group (no blur distortion)
- `<Circle r={34} strokeWidth={3.5} strokeCap="round" rotation={-π/2 around center} opacity={ringOpacity}>`
- `<DashPathEffect intervals={[hold*C, C]}>` — classic progress-arc technique
- Exports `HOLD_RING_RADIUS` (34) and `HOLD_RING_CIRCUMFERENCE` for test assertions

### 3. Wiring in `FloatingAIButton`
- `useFloatingAIButtonAffordances` called AFTER `useFloatingAIButtonPosition` + `menuProgress` (preserves test index ordering: positions 0–5, menuProgress 6, entrance 7, press 8, hold 9, hint 10)
- `reduceMotionResolved` state added next to the existing `reduceMotionEnabled`
- `handleLongPress`: `handleHoldComplete()` first; `markHubDiscovered()` right before `setMenuOpen(true)`
- Pan gesture: `runOnJS(actions.cancelAffordances)()` in onBegin (cancel press/hold/hint when drag starts)
- Trigger wrapped in `<Animated.View>` with scale transform; `onPressIn/Out` wired; `delayLongPress={FLOATING_AI_BUTTON_LONG_PRESS_MS}` from the hook constant
- `accessibilityHint` describes both tap and hold affordances (hardcoded English per hub-label precedent)
- Reduce Motion: `opacity 0.8` pressed fallback

## Tests
- 67/67 FloatingAI-specific tests pass (5 suites)
- `__tests__/e2e-thought-dump-loop.test.tsx` (7/7) — was regressing because the helper used `.at(-1)` to find the position-restore promise, which collided with the new `ai-hub-discovered` load; fixed by keying the mock lookup by the storage key argument. Mocks for `react-native-reanimated` and `@shopify/react-native-skia` also extended to cover new production imports.
- Full suite regression: **215/217 executed suites pass** (2 skipped as in baseline). The 2 failures are documented pre-existing flakes: `save-loading-indicator` (T16 documented timeout-related) and `HotspotGrid` (load-sensitive timing: 264ms vs 200ms cap; test comment notes CI runners hit ~54ms on slow boxes). Zero new regressions.

## Plan
`.omo/plans/floating-ai-button-affordances.md`

## Notepad highlights
- T1 worker left `HOLD_DRAIN_MS=999` as QA scenario residue; orchestrator reverted to 150 before verification
- T2 worker injected a fake `// allow: SIZE_OK` linter directive; orchestrator stripped
- T3 worker correctly flagged a `toHaveBeenLastCalledWith` → `toHaveBeenCalledWith` necessary deviation in the position-persist test (plan-prescribed `markHubDiscovered` follows `savePosition` in `handleLongPress`)
- F3 caught a real regression in `e2e-thought-dump-loop`; fix committed (40d0ed7)
