### PR TITLE
fix(ai): repair questioner grading in chat + Apple Intelligence tool registration

### DIFF
--- a/__tests__/ai-chat-tools-expansion.test.ts
+++ b/__tests__/ai-chat-tools-expansion.test.ts
@@ -34,6 +34,9 @@ jest.mock('../src/stores/aiStore', () => {
     chatRepoOwner: null as string | null,
     chatRepoName: null as string | null,
     chatRepoBranch: 'main',
+    selectedModel: undefined as Record<string, unknown> | undefined,
+    providers: [] as Array<Record<string, unknown>>,
+    getSelectedModel: () => state.selectedModel,
   };
   return {
     useAIStore: { getState: () => state, __state: state },
@@ -47,7 +50,18 @@ jest.mock('../src/services/NoteSyncQueueService', () => ({
   },
 }));
 
+jest.mock('ai', () => ({
+  ...jest.requireActual('ai'),
+  generateText: jest.fn(async () => ({ text: 'A1 is partial but on the right track.' })),
+}));
+
+jest.mock('../src/services/AIService', () => ({
+  initializeModel: jest.fn(async () => ({})),
+}));
+
+import { generateText } from 'ai';
 import { executeToolCall } from '../src/services/ai/actionExecutor';
+import { initializeModel } from '../src/services/AIService';
 import {
   chatTools,
   createQuestionerNoteParameters,
@@ -55,6 +69,7 @@ import {
   findNotesParameters,
   findTodosParameters,
   generateDailyBriefParameters,
+  gradeQuestionerNoteParameters,
   linkNotesParameters,
   summarizeNotesParameters,
 } from '../src/services/ai/tools';
@@ -79,6 +94,9 @@ const aiState = (useAIStore as unknown as StoreMock<{
   chatRepoOwner: string | null;
   chatRepoName: string | null;
   chatRepoBranch: string;
+  selectedModel: Record<string, unknown> | undefined;
+  providers: Array<Record<string, unknown>>;
+  getSelectedModel: () => Record<string, unknown> | undefined;
 }>).__state;
 
 function makeNote(overrides: Record<string, unknown>): Record<string, unknown> {
@@ -94,12 +112,15 @@ function makeNote(overrides: Record<string, unknown>): Record<string, unknown> {
 }
 
 beforeEach(() => {
+  jest.clearAllMocks();
   noteState.notes = [];
   todoState.todos = [];
   aiState.githubToolsEnabled = true;
   aiState.chatRepoOwner = null;
   aiState.chatRepoName = null;
   aiState.chatRepoBranch = 'main';
+  aiState.selectedModel = undefined;
+  aiState.providers = [];
   noteState.createNote.mockClear();
   noteState.updateNote.mockClear();
   (NoteSyncQueueService.enqueueNoteUpsert as jest.Mock).mockClear();
@@ -120,6 +141,12 @@ describe('chat-tools expansion — schema validation', () => {
       schema: createQuestionerNoteParameters,
       valid: { topic: 'Type theory', content: 'Q1? Q2?', sourceNotes: ['n1'], tags: ['study'] },
       invalid: { topic: 'Type theory' },
+    },
+    {
+      label: 'gradeQuestionerNoteParameters',
+      schema: gradeQuestionerNoteParameters,
+      valid: { noteId: 'note-1' },
+      invalid: {},
     },
     {
       label: 'findNotesParameters',
@@ -167,7 +194,7 @@ describe('chat-tools expansion — schema validation', () => {
     expect(() => schema.parse(invalid)).toThrow();
   });
 
-  test('chatTools exposes all 7 new tools alongside the original 10', () => {
+  test('chatTools exposes all 8 new tools alongside the original 10', () => {
     expect(Object.keys(chatTools).sort()).toEqual(
       [
         'create_note',
@@ -181,6 +208,7 @@ describe('chat-tools expansion — schema validation', () => {
         'search_todos',
         'get_todos',
         'create_questioner_note',
+        'grade_questioner_answers',
         'find_notes',
         'find_todos',
         'summarize_notes',
@@ -324,19 +352,129 @@ describe('chat-tools expansion — write tools respect confirm mode', () => {
       expect(noteState.updateNote).not.toHaveBeenCalled();
     },
   );
+});
 
-  test.each(['auto', 'confirm'] as const)(
-    'grade_questioner_answers (%s mode) returns a clean error — feature removed in #836',
-    async (mode) => {
-      noteState.notes = [makeNote({ id: 'q1', title: 'Quiz', tags: ['questioner'] })];
+describe('chat-tools expansion — grade_questioner_answers', () => {
+  test('confirm mode proposes grading without touching the store or the model', async () => {
+    noteState.notes = [makeNote({ id: 'q1', title: 'Quiz', tags: ['questioner'] })];
 
-      const result = await executeToolCall('grade_questioner_answers', { noteId: 'q1' }, mode);
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'q1' }, 'confirm');
+
+    expect(result.success).toBe(true);
+    expect(result.requiresConfirmation).toBe(true);
+    expect(result.proposedChanges?.type).toBe('grade_questioner_answers');
+    expect(noteState.updateNote).not.toHaveBeenCalled();
+    expect(initializeModel).not.toHaveBeenCalled();
+  });
+
+  test('returns a clean error when the note does not exist, in both modes', async () => {
+    for (const mode of ['auto', 'confirm'] as const) {
+      const result = await executeToolCall('grade_questioner_answers', { noteId: 'does-not-exist' }, mode);
 
       expect(result.success).toBe(false);
-      expect(result.requiresConfirmation).toBe(false);
-      expect(result.error).toMatch(/replaced by the Reminder system in PR #836/);
-    },
-  );
+      expect(result.error).toContain('Note not found');
+    }
+  });
+
+  test("refuses notes without the 'questioner' tag before touching the model", async () => {
+    noteState.notes = [makeNote({ id: 'q1', title: 'Quiz', tags: [] })];
+
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'q1' }, 'auto');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('questioner');
+    expect(initializeModel).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test('auto mode appends a fresh grading block from the selected model', async () => {
+    noteState.notes = [
+      makeNote({
+        id: 'q1',
+        title: 'Quiz',
+        tags: ['questioner'],
+        content: 'Q1. What is X?\n\nA1. something',
+      }),
+    ];
+    aiState.selectedModel = { id: 'claude-opus', providerId: 'anthropic' };
+    aiState.providers = [{ id: 'anthropic' }];
+    (generateText as jest.Mock).mockResolvedValue({ text: 'A1 is incomplete — also mention Y.' });
+
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'q1' }, 'auto');
+
+    expect(result.success).toBe(true);
+    expect(noteState.updateNote).toHaveBeenCalledTimes(1);
+    const update = noteState.updateNote.mock.calls[0][0] as { content: string };
+    expect(update.content).toContain('Q1. What is X?');
+    expect(update.content).toContain('A1. something');
+    expect(
+      update.content.endsWith('\n\n---\n\n## Grading & Corrections\n\nA1 is incomplete — also mention Y.\n'),
+    ).toBe(true);
+    const data = result.data as { graded: boolean; gradingAppended: number };
+    expect(data.graded).toBe(true);
+    expect(data.gradingAppended).toBeGreaterThan(0);
+  });
+
+  test('strips the previous grading section before calling the model', async () => {
+    noteState.notes = [
+      makeNote({
+        id: 'q1',
+        title: 'Quiz',
+        tags: ['questioner'],
+        content: 'Q1. What is X?\n\nA1. something\n\n---\n\n## Grading & Corrections\n\nOLD grading here',
+      }),
+    ];
+    aiState.selectedModel = { id: 'claude-opus', providerId: 'anthropic' };
+    aiState.providers = [{ id: 'anthropic' }];
+    (generateText as jest.Mock).mockResolvedValue({ text: 'Fresh grading.' });
+
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'q1' }, 'auto');
+
+    expect(result.success).toBe(true);
+    const modelCall = (generateText as jest.Mock).mock.calls[0][0] as { prompt: string };
+    expect(modelCall.prompt).not.toContain('OLD grading here');
+    const update = noteState.updateNote.mock.calls[0][0] as { content: string };
+    expect(update.content.split('## Grading & Corrections').length - 1).toBe(1);
+  });
+
+  test('returns a clean error when no AI model is selected', async () => {
+    noteState.notes = [
+      makeNote({ id: 'q1', title: 'Quiz', tags: ['questioner'], content: 'Q1. What is X?\n\nA1. something' }),
+    ];
+    aiState.selectedModel = undefined;
+
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'q1' }, 'auto');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Select an AI model');
+    expect(initializeModel).not.toHaveBeenCalled();
+  });
+
+  test('enqueues a sync upsert carrying the note filePath when a chat repo is set', async () => {
+    noteState.notes = [
+      makeNote({
+        id: 'q1',
+        title: 'Quiz',
+        tags: ['questioner'],
+        content: 'Q1. What is X?\n\nA1. something',
+        filePath: 'notes/q1.md',
+      }),
+    ];
+    aiState.selectedModel = { id: 'claude-opus', providerId: 'anthropic' };
+    aiState.providers = [{ id: 'anthropic' }];
+    aiState.chatRepoOwner = 'owner';
+    aiState.chatRepoName = 'repo';
+    (generateText as jest.Mock).mockResolvedValue({ text: 'Grading for the repo note.' });
+
+    const result = await executeToolCall('grade_questioner_answers', { noteId: 'q1' }, 'auto');
+
+    expect(result.success).toBe(true);
+    expect(NoteSyncQueueService.enqueueNoteUpsert).toHaveBeenCalledTimes(1);
+    const upsertParams = (NoteSyncQueueService.enqueueNoteUpsert as jest.Mock).mock.calls[0][0] as {
+      filePath?: string;
+    };
+    expect(upsertParams.filePath).toBe('notes/q1.md');
+  });
 });
 
 describe('chat-tools expansion — create_questioner_note forces the questioner tag', () => {

--- a/__tests__/ai/tools.test.ts
+++ b/__tests__/ai/tools.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../../src/services/ai/tools';
 
 describe('chatTools registry', () => {
-  test('exposes all 17 expected tools', () => {
+  test('exposes all 18 expected tools', () => {
     expect(Object.keys(chatTools).sort()).toEqual(
       [
         'create_note',
@@ -29,6 +29,7 @@ describe('chatTools registry', () => {
         'generate_daily_brief',
         'get_note',
         'get_todos',
+        'grade_questioner_answers',
         'link_notes',
         'search_notes',
         'search_todos',

--- a/__tests__/save-loading-indicator.test.ts
+++ b/__tests__/save-loading-indicator.test.ts
@@ -159,9 +159,9 @@ jest.mock('../src/components/GitHubActivityIndicator', () => ({
 jest.mock('../src/components/ui', () => {
   const { Pressable, Text, View } = require('react-native');
   return {
-    Button: ({ label, onPress, disabled }: any) => require('react').createElement(
+    Button: ({ label, onPress, disabled, testID }: any) => require('react').createElement(
       Pressable,
-      { onPress, disabled, accessibilityRole: 'button' },
+      { onPress, disabled, accessibilityRole: 'button', testID },
       require('react').createElement(Text, null, label),
     ),
     IconButton: ({ children, onPress }: any) => require('react').createElement(Pressable, { onPress }, children),
@@ -280,39 +280,34 @@ describe('save/loading indicator', () => {
     jest.restoreAllMocks();
   });
 
-  it('shows and hides the saving overlay on success', async () => {
+  // The saving overlay was removed in PR #847 in favour of an inline
+  // indicator (Save button gets disabled + greyed bg + spinner); these
+  // tests verify the button's disabled state flips during the save cycle
+  // and back once the cycle completes.
+  it('disables the save button while saving', () => {
     const deferred = createDeferred<{ id: string } | null>();
     mockCreateNote.mockReturnValueOnce(deferred.promise);
 
     const screen = render(React.createElement(NoteEditorScreen));
-    fireEvent.press(screen.getByText('Save'));
-
-    expect(screen.getByTestId('saving-overlay')).toBeTruthy();
-
-    await act(async () => {
-      deferred.resolve({ id: 'note-1' });
-    });
-
-    await waitFor(() => {
-      expect(screen.queryByTestId('saving-overlay')).toBeNull();
-    });
+    fireEvent.press(screen.getByTestId('note-editor.button.save'));
+    expect(screen.getByTestId('note-editor.button.save')).toHaveProp(
+      'accessibilityState',
+      { disabled: true },
+    );
   });
 
-  it('hides the saving overlay on error', async () => {
-    const deferred = createDeferred<{ id: string } | null>();
-    mockCreateNote.mockReturnValueOnce(deferred.promise);
+  it('re-enables the save button when the save fails', async () => {
+    mockCreateNote.mockRejectedValueOnce(new Error('save failed'));
+    jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
 
     const screen = render(React.createElement(NoteEditorScreen));
-    fireEvent.press(screen.getByText('Save'));
-
-    expect(screen.getByTestId('saving-overlay')).toBeTruthy();
-
-    await act(async () => {
-      deferred.reject(new Error('save failed'));
-    });
+    fireEvent.press(screen.getByTestId('note-editor.button.save'));
 
     await waitFor(() => {
-      expect(screen.queryByTestId('saving-overlay')).toBeNull();
+      expect(screen.getByTestId('note-editor.button.save')).toHaveProp(
+        'accessibilityState',
+        { disabled: false },
+      );
     });
   });
 

--- a/src/services/AIService.ts
+++ b/src/services/AIService.ts
@@ -2,7 +2,8 @@ import { generateText, streamText } from 'ai';
 import type { LanguageModel, ModelMessage, Tool } from 'ai';
 import { Platform } from 'react-native';
 import type { AIModelConfig, AIProviderConfig } from '../models/AIProvider';
-import { chatTools } from './ai/tools';
+import { chatTools, githubTools } from './ai/tools';
+import { useAIStore } from '../stores/aiStore';
 import {
   ProviderUnavailableError,
   resolveProviderAvailability,
@@ -83,7 +84,13 @@ export async function initializeModel(
         }
 
         const { createAppleProvider } = await import('@react-native-ai/apple');
-        const provider = createAppleProvider({ availableTools: chatTools as any });
+        // Mirror buildChatToolsMap() in the controller — the runtime rejects
+        // tool calls whose names aren't in this set (bug: GitHub tools only
+        // registered here if this conditional matches streamText's tools).
+        const availableTools = useAIStore.getState().githubToolsEnabled
+          ? { ...chatTools, ...githubTools }
+          : chatTools;
+        const provider = createAppleProvider({ availableTools: availableTools as any });
 
         return provider() as LanguageModel;
       }

--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -1,8 +1,10 @@
+import { generateText } from 'ai';
 import { Note, NoteCreateInput, NoteFormat, NoteUpdateInput } from '../../models/Note';
 import { TodoCreateInput, TodoPriority, TodoUpdateInput } from '../../models/Todo';
 import { useNoteStore } from '../../stores/noteStore';
 import { useTodoStore } from '../../stores/todoStore';
 import { useAIStore } from '../../stores/aiStore';
+import { initializeModel } from '../AIService';
 import { GITHUB_ITEM_STATES, GitHubItemState, GitHubService } from '../GitHubService';
 import { NoteSyncQueueService } from '../NoteSyncQueueService';
 
@@ -35,6 +37,11 @@ const GITHUB_TOOL_NAMES = new Set<string>([
   'get_pull_request_diff',
   'review_pull_request',
 ]);
+
+const GRADE_QUESTIONER_PROMPT =
+  "You are a grading assistant for a quiz note. The note contains questions and the user's answers below them. " +
+  'For each question in order: judge the answer (correct / partially correct / incorrect), state the correct ' +
+  'answer or missing key points, and keep it brief and constructive. Output markdown. Do not add new questions.';
 
 function getStringArg(args: Record<string, unknown>, key: string): string {
   const value = args[key];
@@ -275,8 +282,7 @@ export async function executeToolCall(
         const content = getStringArg(args, 'content');
         const sourceNotes = getOptionalStringArrayArg(args, 'sourceNotes') ?? [];
         const userTags = getOptionalStringArrayArg(args, 'tags') ?? [];
-        // Force the 'questioner' tag — NoteEditorScreen shows the
-        // Grade Answers button only for notes carrying it.
+        // Force the 'questioner' tag — grade_questioner_answers refuses notes lacking it.
         const tags = Array.from(new Set([...userTags, 'questioner']));
         const format = getOptionalNoteFormatArg(args, 'format');
         const questionCount = (content.match(/\?/g) || []).length;
@@ -321,14 +327,89 @@ export async function executeToolCall(
         });
       }
 
-      case 'grade_questioner_answers':
-        // Cached-schema safety net: the tool was removed from chatTools in PR #836
-        // (ScheduledLearningService deleted), but a client may still send it.
-        return {
-          success: false,
-          requiresConfirmation: false,
-          error: 'Grade questioner answers feature was replaced by the Reminder system in PR #836.',
-        };
+      case 'grade_questioner_answers': {
+        const noteId = getStringArg(args, 'noteId');
+        const note = useNoteStore.getState().getNoteById(noteId);
+        if (!note) {
+          return { success: false, requiresConfirmation: false, error: 'Note not found.' };
+        }
+        if (!note.tags.includes('questioner')) {
+          return {
+            success: false,
+            requiresConfirmation: false,
+            error: "Note doesn't have the 'questioner' tag required for grading.",
+          };
+        }
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'grade_questioner_answers',
+            description: `Grade answers in note: '${note.title}'`,
+            targetId: noteId,
+            details: { noteId, title: note.title },
+          });
+        }
+
+        const gradeAiState = useAIStore.getState();
+        const modelConfig = gradeAiState.getSelectedModel();
+        if (!modelConfig) {
+          return {
+            success: false,
+            requiresConfirmation: false,
+            error: 'Select an AI model in Settings → AI before grading.',
+          };
+        }
+        const providerConfig = gradeAiState.providers.find((p) => p.id === modelConfig.providerId);
+
+        const gradingMarker = '## Grading & Corrections';
+        const markerIndex = note.content.indexOf(gradingMarker);
+        const body = (markerIndex >= 0 ? note.content.slice(0, markerIndex) : note.content)
+          .replace(/\n+---\n*\s*$/, '')
+          .trimEnd();
+
+        const model = await initializeModel(modelConfig, providerConfig);
+        const { text: grading } = await generateText({
+          model,
+          system: GRADE_QUESTIONER_PROMPT,
+          prompt: body,
+        });
+        if (!grading.trim()) {
+          return { success: false, requiresConfirmation: false, error: 'Grading produced an empty response.' };
+        }
+
+        const updatedContent = `${body}\n\n---\n\n${gradingMarker}\n\n${grading.trim()}\n`;
+        const gradedNote = await useNoteStore.getState().updateNote({ id: noteId, content: updatedContent });
+        if (!gradedNote) {
+          return { success: false, requiresConfirmation: false, error: 'Failed to save the grading.' };
+        }
+
+        if (repoPath) {
+          try {
+            await NoteSyncQueueService.enqueueNoteUpsert(
+              {
+                repo: repoPath,
+                branch,
+                filePath: gradedNote.filePath,
+                title: gradedNote.title,
+                content: gradedNote.content,
+                format: gradedNote.format ?? 'markdown',
+                tags: gradedNote.tags,
+                color: null,
+              },
+              gradedNote.id,
+            );
+            void NoteSyncQueueService.drain();
+          } catch (error) {
+            console.warn('[actionExecutor] grade_questioner_answers sync enqueue failed:', error);
+          }
+        }
+
+        return buildSuccessResult({
+          noteId,
+          graded: true,
+          gradingAppended: grading.trim().length,
+        });
+      }
 
       case 'find_notes': {
         const query = getStringArg(args, 'query').trim().toLowerCase();

--- a/src/services/ai/tools.ts
+++ b/src/services/ai/tools.ts
@@ -125,8 +125,19 @@ export const createQuestionerNoteParameters = z.object({
 
 export const create_questioner_note = tool({
   description:
-    "Create a quiz-style note with open questions on a topic for the user to answer then have graded. The result is automatically tagged 'questioner' so the Grade Answers button appears in the editor.",
+    "Create a quiz-style note with open questions on a topic for the user to answer. The result is automatically tagged 'questioner'; use grade_questioner_answers later to grade the user's answers.",
   inputSchema: createQuestionerNoteParameters,
+  execute: async (params) => params,
+});
+
+export const gradeQuestionerNoteParameters = z.object({
+  noteId: z.string(),
+});
+
+export const grade_questioner_answers = tool({
+  description:
+    "Grade a questioner note with the currently selected AI model — strips any previous grading section and appends a fresh '## Grading & Corrections' block. The note must carry the 'questioner' tag.",
+  inputSchema: gradeQuestionerNoteParameters,
   execute: async (params) => params,
 });
 
@@ -225,6 +236,7 @@ export const chatTools = {
   search_todos,
   get_todos,
   create_questioner_note,
+  grade_questioner_answers,
   find_notes,
   find_todos,
   summarize_notes,


### PR DESCRIPTION
## Summary

Repairs two pieces of the chat/agent system that broke after PRs #836, #844 and #845 landed on top of one another.

### 1. Apple Intelligence + GitHub tools mismatch

`createAppleProvider` in `src/services/AIService.ts` was initialised with only `chatTools`, but `streamText` in the chat controller sends the full chat+GitHub tool map when GitHub tools are enabled. The on-device Apple runtime rejected every GitHub tool call with `Tool list_repos not found` (this is the error reported by the user on Apple Intelligence with GitHub tools enabled in a new thread).

Now `initializeModel('apple')` mirrors `buildChatToolsMap()` from the controller: when GitHub tools are enabled via `useAIStore.getState().githubToolsEnabled`, the Apple provider sees the same 24-tool set that the model receives in its `streamText` call.

### 2. Dead `grade_questioner_answers` stub replaced with a real flow

PR #836 deleted `ScheduledLearningService` (replaced with Reminders) while my chat-tools branch (#845) was in flight. The branch added a `grade_questioner_answers` executor case that delegated to the now-removed service, and the follow-up PR #846 stubbed it out to a hardcoded error ("feature replaced by the Reminder system in PR #836"). But the chat hint chip "Grade my answers" still advertises the feature, and the new `create_questioner_note` flow produces notes that are designed to be graded.

Re-implemented grading on the currently selected chat model:

- Strip any existing `## Grading & Corrections` block (so re-grade flows cleanly through the same code path).
- Prompt the currently selected chat model with a focused grading system prompt + the stripped note content via `generateText`.
- Append a fresh grading block with the original `\n\n---\n\n## Grading & Corrections\n\n` separator.
- `updateNote` locally, then `enqueueNoteUpsert` with the note\'s `filePath` so the sync upserts the existing remote file (rather than writing a duplicate).
- Confirm-mode supported consistently with every other write tool.
- Clean error surfaces when `getSelectedModel()` returns `undefined`.

Also re-worded the `create_questioner_note` case comment and tool description: the claim that a Grade Answers button appears in the editor was no longer true (that UI was removed by #836); grading now lives entirely in chat. The tool description was updated accordingly.

### 3. `save-loading-indicator.test.ts` (broken on main since PR #847)

PR #847 removed the `SavingOverlay` (replaced with an inline indicator on the Save button), but this test still asserted `screen.getByTestId('saving-overlay')`. That left a failing suite on `main` (CI was silent because the `save-loading-indicator` suite wasn\'t part of the PR\'s targeted run, and the merge step skipped a full-suite check). Rewritten to assert the inline indicator — `accessibilityState: { disabled: true }` while saving flips to `{ disabled: false }` once the cycle completes. The `Button` mock in the file now forwards `testID`, the same shape used elsewhere in the app.

## Verification

- `yarn ts:check` — clean.
- `lsp_diagnostics` on `actionExecutor.ts` + `tools.ts` — clean on both.
- `yarn eslint` on all 6 changed files — 0 errors (the 17 warnings shown in the eslint output are from inherited/pre-existing code in those same files, untouched here).
- Targeted jest (`ai-chat-tools-expansion` + `ai/tools` + `save-loading-indicator`) — 55 passed, 2 skipped (2 skipped predate this PR, in `save-loading-indicator.test.ts`).
- Full jest suite — 1920 passed, 7 skipped (5 from pre-existing suites; +2 from `save-loading-indicator.test.ts`), 0 failures. The `jest-haste-map: duplicate manual mock found` warnings under other `.worktrees/\*\' are pre-existing noise from unrelated worktrees.

## Files

- `src/services/AIService.ts` — Apple `availableTools` mirrors `buildChatToolsMap`.
- `src/services/ai/actionExecutor.ts` — new `GRADE_QUESTIONER_PROMPT` constant; `grade_questioner_answers` case replaces the dead stub; `create_questioner_note` comment re-worded.
- `src/services/ai/tools.ts` — `grade_questioner_answers` schema + tool declaration added; `create_questioner_note` description updated; `chatTools` registry now has 18 entries.
- `__tests__/ai/tools.test.ts` — registry count 17 → 18 with `grade_questioner_answers` included.
- `__tests__/ai-chat-tools-expansion.test.ts` — schema test + registry entry for `grade_questioner_answers`; stub-error `test.each` block replaced with 7 behavior tests covering confirm mode, note-missing / tag-missing / model-missing short-circuits, happy path with correct separator, re-grade stripping, and `filePath`-carried sync.
- `__tests__/save-loading-indicator.test.ts` — Button mock forwards `testID`; tests rewritten around `accessibilityState.disabled` flips.

## Regression guard

The Apple Intelligence + GitHub tools path (fix #1) is only covered by integration use on-device. If this PR ever needs revisiting, add a unit test in `__tests__/ai/AIService.test.ts` that mocks `@react-native-ai/apple` and asserts the `availableTools` passed into `createAppleProvider` includes both `list_repos` and the chat tools when `githubToolsEnabled === true`.