### PR TITLE
feat(dumps): swipe-to-select multi-delete on Thought Dumps

### DIFF
--- a/__tests__/ThoughtDumpScreen.test.tsx
+++ b/__tests__/ThoughtDumpScreen.test.tsx
@@ -21,6 +21,11 @@ jest.mock('../src/services/StorageService', () => ({
   },
 }));
 
+jest.mock('../src/services/ai/thoughtDumpIndexing', () => ({
+  indexDump: jest.fn(),
+  removeDump: jest.fn(),
+}));
+
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
@@ -54,6 +59,39 @@ jest.mock('../src/components/VoiceInputModal', () => {
         </View>
       ) : null,
   };
+});
+
+jest.mock('../src/components/list/SwipeableListItem', () => {
+  const React = require('react');
+  const { TouchableOpacity, View } = require('react-native');
+  const SwipeableListItem = ({ itemId, selected, selectionMode, onToggleSelect, children }: any) => (
+    <View testID={`swipeable-${itemId}`} accessibilityState={{ selected }}>
+      <TouchableOpacity
+        testID={`swipeable-list-item.button.toggle-${itemId}`}
+        onPress={onToggleSelect}
+      >
+        {children}
+      </TouchableOpacity>
+    </View>
+  );
+  return { __esModule: true, default: SwipeableListItem, SwipeableListItem };
+});
+
+jest.mock('../src/components/list/BulkActionBar', () => {
+  const React = require('react');
+  const { TouchableOpacity, View, Text } = require('react-native');
+  const BulkActionBar = ({ count, onCancel, onDelete, itemNoun }: any) =>
+    count === 0 ? null : (
+      <View testID="bulk-action-bar.container">
+        <TouchableOpacity testID="bulk-action-bar.button.cancel" onPress={onCancel}>
+          <Text>cancel</Text>
+        </TouchableOpacity>
+        <TouchableOpacity testID="bulk-action-bar.button.delete" onPress={onDelete}>
+          <Text>{`delete ${count} ${itemNoun}s`}</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  return { __esModule: true, default: BulkActionBar, BulkActionBar };
 });
 
 jest.mock('../src/contexts/ThemeContext', () => ({
@@ -314,6 +352,142 @@ describe('ThoughtDumpScreen', () => {
 
     await waitFor(() => {
       expect(getByTestId('voice-input-modal.button.close-unavailable')).toBeTruthy();
+    });
+  });
+
+  describe('swipe-to-select multi-delete', () => {
+    it('renders SwipeableListItem per dump and BulkActionBar hidden by default', async () => {
+      const dumps = [
+        makeDump({ id: 'dump-1', text: 'A' }),
+        makeDump({ id: 'dump-2', text: 'B' }),
+      ];
+      mockList.mockResolvedValue(dumps);
+
+      const { getByTestId, queryByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => {
+        expect(getByTestId('swipeable-dump-1')).toBeTruthy();
+        expect(getByTestId('swipeable-dump-2')).toBeTruthy();
+        expect(queryByTestId('bulk-action-bar.container')).toBeNull();
+      });
+    });
+
+    it('tapping the toggle button selects the row and shows the BulkActionBar', async () => {
+      const dumps = [makeDump({ id: 'dump-1', text: 'A' })];
+      mockList.mockResolvedValue(dumps);
+
+      const { getByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => expect(getByTestId('swipeable-dump-1')).toBeTruthy());
+
+      fireEvent.press(getByTestId('swipeable-list-item.button.toggle-dump-1'));
+
+      await waitFor(() => {
+        expect(getByTestId('bulk-action-bar.container')).toBeTruthy();
+      });
+    });
+
+    it('bulk delete confirms then deletes each selected dump and cleans index', async () => {
+      const dumps = [
+        makeDump({ id: 'dump-1', text: 'A', filePath: 'thoughts/one.md' }),
+        makeDump({ id: 'dump-2', text: 'B', filePath: 'thoughts/two.md' }),
+      ];
+      mockList.mockResolvedValue(dumps);
+      mockDelete.mockResolvedValue(true);
+
+      const indexMock = require('../src/services/ai/thoughtDumpIndexing');
+      const removeDumpSpy = jest.spyOn(indexMock, 'removeDump').mockImplementation(() => undefined);
+
+      jest.spyOn(Alert, 'alert').mockImplementationOnce((title, message, buttons) => {
+        if (Array.isArray(buttons) && buttons[1]) {
+          (buttons[1].onPress as () => void)();
+        }
+      });
+
+      const { getByTestId, queryByText, queryByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => expect(getByTestId('swipeable-dump-1')).toBeTruthy());
+
+      fireEvent.press(getByTestId('swipeable-list-item.button.toggle-dump-1'));
+      fireEvent.press(getByTestId('swipeable-list-item.button.toggle-dump-2'));
+
+      await waitFor(() => expect(getByTestId('bulk-action-bar.container')).toBeTruthy());
+
+      fireEvent.press(getByTestId('bulk-action-bar.button.delete'));
+
+      await waitFor(() => {
+        expect(mockDelete).toHaveBeenCalledTimes(2);
+        expect(mockDelete).toHaveBeenCalledWith('dump-1', {
+          repoPath: 'owner/repo',
+          branch: 'main',
+          filePath: 'thoughts/one.md',
+        });
+        expect(mockDelete).toHaveBeenCalledWith('dump-2', {
+          repoPath: 'owner/repo',
+          branch: 'main',
+          filePath: 'thoughts/two.md',
+        });
+        expect(removeDumpSpy).toHaveBeenCalledWith('thoughts/one.md');
+        expect(removeDumpSpy).toHaveBeenCalledWith('thoughts/two.md');
+      });
+
+      await waitFor(() => {
+        expect(queryByText('A')).toBeNull();
+        expect(queryByText('B')).toBeNull();
+      });
+
+      await waitFor(() => {
+        expect(queryByTestId('bulk-action-bar.container')).toBeNull();
+      });
+    });
+
+    it('cancel on BulkActionBar clears selection and hides the bar', async () => {
+      const dumps = [makeDump({ id: 'dump-1', text: 'A' })];
+      mockList.mockResolvedValue(dumps);
+      const { getByTestId, queryByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => expect(getByTestId('swipeable-dump-1')).toBeTruthy());
+
+      fireEvent.press(getByTestId('swipeable-list-item.button.toggle-dump-1'));
+      await waitFor(() => expect(getByTestId('bulk-action-bar.container')).toBeTruthy());
+
+      fireEvent.press(getByTestId('bulk-action-bar.button.cancel'));
+      await waitFor(() => expect(queryByTestId('bulk-action-bar.container')).toBeNull());
+    });
+
+    it('does not call ThoughtDumpService.delete when cancel is pressed in confirmation dialog', async () => {
+      const dumps = [
+        makeDump({ id: 'dump-1', text: 'A', filePath: 'thoughts/one.md' }),
+        makeDump({ id: 'dump-2', text: 'B', filePath: 'thoughts/two.md' }),
+      ];
+      mockList.mockResolvedValue(dumps);
+
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementationOnce(() => undefined);
+
+      const { getByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => expect(getByTestId('swipeable-dump-1')).toBeTruthy());
+
+      fireEvent.press(getByTestId('swipeable-list-item.button.toggle-dump-1'));
+      fireEvent.press(getByTestId('swipeable-list-item.button.toggle-dump-2'));
+      fireEvent.press(getByTestId('bulk-action-bar.button.delete'));
+
+      expect(mockDelete).not.toHaveBeenCalled();
+      alertSpy.mockRestore();
+    });
+
+    it('existing single-delete test still works (regression)', async () => {
+      // This is a sentinel — the pre-existing single-delete tests above must not regress.
+      // We verify the per-item button still exists alongside swipe.
+      const dumps = [makeDump({ id: 'dump-1', text: 'First dump' })];
+      mockList.mockResolvedValue(dumps);
+
+      const { getByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => {
+        expect(getByTestId('thought-dump-delete-dump-1')).toBeTruthy();
+        expect(getByTestId('swipeable-dump-1')).toBeTruthy();
+      });
     });
   });
 });

--- a/__tests__/e2e-thought-dump-loop.test.tsx
+++ b/__tests__/e2e-thought-dump-loop.test.tsx
@@ -54,18 +54,21 @@ jest.mock('react-native-reanimated', () => {
 jest.mock('react-native-gesture-handler', () => {
   const React = require('react');
   const RN = require('react-native');
+  const mockPanGesture = (): Record<string, () => unknown> => ({
+    activeOffsetX: () => mockPanGesture(),
+    activeOffsetY: () => mockPanGesture(),
+    failOffsetX: () => mockPanGesture(),
+    failOffsetY: () => mockPanGesture(),
+    onBegin: () => mockPanGesture(),
+    onStart: () => mockPanGesture(),
+    onUpdate: () => mockPanGesture(),
+    onEnd: () => mockPanGesture(),
+    onFinalize: () => mockPanGesture(),
+  });
   return {
     GestureDetector: ({ children }: any) => children,
     Gesture: {
-      Pan: () => ({
-        onBegin: () => ({
-          onStart: () => ({
-            onUpdate: () => ({
-              onEnd: () => ({ onFinalize: () => ({}) }),
-            }),
-          }),
-        }),
-      }),
+      Pan: () => mockPanGesture(),
     },
     PanGestureHandler: React.forwardRef((props: any, ref: any) =>
       React.createElement(RN.View, { ...props, ref }),

--- a/src/screens/ThoughtDumpScreen.tsx
+++ b/src/screens/ThoughtDumpScreen.tsx
@@ -16,6 +16,8 @@ import { ScreenHeader, Button, Input, EmptyState, Modal } from '../components/ui
 import { useScreenHeaderHeight } from '../components/ui';
 import VoiceInputModal from '../components/VoiceInputModal';
 import { indexDump, removeDump } from '../services/ai/thoughtDumpIndexing';
+import { SwipeableListItem } from '../components/list/SwipeableListItem';
+import { BulkActionBar } from '../components/list/BulkActionBar';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -36,9 +38,23 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<ThoughtDump | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
   const [repoPath, setRepoPath] = useState('');
   const [branch, setBranch] = useState<string | undefined>();
   const [showVoiceModal, setShowVoiceModal] = useState(false);
+
+  const selectionMode = selectedIds.size > 0;
+
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
 
   const loadDumps = useCallback(async () => {
     setIsLoading(true);
@@ -118,6 +134,47 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
     }
   };
 
+  const handleBulkDelete = useCallback(async () => {
+    if (selectedIds.size === 0) return;
+    Alert.alert(
+      t('thoughtDump.confirmDelete'),
+      `Delete ${selectedIds.size} ${selectedIds.size === 1 ? 'thought dump' : 'thought dumps'}?`,
+      [
+        { text: t('common.cancel'), style: 'cancel' },
+        {
+          text: t('common.delete'),
+          style: 'destructive',
+          onPress: async () => {
+            const toDelete = dumps.filter((d) => selectedIds.has(d.id));
+            let anyFailed = false;
+            for (const dump of toDelete) {
+              try {
+                const ok = await ThoughtDumpService.delete(dump.id, {
+                  repoPath,
+                  branch,
+                  filePath: dump.filePath,
+                });
+                if (ok) {
+                  setDumps((prev) => prev.filter((d) => d.id !== dump.id));
+                  removeDump(dump.filePath);
+                  onDumpChange?.(dump);
+                } else {
+                  anyFailed = true;
+                }
+              } catch {
+                anyFailed = true;
+              }
+            }
+            clearSelection();
+            if (anyFailed) {
+              Alert.alert(t('common.error'), t('thoughtDump.error'));
+            }
+          },
+        },
+      ],
+    );
+  }, [selectedIds, dumps, repoPath, branch, clearSelection, onDumpChange, removeDump, t]);
+
   const formatRelativeDate = (isoDate: string): string => {
     const now = Date.now();
     const then = new Date(isoDate).getTime();
@@ -134,24 +191,31 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
 
   const renderItem = useCallback(
     ({ item }: { item: ThoughtDump }) => (
-      <View style={[styles.dumpItem, { padding: spacing[3], marginBottom: spacing[2], backgroundColor: colors.surface }]}>
-        <Text style={[styles.dumpText, { color: colors.text }]} numberOfLines={6}>
-          {item.text}
-        </Text>
-        <View style={[styles.dumpFooter, { marginTop: spacing[2] }]}>
-          <Text style={[styles.dumpDate, { color: colors.textSecondary }]}>
-            {formatRelativeDate(item.createdAt)}
+      <SwipeableListItem
+        itemId={item.id}
+        selected={selectedIds.has(item.id)}
+        selectionMode={selectionMode}
+        onToggleSelect={() => toggleSelected(item.id)}
+      >
+        <View style={[styles.dumpItem, { padding: spacing[3], marginBottom: spacing[2], backgroundColor: colors.surface }]}>
+          <Text style={[styles.dumpText, { color: colors.text }]} numberOfLines={6}>
+            {item.text}
           </Text>
-          <Button
-            testID={`thought-dump-delete-${item.id}`}
-            label={t('thoughtDump.delete')}
-            variant="ghost"
-            onPress={() => setDeleteTarget(item)}
-          />
+          <View style={[styles.dumpFooter, { marginTop: spacing[2] }]}>
+            <Text style={[styles.dumpDate, { color: colors.textSecondary }]}>
+              {formatRelativeDate(item.createdAt)}
+            </Text>
+            <Button
+              testID={`thought-dump-delete-${item.id}`}
+              label={t('thoughtDump.delete')}
+              variant="ghost"
+              onPress={() => setDeleteTarget(item)}
+            />
+          </View>
         </View>
-      </View>
+      </SwipeableListItem>
     ),
-    [colors, spacing, t],
+    [colors, spacing, t, selectedIds, selectionMode, toggleSelected],
   );
 
   const renderEmpty = () => {
@@ -210,8 +274,16 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
           data={dumps}
           renderItem={renderItem}
           keyExtractor={(item) => item.id}
-          contentContainerStyle={{ padding: spacing[3], paddingBottom: spacing[6] }}
+          contentContainerStyle={{ padding: spacing[3], paddingBottom: spacing[6] + (selectionMode ? 72 : 0) }}
           ListEmptyComponent={renderEmpty}
+        />
+
+        <BulkActionBar
+          count={selectedIds.size}
+          onCancel={clearSelection}
+          onDelete={handleBulkDelete}
+          bottomOffset={spacing[4]}
+          itemNoun="thought dump"
         />
       </View>
 


### PR DESCRIPTION
## Summary
Swipe-left on any Thought Dump row to select it. Once one or more are selected, a floating bar appears at the bottom with a count, Cancel, and Delete. Tapping Delete opens a pluralized `Alert.alert` confirmation (`Delete N thought dumps?`), then deletes each sequentially using the existing `ThoughtDumpService.delete` + `removeDump` cleanup.

Mirrors the exact `SwipeableListItem` + `BulkActionBar` pattern already proven in `NotesListScreen`, `TodoListScreen`, and `ChatThreadListScreen`. The pre-existing per-item trash button + confirm-modal flow is preserved unchanged.

## Commits
- `feat(dumps): swipe-to-select and bulk delete for Thought Dumps` — 2 files, +262/-16
- `fix(tests): extend local gesture-handler mock in thought-dump e2e test` — 1 file, +12/-9 (test-only fix for an e2e-surface mock that was stale relative to the new swipe integration, mirroring the same pattern as prior fix commit `40d0ed7`)

## Verification evidence
- **Targeted**: `yarn jest __tests__/ThoughtDumpScreen.test.tsx` → 15/15 PASS (9 existing + 6 new)
- **Full regression**: `yarn jest` → 1947/1947 PASS, 217/217 suites executed, 2 skipped / 7 skipped (matches documented baseline)
- **Mutation QA**: temporarily removing the `setDumps` filter inside `handleBulkDelete` caused the bulk-delete test to fail at `expect(queryByText('A')).toBeNull()` as expected; revert → green (proves assertions actually assert the behavior)
- **`yarn ts:check`** → exit 0
- **`yarn eslint <the 3 files>`** → 0 errors (only pre-existing-style `any` in mock factories and two harmless exhaustive-deps warnings)

## Plan
`.omo/plans/thought-dump-swipe-multiselect.md`

## Independent F-wave review
All four Final Verification Wave verdicts returned APPROVE:
- **F1** (Plan compliance, oracle): 14/14 checks PASS; 3 documented plan-deviations all cross-verified and justified
- **F2** (Code quality, oracle): 10/10 checks PASS; zero `any` in production code
- **F3** (Full jest regression, deep worker): 1947/1947, 0 new regressions
- **F4** (Scope fidelity, oracle): 14/14 checks PASS; diff shows exactly 3 files (2 implementation + 1 test-only mock fix)

## Notepad learnings (for future worktree orchestrations)
- `jest.config.js` includes `testPathIgnorePatterns` with `/.worktrees/` — in a worktree-based orchestration, pass `--testPathIgnorePatterns=/node_modules/` on the CLI to rediscover the worktree's own tests. Do NOT edit the config file.
- Render-item `useCallback` deps must include `selectedIds`/`selectionMode`/`toggleSelected` or the memoized row closure goes stale — the plan's recipe omitted these; worker caught and fixed, mirroring `NotesListScreen.renderNote` pattern (L435-437).
