### PR TITLE
fix(sync): git-operation locking — visible delete state, deadlock-free gate, single-commit bulk ops

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -38,6 +38,7 @@ import { ReminderService } from './src/services/ReminderService';
 import { StartupSyncGate } from './src/components/StartupSyncGate';
 import { GitHubActivityIndicator } from './src/components/GitHubActivityIndicator';
 import { bootstrapStorage } from './src/services/StorageBootstrap';
+import { hydrate as hydrateGitOperationRegistry } from './src/stores/gitOperationStore';
 import { useRenderStyleStore } from './src/stores/renderStyleStore';
 import { startForegroundWatcher } from './src/services/ForegroundSyncService';
 import { loadForegroundSyncConfig } from './src/hooks/useForegroundSyncSettings';
@@ -60,6 +61,9 @@ export default function App() {
 
   const checkOnboarding = useCallback(async () => {
     await bootstrapStorage();
+    // Restore durable git-operation locks (queued mutations + failed deletes)
+    // before StartupSyncGate drains/pulls and the UI reads lock state.
+    void hydrateGitOperationRegistry();
     void useRenderStyleStore.getState().hydrate();
     const completed = await OnboardingService.isOnboardingCompleted();
     setShowOnboarding(!completed);

--- a/__tests__/git-state-ui.test.tsx
+++ b/__tests__/git-state-ui.test.tsx
@@ -1,0 +1,402 @@
+import React from 'react';
+import { ActivityIndicator, RefreshControl } from 'react-native';
+import { act, fireEvent, waitFor } from '@testing-library/react-native';
+
+import { renderWithTheme } from './helpers/renderWithTheme';
+import NotesListScreen from '../src/screens/NotesListScreen';
+import TodoListScreen from '../src/screens/TodoListScreen';
+import { GitHubActivityIndicator } from '../src/components/GitHubActivityIndicator';
+import { OfflineBanner } from '../src/components/ui/OfflineBanner';
+import { useGitHubActivityStore } from '../src/stores/githubActivityStore';
+import { useGitOperationStore, gitOperationRegistry } from '../src/stores/gitOperationStore';
+import { GitSyncGate } from '../src/services/git/GitSyncGate';
+import { HapticService } from '../src/utils/haptics';
+
+const mockNavigate = jest.fn();
+const mockSyncNow = jest.fn(async () => ({ ok: true }));
+const mockUseNetworkStatus = jest.fn();
+
+let mockPendingCount = 0;
+const mockPendingCountFn = jest.fn(async () => mockPendingCount);
+
+// ---- i18n: per-file mock that supports switching languages (overrides the
+// en-only react-i18next mock from jest.setup). The offline banner case needs
+// to resolve sync.offlineBanner from two different locale bundles. ----
+jest.mock('react-i18next', () => {
+  const en = require('../src/i18n/en.json');
+  const es = require('../src/i18n/es.json');
+  let current: Record<string, unknown> = en;
+  function resolveKey(obj: Record<string, unknown>, path: string): string {
+    const keys = path.split('.');
+    let currentValue: unknown = obj;
+    for (const k of keys) {
+      if (currentValue && typeof currentValue === 'object' && k in (currentValue as Record<string, unknown>)) {
+        currentValue = (currentValue as Record<string, unknown>)[k];
+      } else {
+        return path;
+      }
+    }
+    return typeof currentValue === 'string' ? currentValue : path;
+  }
+  return {
+    useTranslation: () => ({
+      t: (key: string) => resolveKey(current, key),
+      i18n: { changeLanguage: jest.fn(async () => undefined) },
+    }),
+    initReactI18next: { type: '3rdParty', init: jest.fn() },
+    __setLanguage: (lng: string) => {
+      current = lng === 'es' ? es : en;
+    },
+  };
+});
+
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+jest.mock('../src/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: () => mockUseNetworkStatus(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useIsFocused: () => true,
+}));
+
+jest.mock('@react-navigation/native-stack', () => ({}));
+
+jest.mock('../src/contexts/NoteContext', () => ({
+  useNotes: () => ({
+    notes: [],
+    filteredNotes: [],
+    isLoading: false,
+    searchQuery: '',
+    setSearchQuery: jest.fn(),
+    deleteNote: jest.fn(),
+    refreshNotes: jest.fn(),
+    togglePin: jest.fn(),
+    error: null,
+    createNote: jest.fn(),
+    updateNote: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null }, activeAccountId: null }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({ repositories: [] }),
+}));
+
+jest.mock('../src/contexts/ViewModeContext', () => ({
+  useViewMode: () => ({ viewMode: 'list', setViewMode: jest.fn() }),
+}));
+
+jest.mock('../src/contexts/TodoContext', () => ({
+  useTodos: () => ({
+    todos: [],
+    createTodo: jest.fn(),
+    updateTodo: jest.fn(),
+    toggleTodo: jest.fn(),
+    refreshTodos: jest.fn(async () => undefined),
+  }),
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: { setToken: jest.fn() },
+}));
+
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    pendingCount: () => mockPendingCountFn(),
+    subscribe: jest.fn(() => jest.fn()),
+    drain: jest.fn(async () => ({ succeeded: 0, failed: 0, remaining: 0 })),
+    enqueueNoteDeletes: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock('../src/services/RepoPullService', () => ({
+  pullAllFromRepos: jest.fn(async () => undefined),
+}));
+
+jest.mock('../src/services/git/manualSync', () => ({
+  syncNow: (...args: unknown[]) => mockSyncNow(...args),
+  isSyncNowRunning: jest.fn(() => false),
+}));
+
+jest.mock('../src/services/ShareService', () => ({
+  ShareService: { isAvailable: jest.fn(() => false) },
+}));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: { deleteNote: jest.fn(async () => true), deleteTodo: jest.fn(async () => true) },
+}));
+
+jest.mock('../src/services/TodoGitHubSyncService', () => ({
+  syncTodoToGitHub: jest.fn(async () => ({ success: true })),
+}));
+
+jest.mock('../src/services/git/BatchGitOperations', () => ({
+  batchDeleteFiles: jest.fn(async () => ({ success: true, deleted: [], failed: [] })),
+}));
+
+jest.mock('../src/services/SyncEngineService', () => ({
+  SyncEngineService: { getMode: jest.fn(async () => 'api') },
+}));
+
+jest.mock('../src/services/git/resolveBranch', () => ({
+  resolveBranch: jest.fn(async (_repo: string, hint?: string) => hint ?? 'main'),
+}));
+
+jest.mock('../src/stores/todoStore', () => ({
+  useTodoStore: (selector: (state: { deleteTodo: () => Promise<boolean> }) => unknown) =>
+    selector({ deleteTodo: jest.fn(async () => true) }),
+}));
+
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: {
+    light: jest.fn(),
+    medium: jest.fn(),
+    selection: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({ isTablet: false, maxContentWidth: 720 }),
+}));
+
+jest.mock('../src/hooks/useEntityFilter', () => ({
+  useEntityFilter: () => ({
+    applyFilters: (items: unknown[]) => items,
+    activeCount: 0,
+    state: {
+      selectedRepo: null,
+      selectedBranch: null,
+      selectedFolder: null,
+      selectedTags: [],
+      selectedAccountId: null,
+    },
+    setSelectedRepo: jest.fn(),
+    setSelectedBranch: jest.fn(),
+    setSelectedFolder: jest.fn(),
+    setSelectedAccountId: jest.fn(),
+    toggleTag: jest.fn(),
+    clearAll: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/hooks/useEntityList', () => ({
+  useEntityList: ({ data }: { data: unknown[] }) => ({
+    filteredData: data,
+    searchQuery: '',
+    setSearchQuery: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/components/notes/useNotesListFilters', () => ({
+  useNotesListFilters: () => ({
+    filters: {
+      selectedFormat: null,
+      selectedBranch: null,
+      selectedFolder: null,
+      selectedTags: [],
+      selectedColors: [],
+    },
+    displayNotes: [],
+    hasActiveSearch: false,
+    searchMatchCount: 0,
+    activeFilterCount: 0,
+    allColors: [],
+    allTags: [],
+    allFolders: [],
+    allBranches: [],
+    sortMode: 'recent',
+    setSortMode: jest.fn(),
+    handleClearFilters: jest.fn(),
+    handleSelectRepo: jest.fn(),
+    handleSelectFormat: jest.fn(),
+    handleSelectBranch: jest.fn(),
+    handleSelectFolder: jest.fn(),
+    handleToggleTag: jest.fn(),
+    handleToggleColor: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/components/notes/useNotesListNoteActions', () => ({
+  useNotesListNoteActions: () => ({
+    handleNotePress: jest.fn(),
+    handleColorSelect: jest.fn(),
+    handleDeleteNote: jest.fn(),
+    handleNoteLongPress: jest.fn(),
+    handleTogglePin: jest.fn(),
+    handleExport: jest.fn(),
+    handleOpenColorPicker: jest.fn(),
+    handleDuplicate: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/components/ui', () => {
+  const React = require('react');
+  const { Text, View, Pressable } = require('react-native');
+  return {
+    ScreenHeader: ({ title, actions }: { title: string; actions?: React.ReactNode }) => (
+      <View>
+        <Text testID="screen-header">{title}</Text>
+        {actions}
+      </View>
+    ),
+    IconButton: ({
+      testID,
+      onPress,
+      children,
+    }: {
+      testID?: string;
+      onPress?: () => void;
+      children?: React.ReactNode;
+    }) => (
+      <Pressable testID={testID} onPress={onPress}>
+        {children}
+      </Pressable>
+    ),
+    useScreenHeaderHeight: () => 60,
+    SCREEN_HEADER_BASE_HEIGHT: 60,
+    SCREEN_HEADER_SUBTITLE_HEIGHT: 88,
+    useTabBarHeight: () => 84,
+    TAB_BAR_BASE_HEIGHT: 84,
+  };
+});
+
+jest.mock('../src/components/ColorPicker', () => ({ __esModule: true, default: () => null }));
+jest.mock('../src/components/ui/ConflictBanner', () => ({ ConflictBanner: () => null }));
+jest.mock('../src/components/FilterBar', () => ({ FilterBar: () => null }));
+jest.mock('../src/components/list/BulkActionBar', () => ({ BulkActionBar: () => null }));
+jest.mock('../src/components/notes/NotesListHeader', () => ({ NotesListHeader: () => null }));
+jest.mock('../src/components/notes/NotesViewModePicker', () => ({ NotesViewModePicker: () => null }));
+jest.mock('../src/components/notes/NotesFilterModal', () => ({ NotesFilterModal: () => null }));
+jest.mock('../src/components/notes/NotesContextMenu', () => ({ NotesContextMenu: () => null }));
+jest.mock('../src/components/todos/TodosListHeader', () => ({ TodosListHeader: () => null }));
+jest.mock('../src/components/todos/TodoEditorModal', () => ({ TodoEditorModal: () => null }));
+jest.mock('../src/components/EntityFilterModal', () => ({ EntityFilterModal: () => null }));
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return React.forwardRef(
+    ({ children }: { children?: React.ReactNode }, _ref: React.Ref<unknown>) => (
+      <View>{children}</View>
+    ),
+  );
+});
+
+function textOf(node: { props: { children: unknown } }): string {
+  const children = node.props.children;
+  if (Array.isArray(children)) return children.join('');
+  return String(children ?? '');
+}
+
+function seedCycleBusy(): void {
+  act(() => {
+    gitOperationRegistry.begin({ kind: 'pull', repo: '*', entityIds: [], attempts: 0, status: 'running' });
+  });
+}
+
+describe('git-state surfaces', () => {
+  beforeEach(() => {
+    mockPendingCount = 0;
+    mockNavigate.mockClear();
+    mockSyncNow.mockClear();
+    mockPendingCountFn.mockClear();
+    mockUseNetworkStatus.mockReturnValue({ isConnected: true, isInternetReachable: true });
+    useGitOperationStore.setState({ ops: {} });
+    useGitHubActivityStore.getState().reset();
+    GitSyncGate.__resetForTest();
+  });
+
+  it('shows the persistent cloud-upload badge with the queue count while the pill is hidden', async () => {
+    mockPendingCount = 2;
+
+    const { getByTestId, getByText, queryByTestId } = renderWithTheme(<NotesListScreen />);
+
+    await waitFor(() => expect(getByText('2')).toBeTruthy());
+    expect(getByTestId('icon-cloud-upload')).toBeTruthy();
+    // Transient activity affordance is not rendered while the persistent
+    // queue badge is: no HTTP activity means no pill, but pending>0 still
+    // shows the count.
+    expect(queryByTestId('github-activity-indicator')).toBeNull();
+    expect(useGitHubActivityStore.getState().visible).toBe(false);
+  });
+
+  it('renders a spinner on the cloud icon and no-ops the press while the gate cycle is held', () => {
+    seedCycleBusy();
+
+    const { getByTestId, UNSAFE_getByType } = renderWithTheme(<NotesListScreen />);
+
+    expect(UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+    fireEvent.press(getByTestId('notes-list.icon-button.sync'));
+    expect(mockSyncNow).not.toHaveBeenCalled();
+    expect(HapticService.warning).toHaveBeenCalled();
+  });
+
+  it('never renders a trailing-ellipsis label for the pill (default or provided)', () => {
+    // Default label: store label is null, the fallback must be ellipsis-free.
+    useGitHubActivityStore.setState({ label: null });
+    const defaultRender = renderWithTheme(<GitHubActivityIndicator />);
+    const defaultText = defaultRender.getByText(/Syncing with GitHub/);
+    expect(textOf(defaultText).endsWith('…')).toBe(false);
+    defaultRender.unmount();
+
+    // Provided label with a legacy trailing ellipsis gets stripped defensively.
+    useGitHubActivityStore.setState({ label: 'Pushing note…' });
+    const providedRender = renderWithTheme(<GitHubActivityIndicator />);
+    const providedText = providedRender.getByText(/Pushing note/);
+    expect(textOf(providedText)).toBe('Pushing note');
+    expect(textOf(providedText).includes('…')).toBe(false);
+    providedRender.unmount();
+  });
+
+  it('disables pull-to-refresh on both list screens while a git cycle is held', () => {
+    seedCycleBusy();
+
+    const notes = renderWithTheme(<NotesListScreen />);
+    expect(notes.UNSAFE_getByType(RefreshControl).props.enabled).toBe(false);
+    notes.unmount();
+
+    const todos = renderWithTheme(<TodoListScreen />);
+    expect(todos.UNSAFE_getByType(RefreshControl).props.enabled).toBe(false);
+    todos.unmount();
+  });
+
+  it('keeps pull-to-refresh enabled when idle', () => {
+    const notes = renderWithTheme(<NotesListScreen />);
+    expect(notes.UNSAFE_getByType(RefreshControl).props.enabled).toBe(true);
+    notes.unmount();
+
+    const todos = renderWithTheme(<TodoListScreen />);
+    expect(todos.UNSAFE_getByType(RefreshControl).props.enabled).toBe(true);
+    todos.unmount();
+  });
+
+  it('localizes the offline banner across at least two locales', () => {
+    const i18nMock = require('react-i18next') as unknown as { __setLanguage: (lng: string) => void };
+    mockUseNetworkStatus.mockReturnValue({ isConnected: false, isInternetReachable: false });
+
+    const enResources = require('../src/i18n/en.json');
+    const esResources = require('../src/i18n/es.json');
+
+    i18nMock.__setLanguage('en');
+    const enRender = renderWithTheme(<OfflineBanner />);
+    expect(enRender.getByText(enResources.sync.offlineBanner)).toBeTruthy();
+    enRender.unmount();
+
+    i18nMock.__setLanguage('es');
+    const esRender = renderWithTheme(<OfflineBanner />);
+    expect(esRender.getByText(esResources.sync.offlineBanner)).toBeTruthy();
+    esRender.unmount();
+  });
+});

--- a/__tests__/notes-delete-lock.test.tsx
+++ b/__tests__/notes-delete-lock.test.tsx
@@ -1,0 +1,672 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import NotesListScreen from '../src/screens/NotesListScreen';
+import NoteEditorScreen from '../src/screens/NoteEditorScreen';
+import { Note } from '../src/models/Note';
+import { useNoteStore } from '../src/stores/noteStore';
+import { useGitOperationStore, gitOperationRegistry, hydrate } from '../src/stores/gitOperationStore';
+import { NoteSyncQueueService } from '../src/services/NoteSyncQueueService';
+import { StorageService } from '../src/services/StorageService';
+import { clearDeleteFailure } from '../src/services/git/deleteFailures';
+import { renderWithTheme } from './helpers/renderWithTheme';
+
+type SucceededHandler = (event: { mutation: { id: string; type: string; params: Record<string, any> } }) => void;
+type DroppedHandler = (event: {
+  mutation: { id: string; type: string; params: Record<string, any> };
+  reason: string;
+  error?: string;
+}) => void;
+
+const mockNavigate = jest.fn();
+let mockRouteNoteId = 'editor-note';
+
+jest.mock('../src/services/NoteSyncQueueService', () => {
+  const succeeded = new Set<SucceededHandler>();
+  const dropped = new Set<DroppedHandler>();
+  return {
+    NoteSyncQueueService: {
+      enqueueNoteDelete: jest.fn(async () => undefined),
+      enqueueNoteDeletes: jest.fn(async () => undefined),
+      drain: jest.fn(async () => ({ succeeded: 0, failed: 0, remaining: 0 })),
+      pendingCount: jest.fn(async () => 0),
+      subscribe: jest.fn(() => jest.fn()),
+      getAll: jest.fn(async () => []),
+      onMutationSucceeded: jest.fn((fn: SucceededHandler) => {
+        succeeded.add(fn);
+        return () => succeeded.delete(fn);
+      }),
+      onDroppedMutation: jest.fn((fn: DroppedHandler) => {
+        dropped.add(fn);
+        return () => dropped.delete(fn);
+      }),
+      __testSucceededHandlers: succeeded,
+      __testDroppedHandlers: dropped,
+    },
+  };
+});
+
+jest.mock('../src/services/NoteGitHubSyncService', () => ({
+  syncNoteToGitHub: jest.fn(async () => ({ success: true, filePath: 'notes/x.md', finalContent: null })),
+  deleteNoteFromGitHub: jest.fn(async () => ({ success: true })),
+}));
+
+jest.mock('../src/services/git/deleteFailures', () => ({
+  clearDeleteFailure: jest.fn(async () => undefined),
+  readDeleteFailures: jest.fn(async () => ({})),
+  recordDeleteFailure: jest.fn(async () => undefined),
+  deleteFailureKey: jest.fn((repo: string, branch: string | undefined, filePath: string) => `${repo}::${branch || 'main'}::${filePath}`),
+  DELETE_FAILURES_STORAGE_KEY: '@gitnotes:delete_failures_v1',
+}));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    deleteNote: jest.fn(async () => true),
+    getAllNotes: jest.fn(async () => []),
+    getSavedRepositories: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: { setToken: jest.fn(), isAuthenticated: jest.fn(() => true), getFileSha: jest.fn(), deleteFile: jest.fn() },
+}));
+
+jest.mock('../src/services/RepoPullService', () => ({
+  pullAllFromRepos: jest.fn(async () => undefined),
+}));
+
+jest.mock('../src/services/git/manualSync', () => ({
+  syncNow: jest.fn(async () => ({ ok: true })),
+  isSyncNowRunning: jest.fn(() => false),
+}));
+
+jest.mock('../src/services/ShareService', () => ({
+  ShareService: { shareText: jest.fn(), shareInFormat: jest.fn(async () => true), getAvailableFormats: jest.fn(() => []) },
+}));
+
+jest.mock('../src/services/GitService', () => ({
+  GitService: { getBranches: jest.fn(async () => []), getRepositoryFolders: jest.fn(async () => []) },
+}));
+
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn() }),
+  useIsFocused: () => true,
+  useRoute: () => ({ params: { noteId: mockRouteNoteId } }),
+}));
+
+jest.mock('@react-navigation/native-stack', () => ({}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/contexts/NoteContext', () => {
+  const { useNoteStore: store } = jest.requireActual('../src/stores/noteStore');
+  return {
+    useNotes: () => {
+      const notes = store((s) => s.notes);
+      const isLoading = store((s) => s.isLoading);
+      return {
+        notes,
+        filteredNotes: notes,
+        isLoading,
+        searchQuery: '',
+        setSearchQuery: jest.fn(),
+        deleteNote: (id: string) => store.getState().deleteNote(id),
+        refreshNotes: async () => store.getState().refreshNotes(),
+        togglePin: async () => true,
+        error: null,
+        clearError: jest.fn(),
+        createNote: jest.fn(),
+        updateNote: jest.fn(async (input: any) => {
+          const updated = await store.getState().updateNote(input);
+          return updated ?? null;
+        }),
+        getNoteById: (id: string) => store.getState().getNoteById(id),
+      };
+    },
+  };
+});
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null }, activeAccountId: null }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({ repositories: [{ path: 'owner/repo', name: 'repo', branch: 'main' }] }),
+}));
+
+jest.mock('../src/contexts/ViewModeContext', () => ({
+  useViewMode: () => ({ viewMode: 'list' as const, setViewMode: jest.fn() }),
+}));
+
+jest.mock('../src/contexts/FolderContext', () => ({
+  useFolders: () => ({ folders: [] }),
+}));
+
+jest.mock('../src/contexts/CanvasContext', () => ({
+  useCanvases: () => ({ canvases: [] }),
+}));
+
+jest.mock('../src/stores/githubActivityStore', () => ({
+  githubActivity: { begin: jest.fn(), end: jest.fn() },
+  useGitHubActivityStore: () => ({ inflight: 0 }),
+}));
+
+jest.mock('../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({ isTablet: false, maxContentWidth: 0, columnCount: 1 }),
+}));
+
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: {
+    light: jest.fn(),
+    medium: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    selection: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../src/components/ContextMenu', () => () => null);
+jest.mock('../src/components/ColorPicker', () => ({ __esModule: true, default: () => null }));
+jest.mock('../src/components/SortPicker', () => () => null);
+jest.mock('../src/components/SearchBar', () => {
+  const { TextInput } = require('react-native');
+  return ({ value, onChangeText }: { value: string; onChangeText: (v: string) => void }) => (
+    <TextInput testID="search-bar" value={value} onChangeText={onChangeText} />
+  );
+});
+
+jest.mock('../src/components/ui', () => {
+  const { Pressable, Text, View } = require('react-native');
+  return {
+    Button: ({ label, onPress, disabled, testID }: any) =>
+      require('react').createElement(
+        Pressable,
+        { onPress, disabled, accessibilityRole: 'button', testID },
+        require('react').createElement(Text, null, label),
+      ),
+    IconButton: ({ children, onPress, testID }: any) =>
+      require('react').createElement(Pressable, { onPress, testID }, children),
+    Modal: ({ visible, children }: any) => (visible ? require('react').createElement(View, null, children) : null),
+    ScreenHeader: ({ title, actions }: any) =>
+      require('react').createElement(
+        View,
+        { testID: 'screen-header' },
+        require('react').createElement(Text, null, title),
+        actions,
+      ),
+    useScreenHeaderHeight: () => 60,
+    SCREEN_HEADER_BASE_HEIGHT: 60,
+    SCREEN_HEADER_SUBTITLE_HEIGHT: 88,
+    useTabBarHeight: () => 84,
+    TAB_BAR_BASE_HEIGHT: 84,
+    Card: ({ children }: any) => require('react').createElement(View, null, children),
+    Input: ({ testID, value, onChangeText, multiline }: any) =>
+      require('react').createElement(require('react-native').TextInput, { testID, value, onChangeText, multiline }),
+    EmptyState: ({ title }: any) => require('react').createElement(Text, null, title),
+  };
+});
+
+jest.mock('../src/components/ui/OfflineBanner', () => ({ OfflineBanner: () => null }));
+jest.mock('../src/components/ui/ConflictBanner', () => ({ ConflictBanner: () => null }));
+
+jest.mock('../src/components/notes/NoteCard', () => {
+  const { Pressable, Text } = require('react-native');
+  return {
+    NoteCard: ({ note, onPress, onLongPress }: { note: Note; onPress: (n: Note) => void; onLongPress?: (n: Note) => void }) => (
+      <Pressable
+        testID={`notes-card-${note.id}`}
+        onPress={() => onPress(note)}
+        onLongPress={onLongPress ? () => onLongPress(note) : undefined}
+      >
+        <Text>{note.title}</Text>
+      </Pressable>
+    ),
+  };
+});
+
+jest.mock('../src/components/notes/NotesListHeader', () => ({ NotesListHeader: () => null }));
+jest.mock('../src/components/notes/NotesViewModePicker', () => ({ NotesViewModePicker: () => null }));
+jest.mock('../src/components/notes/NotesFilterModal', () => ({ NotesFilterModal: () => null }));
+jest.mock('../src/components/FilterBar', () => ({ FilterBar: () => null }));
+jest.mock('../src/components/notes/NotesEmptyState', () => ({ NotesEmptyState: () => null }));
+
+jest.mock('../src/components/notes/NotesContextMenu', () => {
+  const { Pressable, Text } = require('react-native');
+  return {
+    NotesContextMenu: ({ note, onDelete }: { note: Note | null; onDelete: (n: Note) => void }) =>
+      note ? (
+        <Pressable testID="notes-context-menu.delete" onPress={() => onDelete(note)}>
+          <Text>Delete</Text>
+        </Pressable>
+      ) : null,
+  };
+});
+
+jest.mock('../src/components/list/SwipeableListItem', () => {
+  const { Pressable, View } = require('react-native');
+  return {
+    SwipeableListItem: ({ itemId, disabled, onToggleSelect, children }: any) => (
+      <View testID={`swipeable-${itemId}`}>
+        <Pressable
+          testID={`swipeable-select-${itemId}`}
+          disabled={disabled}
+          accessibilityState={{ disabled: !!disabled }}
+          onPress={disabled ? undefined : onToggleSelect}
+        >
+          <View>{children}</View>
+        </Pressable>
+      </View>
+    ),
+  };
+});
+
+jest.mock('../src/components/list/BulkActionBar', () => {
+  const { Pressable, Text } = require('react-native');
+  return {
+    BulkActionBar: ({ count, onDelete }: { count: number; onDelete: () => void }) =>
+      count > 0 ? (
+        <Pressable testID="bulk-action-bar.delete" onPress={onDelete}>
+          <Text>Delete {count}</Text>
+        </Pressable>
+      ) : null,
+  };
+});
+
+jest.mock('@shopify/flash-list', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    FlashList: React.forwardRef(({ data = [], renderItem, ListEmptyComponent }: any, _ref: any) => {
+      if (!data.length) {
+        return <View testID="flash-list-empty">{ListEmptyComponent ?? null}</View>;
+      }
+      return <View testID="flash-list">{data.map((item: any, index: number) => renderItem({ item, index }))}</View>;
+    }),
+  };
+});
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return React.forwardRef(({ children }: any, _ref: any) => <View>{children}</View>);
+});
+
+// Editor-only mocks (acceptance case 6).
+jest.mock('expo-clipboard', () => ({ setStringAsync: jest.fn() }));
+jest.mock('react-native-webview', () => ({ WebView: () => null }));
+jest.mock('expo-image', () => ({ Image: () => null }));
+jest.mock('expo-image-picker', () => ({
+  MediaTypeOptions: { Images: 'Images' },
+  requestMediaLibraryPermissionsAsync: jest.fn(async () => ({ granted: true })),
+  launchImageLibraryAsync: jest.fn(async () => ({ canceled: true })),
+}));
+jest.mock('expo-speech', () => ({ speak: jest.fn(), stop: jest.fn(), isSpeakingAsync: jest.fn(async () => false) }));
+jest.mock('react-native-marked', () => ({ useMarkdown: jest.fn(() => []) }));
+jest.mock('../src/components/ui/EmptyState', () => {
+  const { Text } = require('react-native');
+  return { EmptyState: ({ title }: any) => require('react').createElement(Text, null, title) };
+});
+jest.mock('../src/components/ui/SafeAreaView', () => {
+  const { View } = require('react-native');
+  return { SafeAreaView: ({ children }: any) => require('react').createElement(View, null, children) };
+});
+jest.mock('../src/components/GitHubActivityIndicator', () => {
+  const { Text } = require('react-native');
+  return {
+    GitHubActivityIndicator: () => require('react').createElement(Text, { testID: 'github-activity-indicator' }, 'activity'),
+  };
+});
+jest.mock('../src/components/MarkdownEditor', () => () => {
+  const { Text } = require('react-native');
+  return require('react').createElement(Text, null, 'Markdown editor');
+});
+jest.mock('../src/components/GitContextPicker', () => () => null);
+jest.mock('../src/components/StructuredRenderer', () => () => null);
+jest.mock('../src/components/PdfViewer', () => () => null);
+jest.mock('../src/components/TagInput', () => () => null);
+jest.mock('../src/components/VoiceInputModal', () => () => null);
+jest.mock('../src/components/CanvasPreview', () => () => null);
+jest.mock('../src/components/FolderSelectionDialog', () => () => null);
+jest.mock('../src/utils/markdownRenderer', () => ({ NotePreviewRenderer: class {} }));
+jest.mock('../src/components/NoteCard', () => ({
+  __esModule: true,
+  default: ({ note }: any) => {
+    const { Text } = require('react-native');
+    return require('react').createElement(Text, null, note.title);
+  },
+}));
+jest.mock('../src/components/editor/NoteEditorForm', () => {
+  const { Text } = require('react-native');
+  return { NoteEditorForm: () => require('react').createElement(Text, null, 'form') };
+});
+jest.mock('../src/components/editor/NotePreviewPane', () => ({ NotePreviewPane: () => null }));
+jest.mock('../src/components/editor/NoteViewer', () => {
+  const { Pressable, Text } = require('react-native');
+  return {
+    NoteViewer: ({ onEdit }: any) =>
+      require('react').createElement(
+        Pressable,
+        { testID: 'note-viewer.edit', onPress: onEdit },
+        require('react').createElement(Text, null, 'Edit'),
+      ),
+  };
+});
+jest.mock('../src/components/editor/EditorToolbar', () => ({ EditorToolbar: () => null }));
+jest.mock('../src/components/editor/CanvasPickerModal', () => ({ CanvasPickerModal: () => null }));
+jest.mock('../src/components/editor/useNoteEditorPreview', () => ({
+  useNoteEditorPreview: () => ({
+    isSpeaking: false,
+    speakableContent: '',
+    tocEntries: [],
+    showToc: false,
+    previewContent: '',
+    parsedStructuredContent: null,
+    markdownStyles: {},
+    notePreviewRenderer: null,
+    pdfViewerUri: null,
+    pdfLoadError: null,
+    setShowToc: jest.fn(),
+    handleToggleSpeak: jest.fn(),
+    setPdfLoadError: jest.fn(),
+    onOpenNote: jest.fn(),
+    handleTocPress: jest.fn(),
+    currentNotePath: undefined,
+    headingPositions: [],
+    previewScrollRef: { current: null },
+    handlePreviewScroll: jest.fn(),
+    handlePreviewContentSizeChange: jest.fn(),
+  }),
+}));
+
+const createNote = (overrides: Partial<Note> = {}): Note => ({
+  id: `note-${Math.random().toString(36).slice(2, 8)}`,
+  title: 'Test Note',
+  content: 'Test content',
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  format: 'markdown',
+  ...overrides,
+});
+
+function succeededHandlers(): Set<SucceededHandler> {
+  return (NoteSyncQueueService as any).__testSucceededHandlers;
+}
+
+function droppedHandlers(): Set<DroppedHandler> {
+  return (NoteSyncQueueService as any).__testDroppedHandlers;
+}
+
+function emitSucceeded(mutation: any): void {
+  act(() => {
+    succeededHandlers().forEach((fn) => fn({ mutation }));
+  });
+}
+
+function emitDropped(mutation: any, error = '401 unauthorized'): void {
+  act(() => {
+    droppedHandlers().forEach((fn) => fn({ mutation, reason: 'durable', error }));
+  });
+}
+
+function pressLatestRetryAlert(): void {
+  const calls = (Alert.alert as jest.Mock).mock.calls;
+  const lastCall = calls[calls.length - 1];
+  const buttons = lastCall[2] as Array<{ text?: string; onPress?: () => void }>;
+  const retry = buttons.find((b) => b.text === 'Retry');
+  act(() => {
+    retry?.onPress?.();
+  });
+}
+
+async function pressLatestDeleteAlertConfirm(): Promise<void> {
+  const calls = (Alert.alert as jest.Mock).mock.calls;
+  const lastCall = calls[calls.length - 1];
+  const buttons = lastCall[2] as Array<{ text?: string; onPress?: () => void | Promise<void> }>;
+  const confirm = buttons.find((b) => b.text === 'Delete' || b.text === 'delete 1');
+  await act(async () => {
+    await confirm?.onPress?.();
+  });
+}
+
+describe('notes delete lock', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNavigate.mockClear();
+    useNoteStore.setState({ notes: [], isLoading: false, error: null, searchQuery: '' });
+    useGitOperationStore.setState({ ops: {} });
+    (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => []);
+    (NoteSyncQueueService.enqueueNoteDelete as jest.Mock).mockClear();
+    (NoteSyncQueueService.enqueueNoteDeletes as jest.Mock).mockClear();
+    (NoteSyncQueueService.drain as jest.Mock).mockClear();
+    (clearDeleteFailure as jest.Mock).mockClear();
+    (StorageService.deleteNote as jest.Mock).mockClear();
+    jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps the row visible-but-locked with a spinner after a delete press; press handlers no-op and swipe is disabled', async () => {
+    const note = createNote({ id: 'n1', title: 'First', repo: 'owner/repo', branch: 'main', filePath: 'notes/first.md' });
+    useNoteStore.setState({ notes: [note], isLoading: false, error: null });
+
+    const screen = renderWithTheme(<NotesListScreen />);
+    expect(screen.getByText('First')).toBeTruthy();
+
+    fireEvent(screen.getByTestId('notes-card-n1'), 'longPress');
+    fireEvent.press(screen.getByTestId('notes-context-menu.delete'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy();
+    });
+
+    // The note is still in the list and still rendered.
+    expect(screen.getByText('First')).toBeTruthy();
+    // Swipe (selection toggle) is disabled while locked.
+    expect(screen.getByTestId('swipeable-select-n1').props.accessibilityState.disabled).toBe(true);
+    // Card press no-ops: navigation is not invoked.
+    fireEvent.press(screen.getByTestId('notes-card-n1'));
+    expect(mockNavigate).not.toHaveBeenCalledWith('NoteEditor', { noteId: 'n1' });
+    // Swipe press (selection toggle) no-ops: bulk action bar never appears.
+    fireEvent.press(screen.getByTestId('swipeable-select-n1'));
+    expect(screen.queryByTestId('bulk-action-bar.delete')).toBeNull();
+    expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy();
+  });
+
+  it('removes the row and purges local storage when the queue success event fires', async () => {
+    const note = createNote({ id: 'n2', title: 'Second', repo: 'owner/repo', branch: 'main', filePath: 'notes/second.md' });
+    useNoteStore.setState({ notes: [note], isLoading: false, error: null });
+
+    const screen = renderWithTheme(<NotesListScreen />);
+    fireEvent(screen.getByTestId('notes-card-n2'), 'longPress');
+    fireEvent.press(screen.getByTestId('notes-context-menu.delete'));
+    await waitFor(() => expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy());
+
+    const mutation = {
+      id: 'mutation-n2',
+      type: 'note.delete',
+      params: { repo: 'owner/repo', branch: 'main', filePath: 'notes/second.md', localNoteId: 'n2' },
+    };
+    emitSucceeded(mutation);
+
+    await waitFor(() => {
+      expect(StorageService.deleteNote).toHaveBeenCalledWith('n2');
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Second')).toBeNull();
+    });
+    expect(screen.queryByTestId('note-row.lock-spinner')).toBeNull();
+  });
+
+  it('renders a failure icon after a drop and Retry re-enqueues the delete (failure entry cleared)', async () => {
+    const note = createNote({ id: 'n3', title: 'Third', repo: 'owner/repo', branch: 'main', filePath: 'notes/third.md' });
+    useNoteStore.setState({ notes: [note], isLoading: false, error: null });
+
+    const screen = renderWithTheme(<NotesListScreen />);
+    fireEvent(screen.getByTestId('notes-card-n3'), 'longPress');
+    fireEvent.press(screen.getByTestId('notes-context-menu.delete'));
+    await waitFor(() => expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy());
+
+    const mutation = {
+      id: 'mutation-n3',
+      type: 'note.delete',
+      params: { repo: 'owner/repo', branch: 'main', filePath: 'notes/third.md', localNoteId: 'n3' },
+    };
+    emitDropped(mutation, '401 unauthorized');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('note-row.lock-error')).toBeTruthy();
+    });
+    // The row is still present, at normal opacity.
+    expect(screen.getByText('Third')).toBeTruthy();
+
+    // Tapping the row surfaces the failure with a Retry action.
+    fireEvent.press(screen.getByTestId('notes-card-n3'));
+    expect(Alert.alert).toHaveBeenCalled();
+    pressLatestRetryAlert();
+
+    await waitFor(() => {
+      expect(NoteSyncQueueService.enqueueNoteDelete).toHaveBeenCalled();
+      expect(clearDeleteFailure).toHaveBeenCalledWith('owner/repo', 'main', 'notes/third.md');
+      expect(NoteSyncQueueService.drain).toHaveBeenCalled();
+    });
+    // The queue notify → hydrate path (real app) re-derives the queued op,
+    // which takes the row straight back to locked.
+    (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [mutation]);
+    await act(async () => {
+      await hydrate();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy();
+    });
+  });
+
+  it('locks all three rows simultaneously on a bulk delete', async () => {
+    const notes = [
+      createNote({ id: 'b1', title: 'Bulk one', repo: 'owner/repo', branch: 'main', filePath: 'notes/b1.md' }),
+      createNote({ id: 'b2', title: 'Bulk two', repo: 'owner/repo', branch: 'main', filePath: 'notes/b2.md' }),
+      createNote({ id: 'b3', title: 'Bulk three', repo: 'owner/repo', branch: 'main', filePath: 'notes/b3.md' }),
+    ];
+    useNoteStore.setState({ notes, isLoading: false, error: null });
+
+    const screen = renderWithTheme(<NotesListScreen />);
+    for (const id of ['b1', 'b2', 'b3']) {
+      fireEvent.press(screen.getByTestId(`swipeable-select-${id}`));
+    }
+    fireEvent.press(screen.getByTestId('bulk-action-bar.delete'));
+    await pressLatestDeleteAlertConfirm();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('note-row.lock-spinner')).toHaveLength(3);
+    });
+    expect(NoteSyncQueueService.enqueueNoteDeletes).toHaveBeenCalledTimes(1);
+    const params = (NoteSyncQueueService.enqueueNoteDeletes as jest.Mock).mock.calls[0][0];
+    expect(params.map((p: any) => p.filePath).sort()).toEqual(['notes/b1.md', 'notes/b2.md', 'notes/b3.md']);
+    expect(params.map((p: any) => p.localNoteId).sort()).toEqual(['b1', 'b2', 'b3']);
+    // All three rows remain rendered.
+    expect(screen.getByText('Bulk one')).toBeTruthy();
+    expect(screen.getByText('Bulk two')).toBeTruthy();
+    expect(screen.getByText('Bulk three')).toBeTruthy();
+  });
+
+  it('renders the row locked after a restart hydrate from a seeded queue, before any drain', async () => {
+    const note = createNote({ id: 'restart-note', title: 'Restart note', repo: 'owner/repo', branch: 'main', filePath: 'notes/restart.md' });
+    useNoteStore.setState({ notes: [note], isLoading: false, error: null });
+    useGitOperationStore.setState({ ops: {} });
+
+    (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [
+      {
+        id: 'restart-mutation',
+        type: 'note.delete',
+        createdAt: 1,
+        attempts: 0,
+        params: { repo: 'owner/repo', branch: 'main', filePath: 'notes/restart.md', title: 'Restart note', localNoteId: 'restart-note' },
+      },
+    ]);
+
+    await act(async () => {
+      await hydrate();
+    });
+
+    const screen = renderWithTheme(<NotesListScreen />);
+    expect(screen.getByText('Restart note')).toBeTruthy();
+    expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy();
+    expect(NoteSyncQueueService.drain).not.toHaveBeenCalled();
+  });
+
+  it('blocks editor save on a path with a queued delete: sync spy not called and Alert shown', async () => {
+    // Synced note → the header lock is visible: the save button is disabled
+    // while the delete runs.
+    mockRouteNoteId = 'editor-synced';
+    const syncedNote = createNote({
+      id: 'editor-synced',
+      title: 'Editor synced',
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'notes/editor-synced.md',
+    });
+    useNoteStore.setState({ notes: [syncedNote], isLoading: false, error: null });
+    gitOperationRegistry.begin({
+      kind: 'delete',
+      repo: 'owner/repo',
+      branch: 'main',
+      path: 'notes/editor-synced.md',
+      entityIds: [syncedNote.id],
+      status: 'running',
+      attempts: 0,
+    });
+
+    const screen = renderWithTheme(<NoteEditorScreen />);
+    await waitFor(() => expect(screen.getByTestId('note-viewer.edit')).toBeTruthy());
+    fireEvent.press(screen.getByTestId('note-viewer.edit'));
+    await waitFor(() => expect(screen.getByTestId('note-editor.button.save')).toBeTruthy());
+    expect(screen.getByTestId('note-editor.button.save').props.accessibilityState.disabled).toBe(true);
+
+    // Unsynced note (no filePath): the header cannot lock by path, but
+    // handleSave still blocks the save via the derived path.
+    mockRouteNoteId = 'editor-note';
+    useNoteStore.setState({ notes: [], isLoading: false, error: null });
+    useGitOperationStore.setState({ ops: {} });
+    const note = createNote({
+      id: 'editor-note',
+      title: 'Editor note',
+      repo: 'owner/repo',
+      branch: 'main',
+      folderPath: 'notes',
+    });
+    useNoteStore.setState({ notes: [note], isLoading: false, error: null });
+    gitOperationRegistry.begin({
+      kind: 'delete',
+      repo: 'owner/repo',
+      branch: 'main',
+      path: 'notes/editor-note.md',
+      entityIds: [],
+      status: 'running',
+      attempts: 0,
+    });
+
+    const screen2 = renderWithTheme(<NoteEditorScreen />);
+    await waitFor(() => expect(screen2.getByTestId('note-viewer.edit')).toBeTruthy());
+    fireEvent.press(screen2.getByTestId('note-viewer.edit'));
+    await waitFor(() => expect(screen2.getByTestId('note-editor.button.save')).toBeTruthy());
+
+    fireEvent.press(screen2.getByTestId('note-editor.button.save'));
+
+    const { syncNoteToGitHub } = require('../src/services/NoteGitHubSyncService');
+    expect(syncNoteToGitHub).not.toHaveBeenCalled();
+    expect(Alert.alert).toHaveBeenCalled();
+    expect(Alert.alert).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('deleted'));
+  });
+});

--- a/__tests__/repo-tree-delete.test.tsx
+++ b/__tests__/repo-tree-delete.test.tsx
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Alert } from 'react-native';
+import type { AlertButton } from 'react-native';
+import { act, fireEvent, type RenderResult } from '@testing-library/react-native';
+
+import { renderWithTheme } from './helpers/renderWithTheme';
+import { RepoTreeItem } from '../src/components/repo/RepoTreeItem';
+import { deleteDirectory, type TreeNode } from '../src/components/repo/repoTreeShared';
+import { GitHubService } from '../src/services/GitHubService';
+import { HapticService } from '../src/utils/haptics';
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    getRepoContents: jest.fn(),
+    getFileContent: jest.fn(),
+    getFileSha: jest.fn(),
+    deleteFile: jest.fn(),
+    moveFile: jest.fn(),
+  },
+}));
+
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: {
+    light: jest.fn(),
+    medium: jest.fn(),
+    heavy: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    selection: jest.fn(),
+  },
+}));
+
+const mockGitHubService = jest.mocked(GitHubService);
+const mockHaptics = jest.mocked(HapticService);
+
+const fileNode: TreeNode = { name: 'note.md', path: 'notes/note.md', type: 'file', size: 128 };
+const dirNode: TreeNode = { name: 'docs', path: 'docs', type: 'dir' };
+
+const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+function renderTreeItem(
+  node: TreeNode,
+  callbacks: { onRefresh?: () => void; onChildDeleted?: (path: string) => void } = {},
+): RenderResult {
+  return renderWithTheme(
+    <RepoTreeItem
+      node={node}
+      owner="owner"
+      repo="repo"
+      branch="main"
+      level={0}
+      onFilePress={jest.fn()}
+      onRefresh={callbacks.onRefresh}
+      onChildDeleted={callbacks.onChildDeleted}
+    />,
+  );
+}
+
+async function flushDeferredMenuAction(): Promise<void> {
+  // ContextMenu defers item callbacks ~350ms on iOS so the parent modal
+  // can dismiss first — let the real timer fire.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 450));
+  });
+}
+
+async function openMenuAndChooseDelete(tree: RenderResult, rowTestID: string): Promise<void> {
+  const rows = tree.getAllByTestId(rowTestID);
+  fireEvent(rows[rows.length - 1], 'longPress');
+  fireEvent.press(tree.getByTestId('context-menu.item.press-delete'));
+  await flushDeferredMenuAction();
+}
+
+async function confirmLatestAlert(buttonLabel: string): Promise<void> {
+  const calls = alertSpy.mock.calls;
+  const latest = calls[calls.length - 1];
+  const buttons = (latest?.[2] ?? []) as AlertButton[];
+  const button = buttons.find((candidate) => candidate.text === buttonLabel);
+  expect(button).toBeDefined();
+  await act(async () => {
+    await button?.onPress?.();
+  });
+}
+
+function mockFileListing(paths: string[]): void {
+  mockGitHubService.getRepoContents.mockResolvedValue(
+    paths.map((path) => ({
+      name: path.split('/').pop() ?? path,
+      path,
+      type: 'file' as const,
+      size: 10,
+      download_url: null,
+    })),
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGitHubService.getRepoContents.mockResolvedValue([]);
+  mockGitHubService.getFileSha.mockResolvedValue({ kind: 'found', sha: 'default' });
+  mockGitHubService.deleteFile.mockResolvedValue({ content: null, commit: { sha: '' } });
+});
+
+describe('repo tree delete correctness', () => {
+  it('keeps the row and does not confirm deletion when sha lookup errors', async () => {
+    const onChildDeleted = jest.fn();
+    const onRefresh = jest.fn();
+    mockGitHubService.getFileSha.mockResolvedValue({ kind: 'error', message: 'network' });
+    const tree = renderTreeItem(fileNode, { onChildDeleted, onRefresh });
+
+    await openMenuAndChooseDelete(tree, 'repo-tree-item.button.file-press');
+    await confirmLatestAlert('Delete');
+
+    expect(mockGitHubService.deleteFile).not.toHaveBeenCalled();
+    expect(onChildDeleted).not.toHaveBeenCalled();
+    expect(mockHaptics.success).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith('Delete Failed', 'network');
+    expect(tree.getAllByTestId('repo-tree-item.button.file-press').length).toBeGreaterThan(0);
+  });
+
+  it('soft-succeeds deletion when the file is already gone upstream', async () => {
+    const onChildDeleted = jest.fn();
+    const onRefresh = jest.fn();
+    mockGitHubService.getFileSha.mockResolvedValue({ kind: 'not-found' });
+    const tree = renderTreeItem(fileNode, { onChildDeleted, onRefresh });
+
+    await openMenuAndChooseDelete(tree, 'repo-tree-item.button.file-press');
+    await confirmLatestAlert('Delete');
+
+    expect(mockGitHubService.deleteFile).not.toHaveBeenCalled();
+    expect(onChildDeleted).toHaveBeenCalledTimes(1);
+    expect(onChildDeleted).toHaveBeenCalledWith('notes/note.md');
+    expect(mockHaptics.success).toHaveBeenCalledTimes(1);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes with the looked-up sha when the file exists', async () => {
+    const onChildDeleted = jest.fn();
+    const onRefresh = jest.fn();
+    mockGitHubService.getFileSha.mockResolvedValue({ kind: 'found', sha: 's' });
+    const tree = renderTreeItem(fileNode, { onChildDeleted, onRefresh });
+
+    await openMenuAndChooseDelete(tree, 'repo-tree-item.button.file-press');
+    await confirmLatestAlert('Delete');
+
+    expect(mockGitHubService.deleteFile).toHaveBeenCalledTimes(1);
+    expect(mockGitHubService.deleteFile).toHaveBeenCalledWith(
+      'owner',
+      'repo',
+      'notes/note.md',
+      'Delete: notes/note.md',
+      's',
+      'main',
+    );
+    expect(onChildDeleted).toHaveBeenCalledTimes(1);
+    expect(onChildDeleted).toHaveBeenCalledWith('notes/note.md');
+    expect(mockHaptics.success).toHaveBeenCalledTimes(1);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('aggregates folder delete failures into one alert instead of dropping them', async () => {
+    mockFileListing(['docs/a.md', 'docs/b.md', 'docs/c.md']);
+    mockGitHubService.getFileSha.mockImplementation(async (_owner, _repo, path) => ({
+      kind: 'found',
+      sha: `sha-${path}`,
+    }));
+    mockGitHubService.deleteFile.mockImplementation(async (_owner, _repo, path) => {
+      if (path === 'docs/c.md') throw new Error('boom');
+      return { content: null, commit: { sha: '' } };
+    });
+
+    const result = await deleteDirectory('owner', 'repo', 'main', 'docs');
+    expect(result.deleted).toEqual(['docs/a.md', 'docs/b.md']);
+    expect(result.failed).toEqual([{ path: 'docs/c.md', error: 'boom' }]);
+
+    const onChildDeleted = jest.fn();
+    const onRefresh = jest.fn();
+    const tree = renderTreeItem(dirNode, { onChildDeleted, onRefresh });
+
+    await openMenuAndChooseDelete(tree, 'repo-tree-item.button.toggle');
+    await confirmLatestAlert('Delete');
+
+    expect(alertSpy).toHaveBeenCalledWith('Delete Failed', 'Deleted 2, failed 1');
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onChildDeleted).not.toHaveBeenCalled();
+    expect(mockHaptics.success).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/repo-tree-lock.test.tsx
+++ b/__tests__/repo-tree-lock.test.tsx
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Alert, RefreshControl, StyleSheet } from 'react-native';
+import type { AlertButton } from 'react-native';
+import { act, fireEvent, type RenderResult } from '@testing-library/react-native';
+
+import { renderWithTheme } from './helpers/renderWithTheme';
+import { RepoTreeItem } from '../src/components/repo/RepoTreeItem';
+import { type TreeNode } from '../src/components/repo/repoTreeShared';
+import { GitHubService } from '../src/services/GitHubService';
+import { HapticService } from '../src/utils/haptics';
+import { GitSyncGate } from '../src/services/git/GitSyncGate';
+import { useGitOperationStore, gitOperationRegistry, GIT_OP_ALL_REPOS } from '../src/stores/gitOperationStore';
+import { useNoteStore } from '../src/stores/noteStore';
+import { StorageService } from '../src/services/StorageService';
+import { SyncEngineService } from '../src/services/SyncEngineService';
+import { batchDeleteFiles } from '../src/services/git/BatchGitOperations';
+import ExploreScreen from '../src/screens/ExploreScreen';
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    getRepoContents: jest.fn(),
+    getFileContent: jest.fn(),
+    getFileSha: jest.fn(),
+    deleteFile: jest.fn(),
+    moveFile: jest.fn(),
+  },
+}));
+
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: {
+    light: jest.fn(),
+    medium: jest.fn(),
+    heavy: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    selection: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/SyncEngineService', () => ({
+  SyncEngineService: { getMode: jest.fn(async () => 'api') },
+}));
+
+jest.mock('../src/services/git/BatchGitOperations', () => ({
+  batchDeleteFiles: jest.fn(),
+}));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    deleteNote: jest.fn(async () => true),
+    getAllNotes: jest.fn(async () => []),
+    getSavedRepositories: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({
+    repositories: [{ id: 1, name: 'r', path: 'github:owner/repo', branch: 'main' }],
+    refreshRepos: jest.fn(async () => undefined),
+  }),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+  useIsFocused: () => true,
+}));
+
+jest.mock('../src/components/SearchBar', () => {
+  const { TextInput } = require('react-native');
+  return ({ value, onChangeText }: { value: string; onChangeText: (value: string) => void }) => (
+    <TextInput value={value} onChangeText={onChangeText} />
+  );
+});
+
+jest.mock('../src/components/ui', () => {
+  const actual = jest.requireActual('../src/components/ui');
+  const { Text, TouchableOpacity } = require('react-native');
+  return {
+    ...actual,
+    ScreenHeader: ({ title }: { title: string }) => <Text>{title}</Text>,
+    IconButton: ({ children, onPress }: { children?: React.ReactNode; onPress?: () => void }) => (
+      <TouchableOpacity onPress={onPress}>{children}</TouchableOpacity>
+    ),
+    useScreenHeaderHeight: () => 60,
+    SCREEN_HEADER_BASE_HEIGHT: 60,
+    SCREEN_HEADER_SUBTITLE_HEIGHT: 88,
+    useTabBarHeight: () => 84,
+    TAB_BAR_BASE_HEIGHT: 84,
+    EmptyState: () => null,
+  };
+});
+
+jest.mock('../src/components/ui/OfflineBanner', () => ({
+  OfflineBanner: () => null,
+}));
+
+jest.mock('../src/components/RepoFileTree', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockGitHubService = jest.mocked(GitHubService);
+const mockHaptics = jest.mocked(HapticService);
+const mockSyncEngine = jest.mocked(SyncEngineService);
+const mockBatchDelete = jest.mocked(batchDeleteFiles);
+const mockStorageDeleteNote = jest.mocked(StorageService.deleteNote);
+
+const fileNode: TreeNode = { name: 'note.md', path: 'notes/note.md', type: 'file', size: 128 };
+const fooFileNode: TreeNode = { name: 'foo.md', path: 'notes/foo.md', type: 'file', size: 10 };
+const dirNode: TreeNode = { name: 'docs', path: 'docs', type: 'dir' };
+
+const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+function renderTreeItem(
+  node: TreeNode,
+  callbacks: { onRefresh?: () => void; onChildDeleted?: (path: string) => void } = {},
+): RenderResult {
+  return renderWithTheme(
+    <RepoTreeItem
+      node={node}
+      owner="owner"
+      repo="repo"
+      branch="main"
+      level={0}
+      onFilePress={jest.fn()}
+      onRefresh={callbacks.onRefresh}
+      onChildDeleted={callbacks.onChildDeleted}
+    />,
+  );
+}
+
+async function flushDeferredMenuAction(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 450));
+  });
+}
+
+async function openMenuAndChooseDelete(tree: RenderResult, rowTestID: string): Promise<void> {
+  const rows = tree.getAllByTestId(rowTestID);
+  fireEvent(rows[rows.length - 1], 'longPress');
+  fireEvent.press(tree.getByTestId('context-menu.item.press-delete'));
+  await flushDeferredMenuAction();
+}
+
+async function confirmLatestAlert(buttonLabel: string): Promise<void> {
+  const calls = alertSpy.mock.calls;
+  const latest = calls[calls.length - 1];
+  const buttons = (latest?.[2] ?? []) as AlertButton[];
+  const button = buttons.find((candidate) => candidate.text === buttonLabel);
+  expect(button).toBeDefined();
+  await act(async () => {
+    await button?.onPress?.();
+  });
+}
+
+function mockFileListing(paths: string[]): void {
+  mockGitHubService.getRepoContents.mockResolvedValue(
+    paths.map((path) => ({
+      name: path.split('/').pop() ?? path,
+      path,
+      type: 'file' as const,
+      size: 10,
+      download_url: null,
+    })),
+  );
+}
+
+function runningOps(): ReturnType<typeof useGitOperationStore.getState>['ops'] {
+  return useGitOperationStore.getState().ops;
+}
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  GitSyncGate.__resetForTest();
+  useGitOperationStore.setState({ ops: {} });
+  useNoteStore.setState({ notes: [] });
+  mockGitHubService.getRepoContents.mockResolvedValue([]);
+  mockGitHubService.getFileSha.mockResolvedValue({ kind: 'found', sha: 'default' });
+  mockGitHubService.deleteFile.mockResolvedValue({ content: null, commit: { sha: '' } });
+  mockSyncEngine.getMode.mockResolvedValue('api');
+  mockBatchDelete.mockResolvedValue({ success: true, deleted: [], failed: [] });
+  mockStorageDeleteNote.mockResolvedValue(true);
+});
+
+describe('repo tree gate-aware locking', () => {
+  it('file delete publishes a running registry op + push marker and grays the row until it completes; second delete no-ops', async () => {
+    let resolveDelete: ((value: { content: null; commit: { sha: string } }) => void) | undefined;
+    mockGitHubService.deleteFile.mockReturnValue(
+      new Promise<{ content: null; commit: { sha: string } }>((resolve) => {
+        resolveDelete = resolve;
+      }),
+    );
+    const onChildDeleted = jest.fn();
+    const onRefresh = jest.fn();
+    const tree = renderTreeItem(fileNode, { onChildDeleted, onRefresh });
+
+    await openMenuAndChooseDelete(tree, 'repo-tree-item.button.file-press');
+    await confirmLatestAlert('Delete');
+
+    const ops = runningOps();
+    const deleteOp = Object.values(ops).find(
+      (op) => op.kind === 'delete' && op.repo === 'owner/repo' && op.path === 'notes/note.md',
+    );
+    expect(deleteOp).toBeDefined();
+    expect(deleteOp?.status).toBe('running');
+    expect(GitSyncGate.isPushActive('owner/repo')).toBe(true);
+
+    const row = tree.getByTestId('repo-tree-item.row');
+    expect(StyleSheet.flatten(row.props.style)?.opacity).toBe(0.45);
+
+    // Second delete press while locked must no-op: long-press is suppressed.
+    const rows = tree.getAllByTestId('repo-tree-item.button.file-press');
+    fireEvent(rows[rows.length - 1], 'longPress');
+    expect(tree.queryByTestId('context-menu.item.press-delete')).toBeNull();
+    expect(mockGitHubService.deleteFile).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveDelete?.({ content: null, commit: { sha: '' } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(GitSyncGate.isPushActive('owner/repo')).toBe(false);
+    expect(Object.values(runningOps()).some((op) => op.kind === 'delete')).toBe(false);
+    expect(onChildDeleted).toHaveBeenCalledWith('notes/note.md');
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(mockHaptics.success).toHaveBeenCalledTimes(1);
+  });
+
+  it('a pull active for the repo suppresses the long-press context menu and grays every row', async () => {
+    gitOperationRegistry.begin({
+      kind: 'pull',
+      repo: GIT_OP_ALL_REPOS,
+      status: 'running',
+      entityIds: [],
+      attempts: 0,
+    });
+
+    const tree = renderTreeItem(fileNode);
+
+    const rows = tree.getAllByTestId('repo-tree-item.button.file-press');
+    fireEvent(rows[rows.length - 1], 'longPress');
+    expect(tree.queryByTestId('context-menu.item.press-delete')).toBeNull();
+
+    const row = tree.getByTestId('repo-tree-item.row');
+    expect(StyleSheet.flatten(row.props.style)?.opacity).toBe(0.45);
+  });
+
+  it('folder delete in api mode calls batchDeleteFiles once with all collected paths', async () => {
+    mockFileListing(['docs/a.md', 'docs/b.md', 'docs/c.md', 'docs/d.md']);
+    mockBatchDelete.mockResolvedValue({
+      success: true,
+      deleted: ['docs/a.md', 'docs/b.md', 'docs/c.md', 'docs/d.md'],
+      failed: [],
+    });
+    const onChildDeleted = jest.fn();
+    const onRefresh = jest.fn();
+    const tree = renderTreeItem(dirNode, { onChildDeleted, onRefresh });
+
+    await openMenuAndChooseDelete(tree, 'repo-tree-item.button.toggle');
+    await confirmLatestAlert('Delete');
+
+    expect(mockBatchDelete).toHaveBeenCalledTimes(1);
+    expect(mockBatchDelete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'owner',
+        repo: 'repo',
+        branch: 'main',
+        paths: ['docs/a.md', 'docs/b.md', 'docs/c.md', 'docs/d.md'],
+      }),
+    );
+    expect(onChildDeleted).toHaveBeenCalledWith('docs');
+    expect(GitSyncGate.isPushActive('owner/repo')).toBe(false);
+  });
+
+  it('deleting a note file from the tree purges the matching local note via dropByFilePaths', async () => {
+    useNoteStore.setState({
+      notes: [
+        {
+          id: 'n1',
+          title: 'foo',
+          content: 'x',
+          createdAt: 1,
+          updatedAt: 1,
+          tags: [],
+          repo: 'owner/repo',
+          branch: 'main',
+          filePath: 'notes/foo.md',
+          format: 'markdown',
+        },
+      ],
+    });
+
+    const onChildDeleted = jest.fn();
+    const onRefresh = jest.fn();
+    const tree = renderTreeItem(fooFileNode, { onChildDeleted, onRefresh });
+
+    await openMenuAndChooseDelete(tree, 'repo-tree-item.button.file-press');
+    await confirmLatestAlert('Delete');
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockStorageDeleteNote).toHaveBeenCalledWith('n1');
+    expect(useNoteStore.getState().notes.some((note) => note.id === 'n1')).toBe(false);
+  });
+
+  it('Explore disables pull-to-refresh while the gate reports the repo busy', async () => {
+    GitSyncGate.markPushActive('owner/repo');
+
+    const tree = renderWithTheme(<ExploreScreen />);
+
+    const controls = tree.UNSAFE_getAllByType(RefreshControl);
+    expect(controls.length).toBeGreaterThan(0);
+    for (const control of controls) {
+      expect(control.props.enabled).toBe(false);
+    }
+  });
+});

--- a/__tests__/screens/NotesListScreen.test.tsx
+++ b/__tests__/screens/NotesListScreen.test.tsx
@@ -104,6 +104,11 @@ jest.mock('../../src/services/RepoPullService', () => ({
   pullAllFromRepos: jest.fn(async () => undefined),
 }));
 
+jest.mock('../../src/services/git/manualSync', () => ({
+  syncNow: jest.fn(async () => ({ ok: true })),
+  isSyncNowRunning: jest.fn(() => false),
+}));
+
 jest.mock('../../src/services/ShareService', () => ({
   ShareService: { shareText: jest.fn() },
 }));

--- a/__tests__/screens/NotesListScreen.test.tsx
+++ b/__tests__/screens/NotesListScreen.test.tsx
@@ -92,7 +92,12 @@ jest.mock('../../src/services/NoteSyncQueueService', () => ({
     pendingCount: jest.fn(async () => 0),
     subscribe: jest.fn(() => jest.fn()),
     drain: jest.fn(async () => ({ succeeded: 0 })),
+    enqueueNoteDeletes: jest.fn(async () => undefined),
   },
+}));
+
+jest.mock('../../src/services/StorageService', () => ({
+  StorageService: { deleteNote: jest.fn(async () => true) },
 }));
 
 jest.mock('../../src/services/RepoPullService', () => ({

--- a/__tests__/screens/TodoListScreen.test.tsx
+++ b/__tests__/screens/TodoListScreen.test.tsx
@@ -145,6 +145,11 @@ jest.mock('../../src/services/RepoPullService', () => ({
   pullAllFromRepos: jest.fn(async () => undefined),
 }));
 
+jest.mock('../../src/services/git/manualSync', () => ({
+  syncNow: jest.fn(async () => ({ ok: true })),
+  isSyncNowRunning: jest.fn(() => false),
+}));
+
 jest.mock('../../src/stores/githubActivityStore', () => ({
   githubActivity: { begin: jest.fn(), end: jest.fn() },
   useGitHubActivityStore: () => ({ inflight: 0 }),

--- a/__tests__/screens/TodoListScreen.test.tsx
+++ b/__tests__/screens/TodoListScreen.test.tsx
@@ -125,6 +125,22 @@ jest.mock('../../src/services/TodoGitHubSyncService', () => ({
   syncTodoToGitHub: jest.fn(async () => ({ success: true })),
 }));
 
+jest.mock('../../src/services/git/BatchGitOperations', () => ({
+  batchDeleteFiles: jest.fn(async () => ({ success: true, deleted: [], failed: [] })),
+}));
+
+jest.mock('../../src/services/SyncEngineService', () => ({
+  SyncEngineService: { getMode: jest.fn(async () => 'api') },
+}));
+
+jest.mock('../../src/services/StorageService', () => ({
+  StorageService: { deleteTodo: jest.fn(async () => true) },
+}));
+
+jest.mock('../../src/services/git/resolveBranch', () => ({
+  resolveBranch: jest.fn(async (_repo: string, hint?: string) => hint ?? 'main'),
+}));
+
 jest.mock('../../src/services/RepoPullService', () => ({
   pullAllFromRepos: jest.fn(async () => undefined),
 }));

--- a/__tests__/services/BatchGitOperations.test.ts
+++ b/__tests__/services/BatchGitOperations.test.ts
@@ -1,0 +1,270 @@
+jest.mock('../../src/services/GitHubService', () => ({
+  GitHubService: {
+    getBranchHead: jest.fn(),
+    getCommit: jest.fn(),
+    getTreeRaw: jest.fn(),
+    createTree: jest.fn(),
+    createCommit: jest.fn(),
+    updateRef: jest.fn(),
+    getFileSha: jest.fn(),
+    deleteFile: jest.fn(),
+  },
+}));
+
+import { GitHubService } from '../../src/services/GitHubService';
+import { batchDeleteFiles, buildTreeMinusPaths } from '../../src/services/git/BatchGitOperations';
+
+const TREE_ENTRIES = [
+  { path: 'notes', mode: '040000', type: 'tree', sha: 'tree-notes' },
+  { path: 'notes/a.md', mode: '100644', type: 'blob', sha: 'blob-a' },
+  { path: 'notes/b.md', mode: '100644', type: 'blob', sha: 'blob-b' },
+  { path: 'notes/c.md', mode: '100644', type: 'blob', sha: 'blob-c' },
+  { path: 'notes/d.md', mode: '100644', type: 'blob', sha: 'blob-d' },
+  { path: 'notes/e.md', mode: '100644', type: 'blob', sha: 'blob-e' },
+  { path: 'notes/keep.md', mode: '100644', type: 'blob', sha: 'blob-keep' },
+  { path: 'other', mode: '040000', type: 'tree', sha: 'tree-other' },
+  { path: 'other/x.md', mode: '100644', type: 'blob', sha: 'blob-x' },
+  { path: 'readme.md', mode: '100644', type: 'blob', sha: 'blob-readme' },
+];
+
+const FIVE_PATHS = [
+  'notes/a.md',
+  'notes/b.md',
+  'notes/c.md',
+  'notes/d.md',
+  'notes/e.md',
+];
+
+function happyPathMocks(headSha = 'head-1'): void {
+  (GitHubService.getBranchHead as jest.Mock).mockResolvedValue({ sha: headSha });
+  (GitHubService.getCommit as jest.Mock).mockResolvedValue({ treeSha: 'tree-root' });
+  (GitHubService.getTreeRaw as jest.Mock).mockResolvedValue(TREE_ENTRIES);
+  (GitHubService.createTree as jest.Mock).mockResolvedValue({ sha: 'new-tree-1' });
+  (GitHubService.createCommit as jest.Mock).mockResolvedValue({ sha: 'new-commit-1' });
+  (GitHubService.updateRef as jest.Mock).mockResolvedValue(undefined);
+  (GitHubService.getFileSha as jest.Mock).mockResolvedValue({ kind: 'found', sha: 'file-sha' });
+  (GitHubService.deleteFile as jest.Mock).mockResolvedValue({
+    content: null,
+    commit: { sha: 'fallback-commit' },
+  });
+}
+
+describe('batchDeleteFiles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    happyPathMocks();
+  });
+
+  test('5 paths -> ONE createTree + ONE createCommit + ONE updateRef; tree omits exactly those 5 (case 1)', async () => {
+    const result = await batchDeleteFiles({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      paths: FIVE_PATHS,
+      message: 'Delete 5 notes',
+    });
+
+    expect(result).toEqual({ success: true, deleted: FIVE_PATHS, failed: [] });
+    expect(GitHubService.getBranchHead).toHaveBeenCalledTimes(1);
+    expect(GitHubService.getCommit).toHaveBeenCalledTimes(1);
+    expect(GitHubService.getTreeRaw).toHaveBeenCalledTimes(1);
+    expect(GitHubService.createTree).toHaveBeenCalledTimes(1);
+    expect(GitHubService.createCommit).toHaveBeenCalledTimes(1);
+    expect(GitHubService.updateRef).toHaveBeenCalledTimes(1);
+    expect(GitHubService.deleteFile).not.toHaveBeenCalled();
+
+    // Full explicit tree: deleted paths gone, untouched subtree kept with its
+    // original mode/type/sha, stale 'notes' subtree dropped (its descendants
+    // were deleted), survivors preserved — no base_tree anywhere.
+    const [treeOwner, treeRepo, treePayload] = (GitHubService.createTree as jest.Mock).mock.calls[0];
+    expect(treeOwner).toBe('owner');
+    expect(treeRepo).toBe('repo');
+    expect(treePayload).toEqual([
+      { path: 'notes/keep.md', mode: '100644', type: 'blob', sha: 'blob-keep' },
+      { path: 'other', mode: '040000', type: 'tree', sha: 'tree-other' },
+      { path: 'readme.md', mode: '100644', type: 'blob', sha: 'blob-readme' },
+    ]);
+    for (const path of FIVE_PATHS) {
+      expect(treePayload.some((e: { path: string }) => e.path === path)).toBe(false);
+    }
+
+    expect(GitHubService.createCommit).toHaveBeenCalledWith(
+      'owner',
+      'repo',
+      { message: 'Delete 5 notes', tree: 'new-tree-1', parents: ['head-1'] },
+      undefined,
+    );
+    expect(GitHubService.updateRef).toHaveBeenCalledWith(
+      'owner',
+      'repo',
+      'heads/main',
+      'new-commit-1',
+      false,
+      undefined,
+    );
+  });
+
+  test('updateRef 422 once -> full retry with FRESH head, then success (case 2)', async () => {
+    (GitHubService.getBranchHead as jest.Mock)
+      .mockResolvedValueOnce({ sha: 'head-1' })
+      .mockResolvedValueOnce({ sha: 'head-2' });
+    (GitHubService.createTree as jest.Mock)
+      .mockResolvedValueOnce({ sha: 'new-tree-1' })
+      .mockResolvedValueOnce({ sha: 'new-tree-2' });
+    (GitHubService.createCommit as jest.Mock)
+      .mockResolvedValueOnce({ sha: 'new-commit-1' })
+      .mockResolvedValueOnce({ sha: 'new-commit-2' });
+    (GitHubService.updateRef as jest.Mock)
+      .mockRejectedValueOnce(Object.assign(new Error('Update is not a fast forward'), { status: 422 }))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await batchDeleteFiles({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      paths: FIVE_PATHS,
+      message: 'Delete 5 notes',
+    });
+
+    expect(result).toEqual({ success: true, deleted: FIVE_PATHS, failed: [] });
+    // Whole cycle re-ran: fresh head, new tree, new commit, second ref update.
+    expect(GitHubService.getBranchHead).toHaveBeenCalledTimes(2);
+    expect(GitHubService.getCommit).toHaveBeenCalledTimes(2);
+    expect(GitHubService.getTreeRaw).toHaveBeenCalledTimes(2);
+    expect(GitHubService.createTree).toHaveBeenCalledTimes(2);
+    expect(GitHubService.createCommit).toHaveBeenCalledTimes(2);
+    expect(GitHubService.updateRef).toHaveBeenCalledTimes(2);
+    expect((GitHubService.createCommit as jest.Mock).mock.calls[1][2].parents).toEqual(['head-2']);
+    expect(GitHubService.updateRef).toHaveBeenLastCalledWith(
+      'owner',
+      'repo',
+      'heads/main',
+      'new-commit-2',
+      false,
+      undefined,
+    );
+    expect(GitHubService.deleteFile).not.toHaveBeenCalled();
+  });
+
+  test('createTree 500 -> falls back to sequential typed-sha deleteFile for all 5 (case 3)', async () => {
+    (GitHubService.createTree as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('Internal Server Error'), { status: 500 }),
+    );
+
+    const result = await batchDeleteFiles({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      paths: FIVE_PATHS,
+      message: 'Delete 5 notes',
+    });
+
+    expect(GitHubService.createTree).toHaveBeenCalledTimes(1);
+    expect(GitHubService.createCommit).not.toHaveBeenCalled();
+    expect(GitHubService.updateRef).not.toHaveBeenCalled();
+
+    // Sequential fallback covers every path with typed-sha deletes.
+    expect(GitHubService.getFileSha).toHaveBeenCalledTimes(5);
+    expect(GitHubService.deleteFile).toHaveBeenCalledTimes(5);
+    for (const path of FIVE_PATHS) {
+      expect(GitHubService.deleteFile).toHaveBeenCalledWith(
+        'owner',
+        'repo',
+        path,
+        'Delete 5 notes',
+        'file-sha',
+        'main',
+        undefined,
+      );
+    }
+    expect(result).toEqual({ success: true, deleted: FIVE_PATHS, failed: [] });
+  });
+
+  test('1 path -> throws (case 4)', async () => {
+    await expect(
+      batchDeleteFiles({
+        owner: 'owner',
+        repo: 'repo',
+        branch: 'main',
+        paths: ['notes/a.md'],
+        message: 'Delete 1 note',
+      }),
+    ).rejects.toThrow(/at least 2 paths/);
+
+    expect(GitHubService.getBranchHead).not.toHaveBeenCalled();
+    expect(GitHubService.createTree).not.toHaveBeenCalled();
+    expect(GitHubService.deleteFile).not.toHaveBeenCalled();
+  });
+
+  test('updateRef conflict on every attempt exhausts retries then falls back', async () => {
+    (GitHubService.updateRef as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('Cannot force-update ref'), { status: 409 }),
+    );
+    // Two paths already gone remotely, one hard failure among the rest.
+    (GitHubService.getFileSha as jest.Mock).mockImplementation(async (_o, _r, path) => {
+      if (path === 'notes/a.md' || path === 'notes/b.md') return { kind: 'not-found' };
+      return { kind: 'found', sha: 'file-sha' };
+    });
+    (GitHubService.deleteFile as jest.Mock).mockImplementation(async (_o, _r, path) => {
+      if (path === 'notes/e.md') {
+        throw Object.assign(new Error('Server exploded'), { status: 500 });
+      }
+      return { content: null, commit: { sha: 'fallback-commit' } };
+    });
+
+    const result = await batchDeleteFiles({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      paths: FIVE_PATHS,
+      message: 'Delete 5 notes',
+    });
+
+    expect(GitHubService.getBranchHead).toHaveBeenCalledTimes(3);
+    expect(GitHubService.updateRef).toHaveBeenCalledTimes(3);
+    expect(result.success).toBe(false);
+    expect(result.deleted).toEqual(['notes/a.md', 'notes/b.md', 'notes/c.md', 'notes/d.md']);
+    expect(result.failed).toEqual([{ path: 'notes/e.md', error: 'Server exploded' }]);
+  });
+
+  test('fallback records lookup errors per path without aborting the batch', async () => {
+    (GitHubService.createTree as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('Bad Gateway'), { status: 502 }),
+    );
+    (GitHubService.getFileSha as jest.Mock).mockImplementation(async (_o, _r, path) => {
+      if (path === 'notes/b.md') return { kind: 'error', message: 'lookup blew up' };
+      return { kind: 'found', sha: 'file-sha' };
+    });
+
+    const result = await batchDeleteFiles({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      paths: ['notes/a.md', 'notes/b.md'],
+      message: 'Delete 2 notes',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.deleted).toEqual(['notes/a.md']);
+    expect(result.failed).toEqual([{ path: 'notes/b.md', error: 'lookup blew up' }]);
+    expect(GitHubService.deleteFile).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('buildTreeMinusPaths', () => {
+  test('keeps untouched subtrees with original mode/type and drops stale ones', () => {
+    const payload = buildTreeMinusPaths(TREE_ENTRIES, ['readme.md', 'other/x.md']);
+
+    // 'notes' is untouched: kept as ONE subtree entry (its blobs are fully
+    // described by that sha). 'other' had an internal delete so its stale
+    // subtree entry is dropped and no descendants survive.
+    expect(payload).toEqual([
+      { path: 'notes', mode: '040000', type: 'tree', sha: 'tree-notes' },
+    ]);
+  });
+
+  test('deleting a whole directory removes the subtree and everything below it', () => {
+    const payload = buildTreeMinusPaths(TREE_ENTRIES, ['notes', 'readme.md']);
+    expect(payload.map((e) => e.path)).toEqual(['other']);
+  });
+});

--- a/__tests__/services/GitSyncGate.test.ts
+++ b/__tests__/services/GitSyncGate.test.ts
@@ -1,0 +1,292 @@
+jest.mock('../../src/services/NoteGitHubSyncService', () => ({
+  syncNoteToGitHub: jest.fn(),
+  deleteNoteFromGitHub: jest.fn(),
+}));
+
+jest.mock('../../src/services/StorageService', () => ({
+  StorageService: { updateNote: jest.fn(async () => undefined) },
+}));
+
+jest.mock('../../src/services/SyncEngineService', () => ({
+  SyncEngineService: { getMode: jest.fn(async () => 'api') },
+}));
+
+jest.mock('../../src/services/AuthService', () => ({
+  AuthService: { getToken: jest.fn(async () => 'tok') },
+}));
+
+jest.mock('../../src/services/git/LocalGitWriter', () => ({
+  LocalGitWriter: { push: jest.fn(async () => ({ success: true })) },
+}));
+
+jest.mock('../../src/services/git/resolveBranch', () => ({
+  resolveBranch: jest.fn(),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
+import { syncNoteToGitHub } from '../../src/services/NoteGitHubSyncService';
+import { SyncEngineService } from '../../src/services/SyncEngineService';
+import { resolveBranch } from '../../src/services/git/resolveBranch';
+import { GitSyncGate } from '../../src/services/git/GitSyncGate';
+import { useGitOperationStore, GIT_OP_ALL_REPOS } from '../../src/stores/gitOperationStore';
+
+const CYCLE_WATCHDOG_MS = 10 * 60 * 1_000;
+const MARKER_MAX_AGE_MS = 10 * 60 * 1_000;
+
+const resolveBranchMock = resolveBranch as jest.MockedFunction<typeof resolveBranch>;
+
+const flushMicrotasks = async (): Promise<void> => {
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+};
+
+const activeOps = () =>
+  Object.values(useGitOperationStore.getState().ops).filter((op) => op.status === 'running');
+
+const opsByKind = (kind: string) =>
+  Object.values(useGitOperationStore.getState().ops).filter((op) => op.kind === kind);
+
+describe('GitSyncGate', () => {
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    GitSyncGate.__resetForTest();
+    useGitOperationStore.setState({ ops: {} });
+    await AsyncStorage.clear();
+    resolveBranchMock.mockImplementation(async (_repo, hint) => hint ?? 'main');
+    (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: true });
+    (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
+  });
+
+  afterEach(() => {
+    GitSyncGate.__resetForTest();
+    jest.useRealTimers();
+  });
+
+  test('two concurrent cycle acquires serialize — second body runs only after first release (case 1)', async () => {
+    const events: string[] = [];
+
+    const releaseA = await GitSyncGate.acquireCycle();
+    events.push('a-body');
+
+    const bPending = GitSyncGate.acquireCycle().then((release) => {
+      events.push('b-body');
+      return release;
+    });
+    const cPending = GitSyncGate.acquireCycle().then((release) => {
+      events.push('c-body');
+      return release;
+    });
+    await Promise.resolve();
+    expect(events).toEqual(['a-body']);
+    expect(GitSyncGate.isCycleHeld()).toBe(true);
+
+    releaseA();
+    const releaseB = await bPending;
+    expect(events).toEqual(['a-body', 'b-body']);
+    expect(GitSyncGate.isCycleHeld()).toBe(true);
+
+    releaseB();
+    const releaseC = await cPending;
+    expect(events).toEqual(['a-body', 'b-body', 'c-body']);
+
+    releaseC();
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+  });
+
+  test('drain-then-pull inside ONE acquisition never self-deadlocks (case 2)', async () => {
+    await NoteSyncQueueService.enqueueNoteUpsert({
+      repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+    });
+
+    const releaseCycle = await GitSyncGate.acquireCycle();
+    const order: string[] = [];
+    try {
+      // Regression: with the cycle already held, drain() must skip its own
+      // acquisition and run the body directly — awaiting acquireCycle here
+      // would wait on itself forever.
+      const result = await NoteSyncQueueService.drain();
+      order.push('drain');
+      expect(result).toMatchObject({ succeeded: 1, failed: 0, remaining: 0 });
+      expect(GitSyncGate.isCycleHeld()).toBe(true);
+
+      // The pull step of the same cycle proceeds with no gate wait.
+      order.push('pull');
+    } finally {
+      releaseCycle();
+    }
+    expect(order).toEqual(['drain', 'pull']);
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+  });
+
+  test('push marker makes the pull wait per-repo; repo S is unaffected (case 3)', async () => {
+    GitSyncGate.markPushActive('owner/R', 'main');
+    expect(GitSyncGate.isPushActive('owner/R')).toBe(true);
+    expect(GitSyncGate.isPushActive('owner/S')).toBe(false);
+    expect(GitSyncGate.isPushActive()).toBe(true);
+
+    // Repo S pull reads immediately — markers never serialize across repos.
+    await expect(GitSyncGate.waitForIdle('owner/S')).resolves.toBe(true);
+
+    // Repo R pull waits on 250ms polls until the marker clears.
+    let readR = false;
+    const pullR = GitSyncGate.waitForIdle('owner/R').then((idle) => {
+      if (idle) readR = true;
+      return idle;
+    });
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(readR).toBe(false);
+
+    GitSyncGate.clearPushActive('owner/R', 'main');
+    await jest.advanceTimersByTimeAsync(300);
+    await expect(pullR).resolves.toBe(true);
+    expect(readR).toBe(true);
+    expect(GitSyncGate.isPushActive()).toBe(false);
+  });
+
+  test('watchdog force-releases a leaked cycle after 10 minutes (case 4)', async () => {
+    const events: string[] = [];
+    const leakedRelease = await GitSyncGate.acquireCycle();
+    const waiterPending = GitSyncGate.acquireCycle().then((release) => {
+      events.push('waiter-acquired');
+      return release;
+    });
+
+    await jest.advanceTimersByTimeAsync(CYCLE_WATCHDOG_MS - 1_000);
+    expect(GitSyncGate.isCycleHeld()).toBe(true);
+    expect(events).toEqual([]);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(events).toEqual(['waiter-acquired']);
+    expect(GitSyncGate.isCycleHeld()).toBe(true);
+
+    const waiterRelease = await waiterPending;
+    // The leaked holder's late release is a no-op — the waiter owns the cycle.
+    leakedRelease();
+    expect(GitSyncGate.isCycleHeld()).toBe(true);
+    waiterRelease();
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+
+    const failedPulls = opsByKind('pull').filter((op) => op.status === 'failed');
+    expect(failedPulls).toHaveLength(1);
+    expect(failedPulls[0].repo).toBe(GIT_OP_ALL_REPOS);
+    expect(failedPulls[0].error).toMatch(/watchdog/i);
+    expect(activeOps()).toHaveLength(0);
+
+    // The gate is usable again immediately after expiry.
+    const freshRelease = await GitSyncGate.acquireCycle();
+    freshRelease();
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+  });
+
+  test('reentrant drain during a held cycle returns early, not queued behind it (case 5)', async () => {
+    let resolveSync: (value: { success: boolean }) => void = () => {};
+    (syncNoteToGitHub as jest.Mock).mockImplementation(
+      () => new Promise((res) => { resolveSync = res; }),
+    );
+
+    await NoteSyncQueueService.enqueueNoteUpsert({
+      repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+    });
+
+    const firstDrain = NoteSyncQueueService.drain();
+    // drain()'s synchronous prelude wins the reentrancy guard and acquires.
+    expect(GitSyncGate.isCycleHeld()).toBe(true);
+
+    // The reentrant call resolves with the existing early contract while the
+    // cycle is still held — proof it did not queue behind acquireCycle.
+    const second = await NoteSyncQueueService.drain();
+    expect(second).toEqual({ succeeded: 0, failed: 0, remaining: 1 });
+    expect(GitSyncGate.isCycleHeld()).toBe(true);
+
+    // Let the first drain run down to its awaiting syncNoteToGitHub call
+    // (its now-longer gated path takes more hops than the early-return above).
+    await flushMicrotasks();
+    resolveSync({ success: true });
+    const first = await firstDrain;
+    expect(first.succeeded).toBe(1);
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+  });
+
+  test('registry op visible while marker held; removed on clear (case 6)', () => {
+    GitSyncGate.markPushActive('owner/repo', 'dev');
+    const pushOps = opsByKind('push');
+    expect(pushOps).toHaveLength(1);
+    expect(pushOps[0]).toMatchObject({
+      kind: 'push',
+      repo: 'owner/repo',
+      branch: 'dev',
+      entityIds: [],
+      status: 'running',
+    });
+
+    GitSyncGate.clearPushActive('owner/repo', 'dev');
+    expect(opsByKind('push')).toHaveLength(0);
+  });
+
+  test('cycle hold publishes an app-wide pull op; release removes it', async () => {
+    const release = await GitSyncGate.acquireCycle();
+    const pullOps = opsByKind('pull');
+    expect(pullOps).toHaveLength(1);
+    expect(pullOps[0]).toMatchObject({
+      kind: 'pull',
+      repo: GIT_OP_ALL_REPOS,
+      entityIds: [],
+      status: 'running',
+    });
+
+    release();
+    expect(activeOps()).toHaveLength(0);
+  });
+
+  test('branchless markers normalize to main and double-mark refreshes without duplicating', () => {
+    GitSyncGate.markPushActive('owner/repo');
+    GitSyncGate.markPushActive('owner/repo', undefined);
+    expect(opsByKind('push')).toHaveLength(1);
+    expect(opsByKind('push')[0].branch).toBe('main');
+    expect(GitSyncGate.isPushActive('owner/repo')).toBe(true);
+
+    GitSyncGate.clearPushActive('owner/repo');
+    expect(GitSyncGate.isPushActive()).toBe(false);
+    expect(opsByKind('push')).toHaveLength(0);
+  });
+
+  test('waitForIdle resolves false when the marker outlives the timeout', async () => {
+    GitSyncGate.markPushActive('owner/R', 'main');
+
+    const wait = GitSyncGate.waitForIdle('owner/R', 1_000);
+    await jest.advanceTimersByTimeAsync(1_300);
+
+    await expect(wait).resolves.toBe(false);
+    expect(GitSyncGate.isPushActive('owner/R')).toBe(true);
+  });
+
+  test('stuck markers older than 10 minutes are swept on the next markPushActive', () => {
+    GitSyncGate.markPushActive('owner/stuck', 'main');
+
+    jest.setSystemTime(Date.now() + MARKER_MAX_AGE_MS + 1_000);
+    GitSyncGate.markPushActive('owner/fresh', 'main');
+
+    expect(GitSyncGate.isPushActive('owner/stuck')).toBe(false);
+    expect(GitSyncGate.isPushActive('owner/fresh')).toBe(true);
+    const failed = Object.values(useGitOperationStore.getState().ops).filter(
+      (op) => op.status === 'failed',
+    );
+    expect(failed).toHaveLength(1);
+    expect(failed[0].repo).toBe('owner/stuck');
+  });
+
+  test('a throwing drain body releases the cycle and clears push markers in finally', async () => {
+    (SyncEngineService.getMode as jest.Mock).mockRejectedValueOnce(new Error('mode lookup exploded'));
+    await NoteSyncQueueService.enqueueNoteUpsert({
+      repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+    });
+
+    await expect(NoteSyncQueueService.drain()).rejects.toThrow('mode lookup exploded');
+
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+    expect(GitSyncGate.isPushActive()).toBe(false);
+    expect(activeOps()).toHaveLength(0);
+  });
+});

--- a/__tests__/services/NoteSyncQueueService.test.ts
+++ b/__tests__/services/NoteSyncQueueService.test.ts
@@ -41,6 +41,10 @@ jest.mock('../../src/services/git/LocalGitWriter', () => ({
   LocalGitWriter: { push: jest.fn(async () => ({ success: true })) },
 }));
 
+jest.mock('../../src/services/git/BatchGitOperations', () => ({
+  batchDeleteFiles: jest.fn(),
+}));
+
 jest.mock('../../src/services/git/resolveBranch', () => ({
   resolveBranch: jest.fn(),
 }));
@@ -50,6 +54,7 @@ import { NoteSyncQueueService, DroppedMutationEvent } from '../../src/services/N
 import { syncNoteToGitHub, deleteNoteFromGitHub } from '../../src/services/NoteGitHubSyncService';
 import { SyncEngineService } from '../../src/services/SyncEngineService';
 import { LocalGitWriter } from '../../src/services/git/LocalGitWriter';
+import { batchDeleteFiles } from '../../src/services/git/BatchGitOperations';
 import { resolveBranch } from '../../src/services/git/resolveBranch';
 import {
   DELETE_FAILURES_STORAGE_KEY,
@@ -863,6 +868,228 @@ describe('NoteSyncQueueService', () => {
         branch: 'master',
         token: 'tok',
       });
+    });
+  });
+
+  describe('enqueueNoteDeletes (batch)', () => {
+    test('3 deletes -> ONE queue write + ONE tombstone pass with 3 tombstones (acceptance)', async () => {
+      await NoteSyncQueueService.enqueueNoteDeletes([
+        { repo: 'owner/repo', branch: 'main', filePath: 'a.md', title: 'A' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'b.md', title: 'B' },
+        { repo: 'owner/repo', filePath: 'c.md', title: 'C' },
+      ]);
+
+      const queueWrites = (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
+        ([key]: [string]) => key === QUEUE_KEY,
+      );
+      expect(queueWrites).toHaveLength(1);
+      const tombstoneWrites = (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
+        ([key]: [string]) => key === TOMBSTONE_KEY,
+      );
+      expect(tombstoneWrites).toHaveLength(1);
+
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(3);
+      // Branch resolved once per unique (repo, hint) and persisted (c.md hinted undefined).
+      expect(items.map((m) => m.params.branch)).toEqual(['main', 'main', 'main']);
+
+      const rawTombstones = await AsyncStorage.getItem(TOMBSTONE_KEY);
+      expect(Object.keys(JSON.parse(rawTombstones!)).sort()).toEqual([
+        'owner/repo::main::a.md',
+        'owner/repo::main::b.md',
+        'owner/repo::main::c.md',
+      ]);
+    });
+
+    test('dedup holds across batch + existing queue; pinned failures clear', async () => {
+      resolveBranchMock.mockImplementation(async (_repo, hint) => hint ?? 'master');
+      await AsyncStorage.setItem(
+        DELETE_FAILURES_STORAGE_KEY,
+        JSON.stringify({ 'owner/repo::master::a.md': { error: 'old', kind: 'server', at: 1 } }),
+      );
+      // Pre-existing pending upsert for b.md must be dropped by the batch delete.
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'owner/repo', filePath: 'b.md', title: 'B', content: 'x', format: 'markdown',
+      });
+
+      await NoteSyncQueueService.enqueueNoteDeletes([
+        { repo: 'owner/repo', filePath: 'a.md' },
+        { repo: 'owner/repo', filePath: 'b.md' },
+        { repo: 'owner/repo', filePath: 'b.md' },
+        { repo: 'owner/repo', filePath: 'a.md' },
+      ]);
+
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(2);
+      expect(items.map((m) => m.params.filePath).sort()).toEqual(['a.md', 'b.md']);
+      for (const m of items) {
+        expect(m.type).toBe('note.delete');
+        expect(m.params.branch).toBe('master');
+      }
+
+      // Pinned failure cleared for retried delete; tombstones pinned on resolved branch.
+      expect(await readDeleteFailures()).toEqual({});
+      expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'master', 'a.md')).toBe(true);
+      expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'master', 'b.md')).toBe(true);
+    });
+
+    test('resolveBranch runs once per unique (repo, hint), not per item', async () => {
+      await NoteSyncQueueService.enqueueNoteDeletes([
+        { repo: 'r1', filePath: 'a.md' },
+        { repo: 'r1', filePath: 'b.md' },
+        { repo: 'r1', branch: 'dev', filePath: 'c.md' },
+        { repo: 'r2', filePath: 'd.md' },
+      ]);
+      expect(resolveBranchMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('enqueueNoteUpserts (batch)', () => {
+    test('3 upserts -> ONE queue write; same-path+title dedup within the batch', async () => {
+      await NoteSyncQueueService.enqueueNoteUpserts(
+        [
+          { repo: 'owner/repo', branch: 'main', filePath: 'a.md', title: 'A', content: 'first' },
+          { repo: 'owner/repo', branch: 'main', filePath: 'a.md', title: 'A', content: 'second' },
+          { repo: 'owner/repo', branch: 'main', filePath: 'b.md', title: 'B', content: 'x' },
+        ],
+        ['note-1', 'note-1', 'note-2'],
+      );
+
+      const queueWrites = (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
+        ([key]: [string]) => key === QUEUE_KEY,
+      );
+      expect(queueWrites).toHaveLength(1);
+
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(2);
+      const a = items.find((m) => m.params.filePath === 'a.md');
+      expect(a?.type).toBe('note.upsert');
+      if (a?.type === 'note.upsert') {
+        expect(a.params.content).toBe('second');
+        expect(a.localNoteId).toBe('note-1');
+      }
+    });
+
+    test('batch upsert drops pending deletes for matching paths', async () => {
+      await NoteSyncQueueService.enqueueNoteDelete({
+        repo: 'r', branch: 'main', filePath: 'a.md', title: 'A',
+      });
+      await NoteSyncQueueService.enqueueNoteUpserts([
+        { repo: 'r', branch: 'main', filePath: 'a.md', title: 'A', content: 'rebuilt' },
+      ]);
+
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].type).toBe('note.upsert');
+    });
+  });
+
+  describe('api-mode batch delete drain', () => {
+    test('3 due deletes -> ONE batchDeleteFiles with all 3 paths; mixed outcomes mapped (acceptance)', async () => {
+      (batchDeleteFiles as jest.Mock).mockResolvedValue({
+        success: false,
+        deleted: ['a.md', 'b.md'],
+        failed: [{ path: 'c.md', error: '401 Unauthorized' }],
+      });
+      const events: DroppedMutationEvent[] = [];
+      const unsub = NoteSyncQueueService.onDroppedMutation((e) => events.push(e));
+
+      await NoteSyncQueueService.enqueueNoteDeletes([
+        { repo: 'owner/repo', branch: 'main', filePath: 'a.md', title: 'A' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'b.md', title: 'B' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'c.md', title: 'C' },
+      ]);
+      const result = await NoteSyncQueueService.drain();
+
+      expect(batchDeleteFiles).toHaveBeenCalledTimes(1);
+      expect((batchDeleteFiles as jest.Mock).mock.calls[0][0]).toMatchObject({
+        owner: 'owner',
+        repo: 'repo',
+        branch: 'main',
+        paths: ['a.md', 'b.md', 'c.md'],
+        message: 'Delete 3 notes',
+      });
+      // Per-item API path never ran for the batched group.
+      expect(deleteNoteFromGitHub).not.toHaveBeenCalled();
+
+      // Durable drop is a side channel: succeeded counts only real deletes.
+      expect(result).toEqual({ succeeded: 2, failed: 0, remaining: 0 });
+      expect(events).toHaveLength(1);
+      expect(events[0].reason).toBe('durable');
+      expect(events[0].status).toBe(401);
+      expect(events[0].mutation.params.filePath).toBe('c.md');
+
+      const failures = await readDeleteFailures();
+      expect(Object.keys(failures)).toEqual(['owner/repo::main::c.md']);
+      // Tombstones cleared for the deleted paths, pinned for the dropped one.
+      expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'main', 'a.md')).toBe(false);
+      expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'main', 'b.md')).toBe(false);
+      expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'main', 'c.md')).toBe(true);
+      unsub();
+    });
+
+    test('retryable per-path failure keeps the mutation queued with backoff', async () => {
+      (batchDeleteFiles as jest.Mock).mockResolvedValue({
+        success: false,
+        deleted: ['a.md'],
+        failed: [{ path: 'b.md', error: 'network down' }],
+      });
+      const events: DroppedMutationEvent[] = [];
+      const unsub = NoteSyncQueueService.onDroppedMutation((e) => events.push(e));
+
+      await NoteSyncQueueService.enqueueNoteDeletes([
+        { repo: 'owner/repo', branch: 'main', filePath: 'a.md' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'b.md' },
+      ]);
+      const result = await NoteSyncQueueService.drain();
+
+      expect(result).toEqual({ succeeded: 1, failed: 1, remaining: 1 });
+      expect(events).toHaveLength(0);
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].params.filePath).toBe('b.md');
+      expect(items[0].attempts).toBe(1);
+      expect(items[0].lastError).toBe('network down');
+      expect(items[0].nextRetryAt).toBeDefined();
+      unsub();
+    });
+
+    test('groups under 2 deletes and cross-repo deletes never batch together', async () => {
+      (batchDeleteFiles as jest.Mock).mockResolvedValue({
+        success: true,
+        deleted: ['a.md', 'b.md'],
+        failed: [],
+      });
+      (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({ success: true });
+
+      await NoteSyncQueueService.enqueueNoteDeletes([
+        { repo: 'owner/repo', branch: 'main', filePath: 'a.md' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'b.md' },
+        { repo: 'other/repo', branch: 'main', filePath: 'solo.md' },
+      ]);
+      const result = await NoteSyncQueueService.drain();
+
+      expect(batchDeleteFiles).toHaveBeenCalledTimes(1);
+      expect((batchDeleteFiles as jest.Mock).mock.calls[0][0].paths).toEqual(['a.md', 'b.md']);
+      // Single-delete group kept the per-item path (no trees API for singles).
+      expect(deleteNoteFromGitHub).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ succeeded: 3, failed: 0, remaining: 0 });
+    });
+
+    test('batch that throws reverts the group to per-item deleteNoteFromGitHub', async () => {
+      (batchDeleteFiles as jest.Mock).mockRejectedValue(new Error('boom'));
+      (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({ success: true });
+
+      await NoteSyncQueueService.enqueueNoteDeletes([
+        { repo: 'owner/repo', branch: 'main', filePath: 'a.md' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'b.md' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'c.md' },
+      ]);
+      const result = await NoteSyncQueueService.drain();
+
+      expect(batchDeleteFiles).toHaveBeenCalledTimes(1);
+      expect(deleteNoteFromGitHub).toHaveBeenCalledTimes(3);
+      expect(result).toEqual({ succeeded: 3, failed: 0, remaining: 0 });
     });
   });
 });

--- a/__tests__/services/NoteSyncQueueService.test.ts
+++ b/__tests__/services/NoteSyncQueueService.test.ts
@@ -20,39 +20,61 @@ jest.mock('@react-native-async-storage/async-storage', () => {
   };
 });
 
-jest.mock('../src/services/NoteGitHubSyncService', () => ({
+jest.mock('../../src/services/NoteGitHubSyncService', () => ({
   syncNoteToGitHub: jest.fn(),
   deleteNoteFromGitHub: jest.fn(),
 }));
 
-jest.mock('../src/services/StorageService', () => ({
+jest.mock('../../src/services/StorageService', () => ({
   StorageService: { updateNote: jest.fn(async () => undefined) },
 }));
 
-jest.mock('../src/services/SyncEngineService', () => ({
+jest.mock('../../src/services/SyncEngineService', () => ({
   SyncEngineService: { getMode: jest.fn(async () => 'api') },
 }));
 
-jest.mock('../src/services/AuthService', () => ({
+jest.mock('../../src/services/AuthService', () => ({
   AuthService: { getToken: jest.fn(async () => 'tok') },
 }));
 
-jest.mock('../src/services/git/LocalGitWriter', () => ({
+jest.mock('../../src/services/git/LocalGitWriter', () => ({
   LocalGitWriter: { push: jest.fn(async () => ({ success: true })) },
 }));
 
+jest.mock('../../src/services/git/resolveBranch', () => ({
+  resolveBranch: jest.fn(),
+}));
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { NoteSyncQueueService } from '../src/services/NoteSyncQueueService';
-import { syncNoteToGitHub, deleteNoteFromGitHub } from '../src/services/NoteGitHubSyncService';
-import { SyncEngineService } from '../src/services/SyncEngineService';
-import { LocalGitWriter } from '../src/services/git/LocalGitWriter';
+import { NoteSyncQueueService, DroppedMutationEvent } from '../../src/services/NoteSyncQueueService';
+import { syncNoteToGitHub, deleteNoteFromGitHub } from '../../src/services/NoteGitHubSyncService';
+import { SyncEngineService } from '../../src/services/SyncEngineService';
+import { LocalGitWriter } from '../../src/services/git/LocalGitWriter';
+import { resolveBranch } from '../../src/services/git/resolveBranch';
+import {
+  DELETE_FAILURES_STORAGE_KEY,
+  readDeleteFailures,
+} from '../../src/services/git/deleteFailures';
 
 const QUEUE_KEY = '@gitnotes:sync_queue_v1';
+const TOMBSTONE_KEY = '@gitnotes:delete_tombstones_v1';
+const TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1_000;
+
+const resolveBranchMock = resolveBranch as jest.MockedFunction<typeof resolveBranch>;
+
+// Mirrors the real resolver's contract for these tests: an explicit branch
+// short-circuits (no network/fs), otherwise fall back to 'main'. Individual
+// tests override the fallback to simulate a non-main host default branch.
+function defaultResolveBranch(repoPath: string, hint?: string | null): Promise<string> {
+  void repoPath;
+  return Promise.resolve(hint ?? 'main');
+}
 
 describe('NoteSyncQueueService', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     (AsyncStorage as unknown as { __reset: () => void }).__reset();
+    resolveBranchMock.mockImplementation(defaultResolveBranch);
   });
 
   describe('enqueueNoteUpsert', () => {
@@ -587,6 +609,256 @@ describe('NoteSyncQueueService', () => {
       expect(good).toHaveBeenCalled();
       u1();
       u2();
+    });
+  });
+
+  describe('onDroppedMutation', () => {
+    test('unsubscribe stops drop events', async () => {
+      (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({
+        success: false, error: 'Bad credentials', status: 401,
+      });
+      const events: DroppedMutationEvent[] = [];
+      const unsub = NoteSyncQueueService.onDroppedMutation((e) => events.push(e));
+      unsub();
+
+      await NoteSyncQueueService.enqueueNoteDelete({
+        repo: 'r', branch: 'main', filePath: 'a.md',
+      });
+      await NoteSyncQueueService.drain();
+      expect(events).toHaveLength(0);
+    });
+
+    test('listener errors do not break the drain', async () => {
+      (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({
+        success: false, error: 'Bad credentials', status: 401,
+      });
+      const unsub = NoteSyncQueueService.onDroppedMutation(() => {
+        throw new Error('boom');
+      });
+
+      await NoteSyncQueueService.enqueueNoteDelete({
+        repo: 'r', branch: 'main', filePath: 'a.md',
+      });
+      const result = await NoteSyncQueueService.drain();
+      expect(result.remaining).toBe(0);
+      unsub();
+    });
+  });
+
+  describe('resolved-branch tombstones', () => {
+    test('enqueueNoteDelete with undefined branch persists the resolved branch (acceptance 1)', async () => {
+      resolveBranchMock.mockImplementation(async (_repo, hint) => hint ?? 'master');
+
+      await NoteSyncQueueService.enqueueNoteDelete({
+        repo: 'owner/repo', filePath: 'notes/a.md', title: 'A',
+      });
+
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].params.branch).toBe('master');
+      expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'master', 'notes/a.md')).toBe(true);
+
+      // The raw undefined->'main' fallback key is gone (the original bug).
+      const rawTombstones = await AsyncStorage.getItem(TOMBSTONE_KEY);
+      expect(rawTombstones).not.toContain('owner/repo::main::notes/a.md');
+    });
+
+    test('enqueueNoteUpsert with undefined branch persists the resolved branch', async () => {
+      resolveBranchMock.mockImplementation(async (_repo, hint) => hint ?? 'master');
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'owner/repo', filePath: 'notes/a.md', title: 'A', content: 'x', format: 'markdown',
+      });
+
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].params.branch).toBe('master');
+    });
+  });
+
+  describe('durable-drop surfacing + failure pinning', () => {
+    test('durable 401 delete drops with an event and pins the tombstone past TTL (acceptance 2)', async () => {
+      resolveBranchMock.mockImplementation(async (_repo, hint) => hint ?? 'master');
+      (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({
+        success: false, error: 'Bad credentials', status: 401,
+      });
+
+      const events: DroppedMutationEvent[] = [];
+      const unsub = NoteSyncQueueService.onDroppedMutation((e) => events.push(e));
+
+      await NoteSyncQueueService.enqueueNoteDelete({
+        repo: 'owner/repo', filePath: 'notes/a.md', title: 'A',
+      });
+      const result = await NoteSyncQueueService.drain();
+
+      // Drop is a side channel: drain() contract stays {succeeded, failed, remaining}
+      expect(result.succeeded).toBe(0);
+      expect(result.failed).toBe(0);
+      expect(result.remaining).toBe(0);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].reason).toBe('durable');
+      expect(events[0].error).toBe('Bad credentials');
+      expect(events[0].status).toBe(401);
+      expect(events[0].mutation.type).toBe('note.delete');
+      expect(events[0].mutation.params.branch).toBe('master');
+
+      const failures = await readDeleteFailures();
+      expect(Object.keys(failures)).toEqual(['owner/repo::master::notes/a.md']);
+      expect(failures['owner/repo::master::notes/a.md']).toMatchObject({
+        error: 'Bad credentials',
+        kind: 'authentication',
+      });
+      expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'master', 'notes/a.md')).toBe(true);
+
+      // Advance past the 24h TTL — the failure entry keeps it tombstoned.
+      const base = Date.now();
+      const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => base + TOMBSTONE_TTL_MS + 60_000);
+      try {
+        expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'master', 'notes/a.md')).toBe(true);
+      } finally {
+        nowSpy.mockRestore();
+      }
+      unsub();
+    });
+
+    test('durable upsert drop records no delete failure', async () => {
+      (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: false, error: '401 Unauthorized' });
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a', title: 'A', content: '', format: 'markdown',
+      });
+      const result = await NoteSyncQueueService.drain();
+
+      expect(result.failed).toBe(0);
+      expect(result.remaining).toBe(0);
+      expect(await readDeleteFailures()).toEqual({});
+    });
+
+    test('exhausted delete (8 transient failures) drops with an event and pins (acceptance 3)', async () => {
+      (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({
+        success: false, error: 'network down',
+      });
+
+      const events: DroppedMutationEvent[] = [];
+      const unsub = NoteSyncQueueService.onDroppedMutation((e) => events.push(e));
+
+      await NoteSyncQueueService.enqueueNoteDelete({
+        repo: 'r', branch: 'main', filePath: 'a.md', title: 'A',
+      });
+
+      let virtualNow = Date.now();
+      const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => virtualNow);
+      let lastResult = { succeeded: 0, failed: 0, remaining: 1 };
+      try {
+        for (let i = 0; i < 8; i++) {
+          lastResult = await NoteSyncQueueService.drain();
+          virtualNow += 60_000;
+        }
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      expect(lastResult.failed).toBe(1);
+      expect(lastResult.remaining).toBe(0);
+      expect(events).toHaveLength(1);
+      expect(events[0].reason).toBe('exhausted');
+      expect(events[0].error).toBe('network down');
+      expect(events[0].mutation.type).toBe('note.delete');
+
+      const failures = await readDeleteFailures();
+      expect(failures['r::main::a.md']).toMatchObject({
+        error: 'network down',
+        kind: 'exhausted',
+      });
+
+      // Pinned past the TTL like the durable case.
+      const futureSpy = jest
+        .spyOn(Date, 'now')
+        .mockImplementation(() => virtualNow + TOMBSTONE_TTL_MS + 60_000);
+      try {
+        expect(await NoteSyncQueueService.isTombstoned('r', 'main', 'a.md')).toBe(true);
+      } finally {
+        futureSpy.mockRestore();
+      }
+      unsub();
+    });
+
+    test('retry re-enqueue clears the pinned failure entry (acceptance 4)', async () => {
+      (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({
+        success: false, error: 'Bad credentials', status: 401,
+      });
+
+      await NoteSyncQueueService.enqueueNoteDelete({
+        repo: 'r', branch: 'main', filePath: 'a.md', title: 'A',
+      });
+      await NoteSyncQueueService.drain();
+      expect(Object.keys(await readDeleteFailures())).toEqual(['r::main::a.md']);
+      expect(await NoteSyncQueueService.isTombstoned('r', 'main', 'a.md')).toBe(true);
+
+      await NoteSyncQueueService.enqueueNoteDelete({
+        repo: 'r', branch: 'main', filePath: 'a.md', title: 'A',
+      });
+      expect(await readDeleteFailures()).toEqual({});
+
+      // Fresh tombstone covers the retry window...
+      expect(await NoteSyncQueueService.isTombstoned('r', 'main', 'a.md')).toBe(true);
+      // ...but without the pin it expires normally past the TTL.
+      const futureSpy = jest
+        .spyOn(Date, 'now')
+        .mockImplementation(() => Date.now() + TOMBSTONE_TTL_MS + 60_000);
+      try {
+        expect(await NoteSyncQueueService.isTombstoned('r', 'main', 'a.md')).toBe(false);
+      } finally {
+        futureSpy.mockRestore();
+      }
+    });
+
+    test('failure map survives corrupted JSON', async () => {
+      await AsyncStorage.setItem(DELETE_FAILURES_STORAGE_KEY, '{not json');
+      expect(await readDeleteFailures()).toEqual({});
+      expect(await NoteSyncQueueService.isTombstoned('r', 'main', 'a.md')).toBe(false);
+    });
+  });
+
+  describe('clone-mode resolved-branch push', () => {
+    beforeEach(() => {
+      (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
+      (LocalGitWriter.push as jest.Mock).mockResolvedValue({ success: true });
+    });
+
+    afterEach(() => {
+      (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
+    });
+
+    test('group with undefined branch commits and pushes on the resolved branch (acceptance 5)', async () => {
+      resolveBranchMock.mockImplementation(async (_repo, hint) => hint ?? 'master');
+      (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: true });
+      (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({ success: true });
+
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'me/repo', filePath: 'a.md', title: 'A', content: 'x', format: 'markdown',
+      });
+      await NoteSyncQueueService.enqueueNoteDelete({
+        repo: 'me/repo', filePath: 'b.md', title: 'B',
+      });
+
+      const result = await NoteSyncQueueService.drain();
+      expect(result.succeeded).toBe(2);
+      expect(result.failed).toBe(0);
+      expect(result.remaining).toBe(0);
+
+      // Each mutation ran against the resolved branch (commit target).
+      expect((syncNoteToGitHub as jest.Mock).mock.calls[0][0].branch).toBe('master');
+      expect((deleteNoteFromGitHub as jest.Mock).mock.calls[0][0].branch).toBe('master');
+
+      // The single coalesced push targets the same resolved branch.
+      expect(LocalGitWriter.push).toHaveBeenCalledTimes(1);
+      expect(LocalGitWriter.push).toHaveBeenCalledWith({
+        repoPath: 'me/repo',
+        branch: 'master',
+        token: 'tok',
+      });
     });
   });
 });

--- a/__tests__/services/NoteSyncQueueService.test.ts
+++ b/__tests__/services/NoteSyncQueueService.test.ts
@@ -565,6 +565,10 @@ describe('NoteSyncQueueService', () => {
       expect(secondDrain.succeeded).toBe(0);
       expect(secondDrain.remaining).toBe(1);
 
+      // The sync gate adds one acquisition hop inside drain(); give the
+      // in-flight drain enough turns to reach its awaiting syncNoteToGitHub
+      // call (assigning resolveSync) before we resolve it.
+      for (let i = 0; i < 10; i += 1) await Promise.resolve();
       resolveSync({ success: true });
       const first = await firstDrain;
       expect(first.succeeded).toBe(1);

--- a/__tests__/services/git/deleteFailures.test.ts
+++ b/__tests__/services/git/deleteFailures.test.ts
@@ -1,0 +1,90 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  let store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (key: string) => (key in store ? store[key] : null)),
+      setItem: jest.fn(async (key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: jest.fn(async (key: string) => {
+        delete store[key];
+      }),
+      clear: jest.fn(async () => {
+        store = {};
+      }),
+      __reset: () => {
+        store = {};
+      },
+    },
+  };
+});
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  DELETE_FAILURES_STORAGE_KEY,
+  clearDeleteFailure,
+  deleteFailureKey,
+  readDeleteFailures,
+  recordDeleteFailure,
+} from '../../../src/services/git/deleteFailures';
+
+describe('deleteFailures', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    (AsyncStorage as unknown as { __reset: () => void }).__reset();
+  });
+
+  test('deleteFailureKey formats repo::branch::path with main fallback', () => {
+    expect(deleteFailureKey('owner/repo', 'master', 'notes/a.md'))
+      .toBe('owner/repo::master::notes/a.md');
+    expect(deleteFailureKey('owner/repo', undefined, 'notes/a.md'))
+      .toBe('owner/repo::main::notes/a.md');
+  });
+
+  test('record + read round-trips the canonical shape under the canonical key', async () => {
+    await recordDeleteFailure('owner/repo', 'master', 'notes/a.md', {
+      error: 'Bad credentials',
+      kind: 'authentication',
+      at: 12345,
+    });
+
+    const raw = await AsyncStorage.getItem(DELETE_FAILURES_STORAGE_KEY);
+    expect(raw).toBe(JSON.stringify({
+      'owner/repo::master::notes/a.md': { error: 'Bad credentials', kind: 'authentication', at: 12345 },
+    }));
+    expect(await readDeleteFailures()).toEqual({
+      'owner/repo::master::notes/a.md': { error: 'Bad credentials', kind: 'authentication', at: 12345 },
+    });
+  });
+
+  test('record overwrites the entry for the same key', async () => {
+    await recordDeleteFailure('r', 'main', 'a.md', { error: 'first', kind: 'network', at: 1 });
+    await recordDeleteFailure('r', 'main', 'a.md', { error: 'second', kind: 'exhausted', at: 2 });
+    expect(await readDeleteFailures()).toEqual({
+      'r::main::a.md': { error: 'second', kind: 'exhausted', at: 2 },
+    });
+  });
+
+  test('clear removes only the targeted key', async () => {
+    await recordDeleteFailure('r', 'main', 'a.md', { error: 'x', kind: 'network', at: 1 });
+    await recordDeleteFailure('r', 'main', 'b.md', { error: 'y', kind: 'unknown', at: 2 });
+    await clearDeleteFailure('r', 'main', 'a.md');
+    expect(await readDeleteFailures()).toEqual({
+      'r::main::b.md': { error: 'y', kind: 'unknown', at: 2 },
+    });
+  });
+
+  test('clear on an absent key is a no-op write', async () => {
+    await clearDeleteFailure('r', 'main', 'a.md');
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  test('read resolves {} for missing or corrupted payloads', async () => {
+    expect(await readDeleteFailures()).toEqual({});
+    await AsyncStorage.setItem(DELETE_FAILURES_STORAGE_KEY, '{not json');
+    expect(await readDeleteFailures()).toEqual({});
+    await AsyncStorage.setItem(DELETE_FAILURES_STORAGE_KEY, '["array"]');
+    expect(await readDeleteFailures()).toEqual({});
+  });
+});

--- a/__tests__/services/manualSync.test.ts
+++ b/__tests__/services/manualSync.test.ts
@@ -1,0 +1,183 @@
+jest.mock('../../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: { drain: jest.fn() },
+}));
+
+jest.mock('../../src/services/RepoPullService', () => ({
+  pullAllFromRepos: jest.fn(),
+  pullFromSingleRepo: jest.fn(),
+}));
+
+const mockRefreshNotes = jest.fn<() => Promise<void>>();
+const mockRefreshCanvases = jest.fn<() => Promise<void>>();
+const mockRefreshTodos = jest.fn<() => Promise<void>>();
+
+jest.mock('../../src/stores/noteStore', () => ({
+  useNoteStore: { getState: () => ({ refreshNotes: mockRefreshNotes }) },
+}));
+
+jest.mock('../../src/stores/canvasStore', () => ({
+  useCanvasStore: { getState: () => ({ refreshCanvases: mockRefreshCanvases }) },
+}));
+
+jest.mock('../../src/stores/todoStore', () => ({
+  useTodoStore: { getState: () => ({ refreshTodos: mockRefreshTodos }) },
+}));
+
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
+import { pullAllFromRepos, pullFromSingleRepo } from '../../src/services/RepoPullService';
+import type { PullResult } from '../../src/services/RepoPullService';
+import { GitSyncGate } from '../../src/services/git/GitSyncGate';
+import { isSyncNowRunning, syncNow } from '../../src/services/git/manualSync';
+
+const drainMock = jest.mocked(NoteSyncQueueService.drain);
+const pullAllMock = jest.mocked(pullAllFromRepos);
+const pullSingleMock = jest.mocked(pullFromSingleRepo);
+
+const pullResult: PullResult = { repos: 0, notes: 0, canvases: 0, todos: 0, templates: 0 };
+const SYNC_TIMEOUT_MS = 60_000;
+
+const flushMicrotasks = async (): Promise<void> => {
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+};
+
+describe('manualSync.syncNow', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    GitSyncGate.__resetForTest();
+    drainMock.mockResolvedValue({ succeeded: 0, failed: 0, remaining: 0 });
+    pullAllMock.mockResolvedValue(pullResult);
+    pullSingleMock.mockResolvedValue(pullResult);
+    mockRefreshNotes.mockResolvedValue(undefined);
+    mockRefreshCanvases.mockResolvedValue(undefined);
+    mockRefreshTodos.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    GitSyncGate.__resetForTest();
+    jest.useRealTimers();
+  });
+
+  test('runs drain → pull → store refresh inside one held gate cycle (case 1)', async () => {
+    const events: string[] = [];
+    drainMock.mockImplementation(async () => {
+      events.push(`drain:held=${GitSyncGate.isCycleHeld()}`);
+      return { succeeded: 1, failed: 0, remaining: 0 };
+    });
+    pullAllMock.mockImplementation(async () => {
+      events.push(`pull:held=${GitSyncGate.isCycleHeld()}`);
+      return pullResult;
+    });
+    mockRefreshNotes.mockImplementation(async () => {
+      events.push(`refreshNotes:held=${GitSyncGate.isCycleHeld()}`);
+    });
+    mockRefreshCanvases.mockImplementation(async () => {
+      events.push(`refreshCanvases:held=${GitSyncGate.isCycleHeld()}`);
+    });
+    mockRefreshTodos.mockImplementation(async () => {
+      events.push(`refreshTodos:held=${GitSyncGate.isCycleHeld()}`);
+    });
+
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+    const acquireSpy = jest.spyOn(GitSyncGate, 'acquireCycle');
+
+    const result = await syncNow();
+
+    expect(result).toEqual({ ok: true });
+    expect(events).toEqual([
+      'drain:held=true',
+      'pull:held=true',
+      'refreshNotes:held=true',
+      'refreshCanvases:held=true',
+      'refreshTodos:held=true',
+    ]);
+    expect(acquireSpy).toHaveBeenCalledTimes(1);
+    acquireSpy.mockRestore();
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+    expect(isSyncNowRunning()).toBe(false);
+  });
+
+  test('concurrent second call returns already-running without touching services (case 2)', async () => {
+    let resolvePull: ((result: PullResult) => void) | undefined;
+    pullAllMock.mockImplementation(
+      () =>
+        new Promise<PullResult>((resolve) => {
+          resolvePull = resolve;
+        }),
+    );
+
+    const first = syncNow();
+    await flushMicrotasks();
+    expect(isSyncNowRunning()).toBe(true);
+    expect(drainMock).toHaveBeenCalledTimes(1);
+    expect(pullAllMock).toHaveBeenCalledTimes(1);
+
+    const second = await syncNow();
+    expect(second).toEqual({ ok: false, error: 'already-running' });
+    expect(drainMock).toHaveBeenCalledTimes(1);
+    expect(pullAllMock).toHaveBeenCalledTimes(1);
+    expect(mockRefreshNotes).not.toHaveBeenCalled();
+    expect(mockRefreshCanvases).not.toHaveBeenCalled();
+    expect(mockRefreshTodos).not.toHaveBeenCalled();
+
+    resolvePull?.(pullResult);
+    const firstResult = await first;
+    expect(firstResult).toEqual({ ok: true });
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+  });
+
+  test('pull rejection returns ok:false, releases the cycle, next call allowed (case 3)', async () => {
+    pullAllMock.mockRejectedValueOnce(new Error('boom'));
+
+    const first = await syncNow();
+
+    expect(first.ok).toBe(false);
+    expect(first.error).toBe('boom');
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+    expect(isSyncNowRunning()).toBe(false);
+
+    const second = await syncNow();
+    expect(second).toEqual({ ok: true });
+    expect(pullAllMock).toHaveBeenCalledTimes(2);
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+  });
+
+  test('timeout releases the cycle when work settles and resets reentrancy (case 4)', async () => {
+    let resolvePull: ((result: PullResult) => void) | undefined;
+    pullAllMock.mockImplementation(
+      () =>
+        new Promise<PullResult>((resolve) => {
+          resolvePull = resolve;
+        }),
+    );
+
+    const pending = syncNow();
+    await flushMicrotasks();
+    expect(GitSyncGate.isCycleHeld()).toBe(true);
+
+    await jest.advanceTimersByTimeAsync(SYNC_TIMEOUT_MS);
+    const timedOut = await pending;
+    expect(timedOut).toEqual({ ok: false, error: 'Sync timed out' });
+    expect(isSyncNowRunning()).toBe(false);
+    // The timed-out work keeps holding the cycle until it actually settles.
+    expect(GitSyncGate.isCycleHeld()).toBe(true);
+
+    resolvePull?.(pullResult);
+    await flushMicrotasks();
+    expect(GitSyncGate.isCycleHeld()).toBe(false);
+
+    pullAllMock.mockResolvedValue(pullResult);
+    const next = await syncNow();
+    expect(next).toEqual({ ok: true });
+    expect(pullAllMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('single-repo option routes through pullFromSingleRepo', async () => {
+    const result = await syncNow({ repos: ['owner/repo'] });
+
+    expect(result).toEqual({ ok: true });
+    expect(pullSingleMock).toHaveBeenCalledWith('owner/repo');
+    expect(pullAllMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/stores/gitOperationStore.test.ts
+++ b/__tests__/stores/gitOperationStore.test.ts
@@ -17,6 +17,7 @@ import {
   isRepoBusy,
   hasActivePull,
   pendingRunningCount,
+  GIT_OP_ALL_REPOS,
 } from '../../src/stores/gitOperationStore';
 import type { GitOpKind } from '../../src/stores/gitOperationStore';
 
@@ -236,6 +237,19 @@ describe('gitOperationStore', () => {
       expect(hasActivePull(opsState(), 'other/repo')).toBe(true);
       expect(hasActivePull(opsState(), REPO)).toBe(false);
       expect(pendingRunningCount(opsState())).toBe(2);
+    });
+
+    it('a wildcard-repo pull op counts as busy/pulling for every repo (sync cycle op)', () => {
+      const id = beginOp({ kind: 'pull', repo: GIT_OP_ALL_REPOS, status: 'running' });
+
+      expect(isRepoBusy(opsState(), REPO)).toBe(true);
+      expect(isRepoBusy(opsState(), 'third/repo')).toBe(true);
+      expect(hasActivePull(opsState(), REPO)).toBe(true);
+      expect(hasActivePull(opsState(), 'third/repo')).toBe(true);
+
+      useGitOperationStore.getState().succeed(id);
+      expect(isRepoBusy(opsState(), REPO)).toBe(false);
+      expect(hasActivePull(opsState(), REPO)).toBe(false);
     });
   });
 

--- a/__tests__/stores/gitOperationStore.test.ts
+++ b/__tests__/stores/gitOperationStore.test.ts
@@ -1,0 +1,382 @@
+jest.mock('../../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    getAll: jest.fn(async () => []),
+    subscribe: jest.fn(() => () => {}),
+  },
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
+import type { QueuedMutation } from '../../src/services/NoteSyncQueueService';
+import {
+  useGitOperationStore,
+  gitOperationRegistry,
+  hydrate,
+  isPathLocked,
+  isEntityLocked,
+  isRepoBusy,
+  hasActivePull,
+  pendingRunningCount,
+} from '../../src/stores/gitOperationStore';
+import type { GitOpKind } from '../../src/stores/gitOperationStore';
+
+const REPO = 'owner/repo';
+const BRANCH = 'main';
+const PATH = 'notes/hello.md';
+const FAILURES_KEY = '@gitnotes:delete_failures_v1';
+
+const upsertMutation = (
+  id: string,
+  opts: { localNoteId?: string; branch?: string; filePath?: string } = {},
+): QueuedMutation => ({
+  id,
+  type: 'note.upsert',
+  createdAt: 1_000,
+  attempts: 0,
+  localNoteId: opts.localNoteId ?? 'note-1',
+  params: {
+    repo: REPO,
+    branch: opts.branch ?? BRANCH,
+    filePath: opts.filePath ?? PATH,
+    title: 'Hello',
+    content: 'content',
+  },
+});
+
+const deleteMutation = (
+  id: string,
+  opts: { branch?: string; filePath?: string } = {},
+): QueuedMutation => ({
+  id,
+  type: 'note.delete',
+  createdAt: 2_000,
+  attempts: 1,
+  params: {
+    repo: REPO,
+    branch: opts.branch ?? BRANCH,
+    filePath: opts.filePath ?? PATH,
+    title: 'Hello',
+  },
+});
+
+const seedFailureMap = (map: Record<string, { error: string; kind: string; at: number }>) =>
+  AsyncStorage.setItem(FAILURES_KEY, JSON.stringify(map));
+
+const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const opsState = () => useGitOperationStore.getState().ops;
+
+const beginOp = (
+  input: {
+    kind?: GitOpKind;
+    repo?: string;
+    branch?: string;
+    path?: string;
+    entityIds?: string[];
+    status?: 'queued' | 'running';
+  } = {},
+): string =>
+  useGitOperationStore.getState().begin({
+    kind: input.kind ?? 'delete',
+    repo: input.repo ?? REPO,
+    branch: input.branch,
+    path: input.path,
+    entityIds: input.entityIds ?? [],
+    attempts: 0,
+    status: input.status ?? 'queued',
+  });
+
+describe('gitOperationStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useGitOperationStore.setState({ ops: {} });
+    (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => []);
+    (NoteSyncQueueService.subscribe as jest.Mock).mockImplementation(() => () => {});
+    return AsyncStorage.clear();
+  });
+
+  describe('queue subscription', () => {
+    it('subscribes once (module flag) and re-derives live on queue churn', async () => {
+      let churn: (() => void) | undefined;
+      (NoteSyncQueueService.subscribe as jest.Mock).mockImplementation((cb: () => void) => {
+        churn = cb;
+        return () => {};
+      });
+
+      await hydrate();
+      expect(NoteSyncQueueService.subscribe).toHaveBeenCalledTimes(1);
+      expect(churn).toBeDefined();
+
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [upsertMutation('live-1')]);
+      expect(opsState()['live-1']).toBeUndefined();
+      churn!();
+      await flushAsync();
+      expect(opsState()['live-1']).toBeDefined();
+      expect(opsState()['live-1'].status).toBe('queued');
+
+      await hydrate();
+      await hydrate();
+      expect(NoteSyncQueueService.subscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('lifecycle actions', () => {
+    it('begin → setRunning → succeed removes the op', () => {
+      const id = beginOp({ kind: 'upsert', path: PATH, status: 'queued' });
+      expect(opsState()[id].status).toBe('queued');
+
+      useGitOperationStore.getState().setRunning(id);
+      expect(opsState()[id].status).toBe('running');
+
+      useGitOperationStore.getState().succeed(id);
+      expect(opsState()[id]).toBeUndefined();
+      expect(Object.keys(opsState())).toHaveLength(0);
+    });
+
+    it('fail keeps the op with status failed and the error message', () => {
+      const id = beginOp({ kind: 'delete', path: PATH, status: 'running' });
+
+      useGitOperationStore.getState().fail(id, 'HTTP 401');
+
+      const op = opsState()[id];
+      expect(op).toBeDefined();
+      expect(op.status).toBe('failed');
+      expect(op.error).toBe('HTTP 401');
+    });
+
+    it('retry on missing id is a no-op', () => {
+      expect(() => useGitOperationStore.getState().retry('missing-id')).not.toThrow();
+      expect(Object.keys(opsState())).toHaveLength(0);
+    });
+
+    it('retry resets a failed op to queued and clears the error', () => {
+      const id = beginOp({ kind: 'delete', path: PATH });
+      useGitOperationStore.getState().fail(id, 'boom');
+
+      useGitOperationStore.getState().retry(id);
+
+      expect(opsState()[id].status).toBe('queued');
+      expect(opsState()[id].error).toBeUndefined();
+    });
+
+    it('exposes the same actions through the gitOperationRegistry facade', () => {
+      const id = gitOperationRegistry.begin({
+        kind: 'push',
+        repo: REPO,
+        entityIds: [],
+        attempts: 0,
+        status: 'running',
+      });
+      expect(opsState()[id].status).toBe('running');
+
+      gitOperationRegistry.succeed(id);
+      expect(opsState()[id]).toBeUndefined();
+    });
+  });
+
+  describe('selectors', () => {
+    it('isPathLocked true while queued/running, false after succeed', () => {
+      const id = beginOp({ kind: 'delete', branch: BRANCH, path: PATH, status: 'queued' });
+
+      expect(isPathLocked(opsState(), REPO, BRANCH, PATH)).toBe(true);
+
+      useGitOperationStore.getState().setRunning(id);
+      expect(isPathLocked(opsState(), REPO, BRANCH, PATH)).toBe(true);
+
+      useGitOperationStore.getState().succeed(id);
+      expect(isPathLocked(opsState(), REPO, BRANCH, PATH)).toBe(false);
+    });
+
+    it('isPathLocked normalizes undefined branch to main on both sides', () => {
+      beginOp({ kind: 'upsert', branch: undefined, path: PATH });
+      expect(isPathLocked(opsState(), REPO, 'main', PATH)).toBe(true);
+
+      useGitOperationStore.setState({ ops: {} });
+      beginOp({ kind: 'upsert', branch: 'main', path: PATH });
+      expect(isPathLocked(opsState(), REPO, undefined, PATH)).toBe(true);
+    });
+
+    it('isPathLocked false for different repo, branch, or path', () => {
+      beginOp({ kind: 'upsert', branch: BRANCH, path: PATH });
+      expect(isPathLocked(opsState(), 'other/repo', BRANCH, PATH)).toBe(false);
+      expect(isPathLocked(opsState(), REPO, 'develop', PATH)).toBe(false);
+      expect(isPathLocked(opsState(), REPO, BRANCH, 'notes/other.md')).toBe(false);
+    });
+
+    it('ops without a path lock every path on their repo+branch (pull/push)', () => {
+      beginOp({ kind: 'pull', branch: BRANCH, status: 'running' });
+      expect(isPathLocked(opsState(), REPO, BRANCH, 'any/file.md')).toBe(true);
+    });
+
+    it('failed ops do not lock paths or entities', () => {
+      const id = beginOp({ kind: 'delete', branch: BRANCH, path: PATH, entityIds: ['note-1'] });
+      useGitOperationStore.getState().fail(id, 'boom');
+
+      expect(isPathLocked(opsState(), REPO, BRANCH, PATH)).toBe(false);
+      expect(isEntityLocked(opsState(), 'note-1')).toBe(false);
+    });
+
+    it('isEntityLocked via entityIds', () => {
+      const id = beginOp({ kind: 'upsert', path: PATH, entityIds: ['note-1', 'note-2'] });
+
+      expect(isEntityLocked(opsState(), 'note-1')).toBe(true);
+      expect(isEntityLocked(opsState(), 'note-2')).toBe(true);
+      expect(isEntityLocked(opsState(), 'note-3')).toBe(false);
+
+      useGitOperationStore.getState().succeed(id);
+      expect(isEntityLocked(opsState(), 'note-1')).toBe(false);
+    });
+
+    it('isRepoBusy, hasActivePull and pendingRunningCount', () => {
+      beginOp({ kind: 'push', repo: REPO, status: 'running' });
+      beginOp({ kind: 'pull', repo: 'other/repo', status: 'running' });
+
+      expect(isRepoBusy(opsState(), REPO)).toBe(true);
+      expect(isRepoBusy(opsState(), 'third/repo')).toBe(false);
+      expect(hasActivePull(opsState(), 'other/repo')).toBe(true);
+      expect(hasActivePull(opsState(), REPO)).toBe(false);
+      expect(pendingRunningCount(opsState())).toBe(2);
+    });
+  });
+
+  describe('hydrate (durable derivation)', () => {
+    it('maps mocked queue (upsert+delete) and failure entries into ops', async () => {
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [
+        upsertMutation('m-upsert', { localNoteId: 'note-42' }),
+        deleteMutation('m-delete', { filePath: 'notes/gone.md' }),
+      ]);
+      await seedFailureMap({
+        [`${REPO}::master::notes/failed.md`]: { error: 'HTTP 401', kind: 'delete', at: 12_345 },
+      });
+
+      await hydrate();
+
+      const ops = opsState();
+      expect(Object.keys(ops)).toHaveLength(3);
+
+      const upsertOp = ops['m-upsert'];
+      expect(upsertOp).toMatchObject({
+        kind: 'upsert',
+        repo: REPO,
+        branch: BRANCH,
+        path: PATH,
+        entityIds: ['note-42'],
+        status: 'queued',
+      });
+
+      const deleteOp = ops['m-delete'];
+      expect(deleteOp).toMatchObject({
+        kind: 'delete',
+        repo: REPO,
+        path: 'notes/gone.md',
+        entityIds: [],
+        status: 'queued',
+      });
+
+      const failedOp = ops[`${REPO}::master::notes/failed.md`];
+      expect(failedOp).toMatchObject({
+        kind: 'delete',
+        repo: REPO,
+        branch: 'master',
+        path: 'notes/failed.md',
+        status: 'failed',
+        error: 'HTTP 401',
+        createdAt: 12_345,
+      });
+    });
+
+    it('upsert without localNoteId maps to empty entityIds', async () => {
+      const mutation = upsertMutation('m-1');
+      delete (mutation as { localNoteId?: string }).localNoteId;
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [mutation]);
+
+      await hydrate();
+
+      expect(opsState()['m-1'].entityIds).toEqual([]);
+    });
+
+    it('corrupted queue JSON → hydrate resolves empty (no throw)', async () => {
+      (NoteSyncQueueService.getAll as jest.Mock).mockRejectedValue(new Error('corrupt queue JSON'));
+      await expect(hydrate()).resolves.toBeUndefined();
+      expect(Object.keys(opsState())).toHaveLength(0);
+
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [
+        null,
+        'garbage',
+        42,
+        { not: 'a mutation' },
+        { id: 'no-params' },
+      ]);
+      await expect(hydrate()).resolves.toBeUndefined();
+      expect(Object.keys(opsState())).toHaveLength(0);
+
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [upsertMutation('m-ok')]);
+      await AsyncStorage.setItem(FAILURES_KEY, '{{{ not json');
+      await expect(hydrate()).resolves.toBeUndefined();
+      expect(Object.keys(opsState())).toEqual(['m-ok']);
+
+      (AsyncStorage.getItem as jest.Mock).mockImplementationOnce(async () => {
+        throw new Error('storage read failure');
+      });
+      await expect(hydrate()).resolves.toBeUndefined();
+      expect(Object.keys(opsState())).toEqual(['m-ok']);
+    });
+
+    it('double-hydrate is idempotent (no duplicates per mutation id)', async () => {
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [
+        upsertMutation('m-1'),
+        deleteMutation('m-2'),
+      ]);
+      await seedFailureMap({ [`${REPO}::main::notes/f.md`]: { error: 'e', kind: 'delete', at: 1 } });
+
+      await hydrate();
+      await hydrate();
+
+      const ops = opsState();
+      expect(Object.keys(ops)).toHaveLength(3);
+      expect(Object.keys(ops).filter((id) => id === 'm-1')).toHaveLength(1);
+      expect(Object.keys(ops).filter((id) => id === 'm-2')).toHaveLength(1);
+    });
+
+    it('preserves volatile ops while rebuilding durable-derived ones', async () => {
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [upsertMutation('m-1')]);
+      await hydrate();
+      useGitOperationStore.getState().succeed('m-1');
+
+      const pushOpId = gitOperationRegistry.begin({
+        kind: 'push',
+        repo: REPO,
+        branch: BRANCH,
+        entityIds: [],
+        attempts: 0,
+        status: 'running',
+      });
+
+      await hydrate();
+
+      expect(opsState()[pushOpId]).toMatchObject({ kind: 'push', status: 'running' });
+      expect(opsState()['m-1']).toBeDefined();
+      expect(opsState()['m-1'].status).toBe('queued');
+    });
+  });
+
+  describe('lock durability across store refresh', () => {
+    it('path lock survives a simulated refresh that re-creates the note under a new id', async () => {
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [
+        upsertMutation('m-1', { localNoteId: 'note-v1' }),
+      ]);
+      await hydrate();
+      expect(isPathLocked(opsState(), REPO, BRANCH, PATH)).toBe(true);
+      expect(isEntityLocked(opsState(), 'note-v1')).toBe(true);
+
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [
+        upsertMutation('m-1', { localNoteId: 'note-v2' }),
+      ]);
+      await hydrate();
+
+      expect(isPathLocked(opsState(), REPO, BRANCH, PATH)).toBe(true);
+      expect(isEntityLocked(opsState(), 'note-v2')).toBe(true);
+      expect(isEntityLocked(opsState(), 'note-v1')).toBe(false);
+    });
+  });
+});

--- a/__tests__/stores/noteStore.test.ts
+++ b/__tests__/stores/noteStore.test.ts
@@ -124,6 +124,44 @@ describe('useNoteStore', () => {
     });
   });
 
+  describe('dropByFilePaths', () => {
+    it('purges local notes whose repo+filePath match, without touching the queue', async () => {
+      const note = makeNote('1', { repo: 'owner/repo', branch: 'main', filePath: 'notes/foo.md' });
+      useNoteStore.setState({ notes: [note, makeNote('2', { repo: 'other/repo', filePath: 'notes/foo.md' })] });
+      (StorageService.deleteNote as jest.Mock).mockResolvedValue(true);
+
+      const dropped = await useNoteStore.getState().dropByFilePaths('owner/repo', ['notes/foo.md']);
+
+      expect(dropped).toBe(1);
+      expect(StorageService.deleteNote).toHaveBeenCalledWith('1');
+      expect(NoteSyncQueueService.enqueueNoteDelete).not.toHaveBeenCalled();
+      expect(NoteSyncQueueService.drain).not.toHaveBeenCalled();
+      expect(useNoteStore.getState().notes.map((n) => n.id)).toEqual(['2']);
+    });
+
+    it('matches notes by derived default path when filePath is unset', async () => {
+      const note = makeNote('1', { repo: 'owner/repo', branch: 'main', title: 'Foo Bar', format: 'markdown' });
+      useNoteStore.setState({ notes: [note] });
+      (StorageService.deleteNote as jest.Mock).mockResolvedValue(true);
+
+      const dropped = await useNoteStore.getState().dropByFilePaths('owner/repo', ['notes/foo-bar.md']);
+
+      expect(dropped).toBe(1);
+      expect(StorageService.deleteNote).toHaveBeenCalledWith('1');
+      expect(useNoteStore.getState().notes).toHaveLength(0);
+    });
+
+    it('is a no-op when no note matches the repo or paths', async () => {
+      useNoteStore.setState({ notes: [makeNote('1', { repo: 'owner/repo', filePath: 'notes/other.md' })] });
+
+      const dropped = await useNoteStore.getState().dropByFilePaths('owner/repo', ['notes/foo.md']);
+
+      expect(dropped).toBe(0);
+      expect(StorageService.deleteNote).not.toHaveBeenCalled();
+      expect(useNoteStore.getState().notes).toHaveLength(1);
+    });
+  });
+
   describe('togglePin', () => {
     it('toggles isPinned flag', async () => {
       const note = makeNote('1', { isPinned: false });

--- a/__tests__/swipe-delete.test.tsx
+++ b/__tests__/swipe-delete.test.tsx
@@ -84,7 +84,7 @@ jest.mock('../src/contexts/NoteContext', () => {
 });
 
 jest.mock('../src/stores/noteStore', () => {
-  return { useNoteStore: mockUseNoteStore };
+  return { useNoteStore: mockUseNoteStore, deriveDefaultNotePath: jest.fn(() => null) };
 });
 
 jest.mock('../src/services/GitHubService', () => ({

--- a/__tests__/sync-locking.integration.test.ts
+++ b/__tests__/sync-locking.integration.test.ts
@@ -1,0 +1,1033 @@
+/**
+ * Integration scenarios S1–S8 for the git-operation-locking plan.
+ *
+ * What is REAL (never mocked): NoteSyncQueueService (tombstone / dedup /
+ * event / drain logic), gitOperationStore + noteStore + conflictStore,
+ * GitSyncGate, deleteFailures helpers, manualSync.syncNow.
+ *
+ * What is MOCKED (transport only): GitHubService, NoteGitHubSyncService
+ * (the per-item Contents-API transport the queue calls), LocalGitWriter,
+ * BatchGitOperations.batchDeleteFiles, StorageService, SyncEngineService,
+ * AuthService, GitFsService, branch resolution, screen chrome.
+ *
+ * Each scenario asserts USER-VISIBLE state transitions (row present /
+ * locked / removed / failed), not just service call counts.
+ */
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getTreeRecursive: jest.fn(),
+    getTreeRecursiveOrThrow: jest.fn(),
+    getFileContent: jest.fn(),
+    getFileSha: jest.fn(),
+    getFileShaCached: jest.fn(),
+    getFileShaOrNull: jest.fn(),
+    getRepoContents: jest.fn(async () => []),
+    deleteFile: jest.fn(),
+    updateFile: jest.fn(),
+    setToken: jest.fn(),
+    getBranchHead: jest.fn(),
+    getCommit: jest.fn(),
+    getTreeRaw: jest.fn(),
+    createTree: jest.fn(),
+    createCommit: jest.fn(),
+    updateRef: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/NoteGitHubSyncService', () => ({
+  syncNoteToGitHub: jest.fn(),
+  deleteNoteFromGitHub: jest.fn(),
+}));
+
+jest.mock('../src/services/git/LocalGitWriter', () => ({
+  LocalGitWriter: {
+    push: jest.fn(),
+    writeAndCommit: jest.fn(),
+    deleteAndCommit: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/git/BatchGitOperations', () => ({
+  batchDeleteFiles: jest.fn(),
+}));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    getAllNotes: jest.fn(async () => []),
+    saveAllNotes: jest.fn(async () => undefined),
+    deleteNote: jest.fn(async () => true),
+    getSavedRepositories: jest.fn(async () => []),
+    getAllCanvases: jest.fn(async () => []),
+    getAllTodos: jest.fn(async () => []),
+    updateNote: jest.fn(async () => null),
+  },
+}));
+
+jest.mock('../src/services/SyncEngineService', () => ({
+  SyncEngineService: { getMode: jest.fn(async () => 'api') },
+}));
+
+jest.mock('../src/services/AuthService', () => ({
+  AuthService: { getToken: jest.fn(async () => 'tok'), getTokenById: jest.fn(async () => 'tok') },
+}));
+
+jest.mock('../src/services/git/branchResolver', () => ({
+  resolveBranch: jest.fn(async (repo: string, hint?: string | null) => hint ?? 'main'),
+}));
+
+jest.mock('../src/services/GitService', () => ({
+  GitService: {
+    invalidateRepoFoldersCache: jest.fn(async () => undefined),
+    getBranches: jest.fn(async () => []),
+    getRepositoryFolders: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('../src/services/git/GitFsService', () => ({
+  GitFsService: {
+    getCurrentBranch: jest.fn(async () => null),
+    isCloned: jest.fn(async () => false),
+    clone: jest.fn(async () => undefined),
+    fetch: jest.fn(async () => undefined),
+    pullWithFastForward: jest.fn(async () => ({ ok: true })),
+    listTree: jest.fn(async () => []),
+    readFile: jest.fn(async () => null),
+    findMergeBase: jest.fn(async () => null),
+    getCommitOid: jest.fn(async () => null),
+    removeRepo: jest.fn(async () => undefined),
+    readBlobAtRef: jest.fn(async () => null),
+  },
+}));
+
+// Keep pullFromSingleRepo (and therefore pullNotesFromRepo reconcile) REAL so
+// S6 can prove the tombstone guard; make pullAllFromRepos a spy for S4.
+jest.mock('../src/services/RepoPullService', () => {
+  const actual = jest.requireActual('../src/services/RepoPullService');
+  return {
+    ...actual,
+    pullAllFromRepos: jest.fn(async () => ({ repos: 0, notes: 0, canvases: 0, todos: 0, templates: 0 })),
+  };
+});
+
+jest.mock('../src/services/ShareService', () => ({
+  ShareService: { shareText: jest.fn(), shareInFormat: jest.fn(async () => true), getAvailableFormats: jest.fn(() => []) },
+}));
+
+jest.mock('@react-native-community/netinfo', () => {
+  const addEventListener = jest.fn(() => jest.fn());
+  const fetch = jest.fn(() => Promise.resolve({ isConnected: true, isInternetReachable: true }));
+  return { __esModule: true, default: { addEventListener, fetch }, addEventListener, fetch };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn() }),
+  useIsFocused: () => true,
+  useRoute: () => ({ params: {} }),
+}));
+
+jest.mock('@react-navigation/native-stack', () => ({}));
+
+jest.mock('../src/contexts/NoteContext', () => {
+  const { useNoteStore: store } = jest.requireActual('../src/stores/noteStore');
+  return {
+    useNotes: () => {
+      const notes = store((s) => s.notes);
+      const isLoading = store((s) => s.isLoading);
+      return {
+        notes,
+        filteredNotes: notes,
+        isLoading,
+        searchQuery: '',
+        setSearchQuery: jest.fn(),
+        deleteNote: (id: string) => store.getState().deleteNote(id),
+        refreshNotes: async () => store.getState().refreshNotes(),
+        togglePin: async () => true,
+        error: null,
+        clearError: jest.fn(),
+        createNote: jest.fn(),
+        updateNote: jest.fn(async (input: any) => store.getState().updateNote(input) ?? null),
+        getNoteById: (id: string) => store.getState().getNoteById(id),
+      };
+    },
+  };
+});
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ authState: { token: null }, activeAccountId: null }),
+}));
+
+jest.mock('../src/contexts/RepoContext', () => ({
+  useRepos: () => ({ repositories: [{ path: 'owner/repo', name: 'repo', branch: 'main' }] }),
+}));
+
+jest.mock('../src/contexts/ViewModeContext', () => ({
+  useViewMode: () => ({ viewMode: 'list' as const, setViewMode: jest.fn() }),
+}));
+
+jest.mock('../src/contexts/FolderContext', () => ({
+  useFolders: () => ({ folders: [] }),
+}));
+
+jest.mock('../src/contexts/CanvasContext', () => ({
+  useCanvases: () => ({ canvases: [] }),
+}));
+
+jest.mock('../src/stores/githubActivityStore', () => {
+  const useStore = (() => {
+    const hook = () => ({ inflight: 0 });
+    (hook as unknown as { getState: () => unknown }).getState = () => ({ inflight: 0 });
+    return hook;
+  })();
+  return {
+    githubActivity: { begin: jest.fn(), end: jest.fn(), setProgress: jest.fn() },
+    useGitHubActivityStore: useStore,
+  };
+});
+
+jest.mock('../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({ isTablet: false, maxContentWidth: 0, columnCount: 1 }),
+}));
+
+jest.mock('../src/components/ui', () => {
+  const actual = jest.requireActual('../src/components/ui');
+  const ReactMod = require('react');
+  const { Text, TouchableOpacity } = require('react-native');
+  return {
+    ...actual,
+    ScreenHeader: ({ title }: { title: string }) => ReactMod.createElement(Text, null, title),
+    IconButton: ({ children, onPress }: { children?: React.ReactNode; onPress?: () => void }) =>
+      ReactMod.createElement(TouchableOpacity, { onPress }, children),
+    useScreenHeaderHeight: () => 60,
+    SCREEN_HEADER_BASE_HEIGHT: 60,
+    SCREEN_HEADER_SUBTITLE_HEIGHT: 88,
+    useTabBarHeight: () => 84,
+    TAB_BAR_BASE_HEIGHT: 84,
+    EmptyState: () => null,
+  };
+});
+
+jest.mock('../src/components/ui/OfflineBanner', () => ({ OfflineBanner: () => null }));
+jest.mock('../src/components/ui/ConflictBanner', () => ({ ConflictBanner: () => null }));
+
+jest.mock('../src/components/GitHubActivityIndicator', () => {
+  const ReactMod = require('react');
+  const { Text } = require('react-native');
+  return { GitHubActivityIndicator: () => ReactMod.createElement(Text, null, 'activity') };
+});
+
+jest.mock('../src/components/ColorPicker', () => ({ __esModule: true, default: () => null }));
+jest.mock('../src/components/SortPicker', () => () => null);
+jest.mock('../src/components/SearchBar', () => {
+  const ReactMod = require('react');
+  const { TextInput } = require('react-native');
+  return ({ value, onChangeText }: { value: string; onChangeText: (v: string) => void }) =>
+    ReactMod.createElement(TextInput, { testID: 'search-bar', value, onChangeText });
+});
+
+jest.mock('../src/components/notes/NoteCard', () => {
+  const ReactMod = require('react');
+  const { Pressable, Text } = require('react-native');
+  return {
+    NoteCard: ({ note, onPress, onLongPress }: { note: Note; onPress: (n: Note) => void; onLongPress?: (n: Note) => void }) =>
+      ReactMod.createElement(
+        Pressable,
+        {
+          testID: `notes-card-${note.id}`,
+          onPress: () => onPress(note),
+          onLongPress: onLongPress ? () => onLongPress(note) : undefined,
+        },
+        ReactMod.createElement(Text, null, note.title),
+      ),
+  };
+});
+
+jest.mock('../src/components/notes/NotesListHeader', () => ({ NotesListHeader: () => null }));
+jest.mock('../src/components/notes/NotesViewModePicker', () => ({ NotesViewModePicker: () => null }));
+jest.mock('../src/components/notes/NotesFilterModal', () => ({ NotesFilterModal: () => null }));
+jest.mock('../src/components/FilterBar', () => ({ FilterBar: () => null }));
+jest.mock('../src/components/notes/NotesEmptyState', () => ({ NotesEmptyState: () => null }));
+
+jest.mock('../src/components/notes/NotesContextMenu', () => {
+  const ReactMod = require('react');
+  const { Pressable, Text } = require('react-native');
+  return {
+    NotesContextMenu: ({ note, onDelete }: { note: Note | null; onDelete: (n: Note) => void }) =>
+      note
+        ? ReactMod.createElement(
+            Pressable,
+            { testID: 'notes-context-menu.delete', onPress: () => onDelete(note) },
+            ReactMod.createElement(Text, null, 'Delete'),
+          )
+        : null,
+  };
+});
+
+jest.mock('../src/components/list/SwipeableListItem', () => {
+  const ReactMod = require('react');
+  const { Pressable, View } = require('react-native');
+  return {
+    SwipeableListItem: ({ itemId, disabled, onToggleSelect, children }: any) =>
+      ReactMod.createElement(
+        View,
+        { testID: `swipeable-${itemId}` },
+        ReactMod.createElement(
+          Pressable,
+          {
+            testID: `swipeable-select-${itemId}`,
+            disabled,
+            accessibilityState: { disabled: !!disabled },
+            onPress: disabled ? undefined : onToggleSelect,
+          },
+          ReactMod.createElement(View, null, children),
+        ),
+      ),
+  };
+});
+
+jest.mock('../src/components/list/BulkActionBar', () => {
+  const ReactMod = require('react');
+  const { Pressable, Text } = require('react-native');
+  return {
+    BulkActionBar: ({ count, onDelete }: { count: number; onDelete: () => void }) =>
+      count > 0
+        ? ReactMod.createElement(
+            Pressable,
+            { testID: 'bulk-action-bar.delete', onPress: onDelete },
+            ReactMod.createElement(Text, null, `Delete ${count}`),
+          )
+        : null,
+  };
+});
+
+jest.mock('@shopify/flash-list', () => {
+  const ReactMod = require('react');
+  const { View } = require('react-native');
+  return {
+    FlashList: ReactMod.forwardRef(({ data = [], renderItem, ListEmptyComponent }: any, _ref: any) => {
+      if (!data.length) {
+        return ReactMod.createElement(View, { testID: 'flash-list-empty' }, ListEmptyComponent ?? null);
+      }
+      return ReactMod.createElement(
+        View,
+        { testID: 'flash-list' },
+        data.map((item: any, index: number) => renderItem({ item, index })),
+      );
+    }),
+  };
+});
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const ReactMod = require('react');
+  const { View } = require('react-native');
+  return ReactMod.forwardRef(({ children }: any, _ref: any) => ReactMod.createElement(View, null, children));
+});
+
+import React from 'react';
+import { Alert, View } from 'react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import { renderWithTheme } from './helpers/renderWithTheme';
+import NotesListScreen from '../src/screens/NotesListScreen';
+import { RepoTreeItem } from '../src/components/repo/RepoTreeItem';
+import { TreeNode } from '../src/components/repo/repoTreeShared';
+import { Note } from '../src/models/Note';
+import { useNoteStore } from '../src/stores/noteStore';
+import { useGitOperationStore, hydrate } from '../src/stores/gitOperationStore';
+import { useConflictStore } from '../src/stores/conflictStore';
+import { NoteSyncQueueService } from '../src/services/NoteSyncQueueService';
+import { StorageService } from '../src/services/StorageService';
+import { GitHubService } from '../src/services/GitHubService';
+import { deleteNoteFromGitHub, syncNoteToGitHub } from '../src/services/NoteGitHubSyncService';
+import { LocalGitWriter } from '../src/services/git/LocalGitWriter';
+import { batchDeleteFiles } from '../src/services/git/BatchGitOperations';
+import { SyncEngineService } from '../src/services/SyncEngineService';
+import { GitFsService } from '../src/services/git/GitFsService';
+import { GitSyncGate } from '../src/services/git/GitSyncGate';
+import { syncNow } from '../src/services/git/manualSync';
+import { pullFromSingleRepo, pullAllFromRepos } from '../src/services/RepoPullService';
+import { resolveBranch } from '../src/services/git/branchResolver';
+import { HapticService } from '../src/utils/haptics';
+import { readDeleteFailures, DELETE_FAILURES_STORAGE_KEY } from '../src/services/git/deleteFailures';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const QUEUE_KEY = '@gitnotes:sync_queue_v1';
+const TOMBSTONE_KEY = '@gitnotes:delete_tombstones_v1';
+const TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1_000;
+
+const resolveBranchMock = resolveBranch as jest.Mock;
+
+const createNote = (overrides: Partial<Note> = {}): Note => ({
+  id: `note-${Math.random().toString(36).slice(2, 8)}`,
+  title: 'Test Note',
+  content: 'Test content',
+  createdAt: 1,
+  updatedAt: 1,
+  tags: [],
+  format: 'markdown',
+  ...overrides,
+});
+
+async function flushMicrotasks(times = 12): Promise<void> {
+  for (let i = 0; i < times; i += 1) await Promise.resolve();
+}
+
+let alertSpy: jest.SpyInstance;
+
+function pressAlertButton(label: string): void {
+  const calls = alertSpy.mock.calls;
+  const latest = calls[calls.length - 1];
+  const buttons = (latest?.[2] ?? []) as Array<{ text?: string; onPress?: () => void }>;
+  const button = buttons.find((candidate) => candidate.text === label);
+  expect(button).toBeDefined();
+  act(() => {
+    button?.onPress?.();
+  });
+}
+
+async function pressAlertButtonAsync(label: string): Promise<void> {
+  const calls = alertSpy.mock.calls;
+  const latest = calls[calls.length - 1];
+  const buttons = (latest?.[2] ?? []) as Array<{ text?: string; onPress?: () => void | Promise<void> }>;
+  const button = buttons.find((candidate) => candidate.text === label);
+  expect(button).toBeDefined();
+  await act(async () => {
+    await button?.onPress?.();
+  });
+}
+
+async function flushDeferredMenuAction(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 450));
+  });
+}
+
+/**
+ * Parent wrapper around RepoTreeItem that removes the node on
+ * onChildDeleted, so S1 can assert the row is actually GONE.
+ */
+function RemovableTree({ node }: { node: TreeNode }): React.ReactElement {
+  const [removed, setRemoved] = React.useState(false);
+  if (removed) return React.createElement(View, { testID: 'tree-empty' });
+  return React.createElement(RepoTreeItem, {
+    node,
+    owner: 'owner',
+    repo: 'repo',
+    branch: 'main',
+    level: 0,
+    onFilePress: jest.fn(),
+    onRefresh: jest.fn(),
+    onChildDeleted: () => setRemoved(true),
+  });
+}
+
+function renderNotesList(): ReturnType<typeof render> {
+  return renderWithTheme(React.createElement(NotesListScreen));
+}
+
+const fileNode: TreeNode = { name: 'note.md', path: 'notes/note.md', type: 'file', size: 128 };
+
+describe('sync-locking integration scenarios S1–S8', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    GitSyncGate.__resetForTest();
+    useGitOperationStore.setState({ ops: {} });
+    useNoteStore.setState({ notes: [], isLoading: false, error: null, searchQuery: '' });
+    useConflictStore.setState({ conflicts: [], isLoading: false });
+    await AsyncStorage.clear();
+
+    // Default transport behaviors (per-test overrides use mockResolvedValueOnce
+    // or full mockImplementation so nothing leaks across tests).
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
+    (GitHubService.getFileSha as jest.Mock).mockResolvedValue({ kind: 'found', sha: 'default' });
+    (GitHubService.deleteFile as jest.Mock).mockResolvedValue({ content: null, commit: { sha: '' } });
+    (GitHubService.getRepoContents as jest.Mock).mockResolvedValue([]);
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue(null);
+    (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({ success: true });
+    (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: true, filePath: 'notes/x.md', finalContent: null });
+    (LocalGitWriter.push as jest.Mock).mockResolvedValue({ success: true });
+    (LocalGitWriter.deleteAndCommit as jest.Mock).mockResolvedValue({ success: true });
+    (LocalGitWriter.writeAndCommit as jest.Mock).mockResolvedValue({ success: true, filePath: 'x.md' });
+    (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
+    resolveBranchMock.mockImplementation(async (_repo: string, hint?: string | null) => hint ?? 'main');
+    (batchDeleteFiles as jest.Mock).mockResolvedValue({ success: true, deleted: [], failed: [] });
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([]);
+    (StorageService.saveAllNotes as jest.Mock).mockResolvedValue(undefined);
+    (StorageService.deleteNote as jest.Mock).mockResolvedValue(true);
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([]);
+    (StorageService.getAllCanvases as jest.Mock).mockResolvedValue([]);
+    (StorageService.getAllTodos as jest.Mock).mockResolvedValue([]);
+    (StorageService.updateNote as jest.Mock).mockResolvedValue(null);
+    (GitFsService.getCurrentBranch as jest.Mock).mockResolvedValue(null);
+
+    // Re-arm the Alert spy every test: afterEach restoreAllMocks() detaches
+    // module-scope spies, so a fresh spy is required per test.
+    alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+    // Boot-time hydrate (matches App bootstrap) arms the queue subscription
+    // so registry ops re-derive from durable sources on queue churn.
+    await hydrate();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('S1 BUG REPRO — repo-tree file delete skips nothing: sha {kind:error} keeps the row (no haptic, no deleteFile); retry with {kind:found} deletes and the row goes away', async () => {
+    const successHaptic = jest.spyOn(HapticService, 'success');
+
+    // FIRST attempt: sha lookup errors. The row must stay, no delete, no success haptic.
+    (GitHubService.getFileSha as jest.Mock).mockResolvedValueOnce({ kind: 'error', message: 'network' });
+
+    const tree = renderWithTheme(React.createElement(RemovableTree, { node: fileNode }));
+    expect(tree.getByText('note.md')).toBeTruthy();
+
+    const rows = tree.getAllByTestId('repo-tree-item.button.file-press');
+    fireEvent(rows[rows.length - 1], 'longPress');
+    fireEvent.press(tree.getByTestId('context-menu.item.press-delete'));
+    await flushDeferredMenuAction();
+    pressAlertButton('Delete');
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('Delete Failed', expect.stringContaining('network'));
+    });
+    // Row is STILL present (the bug was silent removal on lookup error).
+    expect(tree.getByText('note.md')).toBeTruthy();
+    expect(successHaptic).not.toHaveBeenCalled();
+    expect(GitHubService.deleteFile).not.toHaveBeenCalled();
+    // Registry op failed (drive the failed affordance) rather than silently succeeding.
+    const ops = useGitOperationStore.getState().ops;
+    const failedOp = Object.values(ops).find(
+      (op) => op.kind === 'delete' && op.repo === 'owner/repo' && op.path === 'notes/note.md',
+    );
+    expect(failedOp?.status).toBe('failed');
+    expect(failedOp?.error).toBe('network');
+    expect(GitSyncGate.isPushActive('owner/repo')).toBe(false);
+
+    // SECOND attempt via the failed-row Retry: sha now resolves -> deleteFile -> row gone.
+    (GitHubService.getFileSha as jest.Mock).mockResolvedValueOnce({ kind: 'found', sha: 's123' });
+    fireEvent.press(tree.getByTestId('repo-tree-item.button.failed'));
+    pressAlertButton('Retry');
+
+    await waitFor(() => {
+      expect(GitHubService.deleteFile).toHaveBeenCalledWith(
+        'owner',
+        'repo',
+        'notes/note.md',
+        'Delete: notes/note.md',
+        's123',
+        'main',
+      );
+    });
+    await waitFor(() => {
+      expect(tree.queryByText('note.md')).toBeNull();
+    });
+    expect(tree.getByTestId('tree-empty')).toBeTruthy();
+    expect(successHaptic).toHaveBeenCalledTimes(1);
+    expect(GitSyncGate.isPushActive('owner/repo')).toBe(false);
+  });
+
+  it('S2 — note delete locks the row (visible + spinner), drain success fires the succeeded event, StorageService.deleteNote runs and the row is removed', async () => {
+    let resolveDelete: ((value: { success: boolean }) => void) | undefined;
+    (deleteNoteFromGitHub as jest.Mock).mockImplementation(
+      () => new Promise((res) => { resolveDelete = res; }),
+    );
+
+    const note = createNote({ id: 'n2', title: 'Second', repo: 'owner/repo', branch: 'main', filePath: 'notes/second.md' });
+    useNoteStore.setState({ notes: [note], isLoading: false, error: null });
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([note]);
+
+    const screen = renderNotesList();
+    expect(screen.getByText('Second')).toBeTruthy();
+
+    fireEvent(screen.getByTestId('notes-card-n2'), 'longPress');
+    fireEvent.press(screen.getByTestId('notes-context-menu.delete'));
+
+    // User-visible: row stays, spinner shows, swipe disabled.
+    await waitFor(() => {
+      expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy();
+    });
+    expect(screen.getByText('Second')).toBeTruthy();
+    expect(screen.getByTestId('swipeable-select-n2').props.accessibilityState.disabled).toBe(true);
+
+    // Let the drain reach its transport, then report success.
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    await act(async () => {
+      resolveDelete?.({ success: true });
+    });
+
+    await waitFor(() => {
+      expect(StorageService.deleteNote).toHaveBeenCalledWith('n2');
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Second')).toBeNull();
+    });
+    expect(screen.queryByTestId('note-row.lock-spinner')).toBeNull();
+    expect(useNoteStore.getState().notes.some((n) => n.id === 'n2')).toBe(false);
+    expect(await NoteSyncQueueService.pendingCount()).toBe(0);
+  });
+
+  it('S3 — durable 401 drops with an event, the row turns failed with Retry; tombstone stays pinned past 24h while failed; Retry re-enqueues (failure cleared) and success removes the row', async () => {
+    (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({
+      success: false,
+      error: 'Bad credentials',
+      status: 401,
+    });
+
+    const note = createNote({ id: 'n3', title: 'Third', repo: 'owner/repo', branch: 'main', filePath: 'notes/third.md' });
+    useNoteStore.setState({ notes: [note], isLoading: false, error: null });
+
+    const screen = renderNotesList();
+    fireEvent(screen.getByTestId('notes-card-n3'), 'longPress');
+    fireEvent.press(screen.getByTestId('notes-context-menu.delete'));
+
+    // Durable drop -> failed row (error affordance, row still present).
+    await waitFor(() => {
+      expect(screen.getByTestId('note-row.lock-error')).toBeTruthy();
+    });
+    expect(screen.getByText('Third')).toBeTruthy();
+    expect(screen.queryByTestId('note-row.lock-spinner')).toBeNull();
+
+    // Queue drop side channel emitted once with reason 'durable'.
+    expect(await NoteSyncQueueService.pendingCount()).toBe(0);
+
+    // Failure entry persisted + tombstone PINNED past the 24h TTL while failed.
+    const failures = await readDeleteFailures();
+    expect(Object.keys(failures)).toEqual(['owner/repo::main::notes/third.md']);
+    expect(failures['owner/repo::main::notes/third.md']).toMatchObject({
+      error: 'Bad credentials',
+      kind: 'authentication',
+    });
+    const base = Date.now();
+    const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => base + TOMBSTONE_TTL_MS + 60_000);
+    try {
+      expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'main', 'notes/third.md')).toBe(true);
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    // Retry from the failed row: re-enqueues, clears the failure entry.
+    fireEvent.press(screen.getByTestId('notes-card-n3'));
+    expect(alertSpy).toHaveBeenCalledWith('Delete Failed', expect.any(String), expect.any(Array));
+    let resolveRetryDelete: ((value: { success: boolean }) => void) | undefined;
+    (deleteNoteFromGitHub as jest.Mock).mockImplementation(
+      () => new Promise((res) => { resolveRetryDelete = res; }),
+    );
+    pressAlertButton('Retry');
+
+    // The retry drain holds on the transport, so the row is observable LOCKED
+    // again (failure entry cleared, fresh tombstone, one queued delete).
+    await waitFor(() => {
+      expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy();
+    });
+    expect(await readDeleteFailures()).toEqual({});
+    expect(await NoteSyncQueueService.pendingCount()).toBe(1);
+    expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'main', 'notes/third.md')).toBe(true);
+
+    // Retry drain succeeds -> succeeded event -> storage delete + row removed.
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    await act(async () => {
+      resolveRetryDelete?.({ success: true });
+    });
+    await waitFor(() => {
+      expect(StorageService.deleteNote).toHaveBeenCalledWith('n3');
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Third')).toBeNull();
+    });
+    expect(await NoteSyncQueueService.pendingCount()).toBe(0);
+  });
+
+  it('S4 — syncNow() waits while a push marker is active for repo R; pullAllFromRepos runs only after the marker clears; an unrelated repo S proceeds in parallel', async () => {
+    jest.useFakeTimers();
+    try {
+      const pullAllSpy = pullAllFromRepos as jest.Mock;
+      const pullSingleSpy = jest.spyOn(
+        require('../src/services/RepoPullService'),
+        'pullFromSingleRepo',
+      );
+
+      // Marker held for R: syncNow must NOT read any repo until it clears.
+      GitSyncGate.markPushActive('owner/repo', 'main');
+      expect(GitSyncGate.isPushActive('owner/repo')).toBe(true);
+
+      const sync = syncNow();
+      await flushMicrotasks(20);
+      expect(pullAllSpy).not.toHaveBeenCalled();
+      expect(GitSyncGate.isCycleHeld()).toBe(true);
+      // The app-wide cycle op is published to the registry while waiting.
+      const cycleOp = Object.values(useGitOperationStore.getState().ops).find(
+        (op) => op.kind === 'pull' && op.repo === '*',
+      );
+      expect(cycleOp?.status).toBe('running');
+
+      GitSyncGate.clearPushActive('owner/repo', 'main');
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks(20);
+      await sync;
+      expect(pullAllSpy).toHaveBeenCalledTimes(1);
+      expect(GitSyncGate.isCycleHeld()).toBe(false);
+
+      // Unrelated repo S: a marker on R must not block a targeted sync of S.
+      GitSyncGate.markPushActive('owner/repo', 'main');
+      const targeted = syncNow({ repos: ['s/repo'] });
+      await flushMicrotasks(20);
+      expect(pullSingleSpy).toHaveBeenCalledWith('s/repo');
+      await targeted;
+      expect(GitSyncGate.isCycleHeld()).toBe(false);
+    } finally {
+      jest.useRealTimers();
+      GitSyncGate.__resetForTest();
+    }
+  });
+
+  it('S5 (api mode) — bulk delete of 10 notes is ONE queue write, all 10 rows lock simultaneously, and the drain routes the group through ONE batchDeleteFiles call', async () => {
+    let resolveBatch: ((value: unknown) => void) | undefined;
+    (batchDeleteFiles as jest.Mock).mockImplementation(
+      () => new Promise((res) => { resolveBatch = res; }),
+    );
+
+    const notes = Array.from({ length: 10 }, (_, i) =>
+      createNote({
+        id: `b${i}`,
+        title: `Bulk ${i}`,
+        repo: 'owner/repo',
+        branch: 'main',
+        filePath: `notes/b${i}.md`,
+      }),
+    );
+    useNoteStore.setState({ notes, isLoading: false, error: null });
+
+    const screen = renderNotesList();
+    for (let i = 0; i < 10; i += 1) {
+      fireEvent.press(screen.getByTestId(`swipeable-select-b${i}`));
+    }
+    fireEvent.press(screen.getByTestId('bulk-action-bar.delete'));
+    await pressAlertButtonAsync('Delete');
+
+    // The whole batch is enqueued in ONE queue write...
+    const queueWrites = (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
+      ([key]: [string]) => key === QUEUE_KEY,
+    );
+    expect(queueWrites).toHaveLength(1);
+    expect(NoteSyncQueueService.enqueueNoteDeletes).not.toBeUndefined();
+    const items = await NoteSyncQueueService.getAll();
+    expect(items).toHaveLength(10);
+    expect(items.every((m) => m.type === 'note.delete')).toBe(true);
+
+    // ...and every row is visible AND locked at the same time.
+    await waitFor(() => {
+      expect(screen.getAllByTestId('note-row.lock-spinner')).toHaveLength(10);
+    });
+    for (let i = 0; i < 10; i += 1) {
+      expect(screen.getByText(`Bulk ${i}`)).toBeTruthy();
+    }
+
+    // The drain coalesces the 10 due deletes into ONE batch call.
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    expect(batchDeleteFiles).toHaveBeenCalledTimes(1);
+    expect(batchDeleteFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'owner',
+        repo: 'repo',
+        branch: 'main',
+        paths: Array.from({ length: 10 }, (_, i) => `notes/b${i}.md`),
+        message: 'Delete 10 notes',
+      }),
+    );
+    expect(deleteNoteFromGitHub).not.toHaveBeenCalled();
+
+    // Remote success -> every row is removed via its succeeded event.
+    const deleted = Array.from({ length: 10 }, (_, i) => `notes/b${i}.md`);
+    await act(async () => {
+      resolveBatch?.({ success: true, deleted, failed: [] });
+    });
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('note-row.lock-spinner')).toHaveLength(0);
+    });
+    expect(await NoteSyncQueueService.pendingCount()).toBe(0);
+    expect(useNoteStore.getState().notes).toHaveLength(0);
+  });
+
+  it('S5 (clone mode) — bulk delete of 10 notes is ONE queue write, all rows lock, and the group flushes with exactly ONE LocalGitWriter.push', async () => {
+    (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
+    let resolvePush: ((value: { success: boolean }) => void) | undefined;
+    (LocalGitWriter.push as jest.Mock).mockImplementation(
+      () => new Promise((res) => { resolvePush = res; }),
+    );
+
+    const notes = Array.from({ length: 10 }, (_, i) =>
+      createNote({
+        id: `c${i}`,
+        title: `Clone ${i}`,
+        repo: 'owner/repo',
+        branch: 'main',
+        filePath: `notes/c${i}.md`,
+      }),
+    );
+    useNoteStore.setState({ notes, isLoading: false, error: null });
+
+    const screen = renderNotesList();
+    for (let i = 0; i < 10; i += 1) {
+      fireEvent.press(screen.getByTestId(`swipeable-select-c${i}`));
+    }
+    fireEvent.press(screen.getByTestId('bulk-action-bar.delete'));
+    await pressAlertButtonAsync('Delete');
+
+    const queueWrites = (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
+      ([key]: [string]) => key === QUEUE_KEY,
+    );
+    expect(queueWrites).toHaveLength(1);
+    await waitFor(() => {
+      expect(screen.getAllByTestId('note-row.lock-spinner')).toHaveLength(10);
+    });
+
+    // Clone mode: no batchDeleteFiles; per-item deleteAndCommit (push:false)
+    // then ONE coalesced push for the whole group.
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    expect(batchDeleteFiles).not.toHaveBeenCalled();
+    expect(LocalGitWriter.push).toHaveBeenCalledTimes(1);
+    expect(LocalGitWriter.push).toHaveBeenCalledWith({
+      repoPath: 'owner/repo',
+      branch: 'main',
+      token: 'tok',
+    });
+    const deleteCalls = (deleteNoteFromGitHub as jest.Mock).mock.calls;
+    expect(deleteCalls).toHaveLength(10);
+    for (const [args] of deleteCalls) {
+      expect(args.push).toBe(false);
+    }
+
+    await act(async () => {
+      resolvePush?.({ success: true });
+    });
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('note-row.lock-spinner')).toHaveLength(0);
+    });
+    expect(await NoteSyncQueueService.pendingCount()).toBe(0);
+    expect(useNoteStore.getState().notes).toHaveLength(0);
+  });
+
+  it('S6 — a delete enqueued with note.branch undefined resolves the repo default (master); the tombstone keys on master, so a pull whose remote tree still contains the file does NOT resurrect the note', async () => {
+    resolveBranchMock.mockImplementation(async (_repo: string, hint?: string | null) => hint ?? 'master');
+
+    const note = createNote({
+      id: 'n6',
+      title: 'Sixth',
+      content: 'local-original',
+      repo: 'owner/repo',
+      branch: undefined,
+      filePath: 'notes/sixth.md',
+    });
+    useNoteStore.setState({ notes: [note], isLoading: false, error: null });
+    // Transient (retryable) transport failure keeps the delete queued without
+    // completing it, so the row stays visible-and-locked through the pull.
+    (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({ success: false, error: 'network down' });
+
+    await useNoteStore.getState().deleteNote('n6');
+    await flushMicrotasks();
+
+    const items = await NoteSyncQueueService.getAll();
+    expect(items).toHaveLength(1);
+    expect(items[0].params.branch).toBe('master');
+    expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'master', 'notes/sixth.md')).toBe(true);
+    expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'main', 'notes/sixth.md')).toBe(false);
+    const rawTombstones = await AsyncStorage.getItem(TOMBSTONE_KEY);
+    expect(rawTombstones).toContain('owner/repo::master::notes/sixth.md');
+    expect(rawTombstones).not.toContain('owner/repo::main::notes/sixth.md');
+    // Row is locked (visible + spinner), not removed.
+    expect(useNoteStore.getState().notes.some((n) => n.id === 'n6')).toBe(true);
+
+    // Immediate pull: the remote tree STILL contains the file. The tombstone
+    // guard (keyed on the resolved branch) must skip it.
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
+      { path: 'notes/sixth.md', type: 'blob', sha: 'remote-sha' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue('remote changed content');
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([note]);
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([{ path: 'owner/repo', branch: undefined }]);
+
+    await pullFromSingleRepo('owner/repo');
+    expect(GitHubService.getTreeRecursiveOrThrow).toHaveBeenCalledWith('owner', 'repo', 'master');
+
+    // No resurrection: the note keeps its original local content and id and
+    // stays locked (the pull did not re-fetch/update it).
+    expect(StorageService.saveAllNotes).toHaveBeenCalled();
+    const saved = (StorageService.saveAllNotes as jest.Mock).mock.calls[0][0] as Note[];
+    expect(saved.some((n) => n.id === 'n6' && n.content === 'local-original')).toBe(true);
+    await useNoteStore.getState().refreshNotes();
+    const current = useNoteStore.getState().notes.find((n) => n.id === 'n6');
+    expect(current?.content).toBe('local-original');
+    const ops = useGitOperationStore.getState().ops;
+    expect(Object.values(ops).some((op) => op.status !== 'failed' && op.kind === 'delete' && op.path === 'notes/sixth.md')).toBe(true);
+  });
+
+  it('S7 — clone divergence lifecycle: push {success:false,error:"Push failed: diverged"} is retryable, exhausts at MAX_ATTEMPTS, drops with reason "exhausted", pins the tombstone, fails the registry op, and the conflict store keeps the local-deleted-remote-modified entry unresolved', async () => {
+    (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
+    (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({ success: true });
+    (LocalGitWriter.push as jest.Mock).mockResolvedValue({
+      success: false,
+      error: 'Push failed: diverged',
+    });
+
+    // The divergence read (RepoPullService:108) already persisted this entry;
+    // autoResolve leaves local-deleted-remote-modified unresolved by design.
+    await useConflictStore.getState().addConflict({
+      repoPath: 'owner/repo',
+      branch: 'main',
+      localRef: 'refs/heads/main',
+      remoteRef: 'refs/remotes/origin/main',
+      mergeBaseRef: 'base',
+      files: [
+        {
+          path: 'notes/diverged.md',
+          kind: 'local-deleted-remote-modified',
+          format: 'text',
+          localContent: null,
+          remoteContent: 'remote body',
+          baseContent: 'base body',
+          mergedContent: null,
+          localSha: null,
+          remoteSha: 'rsha',
+          autoResolved: false,
+        },
+      ],
+      detectedAt: Date.now(),
+    });
+
+    const note = createNote({ id: 'n7', title: 'Diverged', repo: 'owner/repo', branch: 'main', filePath: 'notes/diverged.md' });
+    useNoteStore.setState({ notes: [note], isLoading: false, error: null });
+
+    const dropped: Array<{ reason?: string; error?: string; mutation: { type: string } }> = [];
+    const unsub = NoteSyncQueueService.onDroppedMutation((e) => dropped.push(e as never));
+
+    await useNoteStore.getState().deleteNote('n7');
+    await flushMicrotasks();
+
+    // First attempt: delete commit ok (push:false), coalesced push diverges.
+    expect(LocalGitWriter.push).toHaveBeenCalledTimes(1);
+    const queued = await NoteSyncQueueService.getAll();
+    expect(queued).toHaveLength(1);
+    expect(queued[0].attempts).toBe(1);
+    expect(queued[0].lastError).toBe('Push failed: diverged');
+    // Row still visible and locked (no silent loss).
+    expect(useNoteStore.getState().notes.some((n) => n.id === 'n7')).toBe(true);
+
+    // Exhaust the retry budget.
+    let virtualNow = Date.now();
+    const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => virtualNow);
+    let lastResult = { succeeded: 0, failed: 0, remaining: 1 };
+    try {
+      for (let i = 0; i < 8; i += 1) {
+        lastResult = await NoteSyncQueueService.drain();
+        virtualNow += 60_000;
+      }
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(lastResult.failed).toBe(1);
+    expect(lastResult.remaining).toBe(0);
+    expect(LocalGitWriter.push).toHaveBeenCalledTimes(8);
+
+    // Dropped event, NOT silent.
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].reason).toBe('exhausted');
+    expect(dropped[0].error).toBe('Push failed: diverged');
+    expect(dropped[0].mutation.type).toBe('note.delete');
+
+    // Failure entry persisted + tombstone pinned past the TTL.
+    const failures = await readDeleteFailures();
+    expect(failures['owner/repo::main::notes/diverged.md']).toMatchObject({
+      error: 'Push failed: diverged',
+      kind: 'exhausted',
+    });
+    const futureSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => virtualNow + TOMBSTONE_TTL_MS + 60_000);
+    try {
+      expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'main', 'notes/diverged.md')).toBe(true);
+    } finally {
+      futureSpy.mockRestore();
+    }
+
+    // Registry: the delete op for the path is FAILED with the diverged error.
+    const ops = useGitOperationStore.getState().ops;
+    const failedOp = Object.values(ops).find(
+      (op) => op.kind === 'delete' && op.path === 'notes/diverged.md' && op.status === 'failed',
+    );
+    expect(failedOp).toBeDefined();
+    expect(failedOp?.error).toContain('diverged');
+
+    // Linkage with the conflict store: the local-deleted-remote-modified
+    // entry is still there and NOT auto-resolved.
+    const conflict = useConflictStore.getState().getConflict('owner/repo', 'main');
+    expect(conflict).toBeDefined();
+    const file = conflict?.files.find((f) => f.path === 'notes/diverged.md');
+    expect(file?.kind).toBe('local-deleted-remote-modified');
+    expect(file?.autoResolved).toBe(false);
+    expect(useConflictStore.getState().totalUnresolvedFiles()).toBeGreaterThanOrEqual(1);
+
+    unsub();
+  });
+
+  it('S8 — restart: seeded AsyncStorage queue + failure map hydrate into the registry; rows render locked (queued) and failed BEFORE any drain runs', async () => {
+    const now = Date.now();
+    await AsyncStorage.setItem(
+      QUEUE_KEY,
+      JSON.stringify([
+        {
+          id: 'restart-queued',
+          type: 'note.delete',
+          createdAt: now,
+          attempts: 0,
+          params: { repo: 'owner/repo', branch: 'main', filePath: 'notes/restart-queued.md', title: 'Restart queued', localNoteId: 'restart-queued' },
+        },
+      ]),
+    );
+    await AsyncStorage.setItem(
+      DELETE_FAILURES_STORAGE_KEY,
+      JSON.stringify({
+        'owner/repo::main::notes/restart-failed.md': { error: 'Bad credentials', kind: 'authentication', at: now },
+      }),
+    );
+
+    const queuedNote = createNote({ id: 'restart-queued', title: 'Restart queued', repo: 'owner/repo', branch: 'main', filePath: 'notes/restart-queued.md' });
+    const failedNote = createNote({ id: 'restart-failed', title: 'Restart failed', repo: 'owner/repo', branch: 'main', filePath: 'notes/restart-failed.md' });
+    useNoteStore.setState({ notes: [queuedNote, failedNote], isLoading: false, error: null });
+    useGitOperationStore.setState({ ops: {} });
+
+    // Boot hydrate re-derives ops from the seeded durable sources.
+    await hydrate();
+
+    const ops = useGitOperationStore.getState().ops;
+    const queuedOp = Object.values(ops).find((op) => op.id === 'restart-queued');
+    expect(queuedOp).toBeDefined();
+    expect(queuedOp?.status).toBe('queued');
+    expect(queuedOp?.kind).toBe('delete');
+    expect(queuedOp?.entityIds).toContain('restart-queued');
+    const failedOp = Object.values(ops).find((op) => op.id === 'owner/repo::main::notes/restart-failed.md');
+    expect(failedOp).toBeDefined();
+    expect(failedOp?.status).toBe('failed');
+    expect(failedOp?.error).toBe('Bad credentials');
+
+    // Rows render locked/failed BEFORE any drain (kill-safety).
+    const screen = renderNotesList();
+    expect(screen.getByText('Restart queued')).toBeTruthy();
+    expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy();
+    expect(screen.getByText('Restart failed')).toBeTruthy();
+    expect(screen.getByTestId('note-row.lock-error')).toBeTruthy();
+    expect(deleteNoteFromGitHub).not.toHaveBeenCalled();
+    expect(await NoteSyncQueueService.pendingCount()).toBe(1);
+  });
+});

--- a/src/components/ConnectHostModal.tsx
+++ b/src/components/ConnectHostModal.tsx
@@ -394,9 +394,12 @@ export function ConnectHostModal({
                 opacity: isTesting || !token.trim() ? 0.6 : 1,
               }}
             >
-              <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600' }}>
-                {isTesting ? '…' : t('connectHost.test')}
-              </Text>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[2] }}>
+                <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600' }}>
+                  {t('connectHost.test')}
+                </Text>
+                {isTesting ? <ActivityIndicator size="small" color={colors.text} /> : null}
+              </View>
             </TouchableOpacity>
             <TouchableOpacity
               onPress={handleSave}

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -9,6 +9,7 @@ export interface ContextMenuItem {
   label: string;
   onPress: () => void;
   destructive?: boolean;
+  disabled?: boolean;
   subtitle?: string;
   testID?: string;
 }
@@ -76,7 +77,7 @@ export default function ContextMenu({
                 key={i}
                 testID={item.testID ?? `context-menu.item.press-${item.label.toLowerCase().replace(/\s+/g, '-')}`}
               style={styles.item}
-              onPress={() => {
+              onPress={item.disabled ? undefined : () => {
                 onClose();
                 if (Platform.OS === 'ios') {
                   // Defer until parent modal finishes dismissing — otherwise UIKit
@@ -86,18 +87,19 @@ export default function ContextMenu({
                   item.onPress();
                 }
               }}
+              disabled={item.disabled}
               activeOpacity={0.7}
             >
               <Ionicons
                 name={item.icon}
                 size={20}
-                color={item.destructive ? colors.error : colors.primary}
+                color={item.disabled ? colors.textSecondary : item.destructive ? colors.error : colors.primary}
               />
               <View style={styles.itemTextContainer}>
                 <Text
                   style={[
                     styles.itemText,
-                    { color: item.destructive ? colors.error : colors.text },
+                    { color: item.disabled ? colors.textSecondary : item.destructive ? colors.error : colors.text },
                   ]}
                 >
                   {item.label}

--- a/src/components/FolderSelectionDialog.tsx
+++ b/src/components/FolderSelectionDialog.tsx
@@ -8,6 +8,7 @@ import {
   Alert,
   Platform,
   ScrollView,
+  ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -280,11 +281,15 @@ export default function FolderSelectionDialog({
               maxLength={50}
             />
             <TouchableOpacity
-              style={[styles.createButton, { backgroundColor: colors.primary }]}
+              style={[
+                styles.createButton,
+                { backgroundColor: colors.primary, opacity: isSubmitting ? 0.7 : 1 },
+              ]}
               onPress={handleCreateFolder}
               disabled={!newFolderName.trim() || isSubmitting}
             >
-              <Text style={styles.createButtonText}>{isSubmitting ? 'Creating…' : 'Create'}</Text>
+              {isSubmitting ? <ActivityIndicator size="small" color="#fff" /> : null}
+              <Text style={styles.createButtonText}>Create</Text>
             </TouchableOpacity>
           </View>
         )}
@@ -403,6 +408,10 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
   createButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
     paddingHorizontal: 16,
     paddingVertical: 10,
     borderRadius: 8,

--- a/src/components/GitHubActivityIndicator.tsx
+++ b/src/components/GitHubActivityIndicator.tsx
@@ -64,6 +64,8 @@ export function GitHubActivityIndicator() {
   const progress = useGitHubActivityStore((s) => s.progress);
   const [pendingCount, setPendingCount] = useState(0);
 
+  const safeLabel = (label ?? 'Syncing with GitHub').replace(/…+$/, '');
+
   const opacity = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(-12)).current;
 
@@ -118,7 +120,7 @@ export function GitHubActivityIndicator() {
             style={{ color: colors.text, fontSize: type.sm, fontWeight: '600' }}
             numberOfLines={1}
           >
-            {label ?? 'Syncing with GitHub…'}
+            {safeLabel}
             {pendingCount > 0 ? ` (${pendingCount} pending)` : ''}
           </Text>
           {progress && <ProgressBar progress={progress} color={colors.accent} />}

--- a/src/components/RepoFileTree.tsx
+++ b/src/components/RepoFileTree.tsx
@@ -55,9 +55,6 @@ export default function RepoFileTree({ owner, repo, branch, onFilePress }: RepoF
     return (
       <View style={[treeStyles.center]}>
         <ActivityIndicator size="large" color={colors.primary} />
-        <Text style={[treeStyles.loadingText, { color: colors.textSecondary }]}>
-          Loading file tree…
-        </Text>
       </View>
     );
   }

--- a/src/components/StartupSyncGate.tsx
+++ b/src/components/StartupSyncGate.tsx
@@ -8,6 +8,7 @@ import {
   subscribeForegroundSync,
   acquireExternalSync,
 } from '../services/ForegroundSyncService';
+import { GitSyncGate } from '../services/git/GitSyncGate';
 import { useNotes } from '../contexts/NoteContext';
 import { useCanvases } from '../contexts/CanvasContext';
 import { useTodos } from '../contexts/TodoContext';
@@ -72,8 +73,13 @@ export function StartupSyncGate({ children }: { children: React.ReactNode }) {
       try {
         await GitHubService.initialize();
         if (!GitHubService.isAuthenticated()) return;
-        await NoteSyncQueueService.drain();
-        await pullAllFromRepos();
+        const releaseCycle = await GitSyncGate.acquireCycle();
+        try {
+          await NoteSyncQueueService.drain();
+          await pullAllFromRepos();
+        } finally {
+          releaseCycle();
+        }
       } catch (error) {
         console.warn('[SyncDrain] Failed:', error);
       } finally {

--- a/src/components/StartupSyncGate.tsx
+++ b/src/components/StartupSyncGate.tsx
@@ -1,14 +1,12 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { AppState } from 'react-native';
-import { pullAllFromRepos } from '../services/RepoPullService';
 import { GitHubService } from '../services/GitHubService';
-import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
 import {
   isForegroundSyncInFlight,
   subscribeForegroundSync,
   acquireExternalSync,
 } from '../services/ForegroundSyncService';
-import { GitSyncGate } from '../services/git/GitSyncGate';
+import { syncNow } from '../services/git/manualSync';
 import { useNotes } from '../contexts/NoteContext';
 import { useCanvases } from '../contexts/CanvasContext';
 import { useTodos } from '../contexts/TodoContext';
@@ -45,8 +43,10 @@ export function StartupSyncGate({ children }: { children: React.ReactNode }) {
 
     (async () => {
       try {
+        // initialize() must stay before the pull; do NOT hold a gate cycle
+        // here — syncNow acquires it internally and would deadlock otherwise.
         await GitHubService.initialize();
-        await pullAllFromRepos();
+        await syncNow();
       } catch (error) {
         console.warn('[StartupSync] Pull failed:', error);
       } finally {
@@ -73,13 +73,9 @@ export function StartupSyncGate({ children }: { children: React.ReactNode }) {
       try {
         await GitHubService.initialize();
         if (!GitHubService.isAuthenticated()) return;
-        const releaseCycle = await GitSyncGate.acquireCycle();
-        try {
-          await NoteSyncQueueService.drain();
-          await pullAllFromRepos();
-        } finally {
-          releaseCycle();
-        }
+        // Do NOT wrap this in a gate cycle: syncNow acquires the cycle
+        // itself, and holding one here would deadlock its acquisition.
+        await syncNow();
       } catch (error) {
         console.warn('[SyncDrain] Failed:', error);
       } finally {

--- a/src/components/VoiceInputModal.tsx
+++ b/src/components/VoiceInputModal.tsx
@@ -219,7 +219,7 @@ export default function VoiceInputModal({ visible, onDone, onClose }: VoiceInput
               : error
                 ? error
                 : isListening
-                  ? 'Listening…'
+                  ? 'Listening'
                   : transcript
                     ? 'Paused — tap to continue'
                     : 'Tap to speak'}
@@ -231,7 +231,7 @@ export default function VoiceInputModal({ visible, onDone, onClose }: VoiceInput
               <Text style={styles.interimText}>{interim}</Text>
             </Text>
             {!transcript && !interim && (
-              <Text style={styles.placeholder}>Your speech will appear here…</Text>
+              <Text style={styles.placeholder}>Your speech will appear here</Text>
             )}
           </ScrollView>
         </View>

--- a/src/components/ai/ContextPickerModal.tsx
+++ b/src/components/ai/ContextPickerModal.tsx
@@ -177,7 +177,6 @@ export default function ContextPickerModal({
     treeLoading ? (
       <View style={styles.placeholderContainer}>
         <ActivityIndicator color={colors.accent} />
-        <Text style={[styles.placeholderText, { color: colors.textSecondary }]}>Loading files…</Text>
       </View>
     ) : treeError ? (
       renderEmptyState('alert-circle-outline', 'Files unavailable', treeError)
@@ -229,7 +228,6 @@ export default function ContextPickerModal({
     treeLoading ? (
       <View style={styles.placeholderContainer}>
         <ActivityIndicator color={colors.accent} />
-        <Text style={[styles.placeholderText, { color: colors.textSecondary }]}>Loading folders…</Text>
       </View>
     ) : treeError ? (
       renderEmptyState('alert-circle-outline', 'Folders unavailable', treeError)

--- a/src/components/editor/EditorHeader.tsx
+++ b/src/components/editor/EditorHeader.tsx
@@ -3,19 +3,30 @@ import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 
 import { useTheme } from '../../contexts/ThemeContext';
 import { Button } from '../ui';
+import { useEntityLock } from '../../hooks/useGitOpLock';
+import type { UseEntityLockOptions } from '../../hooks/useGitOpLock';
 
 interface EditorHeaderProps {
   noteId?: string;
   isSaving: boolean;
   onCancel: () => void;
   onSave: () => void;
+  lockCtx?: UseEntityLockOptions;
 }
 
-export function EditorHeader({ noteId, isSaving, onCancel, onSave }: EditorHeaderProps) {
+export function EditorHeader({ noteId, isSaving, onCancel, onSave, lockCtx }: EditorHeaderProps) {
   const { colors } = useTheme();
-  const saveTrailingIcon = isSaving ? (
-    <ActivityIndicator testID="note-editor.button.save-spinner" size="small" color={colors.textSecondary} />
-  ) : null;
+  const lock = useEntityLock(noteId, lockCtx);
+  const saveLocked = lock.locked || lock.failed;
+  const saveDisabled = isSaving || saveLocked;
+  const saveTrailingIcon =
+    isSaving || saveLocked ? (
+      <ActivityIndicator
+        testID={isSaving ? 'note-editor.button.save-spinner' : 'note-editor.button.save-lock-spinner'}
+        size="small"
+        color={colors.textSecondary}
+      />
+    ) : null;
 
   return (
     <View style={[styles.header, { borderBottomColor: colors.border, backgroundColor: colors.surface }]}>
@@ -29,10 +40,10 @@ export function EditorHeader({ noteId, isSaving, onCancel, onSave }: EditorHeade
           label="Save"
           testID="note-editor.button.save"
           onPress={onSave}
-          disabled={isSaving}
+          disabled={saveDisabled}
           trailingIcon={saveTrailingIcon}
-          style={isSaving ? styles.saveButtonBusy : undefined}
-          textStyle={[styles.headerButtonText, styles.saveButtonText, isSaving && styles.disabledButton]}
+          style={saveDisabled ? styles.saveButtonBusy : undefined}
+          textStyle={[styles.headerButtonText, styles.saveButtonText, saveDisabled && styles.disabledButton]}
         />
       </View>
     </View>

--- a/src/components/editor/NotePreviewPane.tsx
+++ b/src/components/editor/NotePreviewPane.tsx
@@ -146,7 +146,6 @@ export function NotePreviewPane({
           <BlurView intensity={30} tint={isDark ? 'dark' : 'light'} style={StyleSheet.absoluteFill} />
           <View style={[styles.loadingPill, { backgroundColor: colors.surface, borderColor: colors.border }]}>
             <ActivityIndicator size="small" color={colors.primary} />
-            <Text style={[styles.loadingLabel, { color: colors.textSecondary }]}>Loading note…</Text>
           </View>
         </View>
       ) : null}
@@ -202,9 +201,5 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderRadius: 20,
     borderWidth: StyleSheet.hairlineWidth,
-  },
-  loadingLabel: {
-    fontSize: 13,
-    fontWeight: '500',
   },
 });

--- a/src/components/editor/NoteViewer.tsx
+++ b/src/components/editor/NoteViewer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -141,7 +141,10 @@ export function NoteViewer({
             style={[styles.gradeButton, { backgroundColor: colors.primary, opacity: isGrading ? 0.7 : 1 }]}
           >
             {isGrading ? (
-              <Text style={[styles.gradeButtonText, { color: '#fff' }]}>Grading...</Text>
+              <>
+                <ActivityIndicator size="small" color="#fff" />
+                <Text style={[styles.gradeButtonText, { color: '#fff' }]}>Grade My Answers</Text>
+              </>
             ) : (
               <>
                 <Ionicons name="checkmark-done" size={16} color="#fff" />

--- a/src/components/editor/useNoteEditorDocument.ts
+++ b/src/components/editor/useNoteEditorDocument.ts
@@ -372,7 +372,7 @@ export function useNoteEditorDocument({
               attempts: 0,
             })
           : null;
-        githubActivity.begin('Pushing note…');
+        githubActivity.begin('Pushing note');
         try {
           const existingForColor = getNoteByIdRef.current(savedNoteId);
           const syncParams = {

--- a/src/components/editor/useNoteEditorDocument.ts
+++ b/src/components/editor/useNoteEditorDocument.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useTranslation } from 'react-i18next';
 
 import { RootStackParamList } from '../../navigation/types';
 import { Folder } from '../../models/Folder';
@@ -15,6 +16,8 @@ import { syncNoteToGitHub } from '../../services/NoteGitHubSyncService';
 import { NoteSyncQueueService } from '../../services/NoteSyncQueueService';
 import { classifyGitHubSyncError, isRetryableFailure, syncStatusForError } from '../../services/git/syncFailure';
 import { githubActivity } from '../../stores/githubActivityStore';
+import { useGitOperationStore, gitOperationRegistry } from '../../stores/gitOperationStore';
+import type { GitOp } from '../../stores/gitOperationStore';
 import { canvasToLink } from '../../models/Canvas';
 import { getExtensionForFormat, extractCanvasJsonRefs, slugifyLocal } from './editorShared';
 import { useHardWrap, applyHardWrap } from '../../hooks/useHardWrap';
@@ -45,6 +48,30 @@ function showDurableSyncFailureAlert(kind: ReturnType<typeof classifyGitHubSyncE
   }
 }
 
+function normalizeBranch(branch: string | undefined): string {
+  return branch || 'main';
+}
+
+function hasActiveDeleteLock(
+  ops: Record<string, GitOp>,
+  entityId: string | undefined,
+  repo: string | undefined,
+  branch: string | undefined,
+  path: string | undefined,
+): boolean {
+  return Object.values(ops).some(
+    (op) =>
+      op.kind === 'delete' &&
+      (op.status === 'queued' || op.status === 'running') &&
+      ((!!entityId && op.entityIds.includes(entityId)) ||
+        (!!repo &&
+          !!path &&
+          op.repo === repo &&
+          normalizeBranch(op.branch) === normalizeBranch(branch) &&
+          op.path === path)),
+  );
+}
+
 interface NoteEditorDocumentParams {
   noteId?: string;
   initialFormat?: NoteFormat;
@@ -57,6 +84,7 @@ interface NoteEditorDocumentParams {
   activeAccountId?: string | null;
   repositories: { path: string }[];
   folders: Folder[];
+  notes: Note[];
   getNoteById: (id: string) => Note | undefined;
   createNote: (...args: any[]) => Promise<any>;
   updateNote: (...args: any[]) => Promise<any>;
@@ -75,11 +103,13 @@ export function useNoteEditorDocument({
   activeAccountId,
   repositories,
   folders,
+  notes,
   getNoteById,
   createNote,
   updateNote,
   navigation,
 }: NoteEditorDocumentParams) {
+  const { t } = useTranslation();
   const [title, setTitle] = useState(initialTitle ?? '');
   const { state: content, setState: setContent, undo, redo, canUndo, canRedo } = useUndo(initialContent ?? '');
   const [repo, setRepo] = useState<string | undefined>(initialRepo);
@@ -127,6 +157,11 @@ export function useNoteEditorDocument({
   useEffect(() => {
     getNoteByIdRef.current = getNoteById;
   }, [getNoteById]);
+
+  // Guards the notFound effect below against re-copying editor state on
+  // unrelated store churn: hydrate once per noteId, then only react to the
+  // note actually disappearing.
+  const hydratedNoteIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!noteId && !repo && repositories.length > 0) {
@@ -192,6 +227,8 @@ export function useNoteEditorDocument({
       return;
     }
     setNotFound(false);
+    if (hydratedNoteIdRef.current === noteId) return;
+    hydratedNoteIdRef.current = noteId;
 
     setTitle(existingNote.title);
     setContent(existingNote.content);
@@ -205,7 +242,7 @@ export function useNoteEditorDocument({
     setNoteFormat(existingNote.format ?? 'markdown');
     setTags(existingNote.tags || []);
     setAttachments(existingNote.attachments || []);
-  }, [noteId, setContent, activeAccountId]);
+  }, [noteId, setContent, activeAccountId, notes]);
 
   const handleTitleChange = useCallback((text: string) => {
     setTitle(text);
@@ -264,6 +301,13 @@ export function useNoteEditorDocument({
       return;
     }
 
+    const syncBlockPath =
+      existingFilePath ?? (folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : undefined);
+    if (hasActiveDeleteLock(useGitOperationStore.getState().ops, noteId, repo, branch, syncBlockPath)) {
+      Alert.alert(t('common.error'), t('sync.deleteInProgress'));
+      return;
+    }
+
     const finalContent = applyHardWrap(content.trim(), hardWrapEnabled && noteFormat === 'markdown');
 
     setIsSaving(true);
@@ -315,13 +359,26 @@ export function useNoteEditorDocument({
       }
 
       if (repo && savedNoteId) {
+        const syncPath =
+          existingFilePath ?? (folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : undefined);
+        const upsertOpId = syncPath
+          ? gitOperationRegistry.begin({
+              kind: 'upsert',
+              repo,
+              branch,
+              path: syncPath,
+              entityIds: [savedNoteId],
+              status: 'running',
+              attempts: 0,
+            })
+          : null;
         githubActivity.begin('Pushing note…');
         try {
           const existingForColor = getNoteByIdRef.current(savedNoteId);
           const syncParams = {
             repo,
             branch,
-            filePath: existingFilePath ?? (folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : undefined),
+            filePath: syncPath,
             title: title.trim(),
             content: finalContent,
             format: noteFormat,
@@ -379,7 +436,7 @@ export function useNoteEditorDocument({
           const syncParams = {
             repo,
             branch,
-            filePath: existingFilePath ?? (folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : undefined),
+            filePath: syncPath,
             title: title.trim(),
             content: finalContent,
             format: noteFormat,
@@ -411,6 +468,7 @@ export function useNoteEditorDocument({
             }
           }
         } finally {
+          if (upsertOpId) gitOperationRegistry.succeed(upsertOpId);
           githubActivity.end();
         }
       }
@@ -424,7 +482,7 @@ export function useNoteEditorDocument({
     } finally {
       setIsSaving(false);
     }
-  }, [title, content, repo, noteId, updateNote, tags, branch, commit, folderPath, noteFormat, attachments, accountId, createNote, navigation, hardWrapEnabled]);
+  }, [title, content, repo, noteId, updateNote, tags, branch, commit, folderPath, noteFormat, attachments, accountId, createNote, navigation, hardWrapEnabled, t]);
 
   const handleCancelEdit = useCallback(() => {
     if (hasChanges && (title.trim() || content.trim())) {

--- a/src/components/home/BentoRecent.tsx
+++ b/src/components/home/BentoRecent.tsx
@@ -9,9 +9,10 @@ interface Props {
   items: RecentItem[];
   onOpen: (item: RecentItem) => void;
   onLongPress?: (item: RecentItem) => void;
+  lockedIds?: Set<string>;
 }
 
-export function BentoRecent({ items, onOpen, onLongPress }: Props) {
+export function BentoRecent({ items, onOpen, onLongPress, lockedIds }: Props) {
   const { colors } = useTheme();
   const { columnCount } = useResponsive('bento');
 
@@ -37,6 +38,7 @@ export function BentoRecent({ items, onOpen, onLongPress }: Props) {
                     size="medium"
                     onPress={() => onOpen(item)}
                     onLongPress={onLongPress ? () => onLongPress(item) : undefined}
+                    locked={lockedIds?.has(item.data.id)}
                     testIDSlot={`recent-${flatIdx}`}
                   />
                 </View>

--- a/src/components/home/BentoTile.tsx
+++ b/src/components/home/BentoTile.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { View, Text, StyleSheet, Pressable, ActivityIndicator } from 'react-native';
 import type { TextLayoutEvent } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -15,6 +15,7 @@ interface Props {
   onLongPress?: () => void;
   widthOverride?: number;
   hidePinGlyph?: boolean;
+  locked?: boolean;
   // Stable slot label for testIDs — render-order index from the parent list.
   // Maestro can't pin against the dynamic note id (changes every install).
   testIDSlot: string;
@@ -132,12 +133,13 @@ const TILE_WIDTH_HINT: Record<BentoSize, number> = { large: 320, medium: 160, sm
 const SNIPPET_LINES: Record<BentoSize, number> = { large: 3, medium: 2, small: 1, pinned: 2 };
 const COLOR_STRIPE_WIDTH = 4;
 
-export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hidePinGlyph, testIDSlot }: Props) {
+export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hidePinGlyph, locked, testIDSlot }: Props) {
   const { colors } = useTheme();
   const isLarge = size === 'large';
   const isMedium = size === 'medium';
   const isPinned = size === 'pinned';
   const isCanvas = item.kind === 'canvas';
+  const isLocked = locked === true;
   const [titleLines, setTitleLines] = useState(1);
   const handleTitleLayout = useCallback(
     (e: TextLayoutEvent) => {
@@ -166,8 +168,8 @@ export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hid
     return (
       <Pressable
         testID={`bento-tile.button.press-${testIDSlot}`}
-        onPress={onPress}
-        onLongPress={onLongPress}
+        onPress={isLocked ? undefined : onPress}
+        onLongPress={isLocked ? undefined : onLongPress}
         style={({ pressed }) => [
           styles.tile,
           {
@@ -175,14 +177,15 @@ export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hid
             borderColor: colors.border,
             height: tileHeight,
             borderRadius: tileRadius,
-            opacity: pressed ? 0.92 : 1,
+            opacity: isLocked ? 0.45 : pressed ? 0.92 : 1,
             transform: [{ scale: pressed ? 0.985 : 1 }],
           },
           widthStyle,
         ]}
-accessibilityRole="button"
+        accessibilityRole="button"
         accessibilityLabel={`canvas ${titleFor(item)}`}
       >
+        {isLocked ? <ActivityIndicator size="small" color={colors.primary} style={styles.lockSpinner} /> : null}
         <View style={[styles.thumbWrap, { height: thumbHeight, backgroundColor: '#FFFFFF' }]}>
           <CanvasThumbnail scene={scene} width={widthOverride ?? TILE_WIDTH_HINT[size]} height={thumbHeight} />
           <View style={[styles.canvasBadge, { backgroundColor: colors.background }]}>
@@ -219,8 +222,8 @@ accessibilityRole="button"
     return (
       <Pressable
         testID={`bento-tile.button.press-${testIDSlot}`}
-        onPress={onPress}
-        onLongPress={onLongPress}
+        onPress={isLocked ? undefined : onPress}
+        onLongPress={isLocked ? undefined : onLongPress}
         style={({ pressed }) => [
           styles.tile,
           {
@@ -229,7 +232,7 @@ accessibilityRole="button"
             height: tileHeight,
             padding: tilePad,
             borderRadius: tileRadius,
-            opacity: pressed ? 0.92 : 1,
+            opacity: isLocked ? 0.45 : pressed ? 0.92 : 1,
             transform: [{ scale: pressed ? 0.985 : 1 }],
           },
           noteColorHex ? { borderLeftColor: noteColorHex, borderLeftWidth: COLOR_STRIPE_WIDTH } : null,
@@ -238,6 +241,7 @@ accessibilityRole="button"
         accessibilityRole="button"
         accessibilityLabel={`document ${titleFor(item)}`}
       >
+        {isLocked ? <ActivityIndicator size="small" color={colors.primary} style={styles.lockSpinner} /> : null}
         <View style={[styles.badge, { backgroundColor: accent + '1F' }]}>
           <Ionicons name={iconFor(item.kind)} size={ICON_SIZE[size]} color={accent} />
         </View>
@@ -281,8 +285,8 @@ accessibilityRole="button"
   return (
     <Pressable
       testID={`bento-tile.button.press-${testIDSlot}`}
-      onPress={onPress}
-      onLongPress={onLongPress}
+      onPress={isLocked ? undefined : onPress}
+      onLongPress={isLocked ? undefined : onLongPress}
       style={({ pressed }) => [
         styles.tile,
         {
@@ -291,7 +295,7 @@ accessibilityRole="button"
           height: tileHeight,
           padding: tilePad,
           borderRadius: tileRadius,
-          opacity: pressed ? 0.92 : 1,
+          opacity: isLocked ? 0.45 : pressed ? 0.92 : 1,
           transform: [{ scale: pressed ? 0.985 : 1 }],
         },
         noteColorHex ? { borderLeftColor: noteColorHex, borderLeftWidth: COLOR_STRIPE_WIDTH } : null,
@@ -300,6 +304,7 @@ accessibilityRole="button"
       accessibilityRole="button"
       accessibilityLabel={`${item.kind} ${titleFor(item)}`}
     >
+      {isLocked ? <ActivityIndicator size="small" color={colors.primary} style={styles.lockSpinner} /> : null}
       <View style={[styles.badge, { backgroundColor: accent + '1F' }]}>
         <Ionicons name={iconFor(item.kind)} size={ICON_SIZE[size]} color={accent} />
       </View>
@@ -363,6 +368,12 @@ const styles = StyleSheet.create({
   tile: {
     borderWidth: StyleSheet.hairlineWidth,
     overflow: 'hidden',
+  },
+  lockSpinner: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    zIndex: 3,
   },
   badge: {
     width: 38,

--- a/src/components/home/DailyQuoteCard.tsx
+++ b/src/components/home/DailyQuoteCard.tsx
@@ -46,7 +46,7 @@ export function DailyQuoteCard({
       <View style={styles.container}>
         <ActivityIndicator color={colors.textSecondary} size="small" />
         <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
-          {t('home.dailyQuote.loading', { defaultValue: 'Finding your quote…' })}
+          {t('home.dailyQuote.loading', { defaultValue: 'Finding your quote' })}
         </Text>
       </View>
     );

--- a/src/components/home/HomeNoteContextMenu.tsx
+++ b/src/components/home/HomeNoteContextMenu.tsx
@@ -37,6 +37,7 @@ interface HomeNoteContextMenuProps {
   onPickColor?: (item: RecentItem) => void;
   onDuplicate?: (item: RecentItem) => Promise<void>;
   onDelete?: (item: RecentItem) => Promise<void>;
+  deleteDisabled?: boolean;
 }
 
 export function HomeNoteContextMenu({
@@ -49,6 +50,7 @@ export function HomeNoteContextMenu({
   onPickColor,
   onDuplicate,
   onDelete,
+  deleteDisabled = false,
 }: HomeNoteContextMenuProps) {
   const [exportPickerItem, setExportPickerItem] = React.useState<RecentItem | null>(null);
 
@@ -150,6 +152,7 @@ export function HomeNoteContextMenu({
             icon: 'trash-outline' as IconName,
             label: 'Delete',
             destructive: true,
+            disabled: deleteDisabled,
             testID: 'home-note-context-menu.item.delete',
             onPress: handleDelete,
           },

--- a/src/components/home/QuickAccessShelf.tsx
+++ b/src/components/home/QuickAccessShelf.tsx
@@ -9,12 +9,13 @@ interface Props {
   items: RecentItem[];
   onOpen: (item: RecentItem) => void;
   onLongPress?: (item: RecentItem) => void;
+  lockedIds?: Set<string>;
 }
 
 const CARD_WIDTH = 176;
 const EDGE_INSET = 20;
 
-export function QuickAccessShelf({ items, onOpen, onLongPress }: Props) {
+export function QuickAccessShelf({ items, onOpen, onLongPress, lockedIds }: Props) {
   const { colors } = useTheme();
   if (items.length === 0) return null;
 
@@ -38,6 +39,7 @@ export function QuickAccessShelf({ items, onOpen, onLongPress }: Props) {
             hidePinGlyph
             onPress={() => onOpen(item)}
             onLongPress={onLongPress ? () => onLongPress(item) : undefined}
+            locked={lockedIds?.has(item.data.id)}
             testIDSlot={`pinned-${idx}`}
           />
         ))}

--- a/src/components/list/SwipeableListItem.tsx
+++ b/src/components/list/SwipeableListItem.tsx
@@ -17,6 +17,7 @@ interface SwipeableListItemProps {
   selectionMode: boolean;
   onToggleSelect: () => void;
   children: React.ReactNode;
+  disabled?: boolean;
 }
 
 const SWIPE_THRESHOLD = 36;
@@ -28,6 +29,7 @@ export function SwipeableListItem({
   selectionMode,
   onToggleSelect,
   children,
+  disabled = false,
 }: SwipeableListItemProps) {
   const { colors } = useTheme();
   const translateX = useSharedValue(0);
@@ -58,7 +60,8 @@ export function SwipeableListItem({
     <TouchableOpacity
       testID={`swipeable-list-item.button.toggle-${itemId}`}
       activeOpacity={0.7}
-      onPress={() => {
+      disabled={disabled}
+      onPress={disabled ? undefined : () => {
         HapticService.selection();
         onToggleSelect();
       }}
@@ -69,24 +72,30 @@ export function SwipeableListItem({
     children
   );
 
+  const row = (
+    <Animated.View
+      testID={`swipeable-${itemId}`}
+      className="rounded-sm"
+      style={[
+        selected && {
+          shadowColor: colors.error,
+          shadowOpacity: 0.55,
+          shadowRadius: 10,
+          shadowOffset: { width: 0, height: 0 },
+          elevation: 8,
+        },
+        animatedStyle,
+      ]}
+    >
+      {cardContent}
+    </Animated.View>
+  );
+
+  if (disabled) return row;
+
   return (
     <GestureDetector gesture={pan}>
-      <Animated.View
-        testID={`swipeable-${itemId}`}
-        className="rounded-sm"
-        style={[
-          selected && {
-            shadowColor: colors.error,
-            shadowOpacity: 0.55,
-            shadowRadius: 10,
-            shadowOffset: { width: 0, height: 0 },
-            elevation: 8,
-          },
-          animatedStyle,
-        ]}
-      >
-        {cardContent}
-      </Animated.View>
+      {row}
     </GestureDetector>
   );
 }

--- a/src/components/notes/useNotesListNoteActions.ts
+++ b/src/components/notes/useNotesListNoteActions.ts
@@ -113,7 +113,7 @@ export function useNotesListNoteActions({
 
   const handleDeleteNote = useCallback(
     async (note: Note) => {
-      githubActivity.begin('Deleting note…');
+      githubActivity.begin('Deleting note');
       setIsDeleting(true);
       try {
         if (!(await deleteNote(note.id))) {

--- a/src/components/repo/RepoTreeItem.tsx
+++ b/src/components/repo/RepoTreeItem.tsx
@@ -1,24 +1,69 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Alert, LayoutAnimation, Pressable, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 import { useTheme } from '../../contexts/ThemeContext';
 import { GitHubService } from '../../services/GitHubService';
 import { HapticService } from '../../utils/haptics';
+import { GitSyncGate } from '../../services/git/GitSyncGate';
+import {
+  gitOperationRegistry,
+  useGitOperationStore,
+  isPathLocked,
+  hasActivePull,
+} from '../../stores/gitOperationStore';
+import type { GitOp } from '../../stores/gitOperationStore';
+import { useNoteStore } from '../../stores/noteStore';
 import ContextMenu from '../ContextMenu';
 import { GroupRow } from '../ui';
-import { deleteDirectory, fetchChildren, formatBytes, getFileIcon, moveDirectory, TreeItemProps } from './repoTreeShared';
+import {
+  deleteDirectoryModeAware,
+  fetchChildren,
+  formatBytes,
+  getFileIcon,
+  moveDirectory,
+  TreeItemProps,
+} from './repoTreeShared';
 import { RepoTreeMoveDialog } from './RepoTreeMoveDialog';
 import { RepoTreeRenameDialog } from './RepoTreeRenameDialog';
 import { treeStyles } from './repoTreeStyles';
 
+const DIVERGENCE_HINT =
+  ' This usually means the branch has diverged from the remote — open the merge banner to resolve it.';
+
+function normalizeBranch(branch: string | undefined): string {
+  return branch || 'main';
+}
+
+function isActiveStatus(status: GitOp['status']): boolean {
+  return status === 'queued' || status === 'running';
+}
+
+/** Appends the conflict-banner/merge hint when the error smells like a divergence. */
+function divergenceHintFor(message: string): string {
+  return /diverged|non-fast-forward|push rejected/i.test(message) ? DIVERGENCE_HINT : '';
+}
+
 /**
- * Single user-facing failure report for tree mutations. Isolated here so
- * the registry fail-state wiring (git-operation-locking Todo 8) can replace
- * this alert in one place.
+ * Single user-facing failure report for tree mutations: fails the registry
+ * op (drives the row's failed state + Retry) and surfaces the immediate
+ * alert. Isolated here so all mutation error paths share one funnel.
  */
-function announceMutationFailure(title: string, message: string): void {
-  Alert.alert(title, message);
+function announceMutationFailure(opId: string | null, title: string, message: string): void {
+  if (opId) gitOperationRegistry.fail(opId, message);
+  const hint = message.includes(DIVERGENCE_HINT) ? '' : divergenceHintFor(message);
+  Alert.alert(title, message + hint);
+}
+
+function failedTitleFor(kind: GitOp['kind']): string {
+  switch (kind) {
+    case 'rename':
+      return 'Rename Failed';
+    case 'move':
+      return 'Move Failed';
+    default:
+      return 'Delete Failed';
+  }
 }
 
 export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, onRefresh, onChildDeleted }: TreeItemProps) {
@@ -32,7 +77,86 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
   const [showRename, setShowRename] = useState(false);
   const [showMove, setShowMove] = useState(false);
 
+  const ops = useGitOperationStore((s) => s.ops);
+  const repoPath = `${owner}/${repo}`;
   const isDir = node.type === 'dir';
+
+  /** opId -> re-runnable mutation (same op id, so Retry keeps one registry op). */
+  const retryRunners = useRef<Map<string, () => Promise<void>>>(new Map());
+
+  const rowLocked =
+    isPathLocked(ops, repoPath, branch, node.path) || hasActivePull(ops, repoPath);
+
+  const failedOp = useMemo(
+    () =>
+      Object.values(ops).find(
+        (op) =>
+          op.status === 'failed' &&
+          op.repo === repoPath &&
+          normalizeBranch(op.branch) === normalizeBranch(branch) &&
+          op.path === node.path,
+      ),
+    [branch, node.path, ops, repoPath],
+  );
+
+  const ownOpActive = useMemo(
+    () =>
+      Object.values(ops).some(
+        (op) =>
+          isActiveStatus(op.status) &&
+          op.repo === repoPath &&
+          normalizeBranch(op.branch) === normalizeBranch(branch) &&
+          op.path === node.path,
+      ),
+    [branch, node.path, ops, repoPath],
+  );
+
+  /** Begin a mutation op, retiring any stale failed op on this path first. */
+  const beginMutation = useCallback(
+    (kind: GitOp['kind']) => {
+      const current = useGitOperationStore.getState().ops;
+      for (const [id, op] of Object.entries(current)) {
+        if (
+          op.status === 'failed' &&
+          op.repo === repoPath &&
+          normalizeBranch(op.branch) === normalizeBranch(branch) &&
+          op.path === node.path
+        ) {
+          useGitOperationStore.getState().succeed(id);
+          retryRunners.current.delete(id);
+        }
+      }
+      return gitOperationRegistry.begin({
+        kind,
+        repo: repoPath,
+        branch,
+        path: node.path,
+        entityIds: [],
+        status: 'running',
+        attempts: 0,
+      });
+    },
+    [branch, node.path, repoPath],
+  );
+
+  const handleRetry = useCallback(
+    (op: GitOp) => {
+      gitOperationRegistry.retry(op.id);
+      const run = retryRunners.current.get(op.id);
+      if (run) void run();
+    },
+    [],
+  );
+
+  const handleFailedOpPress = useCallback(() => {
+    if (!failedOp) return;
+    const message = failedOp.error ?? 'Operation failed';
+    const hint = message.includes(DIVERGENCE_HINT) ? '' : divergenceHintFor(message);
+    Alert.alert(failedTitleFor(failedOp.kind), message + hint, [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Retry', onPress: () => handleRetry(failedOp) },
+    ]);
+  }, [failedOp, handleRetry]);
 
   const handleToggle = useCallback(async () => {
     if (!isDir) return;
@@ -64,77 +188,152 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
     onFilePress?.(node);
   }, [isDir, node, onFilePress]);
 
-  const handleRename = useCallback(async (oldPath: string, newName: string) => {
-    const pathParts = oldPath.split('/');
-    pathParts[pathParts.length - 1] = newName;
-    const newPath = pathParts.join('/');
+  const runRename = useCallback(
+    async (opId: string, oldPath: string, newName: string) => {
+      const pathParts = oldPath.split('/');
+      pathParts[pathParts.length - 1] = newName;
+      const newPath = pathParts.join('/');
 
-    setIsOperating(true);
-    try {
-      if (isDir) {
-        await moveDirectory(owner, repo, branch, oldPath, newPath);
-      } else {
-        const content = await GitHubService.getFileContent(owner, repo, oldPath, branch);
-        if (content === null) {
-          Alert.alert('Error', 'Could not read file content.');
-          return;
+      setIsOperating(true);
+      GitSyncGate.markPushActive(repoPath, branch);
+      try {
+        if (isDir) {
+          await moveDirectory(owner, repo, branch, oldPath, newPath);
+        } else {
+          const content = await GitHubService.getFileContent(owner, repo, oldPath, branch);
+          if (content === null) {
+            Alert.alert('Error', 'Could not read file content.');
+            return;
+          }
+          const shaResult = await GitHubService.getFileSha(owner, repo, oldPath, branch);
+          if (shaResult.kind === 'error') {
+            announceMutationFailure(opId, 'Rename Failed', shaResult.message);
+            return;
+          }
+          const sha = shaResult.kind === 'found' ? shaResult.sha : '';
+          const moved = await GitHubService.moveFile(owner, repo, oldPath, newPath, content, `Rename: ${oldPath} → ${newPath}`, sha, branch || 'main');
+          if (!moved) {
+            Alert.alert('Error', 'Failed to rename file.');
+            return;
+          }
         }
-        const shaResult = await GitHubService.getFileSha(owner, repo, oldPath, branch);
-        if (shaResult.kind === 'error') {
-          announceMutationFailure('Rename Failed', shaResult.message);
-          return;
-        }
-        const sha = shaResult.kind === 'found' ? shaResult.sha : '';
-        const moved = await GitHubService.moveFile(owner, repo, oldPath, newPath, content, `Rename: ${oldPath} → ${newPath}`, sha, branch || 'main');
-        if (!moved) {
-          Alert.alert('Error', 'Failed to rename file.');
-          return;
-        }
+        gitOperationRegistry.succeed(opId);
+        retryRunners.current.delete(opId);
+        HapticService.success();
+        onRefresh?.();
+      } catch (error) {
+        announceMutationFailure(opId, 'Rename Failed', error instanceof Error ? error.message : 'Unknown error');
+      } finally {
+        GitSyncGate.clearPushActive(repoPath, branch);
+        setIsOperating(false);
       }
-      HapticService.success();
-      onRefresh?.();
-    } catch (error) {
-      announceMutationFailure('Rename Failed', error instanceof Error ? error.message : 'Unknown error');
-    } finally {
-      setIsOperating(false);
-    }
-  }, [branch, isDir, onRefresh, owner, repo]);
+    },
+    [branch, isDir, onRefresh, owner, repo, repoPath],
+  );
+
+  const handleRename = useCallback(
+    (oldPath: string, newName: string) => {
+      const opId = beginMutation('rename');
+      retryRunners.current.set(opId, () => runRename(opId, oldPath, newName));
+      void runRename(opId, oldPath, newName);
+    },
+    [beginMutation, runRename],
+  );
 
   const handleChildDeleted = useCallback((path: string) => {
     setChildren((prev) => prev.filter((c) => c.path !== path));
   }, []);
 
-  const handleMove = useCallback(async (oldPath: string, newPath: string) => {
-    setIsOperating(true);
-    try {
-      if (isDir) {
-        await moveDirectory(owner, repo, branch, oldPath, newPath);
-      } else {
-        const content = await GitHubService.getFileContent(owner, repo, oldPath, branch);
-        if (content === null) {
-          Alert.alert('Error', 'Could not read file content.');
-          return;
+  const runMove = useCallback(
+    async (opId: string, oldPath: string, newPath: string) => {
+      setIsOperating(true);
+      GitSyncGate.markPushActive(repoPath, branch);
+      try {
+        if (isDir) {
+          await moveDirectory(owner, repo, branch, oldPath, newPath);
+        } else {
+          const content = await GitHubService.getFileContent(owner, repo, oldPath, branch);
+          if (content === null) {
+            Alert.alert('Error', 'Could not read file content.');
+            return;
+          }
+          const shaResult = await GitHubService.getFileSha(owner, repo, oldPath, branch);
+          if (shaResult.kind === 'error') {
+            announceMutationFailure(opId, 'Move Failed', shaResult.message);
+            return;
+          }
+          const sha = shaResult.kind === 'found' ? shaResult.sha : '';
+          const moved = await GitHubService.moveFile(owner, repo, oldPath, newPath, content, `Move: ${oldPath} → ${newPath}`, sha, branch || 'main');
+          if (!moved) {
+            Alert.alert('Error', 'Failed to move file.');
+            return;
+          }
         }
-        const shaResult = await GitHubService.getFileSha(owner, repo, oldPath, branch);
-        if (shaResult.kind === 'error') {
-          announceMutationFailure('Move Failed', shaResult.message);
-          return;
-        }
-        const sha = shaResult.kind === 'found' ? shaResult.sha : '';
-        const moved = await GitHubService.moveFile(owner, repo, oldPath, newPath, content, `Move: ${oldPath} → ${newPath}`, sha, branch || 'main');
-        if (!moved) {
-          Alert.alert('Error', 'Failed to move file.');
-          return;
-        }
+        gitOperationRegistry.succeed(opId);
+        retryRunners.current.delete(opId);
+        HapticService.success();
+        onRefresh?.();
+      } catch (error) {
+        announceMutationFailure(opId, 'Move Failed', error instanceof Error ? error.message : 'Unknown error');
+      } finally {
+        GitSyncGate.clearPushActive(repoPath, branch);
+        setIsOperating(false);
       }
-      HapticService.success();
-      onRefresh?.();
-    } catch (error) {
-      announceMutationFailure('Move Failed', error instanceof Error ? error.message : 'Unknown error');
-    } finally {
-      setIsOperating(false);
-    }
-  }, [branch, isDir, onRefresh, owner, repo]);
+    },
+    [branch, isDir, onRefresh, owner, repo, repoPath],
+  );
+
+  const handleMove = useCallback(
+    (oldPath: string, newPath: string) => {
+      const opId = beginMutation('move');
+      retryRunners.current.set(opId, () => runMove(opId, oldPath, newPath));
+      void runMove(opId, oldPath, newPath);
+    },
+    [beginMutation, runMove],
+  );
+
+  const runDelete = useCallback(
+    async (opId: string) => {
+      setIsOperating(true);
+      GitSyncGate.markPushActive(repoPath, branch);
+      try {
+        if (isDir) {
+          const result = await deleteDirectoryModeAware(owner, repo, branch, node.path);
+          if (result.failed.length > 0) {
+            const aggregate = `Deleted ${result.deleted.length}, failed ${result.failed.length}`;
+            const divergent = result.failed.some((failure) => /diverged|non-fast-forward|push rejected/i.test(failure.error));
+            announceMutationFailure(opId, 'Delete Failed', divergent ? aggregate + DIVERGENCE_HINT : aggregate);
+            onRefresh?.();
+            return;
+          }
+          // Children are removed strictly per the aggregate `deleted` list:
+          // full success removes the folder row, partial failure keeps it.
+          onChildDeleted?.(node.path);
+        } else {
+          const shaResult = await GitHubService.getFileSha(owner, repo, node.path, branch);
+          if (shaResult.kind === 'error') {
+            announceMutationFailure(opId, 'Delete Failed', shaResult.message);
+            return;
+          }
+          if (shaResult.kind === 'found') {
+            await GitHubService.deleteFile(owner, repo, node.path, `Delete: ${node.path}`, shaResult.sha, branch || 'main');
+          }
+          onChildDeleted?.(node.path);
+          void useNoteStore.getState().dropByFilePaths(repoPath, [node.path]);
+        }
+        gitOperationRegistry.succeed(opId);
+        retryRunners.current.delete(opId);
+        HapticService.success();
+        onRefresh?.();
+      } catch (error) {
+        announceMutationFailure(opId, 'Delete Failed', error instanceof Error ? error.message : 'Unknown error');
+      } finally {
+        GitSyncGate.clearPushActive(repoPath, branch);
+        setIsOperating(false);
+      }
+    },
+    [branch, isDir, node.path, onChildDeleted, onRefresh, owner, repo, repoPath],
+  );
 
   const handleDelete = useCallback(() => {
     Alert.alert('Delete', `Are you sure you want to delete "${node.name}"?${isDir ? ' This will delete all contents.' : ''}`, [
@@ -142,84 +341,74 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
       {
         text: 'Delete',
         style: 'destructive',
-        onPress: async () => {
-          setIsOperating(true);
-          try {
-            if (isDir) {
-              const result = await deleteDirectory(owner, repo, branch, node.path);
-              if (result.failed.length > 0) {
-                announceMutationFailure('Delete Failed', `Deleted ${result.deleted.length}, failed ${result.failed.length}`);
-                onRefresh?.();
-                return;
-              }
-            } else {
-              const shaResult = await GitHubService.getFileSha(owner, repo, node.path, branch);
-              if (shaResult.kind === 'error') {
-                announceMutationFailure('Delete Failed', shaResult.message);
-                return;
-              }
-              if (shaResult.kind === 'found') {
-                await GitHubService.deleteFile(owner, repo, node.path, `Delete: ${node.path}`, shaResult.sha, branch || 'main');
-              }
-            }
-            HapticService.success();
-            onChildDeleted?.(node.path);
-            onRefresh?.();
-          } catch (error) {
-            announceMutationFailure('Delete Failed', error instanceof Error ? error.message : 'Unknown error');
-          } finally {
-            setIsOperating(false);
-          }
+        onPress: () => {
+          const opId = beginMutation('delete');
+          retryRunners.current.set(opId, () => runDelete(opId));
+          void runDelete(opId);
         },
       },
     ]);
-  }, [branch, isDir, node, onRefresh, onChildDeleted, owner, repo]);
+  }, [beginMutation, isDir, node.name, runDelete]);
 
   const iconName = isDir ? (expanded ? 'folder-open' : 'folder') : getFileIcon(node.name);
   const iconColor = isDir ? '#FF9500' : colors.textSecondary;
 
+  const trailing = (() => {
+    if (isOperating || ownOpActive) {
+      return <ActivityIndicator size="small" color={colors.primary} />;
+    }
+    if (failedOp) {
+      return (
+        <Pressable testID="repo-tree-item.button.failed" onPress={handleFailedOpPress} hitSlop={8}>
+          <Ionicons name="alert-circle" size={20} color={colors.error} />
+        </Pressable>
+      );
+    }
+    if (!isDir) {
+      return (
+        <View style={treeStyles.fileMetaRow}>
+          {node.size != null ? <Text style={[treeStyles.size, { color: colors.textSecondary }]}>{formatBytes(node.size)}</Text> : null}
+          <Text style={[treeStyles.ext, { color: colors.textSecondary }]}>{node.name.split('.').pop()}</Text>
+        </View>
+      );
+    }
+    return null;
+  })();
+
   return (
     <View>
-      <View testID="repo-tree-item.button.toggle">
-        <View testID="repo-tree-item.button.file-press">
-          <GroupRow
-            testID={isDir ? "repo-tree-item.button.toggle" : "repo-tree-item.button.file-press"}
-        onPress={isDir ? handleToggle : handleFileOnlyPress}
-        onLongPress={() => { HapticService.medium(); setShowContextMenu(true); }}
-        disabled={isOperating}
-        style={{ paddingLeft: 16 + level * 20 }}
-        leading={
-          <View style={treeStyles.leading}>
-            {isDir ? (
-              loading ? (
-                <View style={treeStyles.chevronSlot}>
-                  <ActivityIndicator size="small" color={colors.textSecondary} />
-                </View>
+      <View testID="repo-tree-item.row" style={rowLocked || isOperating ? { opacity: 0.45 } : undefined}>
+        <View testID="repo-tree-item.button.toggle">
+          <View testID="repo-tree-item.button.file-press">
+            <GroupRow
+              testID={isDir ? "repo-tree-item.button.toggle" : "repo-tree-item.button.file-press"}
+          onPress={isDir ? handleToggle : handleFileOnlyPress}
+          onLongPress={() => { HapticService.medium(); setShowContextMenu(true); }}
+          disabled={rowLocked || isOperating}
+          style={{ paddingLeft: 16 + level * 20 }}
+          leading={
+            <View style={treeStyles.leading}>
+              {isDir ? (
+                loading ? (
+                  <View style={treeStyles.chevronSlot}>
+                    <ActivityIndicator size="small" color={colors.textSecondary} />
+                  </View>
+                ) : (
+                  <Pressable onPress={handleToggle} hitSlop={8} style={treeStyles.chevronSlot} accessibilityLabel={expanded ? 'Collapse' : 'Expand'}>
+                    <Ionicons name={expanded ? 'chevron-down' : 'chevron-forward'} size={16} color={colors.textSecondary} />
+                  </Pressable>
+                )
               ) : (
-                <Pressable onPress={handleToggle} hitSlop={8} style={treeStyles.chevronSlot} accessibilityLabel={expanded ? 'Collapse' : 'Expand'}>
-                  <Ionicons name={expanded ? 'chevron-down' : 'chevron-forward'} size={16} color={colors.textSecondary} />
-                </Pressable>
-              )
-            ) : (
-              <View style={treeStyles.chevronSlot} />
-            )}
-            <Ionicons name={iconName} size={20} color={iconColor} />
+                <View style={treeStyles.chevronSlot} />
+              )}
+              <Ionicons name={iconName} size={20} color={iconColor} />
+            </View>
+          }
+          trailing={<View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>{trailing}</View>}
+        >
+          <Text style={[treeStyles.name, { color: colors.text }]} numberOfLines={1}>{node.name}</Text>
+        </GroupRow>
           </View>
-        }
-        trailing={
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-            {isOperating ? <ActivityIndicator size="small" color={colors.primary} /> : null}
-            {!isDir ? (
-              <View style={treeStyles.fileMetaRow}>
-                {node.size != null ? <Text style={[treeStyles.size, { color: colors.textSecondary }]}>{formatBytes(node.size)}</Text> : null}
-                <Text style={[treeStyles.ext, { color: colors.textSecondary }]}>{node.name.split('.').pop()}</Text>
-              </View>
-            ) : null}
-          </View>
-        }
-      >
-        <Text style={[treeStyles.name, { color: colors.text }]} numberOfLines={1}>{node.name}</Text>
-      </GroupRow>
         </View>
       </View>
 

--- a/src/components/repo/RepoTreeItem.tsx
+++ b/src/components/repo/RepoTreeItem.tsx
@@ -12,6 +12,15 @@ import { RepoTreeMoveDialog } from './RepoTreeMoveDialog';
 import { RepoTreeRenameDialog } from './RepoTreeRenameDialog';
 import { treeStyles } from './repoTreeStyles';
 
+/**
+ * Single user-facing failure report for tree mutations. Isolated here so
+ * the registry fail-state wiring (git-operation-locking Todo 8) can replace
+ * this alert in one place.
+ */
+function announceMutationFailure(title: string, message: string): void {
+  Alert.alert(title, message);
+}
+
 export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, onRefresh, onChildDeleted }: TreeItemProps) {
   const { colors } = useTheme();
   const [expanded, setExpanded] = useState(false);
@@ -70,8 +79,13 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
           Alert.alert('Error', 'Could not read file content.');
           return;
         }
-        const sha = await GitHubService.getFileShaOrNull(owner, repo, oldPath, branch);
-        const moved = await GitHubService.moveFile(owner, repo, oldPath, newPath, content, `Rename: ${oldPath} → ${newPath}`, sha || '', branch || 'main');
+        const shaResult = await GitHubService.getFileSha(owner, repo, oldPath, branch);
+        if (shaResult.kind === 'error') {
+          announceMutationFailure('Rename Failed', shaResult.message);
+          return;
+        }
+        const sha = shaResult.kind === 'found' ? shaResult.sha : '';
+        const moved = await GitHubService.moveFile(owner, repo, oldPath, newPath, content, `Rename: ${oldPath} → ${newPath}`, sha, branch || 'main');
         if (!moved) {
           Alert.alert('Error', 'Failed to rename file.');
           return;
@@ -80,7 +94,7 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
       HapticService.success();
       onRefresh?.();
     } catch (error) {
-      Alert.alert('Rename Failed', error instanceof Error ? error.message : 'Unknown error');
+      announceMutationFailure('Rename Failed', error instanceof Error ? error.message : 'Unknown error');
     } finally {
       setIsOperating(false);
     }
@@ -101,8 +115,13 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
           Alert.alert('Error', 'Could not read file content.');
           return;
         }
-        const sha = await GitHubService.getFileShaOrNull(owner, repo, oldPath, branch);
-        const moved = await GitHubService.moveFile(owner, repo, oldPath, newPath, content, `Move: ${oldPath} → ${newPath}`, sha || '', branch || 'main');
+        const shaResult = await GitHubService.getFileSha(owner, repo, oldPath, branch);
+        if (shaResult.kind === 'error') {
+          announceMutationFailure('Move Failed', shaResult.message);
+          return;
+        }
+        const sha = shaResult.kind === 'found' ? shaResult.sha : '';
+        const moved = await GitHubService.moveFile(owner, repo, oldPath, newPath, content, `Move: ${oldPath} → ${newPath}`, sha, branch || 'main');
         if (!moved) {
           Alert.alert('Error', 'Failed to move file.');
           return;
@@ -111,7 +130,7 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
       HapticService.success();
       onRefresh?.();
     } catch (error) {
-      Alert.alert('Move Failed', error instanceof Error ? error.message : 'Unknown error');
+      announceMutationFailure('Move Failed', error instanceof Error ? error.message : 'Unknown error');
     } finally {
       setIsOperating(false);
     }
@@ -127,18 +146,27 @@ export function RepoTreeItem({ node, owner, repo, branch, level, onFilePress, on
           setIsOperating(true);
           try {
             if (isDir) {
-              await deleteDirectory(owner, repo, branch, node.path);
+              const result = await deleteDirectory(owner, repo, branch, node.path);
+              if (result.failed.length > 0) {
+                announceMutationFailure('Delete Failed', `Deleted ${result.deleted.length}, failed ${result.failed.length}`);
+                onRefresh?.();
+                return;
+              }
             } else {
-              const sha = await GitHubService.getFileShaOrNull(owner, repo, node.path, branch);
-              if (sha) {
-                await GitHubService.deleteFile(owner, repo, node.path, `Delete: ${node.path}`, sha, branch || 'main');
+              const shaResult = await GitHubService.getFileSha(owner, repo, node.path, branch);
+              if (shaResult.kind === 'error') {
+                announceMutationFailure('Delete Failed', shaResult.message);
+                return;
+              }
+              if (shaResult.kind === 'found') {
+                await GitHubService.deleteFile(owner, repo, node.path, `Delete: ${node.path}`, shaResult.sha, branch || 'main');
               }
             }
             HapticService.success();
             onChildDeleted?.(node.path);
             onRefresh?.();
           } catch (error) {
-            Alert.alert('Delete Failed', error instanceof Error ? error.message : 'Unknown error');
+            announceMutationFailure('Delete Failed', error instanceof Error ? error.message : 'Unknown error');
           } finally {
             setIsOperating(false);
           }

--- a/src/components/repo/repoTreeShared.ts
+++ b/src/components/repo/repoTreeShared.ts
@@ -1,5 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
 import { GitHubContent, GitHubService } from '../../services/GitHubService';
+import { AuthService } from '../../services/AuthService';
+import { SyncEngineService } from '../../services/SyncEngineService';
+import { LocalGitWriter } from '../../services/git/LocalGitWriter';
+import { batchDeleteFiles } from '../../services/git/BatchGitOperations';
+import { getGitHostService } from '../../services/git/gitHostFactory';
 
 export interface TreeNode {
   name: string;
@@ -95,6 +100,121 @@ export interface DirectoryDeleteResult {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Recursively collects every leaf file path under `dirPath`. Used by the
+ * mode-aware folder delete to batch one API commit (or one clone push).
+ */
+export async function collectLeafFilePaths(
+  owner: string,
+  repo: string,
+  branch: string | undefined,
+  dirPath: string,
+): Promise<string[]> {
+  const items = await fetchChildren(owner, repo, dirPath, branch);
+  const paths: string[] = [];
+  for (const item of items) {
+    if (item.type === 'dir') {
+      paths.push(...(await collectLeafFilePaths(owner, repo, branch, item.path)));
+    } else {
+      paths.push(item.path);
+    }
+  }
+  return paths;
+}
+
+async function resolveCloneAuthor(): Promise<{ name: string; email: string }> {
+  const host = getGitHostService('github');
+  const user = await host.getAuthenticatedUser();
+  const name = user?.login || 'gitnotes';
+  const email = user?.email || `${name}@users.noreply.gitnotes`;
+  return { name, email };
+}
+
+/**
+ * Clone-mode folder delete: one local `deleteAndCommit(push:false)` per
+ * leaf file, then ONE trailing `LocalGitWriter.push` flushes the whole
+ * folder (mirrors `NoteSyncQueueService.processDrainGroup`'s coalesced
+ * push). A failed flush strands every locally-committed delete, so they
+ * all surface as failures.
+ */
+async function deleteDirectoryClone(
+  owner: string,
+  repo: string,
+  branch: string | undefined,
+  paths: string[],
+): Promise<DirectoryDeleteResult> {
+  const targetBranch = branch || 'main';
+  const repoPath = `${owner}/${repo}`;
+  const author = await resolveCloneAuthor();
+  const token = (await AuthService.getToken()) ?? undefined;
+
+  const deleted: string[] = [];
+  const failed: DirectoryDeleteFailure[] = [];
+  for (const path of paths) {
+    const result = await LocalGitWriter.deleteAndCommit({
+      repoPath,
+      branch: targetBranch,
+      filePath: path,
+      message: `Delete: ${path}`,
+      author,
+      token,
+      push: false,
+    });
+    if (result.success) {
+      deleted.push(path);
+    } else {
+      failed.push({ path, error: result.error ?? 'Delete failed' });
+    }
+  }
+
+  if (deleted.length > 0) {
+    const flushResult = await LocalGitWriter.push({ repoPath, branch: targetBranch, token });
+    if (!flushResult.success) {
+      const pushError = flushResult.error ?? 'Push failed';
+      for (const path of deleted) failed.push({ path, error: pushError });
+      return { deleted: [], failed };
+    }
+  }
+  return { deleted, failed };
+}
+
+/**
+ * Mode-aware folder delete. API mode batches every collected path into ONE
+ * `batchDeleteFiles` commit (>= 2 paths; a single-path folder falls back to
+ * per-file deletes). Clone mode commits locally with push deferred and
+ * flushes with one trailing push.
+ */
+export async function deleteDirectoryModeAware(
+  owner: string,
+  repo: string,
+  branch: string | undefined,
+  dirPath: string,
+): Promise<DirectoryDeleteResult> {
+  const paths = await collectLeafFilePaths(owner, repo, branch, dirPath);
+  if (paths.length === 0) return { deleted: [], failed: [] };
+
+  const mode = await SyncEngineService.getMode(`${owner}/${repo}`);
+  if (mode === 'clone') {
+    return deleteDirectoryClone(owner, repo, branch, paths);
+  }
+
+  if (paths.length >= 2) {
+    try {
+      const result = await batchDeleteFiles({
+        owner,
+        repo,
+        branch: branch || 'main',
+        paths,
+        message: `Delete folder: ${dirPath}`,
+      });
+      return { deleted: result.deleted, failed: result.failed };
+    } catch (error) {
+      console.warn('[repoTreeShared] batch delete failed, falling back to per-file:', error);
+    }
+  }
+  return deleteDirectory(owner, repo, branch, dirPath);
 }
 
 export async function moveDirectory(

--- a/src/components/repo/repoTreeShared.ts
+++ b/src/components/repo/repoTreeShared.ts
@@ -83,12 +83,41 @@ export function formatBytes(bytes?: number): string {
   return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unit]}`;
 }
 
+export interface DirectoryDeleteFailure {
+  path: string;
+  error: string;
+}
+
+export interface DirectoryDeleteResult {
+  deleted: string[];
+  failed: DirectoryDeleteFailure[];
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export async function moveDirectory(
   owner: string,
   repo: string,
   branch: string | undefined,
   oldDirPath: string,
   newDirPath: string,
+): Promise<void> {
+  const failedPaths: string[] = [];
+  await moveDirectoryItems(owner, repo, branch, oldDirPath, newDirPath, failedPaths);
+  if (failedPaths.length > 0) {
+    throw new Error(`Failed to move ${failedPaths.length} item(s): ${failedPaths.join(', ')}`);
+  }
+}
+
+async function moveDirectoryItems(
+  owner: string,
+  repo: string,
+  branch: string | undefined,
+  oldDirPath: string,
+  newDirPath: string,
+  failedPaths: string[],
 ): Promise<void> {
   const targetBranch = branch || 'main';
   const items = await fetchChildren(owner, repo, oldDirPath, branch);
@@ -98,31 +127,41 @@ export async function moveDirectory(
     const newPath = `${newDirPath}/${relativePath}`;
 
     if (item.type === 'dir') {
-      await moveDirectory(owner, repo, branch, item.path, newPath);
-    } else {
-      const content = await GitHubService.getFileContent(owner, repo, item.path, branch);
-      if (content === null) continue;
-      const sha = await GitHubService.getFileShaOrNull(owner, repo, item.path, branch);
-      await GitHubService.moveFile(
-        owner,
-        repo,
-        item.path,
-        newPath,
-        content,
-        `Move: ${item.path} → ${newPath}`,
-        sha || '',
-        targetBranch,
-      );
+      await moveDirectoryItems(owner, repo, branch, item.path, newPath, failedPaths);
+      continue;
     }
+
+    const content = await GitHubService.getFileContent(owner, repo, item.path, branch);
+    if (content === null) {
+      failedPaths.push(item.path);
+      continue;
+    }
+    const shaResult = await GitHubService.getFileSha(owner, repo, item.path, branch);
+    if (shaResult.kind === 'error') {
+      failedPaths.push(item.path);
+      continue;
+    }
+    const sha = shaResult.kind === 'found' ? shaResult.sha : '';
+    const moved = await GitHubService.moveFile(
+      owner,
+      repo,
+      item.path,
+      newPath,
+      content,
+      `Move: ${item.path} → ${newPath}`,
+      sha,
+      targetBranch,
+    );
+    if (!moved) failedPaths.push(item.path);
   }
 
-  const oldSha = await GitHubService.getFileShaOrNull(owner, repo, oldDirPath, branch);
-  if (oldSha) {
+  const oldSha = await GitHubService.getFileSha(owner, repo, oldDirPath, branch);
+  if (oldSha.kind === 'found') {
     const gitkeepPath = `${oldDirPath}/.gitkeep`;
-    const gitkeepSha = await GitHubService.getFileShaOrNull(owner, repo, gitkeepPath, branch);
-    if (gitkeepSha) {
+    const gitkeepSha = await GitHubService.getFileSha(owner, repo, gitkeepPath, branch);
+    if (gitkeepSha.kind === 'found') {
       try {
-        await GitHubService.deleteFile(owner, repo, gitkeepPath, `Clean up: ${gitkeepPath}`, gitkeepSha, targetBranch);
+        await GitHubService.deleteFile(owner, repo, gitkeepPath, `Clean up: ${gitkeepPath}`, gitkeepSha.sha, targetBranch);
       } catch (cleanupError) {
         console.warn('[repoTreeShared] gitkeep cleanup failed:', cleanupError);
       }
@@ -135,22 +174,36 @@ export async function deleteDirectory(
   repo: string,
   branch: string | undefined,
   dirPath: string,
-): Promise<void> {
+): Promise<DirectoryDeleteResult> {
   const targetBranch = branch || 'main';
   const items = await fetchChildren(owner, repo, dirPath, branch);
+  const deleted: string[] = [];
+  const failed: DirectoryDeleteFailure[] = [];
 
   for (const item of items) {
     if (item.type === 'dir') {
-      await deleteDirectory(owner, repo, branch, item.path);
-    } else {
-      const sha = await GitHubService.getFileShaOrNull(owner, repo, item.path, branch);
-      if (sha) {
-        try {
-          await GitHubService.deleteFile(owner, repo, item.path, `Delete: ${item.path}`, sha, targetBranch);
-        } catch (deleteError) {
-          console.warn('[repoTreeShared] delete failed:', deleteError);
-        }
-      }
+      const nested = await deleteDirectory(owner, repo, branch, item.path);
+      deleted.push(...nested.deleted);
+      failed.push(...nested.failed);
+      continue;
+    }
+
+    const shaResult = await GitHubService.getFileSha(owner, repo, item.path, branch);
+    if (shaResult.kind === 'error') {
+      failed.push({ path: item.path, error: shaResult.message });
+      continue;
+    }
+    if (shaResult.kind === 'not-found') {
+      deleted.push(item.path);
+      continue;
+    }
+    try {
+      await GitHubService.deleteFile(owner, repo, item.path, `Delete: ${item.path}`, shaResult.sha, targetBranch);
+      deleted.push(item.path);
+    } catch (deleteError) {
+      failed.push({ path: item.path, error: errorMessage(deleteError) });
     }
   }
+
+  return { deleted, failed };
 }

--- a/src/components/repo/repoTreeStyles.ts
+++ b/src/components/repo/repoTreeStyles.ts
@@ -39,10 +39,6 @@ export const treeStyles = StyleSheet.create({
     gap: 8,
     paddingTop: 60,
   },
-  loadingText: {
-    fontSize: 14,
-    marginTop: 4,
-  },
   emptyText: {
     fontSize: 16,
     fontWeight: '600',

--- a/src/components/settings/AddReminderScreen.tsx
+++ b/src/components/settings/AddReminderScreen.tsx
@@ -574,7 +574,7 @@ export function AddReminderScreen() {
           testID="add-reminder-submit"
         >
           {submitState === 'saving'
-            ? 'Saving…'
+            ? 'Saving'
             : submitState === 'added'
               ? 'Reminder Added'
               : 'Add Reminder'}

--- a/src/components/settings/CloneProgressModal.tsx
+++ b/src/components/settings/CloneProgressModal.tsx
@@ -58,7 +58,7 @@ export function CloneProgressModal({ progress, onCancel, onRetry }: CloneProgres
       ) : (
         <>
           <Text style={{ color: colors.textSecondary, fontSize: type.sm, marginBottom: spacing[4] }}>
-            {progress?.phase ?? 'Preparing…'} · {pctLabel}
+            {progress?.phase ?? 'Preparing'} · {pctLabel}
           </Text>
 
           <View

--- a/src/components/ui/OfflineBanner.tsx
+++ b/src/components/ui/OfflineBanner.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import { useTranslation } from 'react-i18next';
 
 import { useNetworkStatus } from '../../hooks/useNetworkStatus';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -7,6 +8,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 export function OfflineBanner() {
   const { isConnected } = useNetworkStatus();
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   if (isConnected) return null;
 
@@ -16,7 +18,7 @@ export function OfflineBanner() {
       style={{ backgroundColor: `${colors.error}20`, borderColor: `${colors.error}33` }}
     >
       <Text className="text-sm font-semibold" style={{ color: colors.error }}>
-        You're offline — changes won't sync
+        {t('sync.offlineBanner')}
       </Text>
     </View>
   );

--- a/src/hooks/useGitOpLock.ts
+++ b/src/hooks/useGitOpLock.ts
@@ -1,0 +1,104 @@
+import { useCallback, useMemo } from 'react';
+
+import { useGitOperationStore } from '../stores/gitOperationStore';
+import type { GitOp } from '../stores/gitOperationStore';
+import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
+import { clearDeleteFailure } from '../services/git/deleteFailures';
+import { useNoteStore } from '../stores/noteStore';
+
+export interface UseEntityLockOptions {
+  repo?: string;
+  branch?: string;
+  path?: string;
+}
+
+export interface UseEntityLockResult {
+  locked: boolean;
+  failed: boolean;
+  error?: string;
+  retry: () => void;
+}
+
+function normalizeBranch(branch: string | undefined): string {
+  return branch || 'main';
+}
+
+function opMatchesContext(op: GitOp, entityId: string | undefined, ctx?: UseEntityLockOptions): boolean {
+  const entityMatch = !!entityId && op.entityIds.includes(entityId);
+  const pathMatch =
+    !!ctx?.repo &&
+    !!ctx.path &&
+    op.repo === ctx.repo &&
+    normalizeBranch(op.branch) === normalizeBranch(ctx.branch) &&
+    (op.path === undefined || op.path === ctx.path);
+  return entityMatch || pathMatch;
+}
+
+/**
+ * Lock state for a single item. Lock lookups key PRIMARILY by
+ * (repo, resolvedBranch, path) — a queued delete survives pull
+ * re-creation because paths stay stable while note ids do not — with
+ * entityIds as a secondary index (cover for calls that only know the id).
+ *
+ * `retry()` clears the durable failure entry, drops every registry op on
+ * this path (volatile row-locks included), re-enqueues the delete and
+ * drains once so the failed row goes straight back to locked.
+ */
+export function useEntityLock(
+  entityId?: string,
+  ctx?: UseEntityLockOptions,
+): UseEntityLockResult {
+  const ops = useGitOperationStore((s) => s.ops);
+
+  const { activeOp, failedOp } = useMemo(() => {
+    let foundActive: GitOp | undefined;
+    let foundFailed: GitOp | undefined;
+    for (const op of Object.values(ops)) {
+      if (!opMatchesContext(op, entityId, ctx)) continue;
+      if (op.status === 'queued' || op.status === 'running') {
+        foundActive = foundActive ?? op;
+      } else if (op.status === 'failed') {
+        foundFailed = foundFailed ?? op;
+      }
+    }
+    return { activeOp: foundActive, failedOp: foundFailed };
+  }, [ops, entityId, ctx?.repo, ctx?.branch, ctx?.path]);
+
+  const retry = useCallback(() => {
+    const op = failedOp;
+    if (!op?.path) return;
+    const { repo, branch, path } = op;
+    void (async () => {
+      // Clear BOTH the volatile begin() row-lock and the durable failure-
+      // entry op for this (repo, path), or the row would pin forever.
+      const current = useGitOperationStore.getState().ops;
+      for (const candidate of Object.values(current)) {
+        if (
+          candidate.kind === 'delete' &&
+          candidate.repo === repo &&
+          (candidate.path === undefined || candidate.path === path)
+        ) {
+          useGitOperationStore.getState().succeed(candidate.id);
+        }
+      }
+      await clearDeleteFailure(repo, branch, path);
+      const note = entityId ? useNoteStore.getState().getNoteById(entityId) : undefined;
+      await NoteSyncQueueService.enqueueNoteDelete({
+        repo,
+        branch,
+        filePath: path,
+        title: note?.title,
+        accountId: note?.accountId,
+        localNoteId: note?.id ?? entityId,
+      });
+      void NoteSyncQueueService.drain();
+    })();
+  }, [failedOp, entityId]);
+
+  return {
+    locked: !!activeOp,
+    failed: !!failedOp,
+    error: failedOp?.error,
+    retry,
+  };
+}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -192,7 +192,7 @@
   "home": {
     "title": "Start",
     "dailyQuote": {
-      "loading": "Zitat wird gesucht…"
+      "loading": "Zitat wird gesucht"
     }
   },
   "hints": {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -298,7 +298,8 @@
     "saveMerged": "Save merged",
     "deleteFailed": "Löschen fehlgeschlagen",
     "retry": "Erneut versuchen",
-    "deleteInProgress": "Diese Notiz wird gelöscht. Speichern ist deaktiviert, bis der Löschvorgang abgeschlossen ist."
+    "deleteInProgress": "Diese Notiz wird gelöscht. Speichern ist deaktiviert, bis der Löschvorgang abgeschlossen ist.",
+    "offlineBanner": "Du bist offline — Änderungen werden nicht synchronisiert"
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -295,7 +295,10 @@
     "tabRemote": "Remote",
     "keepMine": "Keep mine",
     "keepTheirs": "Keep theirs",
-    "saveMerged": "Save merged"
+    "saveMerged": "Save merged",
+    "deleteFailed": "Löschen fehlgeschlagen",
+    "retry": "Erneut versuchen",
+    "deleteInProgress": "Diese Notiz wird gelöscht. Speichern ist deaktiviert, bis der Löschvorgang abgeschlossen ist."
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -473,7 +473,8 @@
     "saveMerged": "Save merged",
     "deleteFailed": "Delete Failed",
     "retry": "Retry",
-    "deleteInProgress": "This note is being deleted. Saving is disabled until the delete completes."
+    "deleteInProgress": "This note is being deleted. Saving is disabled until the delete completes.",
+    "offlineBanner": "You're offline — changes won't sync"
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -470,7 +470,10 @@
     "tabRemote": "Remote",
     "keepMine": "Keep mine",
     "keepTheirs": "Keep theirs",
-    "saveMerged": "Save merged"
+    "saveMerged": "Save merged",
+    "deleteFailed": "Delete Failed",
+    "retry": "Retry",
+    "deleteInProgress": "This note is being deleted. Saving is disabled until the delete completes."
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -52,7 +52,7 @@
   "home": {
     "title": "Home",
     "dailyQuote": {
-      "loading": "Finding your quote…"
+      "loading": "Finding your quote"
     },
     "appTitle": "GitNotēs",
     "subtitle": "Your development notes, organized.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -192,7 +192,7 @@
   "home": {
     "title": "Inicio",
     "dailyQuote": {
-      "loading": "Buscando tu cita…"
+      "loading": "Buscando tu cita"
     }
   },
   "hints": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -298,7 +298,8 @@
     "saveMerged": "Save merged",
     "deleteFailed": "Error al eliminar",
     "retry": "Reintentar",
-    "deleteInProgress": "Esta nota se está eliminando. Guardar está desactivado hasta que se complete la eliminación."
+    "deleteInProgress": "Esta nota se está eliminando. Guardar está desactivado hasta que se complete la eliminación.",
+    "offlineBanner": "Estás sin conexión — los cambios no se sincronizarán"
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -295,7 +295,10 @@
     "tabRemote": "Remote",
     "keepMine": "Keep mine",
     "keepTheirs": "Keep theirs",
-    "saveMerged": "Save merged"
+    "saveMerged": "Save merged",
+    "deleteFailed": "Error al eliminar",
+    "retry": "Reintentar",
+    "deleteInProgress": "Esta nota se está eliminando. Guardar está desactivado hasta que se complete la eliminación."
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -295,7 +295,10 @@
     "tabRemote": "Remote",
     "keepMine": "Keep mine",
     "keepTheirs": "Keep theirs",
-    "saveMerged": "Save merged"
+    "saveMerged": "Save merged",
+    "deleteFailed": "Échec de la suppression",
+    "retry": "Réessayer",
+    "deleteInProgress": "Cette note est en cours de suppression. L'enregistrement est désactivé jusqu'à la fin de la suppression."
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -298,7 +298,8 @@
     "saveMerged": "Save merged",
     "deleteFailed": "Échec de la suppression",
     "retry": "Réessayer",
-    "deleteInProgress": "Cette note est en cours de suppression. L'enregistrement est désactivé jusqu'à la fin de la suppression."
+    "deleteInProgress": "Cette note est en cours de suppression. L'enregistrement est désactivé jusqu'à la fin de la suppression.",
+    "offlineBanner": "Vous êtes hors ligne — les modifications ne seront pas synchronisées"
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -192,7 +192,7 @@
   "home": {
     "title": "Accueil",
     "dailyQuote": {
-      "loading": "Recherche de votre citation…"
+      "loading": "Recherche de votre citation"
     }
   },
   "hints": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -298,7 +298,8 @@
     "saveMerged": "Save merged",
     "deleteFailed": "削除に失敗しました",
     "retry": "再試行",
-    "deleteInProgress": "このノートは削除中です。削除が完了するまで保存は無効です。"
+    "deleteInProgress": "このノートは削除中です。削除が完了するまで保存は無効です。",
+    "offlineBanner": "オフラインです — 変更は同期されません"
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -192,7 +192,7 @@
   "home": {
     "title": "ホーム",
     "dailyQuote": {
-      "loading": "名言を検索中…"
+      "loading": "名言を検索中"
     }
   },
   "hints": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -295,7 +295,10 @@
     "tabRemote": "Remote",
     "keepMine": "Keep mine",
     "keepTheirs": "Keep theirs",
-    "saveMerged": "Save merged"
+    "saveMerged": "Save merged",
+    "deleteFailed": "削除に失敗しました",
+    "retry": "再試行",
+    "deleteInProgress": "このノートは削除中です。削除が完了するまで保存は無効です。"
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -295,7 +295,10 @@
     "tabRemote": "Remote",
     "keepMine": "Keep mine",
     "keepTheirs": "Keep theirs",
-    "saveMerged": "Save merged"
+    "saveMerged": "Save merged",
+    "deleteFailed": "삭제 실패",
+    "retry": "다시 시도",
+    "deleteInProgress": "이 노트를 삭제하는 중입니다. 삭제가 완료될 때까지 저장이 비활성화됩니다."
   },
   "onboarding": {
     "steps": {

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -192,7 +192,7 @@
   "home": {
     "title": "홈",
     "dailyQuote": {
-      "loading": "명언을 찾는 중…"
+      "loading": "명언을 찾는 중"
     }
   },
   "hints": {

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -298,7 +298,8 @@
     "saveMerged": "Save merged",
     "deleteFailed": "삭제 실패",
     "retry": "다시 시도",
-    "deleteInProgress": "이 노트를 삭제하는 중입니다. 삭제가 완료될 때까지 저장이 비활성화됩니다."
+    "deleteInProgress": "이 노트를 삭제하는 중입니다. 삭제가 완료될 때까지 저장이 비활성화됩니다.",
+    "offlineBanner": "오프라인입니다 — 변경 사항이 동기화되지 않습니다"
   },
   "onboarding": {
     "steps": {

--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -7,6 +7,7 @@ import {
   Alert,
   Modal,
   TextInput,
+  ActivityIndicator,
 } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -17,6 +18,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useRepos } from '../contexts/RepoContext';
 import { RootStackParamList } from '../navigation/types';
 import { Canvas } from '../models/Canvas';
+import { useEntityLock } from '../hooks/useGitOpLock';
 import SearchBar from '../components/SearchBar';
 import { ScreenHeader, IconButton, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
@@ -36,6 +38,79 @@ const CANVAS_PRESET_DIMS: Record<(typeof CANVAS_PRESET_KEYS)[number], { w: numbe
   'canvases.presets.square': { w: 1024, h: 1024, desc: '1024 × 1024' },
   'canvases.presets.a4': { w: 794, h: 1123, desc: '794 × 1123' },
 };
+
+interface CanvasRowProps {
+  item: Canvas;
+  onOpen: (id: string) => void;
+  onDelete: (canvas: Canvas) => void;
+}
+
+function CanvasRow({ item, onOpen, onDelete }: CanvasRowProps) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const lock = useEntityLock(item.id, { repo: item.repo, branch: item.branch, path: item.filePath });
+  const locked = lock.locked;
+  const elementCount = item.scene?.elements?.length ?? 0;
+  const date = new Date(item.updatedAt);
+  const dateStr = date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <View style={{ opacity: locked ? 0.45 : 1 }}>
+      <TouchableOpacity
+        testID="canvas-list.button.open"
+        className="flex-row items-center p-3.5 rounded-md border mb-2.5"
+        style={{ backgroundColor: colors.surface, borderColor: colors.border }}
+        onPress={locked ? undefined : () => onOpen(item.id)}
+        activeOpacity={0.7}
+      >
+        <View className="flex-1">
+          <View className="flex-row items-center gap-2 mb-1">
+            <Ionicons name="easel-outline" size={18} color={colors.primary} />
+            <Text className="text-base font-semibold flex-1" style={{ color: colors.text }} numberOfLines={1}>
+              {item.title || t('canvases.untitled')}
+            </Text>
+          </View>
+          <Text className="text-xs mb-1" style={{ color: colors.textSecondary }}>
+            {elementCount} element{elementCount !== 1 ? 's' : ''} · {dateStr}
+          </Text>
+          {item.repo && (
+            <View className="flex-row items-center gap-1 mt-1">
+              <Ionicons name="git-branch-outline" size={12} color={colors.primary} />
+              <Text className="text-xs font-medium" style={{ color: colors.primary }} numberOfLines={1}>
+                {item.repo.split('/').pop()}{item.branch ? ` · ${item.branch}` : ''}
+              </Text>
+            </View>
+          )}
+          {item.tags.length > 0 && (
+            <View className="flex-row gap-1.5 flex-wrap">
+              {item.tags.slice(0, 3).map((tag) => (
+                <View key={tag} className="px-2 py-0.5 rounded-sm" style={{ backgroundColor: colors.primary + '18' }}>
+                  <Text className="text-xs font-medium" style={{ color: colors.primary }}>{tag}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+        {locked ? (
+          <ActivityIndicator size="small" testID="canvas-row.lock-spinner" color={colors.primary} />
+        ) : (
+          <TouchableOpacity
+            testID="canvas-list.button.delete"
+            className="p-3"
+            onPress={() => onDelete(item)}
+          >
+            <Ionicons name="trash-outline" size={20} color={colors.textSecondary} />
+          </TouchableOpacity>
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+}
 
 export default function CanvasListScreen() {
   const { t } = useTranslation();
@@ -107,63 +182,10 @@ export default function CanvasListScreen() {
   );
 
   const renderCanvas = useCallback(
-    ({ item }: { item: Canvas }) => {
-      const elementCount = item.scene?.elements?.length ?? 0;
-      const date = new Date(item.updatedAt);
-      const dateStr = date.toLocaleDateString(undefined, {
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      });
-
-      return (
-        <TouchableOpacity
-          testID="canvas-list.button.open"
-          className="flex-row items-center p-3.5 rounded-md border mb-2.5"
-          style={{ backgroundColor: colors.surface, borderColor: colors.border }}
-          onPress={() => handleOpen(item.id)}
-          activeOpacity={0.7}
-        >
-          <View className="flex-1">
-            <View className="flex-row items-center gap-2 mb-1">
-              <Ionicons name="easel-outline" size={18} color={colors.primary} />
-              <Text className="text-base font-semibold flex-1" style={{ color: colors.text }} numberOfLines={1}>
-                {item.title || t('canvases.untitled')}
-              </Text>
-            </View>
-            <Text className="text-xs mb-1" style={{ color: colors.textSecondary }}>
-              {elementCount} element{elementCount !== 1 ? 's' : ''} · {dateStr}
-            </Text>
-            {item.repo && (
-              <View className="flex-row items-center gap-1 mt-1">
-                <Ionicons name="git-branch-outline" size={12} color={colors.primary} />
-                <Text className="text-xs font-medium" style={{ color: colors.primary }} numberOfLines={1}>
-                  {item.repo.split('/').pop()}{item.branch ? ` · ${item.branch}` : ''}
-                </Text>
-              </View>
-            )}
-            {item.tags.length > 0 && (
-              <View className="flex-row gap-1.5 flex-wrap">
-                {item.tags.slice(0, 3).map((tag) => (
-                  <View key={tag} className="px-2 py-0.5 rounded-sm" style={{ backgroundColor: colors.primary + '18' }}>
-                    <Text className="text-xs font-medium" style={{ color: colors.primary }}>{tag}</Text>
-                  </View>
-                ))}
-              </View>
-            )}
-          </View>
-          <TouchableOpacity
-            testID="canvas-list.button.delete"
-            className="p-3"
-            onPress={() => handleDelete(item)}
-          >
-            <Ionicons name="trash-outline" size={20} color={colors.textSecondary} />
-          </TouchableOpacity>
-        </TouchableOpacity>
-      );
-    },
-    [colors, handleOpen, handleDelete, t],
+    ({ item }: { item: Canvas }) => (
+      <CanvasRow item={item} onOpen={handleOpen} onDelete={handleDelete} />
+    ),
+    [handleOpen, handleDelete],
   );
 
   return (

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -17,7 +17,10 @@ import { useRepos } from '../contexts/RepoContext';
 import { GitRepository } from '../services/GitService';
 import { HapticService } from '../utils/haptics';
 import { parseRepoPath } from '../utils/gitPathParser';
+import { GitSyncGate } from '../services/git/GitSyncGate';
+import { useGitOperationStore, hasActivePull } from '../stores/gitOperationStore';
 import RepoFileTree, { TreeNode } from '../components/RepoFileTree';
+import { treeStyles } from '../components/repo/repoTreeStyles';
 import { RootStackParamList } from '../navigation/types';
 import { EmptyState, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
@@ -56,6 +59,8 @@ export default function ExploreScreen() {
   const refreshingRef = useRef(false);
   const isFocused = useIsFocused();
 
+  const ops = useGitOperationStore((s) => s.ops);
+
   // Reset refresh state when screen loses focus (tab switch, stack push, etc.)
   useEffect(() => {
     if (!isFocused) {
@@ -78,6 +83,13 @@ export default function ExploreScreen() {
     if (!selectedRepo) return null;
     return parseRepoPath(selectedRepo.path);
   }, [selectedRepo]);
+
+  // Explore performs NO git pull — it only refreshes the repo list. When the
+  // gate reports the selected repo busy (push marker or cycle hold affecting
+  // it), the tree area shows its busy state and pull-to-refresh is disabled.
+  const repoPath = repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : null;
+  const gateBusy = GitSyncGate.isCycleHeld() || GitSyncGate.isPushActive();
+  const repoBusy = repoPath ? GitSyncGate.isPushActive(repoPath) || hasActivePull(ops, repoPath) : false;
 
   useEffect(() => {
     if (repos.length === 0) {
@@ -186,7 +198,7 @@ export default function ExploreScreen() {
             renderItem={renderRepoItem}
             contentContainerStyle={{ paddingBottom: tabBarHeight + 16 }}
             refreshControl={
-              <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.primary} />
+              <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.primary} enabled={!gateBusy} />
             }
           />
         )}
@@ -268,36 +280,42 @@ export default function ExploreScreen() {
           style={{ backgroundColor: colors.background }}
           contentContainerStyle={{ paddingBottom: 32, backgroundColor: colors.background }}
           refreshControl={
-            <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.primary} />
+            <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.primary} enabled={!repoBusy} />
           }
         >
-          <RepoFileTree
-            owner={repoInfo.owner}
-            repo={repoInfo.repo}
-            branch={selectedRepo?.branch}
-            onFilePress={(node: TreeNode) => {
-              const kind = classifyFile(node.name);
-              const params = {
-                owner: repoInfo.owner,
-                repo: repoInfo.repo,
-                branch: selectedRepo?.branch,
-                path: node.path,
-                title: node.name,
-                size: node.size,
-              };
-              if (kind === 'pdf') {
-                navigation.navigate('PdfViewer', params);
-              } else if (kind === 'image') {
-                navigation.navigate('ImageViewer', params);
-              } else if (kind === 'video') {
-                navigation.navigate('VideoViewer', params);
-              } else if (kind === 'json') {
-                navigation.navigate('FileViewer', params);
-              } else {
-                navigation.navigate('FileViewer', params);
-              }
-            }}
-          />
+          {repoBusy ? (
+            <View style={[treeStyles.center]}>
+              <ActivityIndicator size="large" color={colors.primary} />
+            </View>
+          ) : (
+            <RepoFileTree
+              owner={repoInfo.owner}
+              repo={repoInfo.repo}
+              branch={selectedRepo?.branch}
+              onFilePress={(node: TreeNode) => {
+                const kind = classifyFile(node.name);
+                const params = {
+                  owner: repoInfo.owner,
+                  repo: repoInfo.repo,
+                  branch: selectedRepo?.branch,
+                  path: node.path,
+                  title: node.name,
+                  size: node.size,
+                };
+                if (kind === 'pdf') {
+                  navigation.navigate('PdfViewer', params);
+                } else if (kind === 'image') {
+                  navigation.navigate('ImageViewer', params);
+                } else if (kind === 'video') {
+                  navigation.navigate('VideoViewer', params);
+                } else if (kind === 'json') {
+                  navigation.navigate('FileViewer', params);
+                } else {
+                  navigation.navigate('FileViewer', params);
+                }
+              }}
+            />
+          )}
         </ScrollView>
       </SafeAreaView>
     );

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, Pressable, Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -32,6 +32,7 @@ import ColorPicker from '../components/ColorPicker';
 import { ShareFormat } from '../services/ShareService';
 import { syncNoteToGitHub } from '../services/NoteGitHubSyncService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
+import { useGitOperationStore } from '../stores/gitOperationStore';
 import { useTranslation } from 'react-i18next';
 import { DailyQuoteCard } from '../components/home/DailyQuoteCard';
 import { useDailyQuote } from '../hooks/useDailyQuote';
@@ -66,6 +67,17 @@ export default function HomeScreen() {
   const [contextMenuItem, setContextMenuItem] = useState<RecentItem | null>(null);
   const [colorPickerItem, setColorPickerItem] = useState<RecentItem | null>(null);
   const { quote, isLoading: quoteLoading, refresh: quoteRefresh } = useDailyQuote();
+  const gitOps = useGitOperationStore((s) => s.ops);
+  const lockedIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const op of Object.values(gitOps)) {
+      if (op.status === 'queued' || op.status === 'running') {
+        for (const entityId of op.entityIds) ids.add(entityId);
+      }
+    }
+    return ids;
+  }, [gitOps]);
+  const contextMenuLocked = contextMenuItem ? lockedIds.has(contextMenuItem.data.id) : false;
 
   useEffect(() => {
     (async () => {
@@ -398,8 +410,8 @@ export default function HomeScreen() {
         </Pressable>
       </View>
 
-      <QuickAccessShelf items={pinnedItems} onOpen={handleOpenRecentItem} onLongPress={handleLongPressRecentItem} />
-      <BentoRecent items={recentItems} onOpen={handleOpenRecentItem} onLongPress={handleLongPressRecentItem} />
+      <QuickAccessShelf items={pinnedItems} onOpen={handleOpenRecentItem} onLongPress={handleLongPressRecentItem} lockedIds={lockedIds} />
+      <BentoRecent items={recentItems} onOpen={handleOpenRecentItem} onLongPress={handleLongPressRecentItem} lockedIds={lockedIds} />
 
       <Modal visible={showFormatPicker} onRequestClose={handleFormatPickerClose} fullWidth>
         <Text className="text-lg font-bold text-center mb-4" style={{ color: colors.text }}>{t('home.format.pickerTitle')}</Text>
@@ -452,6 +464,7 @@ export default function HomeScreen() {
         onShare={handleShare}
         onPickColor={handlePickColor}
         onDelete={handleDelete}
+        deleteDisabled={contextMenuLocked}
       />
 
       <ColorPicker

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -68,11 +68,14 @@ function NoteEditorScreenInner() {
     activeAccountId,
     repositories,
     folders,
+    notes,
     getNoteById,
     createNote,
     updateNote,
     navigation,
   });
+
+  const editingNote = noteId ? notes.find((n) => n.id === noteId) : undefined;
 
   const markdownOverrides = useRenderStyle('markdown');
   const markdownStyles = React.useMemo(
@@ -161,7 +164,13 @@ function NoteEditorScreenInner() {
   return (
     <SafeAreaView edges={['top', 'bottom']} className="flex-1" style={{ backgroundColor: colors.surface }}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} className="flex-1">
-        <EditorHeader noteId={noteId} isSaving={document.isSaving} onCancel={document.handleCancelEdit} onSave={document.handleSave} />
+        <EditorHeader
+          noteId={noteId}
+          isSaving={document.isSaving}
+          onCancel={document.handleCancelEdit}
+          onSave={document.handleSave}
+          lockCtx={editingNote ? { repo: editingNote.repo, branch: editingNote.branch, path: editingNote.filePath } : undefined}
+        />
 
         <EditorToolbar
           canUndo={document.canUndo}

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -13,6 +13,10 @@ import { RootStackParamList } from '../navigation/types';
 import { Note } from '../models/Note';
 import { GitHubService } from '../services/GitHubService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
+import type { NoteDeleteParams } from '../services/NoteSyncQueueService';
+import { StorageService } from '../services/StorageService';
+import { gitOperationRegistry } from '../stores/gitOperationStore';
+import { deriveDefaultNotePath } from '../stores/noteStore';
 import { pullAllFromRepos } from '../services/RepoPullService';
 import ColorPicker from '../components/ColorPicker';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
@@ -239,15 +243,49 @@ export default function NotesListScreen() {
             if (isDeletingRef.current) return;
             isDeletingRef.current = true;
             setIsDeleting(true);
-            const failedIds = new Set<string>();
             try {
-              for (const id of ids) {
-                try {
-                  const ok = await deleteNote(id);
-                  if (!ok) failedIds.add(id);
-                } catch { failedIds.add(id); }
+              const selectedNotes = notes.filter((note) => selectedIds.has(note.id));
+              const deleteTargets: { note: Note; filePath: string }[] = [];
+              for (const note of selectedNotes) {
+                if (!note.repo) continue;
+                const filePath = note.filePath ?? deriveDefaultNotePath(note);
+                if (filePath) deleteTargets.push({ note, filePath });
               }
-              if (failedIds.size > 0) {
+              if (deleteTargets.length > 0) {
+                const params: NoteDeleteParams[] = deleteTargets.map(({ note, filePath }) => ({
+                  repo: note.repo!,
+                  branch: note.branch,
+                  filePath,
+                  title: note.title,
+                  accountId: note.accountId,
+                }));
+                await NoteSyncQueueService.enqueueNoteDeletes(params);
+                for (const { note, filePath } of deleteTargets) {
+                  gitOperationRegistry.begin({
+                    kind: 'delete',
+                    repo: note.repo!,
+                    branch: note.branch,
+                    path: filePath,
+                    entityIds: [note.id],
+                    status: 'running',
+                    attempts: 0,
+                  });
+                }
+              }
+              let localFailure = false;
+              for (const note of selectedNotes) {
+                try {
+                  const removed = await StorageService.deleteNote(note.id);
+                  if (!removed) localFailure = true;
+                } catch {
+                  localFailure = true;
+                }
+              }
+              await refreshNotes();
+              if (deleteTargets.length > 0) {
+                void NoteSyncQueueService.drain();
+              }
+              if (localFailure) {
                 HapticService.warning();
               } else {
                 HapticService.success();
@@ -261,7 +299,7 @@ export default function NotesListScreen() {
         },
       ],
     );
-  }, [selectedIds, deleteNote, clearSelection, t]);
+  }, [selectedIds, notes, clearSelection, refreshNotes, t]);
 
   useEffect(() => {
     if (authState.token) GitHubService.setToken(authState.token);

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -14,7 +14,8 @@ import { Note } from '../models/Note';
 import { GitHubService } from '../services/GitHubService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
 import type { NoteDeleteParams } from '../services/NoteSyncQueueService';
-import { gitOperationRegistry } from '../stores/gitOperationStore';
+import { gitOperationRegistry, useGitOperationStore } from '../stores/gitOperationStore';
+import { GitSyncGate } from '../services/git/GitSyncGate';
 import { deriveDefaultNotePath, useNoteStore } from '../stores/noteStore';
 import { useEntityLock } from '../hooks/useGitOpLock';
 import { syncNow } from '../services/git/manualSync';
@@ -190,6 +191,16 @@ export default function NotesListScreen() {
 
   const isFocused = useIsFocused();
   const { inflight } = useGitHubActivityStore();
+
+  // GitSyncGate publishes registry ops for the held cycle (kind 'pull')
+  // and push markers (kind 'push'); the registry is the reactive busy source.
+  const gateBusy = useGitOperationStore((s) =>
+    Object.values(s.ops).some(
+      (op) =>
+        (op.status === 'queued' || op.status === 'running') &&
+        (op.kind === 'pull' || op.kind === 'push'),
+    ),
+  );
 
   // Reset refresh state when screen loses focus (tab switch, stack push, etc.)
   useEffect(() => {
@@ -443,6 +454,7 @@ export default function NotesListScreen() {
   const handlePullToRefresh = useCallback(async () => {
     if (isPullRefreshingRef.current) return;
     if (useGitHubActivityStore.getState().inflight > 0) return;
+    if (GitSyncGate.isCycleHeld()) return;
     isPullRefreshingRef.current = true;
     setIsPullRefreshing(true);
     HapticService.light();
@@ -470,6 +482,10 @@ export default function NotesListScreen() {
 
   const handleManualSync = useCallback(async () => {
     if (isManualSyncing) return;
+    if (gateBusy) {
+      HapticService.warning();
+      return;
+    }
     HapticService.light();
     setIsManualSyncing(true);
     try {
@@ -485,7 +501,7 @@ export default function NotesListScreen() {
     } finally {
       setIsManualSyncing(false);
     }
-  }, [isManualSyncing]);
+  }, [isManualSyncing, gateBusy]);
 
   const handleViewModeChange = useCallback(
     (mode: ViewMode) => {
@@ -642,6 +658,7 @@ export default function NotesListScreen() {
               testID="notes-list.swipe.pull-refresh"
               refreshing={isPullRefreshing}
               onRefresh={handlePullToRefresh}
+              enabled={!gateBusy}
               tintColor={colors.primary}
               colors={[colors.primary]}
             />
@@ -744,11 +761,10 @@ export default function NotesListScreen() {
                 size="sm"
                 testID="notes-list.icon-button.sync"
                 active={pendingSync > 0}
-                disabled={isManualSyncing}
                 onPress={handleManualSync}
                 accessibilityLabel={t('common.sync')}
               >
-                {isManualSyncing ? (
+                {isManualSyncing || gateBusy ? (
                   <ActivityIndicator size="small" color={colors.primary} />
                 ) : (
                   <Ionicons

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import { Alert, View, Text, ActivityIndicator, RefreshControl, FlatList, TouchableOpacity, InteractionManager } from 'react-native';
+import { Alert, View, Text, ActivityIndicator, RefreshControl, FlatList, TouchableOpacity, InteractionManager, StyleSheet } from 'react-native';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
@@ -14,9 +14,9 @@ import { Note } from '../models/Note';
 import { GitHubService } from '../services/GitHubService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
 import type { NoteDeleteParams } from '../services/NoteSyncQueueService';
-import { StorageService } from '../services/StorageService';
 import { gitOperationRegistry } from '../stores/gitOperationStore';
-import { deriveDefaultNotePath } from '../stores/noteStore';
+import { deriveDefaultNotePath, useNoteStore } from '../stores/noteStore';
+import { useEntityLock } from '../hooks/useGitOpLock';
 import { syncNow } from '../services/git/manualSync';
 import ColorPicker from '../components/ColorPicker';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
@@ -47,6 +47,106 @@ import { useTranslation } from 'react-i18next';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
+interface LockedNoteRowProps {
+  item: Note;
+  index: number;
+  viewMode: ViewMode;
+  selectionMode: boolean;
+  selected: boolean;
+  highlighted: boolean;
+  isOffline: boolean;
+  isCached: boolean;
+  onToggleSelect: () => void;
+  onTagPress: (tag: string) => void;
+  prevDateKey: string | undefined;
+  onPress: (note: Note) => void;
+  onLongPress: (note: Note) => void;
+}
+
+function LockedNoteRow({
+  item,
+  index,
+  viewMode,
+  selectionMode,
+  selected,
+  highlighted,
+  isOffline,
+  isCached,
+  onToggleSelect,
+  onTagPress,
+  prevDateKey,
+  onPress,
+  onLongPress,
+}: LockedNoteRowProps) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const lock = useEntityLock(item.id, {
+    repo: item.repo,
+    branch: item.branch,
+    path: item.filePath ?? deriveDefaultNotePath(item) ?? undefined,
+  });
+
+  const handlePress = useCallback(() => {
+    if (lock.locked) return;
+    if (lock.failed) {
+      Alert.alert(t('sync.deleteFailed'), lock.error ?? t('errors.failedDeleteNoteBody'), [
+        { text: t('common.cancel'), style: 'cancel' },
+        { text: t('sync.retry'), onPress: lock.retry },
+      ]);
+      return;
+    }
+    onPress(item);
+  }, [lock, onPress, item, t]);
+
+  const handleLongPress = useCallback(() => {
+    if (lock.locked || lock.failed) return;
+    onLongPress(item);
+  }, [lock, onLongPress, item]);
+
+  return (
+    <SwipeableListItem
+      itemId={item.id}
+      selected={selected}
+      selectionMode={selectionMode}
+      onToggleSelect={onToggleSelect}
+      disabled={lock.locked || lock.failed}
+    >
+      <View style={{ opacity: lock.locked ? 0.45 : 1 }}>
+        <NotesListCard
+          note={item}
+          viewMode={viewMode}
+          onPress={handlePress}
+          onLongPress={handleLongPress}
+          highlighted={highlighted}
+          isOffline={isOffline}
+          isCached={isCached}
+          onTagPress={onTagPress}
+          prevDateKey={prevDateKey}
+          index={index}
+        />
+        {lock.locked ? (
+          <View pointerEvents="none" style={styles.rowLockTrailing}>
+            <ActivityIndicator size="small" testID="note-row.lock-spinner" color={colors.primary} />
+          </View>
+        ) : lock.failed ? (
+          <View pointerEvents="none" style={styles.rowLockTrailing} testID="note-row.lock-error">
+            <Ionicons name="alert-circle" size={18} color={colors.error} />
+          </View>
+        ) : null}
+      </View>
+    </SwipeableListItem>
+  );
+}
+
+const styles = StyleSheet.create({
+  rowLockTrailing: {
+    position: 'absolute',
+    right: 12,
+    top: 12,
+    zIndex: 5,
+  },
+});
+
 export default function NotesListScreen() {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
@@ -65,7 +165,6 @@ export default function NotesListScreen() {
     searchQuery,
     setSearchQuery,
     deleteNote,
-    refreshNotes,
     togglePin,
     error,
     clearError,
@@ -246,20 +345,18 @@ export default function NotesListScreen() {
             try {
               const selectedNotes = notes.filter((note) => selectedIds.has(note.id));
               const deleteTargets: { note: Note; filePath: string }[] = [];
+              const localOnlyIds: string[] = [];
               for (const note of selectedNotes) {
-                if (!note.repo) continue;
+                if (!note.repo) {
+                  localOnlyIds.push(note.id);
+                  continue;
+                }
                 const filePath = note.filePath ?? deriveDefaultNotePath(note);
                 if (filePath) deleteTargets.push({ note, filePath });
+                else localOnlyIds.push(note.id);
               }
               if (deleteTargets.length > 0) {
-                const params: NoteDeleteParams[] = deleteTargets.map(({ note, filePath }) => ({
-                  repo: note.repo!,
-                  branch: note.branch,
-                  filePath,
-                  title: note.title,
-                  accountId: note.accountId,
-                }));
-                await NoteSyncQueueService.enqueueNoteDeletes(params);
+                // All rows lock simultaneously; each is removed only on its queue success event.
                 for (const { note, filePath } of deleteTargets) {
                   gitOperationRegistry.begin({
                     kind: 'delete',
@@ -271,19 +368,25 @@ export default function NotesListScreen() {
                     attempts: 0,
                   });
                 }
+                const params: NoteDeleteParams[] = deleteTargets.map(({ note, filePath }) => ({
+                  repo: note.repo!,
+                  branch: note.branch,
+                  filePath,
+                  title: note.title,
+                  accountId: note.accountId,
+                  localNoteId: note.id,
+                }));
+                await NoteSyncQueueService.enqueueNoteDeletes(params);
+                void NoteSyncQueueService.drain();
               }
               let localFailure = false;
-              for (const note of selectedNotes) {
+              for (const id of localOnlyIds) {
                 try {
-                  const removed = await StorageService.deleteNote(note.id);
+                  const removed = await useNoteStore.getState().deleteNote(id);
                   if (!removed) localFailure = true;
                 } catch {
                   localFailure = true;
                 }
-              }
-              await refreshNotes();
-              if (deleteTargets.length > 0) {
-                void NoteSyncQueueService.drain();
               }
               if (localFailure) {
                 HapticService.warning();
@@ -299,7 +402,7 @@ export default function NotesListScreen() {
         },
       ],
     );
-  }, [selectedIds, notes, clearSelection, refreshNotes, t]);
+  }, [selectedIds, notes, clearSelection, t]);
 
   useEffect(() => {
     if (authState.token) GitHubService.setToken(authState.token);
@@ -429,25 +532,21 @@ export default function NotesListScreen() {
       const prevDateKey =
         viewMode === 'journal' && prev?.updatedAt ? formatJournalDate(new Date(prev.updatedAt)) : undefined;
       return (
-        <SwipeableListItem
-          itemId={item.id}
+        <LockedNoteRow
+          item={item}
+          index={index}
+          viewMode={viewMode}
           selected={selectedIds.has(item.id)}
           selectionMode={selectionMode}
           onToggleSelect={() => toggleSelected(item.id)}
-        >
-          <NotesListCard
-            note={item}
-            viewMode={viewMode}
-            onPress={handleNotePress}
-            onLongPress={handleNoteLongPress}
-            highlighted={hasActiveSearch && index === currentSearchMatchIndex}
-            isOffline={isConnected === false}
-            isCached={!!item.content?.trim()}
-            onTagPress={handleTagPress}
-            prevDateKey={prevDateKey}
-            index={index}
-          />
-        </SwipeableListItem>
+          onPress={handleNotePress}
+          onLongPress={handleNoteLongPress}
+          highlighted={hasActiveSearch && index === currentSearchMatchIndex}
+          isOffline={isConnected === false}
+          isCached={!!item.content?.trim()}
+          onTagPress={handleTagPress}
+          prevDateKey={prevDateKey}
+        />
       );
     },
     [

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -17,7 +17,7 @@ import type { NoteDeleteParams } from '../services/NoteSyncQueueService';
 import { StorageService } from '../services/StorageService';
 import { gitOperationRegistry } from '../stores/gitOperationStore';
 import { deriveDefaultNotePath } from '../stores/noteStore';
-import { pullAllFromRepos } from '../services/RepoPullService';
+import { syncNow } from '../services/git/manualSync';
 import ColorPicker from '../components/ColorPicker';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import { ConflictBanner } from '../components/ui/ConflictBanner';
@@ -349,52 +349,40 @@ export default function NotesListScreen() {
       setIsPullRefreshing(false);
     }, 30000);
 
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    const timeout = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(() => reject(new Error('Sync timed out')), 60000);
-    });
     try {
-      await Promise.race([
-        (async () => {
-          await NoteSyncQueueService.drain();
-          await pullAllFromRepos();
-        })(),
-        timeout,
-      ]);
-      await refreshNotes();
-      HapticService.success();
-    } catch (pullError) {
-      HapticService.warning();
-      console.warn('[Sync] pull-refresh failed:', pullError);
+      // Do NOT acquire the gate cycle here: syncNow acquires it internally,
+      // and a held cycle would deadlock its own acquisition.
+      const result = await syncNow();
+      if (result.ok) {
+        HapticService.success();
+      } else {
+        HapticService.warning();
+      }
     } finally {
-      if (timeoutId !== null) clearTimeout(timeoutId);
       clearTimeout(safetyTimeout);
       isPullRefreshingRef.current = false;
       setIsPullRefreshing(false);
     }
-  }, [refreshNotes]);
+  }, []);
 
   const handleManualSync = useCallback(async () => {
     if (isManualSyncing) return;
     HapticService.light();
     setIsManualSyncing(true);
     try {
-      // Bidirectional: drain pending upserts AND pull remote changes (#621).
-      // Mirrors handlePullToRefresh so the cloud icon and the swipe gesture
-      // perform the same work — the icon previously only pushed, which left
-      // remote ADD/UPDATE/DELETE invisible to users who tapped it expecting
-      // a sync.
-      await NoteSyncQueueService.drain();
-      await pullAllFromRepos();
-      await refreshNotes();
-      HapticService.success();
-    } catch (error) {
-      HapticService.warning();
-      console.warn('[Sync] manual sync failed:', error);
+      // Bidirectional manual sync (#621). Do NOT acquire the gate cycle
+      // here: syncNow acquires it internally, and a held cycle would
+      // deadlock its own acquisition.
+      const result = await syncNow();
+      if (result.ok) {
+        HapticService.success();
+      } else {
+        HapticService.warning();
+      }
     } finally {
       setIsManualSyncing(false);
     }
-  }, [isManualSyncing, refreshNotes]);
+  }, [isManualSyncing]);
 
   const handleViewModeChange = useCallback(
     (mode: ViewMode) => {

--- a/src/screens/PdfViewerScreen.tsx
+++ b/src/screens/PdfViewerScreen.tsx
@@ -263,7 +263,6 @@ export default function PdfViewerScreen() {
       ) : !localUri ? (
         <View className="flex-1 items-center justify-center p-6">
           <ActivityIndicator size="large" color={colors.primary} />
-          <Text className="mt-3 text-sm" style={{ color: colors.textSecondary }}>Loading PDF…</Text>
         </View>
       ) : (
         // Wrapper acts as the blend stacking context for the invert overlay.

--- a/src/screens/RenderStyleEditorScreen.tsx
+++ b/src/screens/RenderStyleEditorScreen.tsx
@@ -410,7 +410,7 @@ export default function RenderStyleEditorScreen() {
         </Text>
       </ScrollView>
 
-      {isSaving ? <SavingOverlay visible label="Saving…" /> : null}
+      {isSaving ? <SavingOverlay visible /> : null}
     </SafeAreaView>
   );
 }

--- a/src/screens/RenderStyleSettingsScreen.tsx
+++ b/src/screens/RenderStyleSettingsScreen.tsx
@@ -197,7 +197,6 @@ function RepoPickerSheet(props: RepoPickerProps) {
           {discovering ? (
             <View className="flex-row items-center gap-3 px-4 py-3">
               <ActivityIndicator color={colors.primary} />
-              <Text className="text-xs mt-0.5" style={{ color: colors.textSecondary }}>Scanning for existing settings/render.json…</Text>
             </View>
           ) : null}
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -302,7 +302,7 @@ export default function SettingsScreen() {
     if (cloneProgress?.error) {
       setCloneProgress(null);
     } else {
-      setCloneProgress((prev) => (prev ? { ...prev, phase: 'Cancelling…' } : prev));
+      setCloneProgress((prev) => (prev ? { ...prev, phase: 'Cancelling' } : prev));
     }
   }, [cloneProgress]);
 

--- a/src/screens/ThoughtDumpScreen.tsx
+++ b/src/screens/ThoughtDumpScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { View, StyleSheet, FlatList, Alert, Text, Pressable } from 'react-native';
+import { View, StyleSheet, FlatList, Alert, Text, Pressable, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -12,6 +12,8 @@ import { RootStackParamList } from '../navigation/types';
 import { ThoughtDumpService } from '../services/ThoughtDumpService';
 import { StorageService } from '../services/StorageService';
 import { ThoughtDump } from '../models/ThoughtDump';
+import { gitOperationRegistry } from '../stores/gitOperationStore';
+import { useEntityLock } from '../hooks/useGitOpLock';
 import { ScreenHeader, Button, Input, EmptyState, Modal } from '../components/ui';
 import { useScreenHeaderHeight } from '../components/ui';
 import VoiceInputModal from '../components/VoiceInputModal';
@@ -23,6 +25,72 @@ type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 interface Props {
   onDumpChange?: (dump: ThoughtDump) => void;
+}
+
+interface LockedDumpRowProps {
+  item: ThoughtDump;
+  repoPath: string;
+  branch: string | undefined;
+  onRequestDelete: (dump: ThoughtDump) => void;
+  formatRelativeDate: (isoDate: string) => string;
+  selected: boolean;
+  selectionMode: boolean;
+  onToggleSelect: () => void;
+}
+
+function LockedDumpRow({
+  item,
+  repoPath,
+  branch,
+  onRequestDelete,
+  formatRelativeDate,
+  selected,
+  selectionMode,
+  onToggleSelect,
+}: LockedDumpRowProps) {
+  const { t } = useTranslation();
+  const { colors, spacing } = useTokens();
+  const lock = useEntityLock(item.id, { repo: repoPath || undefined, branch, path: item.filePath });
+  return (
+    <SwipeableListItem
+      itemId={item.id}
+      selected={selected}
+      selectionMode={selectionMode}
+      onToggleSelect={onToggleSelect}
+      disabled={lock.locked}
+    >
+      <View
+        style={[
+          styles.dumpItem,
+          {
+            padding: spacing[3],
+            marginBottom: spacing[2],
+            backgroundColor: colors.surface,
+            opacity: lock.locked ? 0.45 : 1,
+          },
+        ]}
+      >
+        <Text style={[styles.dumpText, { color: colors.text }]} numberOfLines={6}>
+          {item.text}
+        </Text>
+        <View style={[styles.dumpFooter, { marginTop: spacing[2] }]}>
+          <Text style={[styles.dumpDate, { color: colors.textSecondary }]}>
+            {formatRelativeDate(item.createdAt)}
+          </Text>
+          {lock.locked ? (
+            <ActivityIndicator size="small" testID={`thought-dump-lock-${item.id}`} color={colors.primary} />
+          ) : (
+            <Button
+              testID={`thought-dump-delete-${item.id}`}
+              label={t('thoughtDump.delete')}
+              variant="ghost"
+              onPress={() => onRequestDelete(item)}
+            />
+          )}
+        </View>
+      </View>
+    </SwipeableListItem>
+  );
 }
 
 export default function ThoughtDumpScreen({ onDumpChange }: Props) {
@@ -116,6 +184,15 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
     if (!target) return;
     setDeleteTarget(null);
 
+    const opId = gitOperationRegistry.begin({
+      kind: 'delete',
+      repo: repoPath,
+      branch,
+      path: target.filePath,
+      entityIds: [target.id],
+      status: 'running',
+      attempts: 0,
+    });
     try {
       const success = await ThoughtDumpService.delete(target.id, {
         repoPath,
@@ -123,13 +200,16 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
         filePath: target.filePath,
       });
       if (success) {
+        gitOperationRegistry.succeed(opId);
         setDumps((prev) => prev.filter((d) => d.id !== target.id));
         removeDump(target.filePath);
         onDumpChange?.(target);
       } else {
+        gitOperationRegistry.fail(opId, 'Delete failed');
         Alert.alert(t('common.error'), t('thoughtDump.error'));
       }
     } catch {
+      gitOperationRegistry.fail(opId, 'Delete failed');
       Alert.alert(t('common.error'), t('thoughtDump.error'));
     }
   };
@@ -191,31 +271,18 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
 
   const renderItem = useCallback(
     ({ item }: { item: ThoughtDump }) => (
-      <SwipeableListItem
-        itemId={item.id}
+      <LockedDumpRow
+        item={item}
+        repoPath={repoPath}
+        branch={branch}
+        onRequestDelete={(dump) => setDeleteTarget(dump)}
+        formatRelativeDate={formatRelativeDate}
         selected={selectedIds.has(item.id)}
         selectionMode={selectionMode}
         onToggleSelect={() => toggleSelected(item.id)}
-      >
-        <View style={[styles.dumpItem, { padding: spacing[3], marginBottom: spacing[2], backgroundColor: colors.surface }]}>
-          <Text style={[styles.dumpText, { color: colors.text }]} numberOfLines={6}>
-            {item.text}
-          </Text>
-          <View style={[styles.dumpFooter, { marginTop: spacing[2] }]}>
-            <Text style={[styles.dumpDate, { color: colors.textSecondary }]}>
-              {formatRelativeDate(item.createdAt)}
-            </Text>
-            <Button
-              testID={`thought-dump-delete-${item.id}`}
-              label={t('thoughtDump.delete')}
-              variant="ghost"
-              onPress={() => setDeleteTarget(item)}
-            />
-          </View>
-        </View>
-      </SwipeableListItem>
+      />
     ),
-    [colors, spacing, t, selectedIds, selectionMode, toggleSelected],
+    [repoPath, branch, formatRelativeDate, selectedIds, selectionMode, toggleSelected],
   );
 
   const renderEmpty = () => {

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -38,7 +38,8 @@ import { SwipeableListItem } from '../components/list/SwipeableListItem';
 import { BulkActionBar } from '../components/list/BulkActionBar';
 import { useResponsive } from '../hooks/useResponsive';
 import { useGitHubActivityStore } from '../stores/githubActivityStore';
-import { gitOperationRegistry } from '../stores/gitOperationStore';
+import { gitOperationRegistry, useGitOperationStore } from '../stores/gitOperationStore';
+import { GitSyncGate } from '../services/git/GitSyncGate';
 import { useEntityLock } from '../hooks/useGitOpLock';
 import { useTranslation } from 'react-i18next';
 import { LastSelectionPreferenceService } from '../services/LastSelectionPreferenceService';
@@ -127,6 +128,16 @@ export default function TodoListScreen() {
   const selectionMode = selectedIds.size > 0;
   const isFocused = useIsFocused();
   const { inflight } = useGitHubActivityStore();
+
+  // GitSyncGate publishes registry ops for the held cycle (kind 'pull')
+  // and push markers (kind 'push'); the registry is the reactive busy source.
+  const gateBusy = useGitOperationStore((s) =>
+    Object.values(s.ops).some(
+      (op) =>
+        (op.status === 'queued' || op.status === 'running') &&
+        (op.kind === 'pull' || op.kind === 'push'),
+    ),
+  );
 
   // Reset refresh state when screen loses focus (tab switch, stack push, etc.)
   useEffect(() => {
@@ -537,6 +548,7 @@ export default function TodoListScreen() {
   const handlePullToRefresh = useCallback(async () => {
     if (isRefreshingRef.current) return;
     if (useGitHubActivityStore.getState().inflight > 0) return;
+    if (GitSyncGate.isCycleHeld()) return;
     isRefreshingRef.current = true;
     setIsRefreshing(true);
     HapticService.light();
@@ -651,8 +663,10 @@ export default function TodoListScreen() {
         refreshControl={
           gitOperationActive ? undefined : (
             <RefreshControl
+              testID="todo-list.swipe.pull-refresh"
               refreshing={isRefreshing}
               onRefresh={handlePullToRefresh}
+              enabled={!gateBusy}
               tintColor={colors.primary}
               colors={[colors.primary]}
             />

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { View, Alert, Platform, RefreshControl } from 'react-native';
+import { View, Alert, Platform, RefreshControl, ActivityIndicator } from 'react-native';
 import { FlatList } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
@@ -38,10 +38,47 @@ import { SwipeableListItem } from '../components/list/SwipeableListItem';
 import { BulkActionBar } from '../components/list/BulkActionBar';
 import { useResponsive } from '../hooks/useResponsive';
 import { useGitHubActivityStore } from '../stores/githubActivityStore';
+import { gitOperationRegistry } from '../stores/gitOperationStore';
+import { useEntityLock } from '../hooks/useGitOpLock';
 import { useTranslation } from 'react-i18next';
 import { LastSelectionPreferenceService } from '../services/LastSelectionPreferenceService';
 
 const FILTER_COMPLETED_PERSISTENCE_KEY = '@gitnotes:filters:todo-completed';
+
+interface LockedTodoRowProps {
+  item: Todo;
+  selected: boolean;
+  selectionMode: boolean;
+  onToggleSelect: () => void;
+  onPress: (todo: Todo) => void;
+  onToggle: (id: string) => void;
+}
+
+function LockedTodoRow({ item, selected, selectionMode, onToggleSelect, onPress, onToggle }: LockedTodoRowProps) {
+  const { colors } = useTheme();
+  const lock = useEntityLock(item.id, { repo: item.repo, branch: item.branch, path: item.filePath });
+  return (
+    <SwipeableListItem
+      itemId={item.id}
+      selected={selected}
+      selectionMode={selectionMode}
+      onToggleSelect={onToggleSelect}
+      disabled={lock.locked}
+    >
+      <View style={{ opacity: lock.locked ? 0.45 : 1 }}>
+        <TodoCard todo={item} onPress={onPress} onToggle={onToggle} />
+        {lock.locked ? (
+          <ActivityIndicator
+            size="small"
+            testID="todo-row.lock-spinner"
+            color={colors.primary}
+            style={{ position: 'absolute', right: 12, top: 12, zIndex: 5 }}
+          />
+        ) : null}
+      </View>
+    </SwipeableListItem>
+  );
+}
 
 export default function TodoListScreen() {
   const { t } = useTranslation();
@@ -193,6 +230,19 @@ export default function TodoListScreen() {
         continue;
       }
 
+      const opByTodoId = new Map<string, string>();
+      for (const todo of group.todos) {
+        opByTodoId.set(todo.id, gitOperationRegistry.begin({
+          kind: 'delete',
+          repo: todo.repo!,
+          branch: todo.branch,
+          path: todo.filePath!,
+          entityIds: [todo.id],
+          status: 'running',
+          attempts: 0,
+        }));
+      }
+
       let result;
       try {
         result = await batchDeleteFiles({
@@ -216,15 +266,23 @@ export default function TodoListScreen() {
       const deletedPaths = new Set(result.deleted);
       const removedIds: string[] = [];
       for (const todo of group.todos) {
+        const opId = opByTodoId.get(todo.id);
         if (!deletedPaths.has(todo.filePath!)) {
           failedIds.add(todo.id);
+          if (opId) gitOperationRegistry.fail(opId, result.failed[0]?.error ?? 'Delete failed');
           continue;
         }
         try {
-          if (await StorageService.deleteTodo(todo.id)) removedIds.push(todo.id);
-          else failedIds.add(todo.id);
+          if (await StorageService.deleteTodo(todo.id)) {
+            removedIds.push(todo.id);
+            if (opId) gitOperationRegistry.succeed(opId);
+          } else {
+            failedIds.add(todo.id);
+            if (opId) gitOperationRegistry.fail(opId, 'Failed to delete todo locally');
+          }
         } catch {
           failedIds.add(todo.id);
+          if (opId) gitOperationRegistry.fail(opId, 'Failed to delete todo locally');
         }
       }
       if (removedIds.length > 0) {
@@ -501,14 +559,14 @@ export default function TodoListScreen() {
 
   const renderTodoItem = useCallback(
     ({ item }: { item: Todo }) => (
-      <SwipeableListItem
-        itemId={item.id}
+      <LockedTodoRow
+        item={item}
         selected={selectedIds.has(item.id)}
         selectionMode={selectionMode}
         onToggleSelect={() => toggleSelected(item.id)}
-      >
-        <TodoCard todo={item} onPress={openEditModal} onToggle={handleToggleTodo} />
-      </SwipeableListItem>
+        onPress={openEditModal}
+        onToggle={handleToggleTodo}
+      />
     ),
     [
       handleToggleTodo,

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -13,7 +13,7 @@ import { slugifyTodoText, Todo, TodoPriority } from '../models/Todo';
 import { SortMode } from '../types/SortTypes';
 import { HapticService } from '../utils/haptics';
 import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
-import { pullAllFromRepos } from '../services/RepoPullService';
+import { syncNow } from '../services/git/manualSync';
 import { batchDeleteFiles } from '../services/git/BatchGitOperations';
 import { resolveBranch } from '../services/git/resolveBranch';
 import { formatSyncError } from '../services/git/formatSyncError';
@@ -49,7 +49,7 @@ export default function TodoListScreen() {
   const headerHeight = useScreenHeaderHeight();
   const tabBarHeight = useTabBarHeight();
   const navigation = useNavigation();
-  const { todos, createTodo, updateTodo, toggleTodo, refreshTodos } = useTodos();
+  const { todos, createTodo, updateTodo, toggleTodo } = useTodos();
   const deleteTodo = useTodoStore((state) => state.deleteTodo);
   const { activeAccountId } = useAuth();
   const { repositories } = useRepos();
@@ -489,16 +489,15 @@ export default function TodoListScreen() {
     }, 30000);
 
     try {
-      await pullAllFromRepos();
-    } catch (err) {
-      console.warn('[TodoList] Pull failed:', err);
+      // Do NOT acquire the gate cycle here: syncNow acquires it internally,
+      // and a held cycle would deadlock its own acquisition.
+      await syncNow();
     } finally {
       clearTimeout(safetyTimeout);
-      await refreshTodos();
       isRefreshingRef.current = false;
       setIsRefreshing(false);
     }
-  }, [refreshTodos]);
+  }, []);
 
   const renderTodoItem = useCallback(
     ({ item }: { item: Todo }) => (

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -14,6 +14,12 @@ import { SortMode } from '../types/SortTypes';
 import { HapticService } from '../utils/haptics';
 import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
 import { pullAllFromRepos } from '../services/RepoPullService';
+import { batchDeleteFiles } from '../services/git/BatchGitOperations';
+import { resolveBranch } from '../services/git/resolveBranch';
+import { formatSyncError } from '../services/git/formatSyncError';
+import { SyncEngineService } from '../services/SyncEngineService';
+import { StorageService } from '../services/StorageService';
+import { parseRepoPath } from '../utils/gitPathParser';
 import { IconButton, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
@@ -158,6 +164,82 @@ export default function TodoListScreen() {
     persistenceKey: '@gitnotes:filters:todo-list',
   });
 
+  const runApiBatchDeletes = useCallback(async (batchable: Todo[], failedIds: Set<string>) => {
+    const branchByHintKey = new Map<string, string>();
+    const groups = new Map<string, { repo: string; branch: string; todos: Todo[] }>();
+    for (const todo of batchable) {
+      const hintKey = `${todo.repo}\n${todo.branch ?? ''}`;
+      if (!branchByHintKey.has(hintKey)) {
+        branchByHintKey.set(hintKey, await resolveBranch(todo.repo!, todo.branch));
+      }
+      const branch = branchByHintKey.get(hintKey)!;
+      const groupKey = `${todo.repo}\n${branch}`;
+      const group = groups.get(groupKey) ?? { repo: todo.repo!, branch, todos: [] };
+      group.todos.push(todo);
+      groups.set(groupKey, group);
+    }
+
+    for (const group of groups.values()) {
+      const repoInfo = parseRepoPath(group.repo);
+      if (!repoInfo || group.todos.length < 2) {
+        for (const todo of group.todos) {
+          try {
+            const ok = await deleteTodo(todo.id);
+            if (!ok) failedIds.add(todo.id);
+          } catch {
+            failedIds.add(todo.id);
+          }
+        }
+        continue;
+      }
+
+      let result;
+      try {
+        result = await batchDeleteFiles({
+          owner: repoInfo.owner,
+          repo: repoInfo.repo,
+          branch: group.branch,
+          paths: group.todos.map((todo) => todo.filePath!),
+          message: `Delete ${group.todos.length} todos`,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        result = {
+          success: false,
+          deleted: [] as string[],
+          failed: group.todos.map((todo) => ({ path: todo.filePath!, error: message })),
+        };
+      }
+
+      // Remote-first (#489): local rows disappear ONLY for paths the batch
+      // actually deleted; failures keep their rows plus the store error state.
+      const deletedPaths = new Set(result.deleted);
+      const removedIds: string[] = [];
+      for (const todo of group.todos) {
+        if (!deletedPaths.has(todo.filePath!)) {
+          failedIds.add(todo.id);
+          continue;
+        }
+        try {
+          if (await StorageService.deleteTodo(todo.id)) removedIds.push(todo.id);
+          else failedIds.add(todo.id);
+        } catch {
+          failedIds.add(todo.id);
+        }
+      }
+      if (removedIds.length > 0) {
+        const removedSet = new Set(removedIds);
+        useTodoStore.setState((state) => ({
+          todos: state.todos.filter((todo) => !removedSet.has(todo.id)),
+        }));
+      }
+      if (result.failed.length > 0) {
+        console.warn('[TodoList] bulk delete failed for paths:', result.failed);
+        useTodoStore.setState({ error: formatSyncError(result.failed[0].error, 'delete') });
+      }
+    }
+  }, [deleteTodo]);
+
   const handleBulkDelete = useCallback(() => {
     const ids = Array.from(selectedIds);
     if (ids.length === 0) return;
@@ -176,12 +258,27 @@ export default function TodoListScreen() {
             isDeletingRef.current = true;
             const failedIds = new Set<string>();
             try {
-              for (const id of ids) {
-                try {
-                  const ok = await deleteTodo(id);
-                  if (!ok) failedIds.add(id);
-                } catch { failedIds.add(id); }
+              const selectedTodos = todos.filter((todo) => selectedIds.has(todo.id));
+              const batchable: Todo[] = [];
+              const perItem: Todo[] = [];
+              for (const todo of selectedTodos) {
+                if (!todo.repo || !todo.filePath) {
+                  perItem.push(todo);
+                  continue;
+                }
+                const mode = await SyncEngineService.getMode(todo.repo);
+                if (mode === 'api') batchable.push(todo);
+                else perItem.push(todo);
               }
+              for (const todo of perItem) {
+                try {
+                  const ok = await deleteTodo(todo.id);
+                  if (!ok) failedIds.add(todo.id);
+                } catch {
+                  failedIds.add(todo.id);
+                }
+              }
+              await runApiBatchDeletes(batchable, failedIds);
               if (failedIds.size > 0) {
                 HapticService.warning();
               } else {
@@ -195,7 +292,7 @@ export default function TodoListScreen() {
         },
       ],
     );
-  }, [selectedIds, deleteTodo, clearSelection, t]);
+  }, [selectedIds, todos, deleteTodo, clearSelection, runApiBatchDeletes, t]);
 
   const resetForm = useCallback(() => {
     setTodoText('');

--- a/src/services/BackgroundSyncService.ts
+++ b/src/services/BackgroundSyncService.ts
@@ -4,6 +4,7 @@ import { GitHubService } from './GitHubService';
 import { StorageService } from './StorageService';
 import { NoteSyncQueueService } from './NoteSyncQueueService';
 import { pullAllFromRepos } from './RepoPullService';
+import { GitSyncGate } from './git/GitSyncGate';
 
 const TASK_NAME = 'background-sync';
 
@@ -23,8 +24,15 @@ TaskManager.defineTask(TASK_NAME, async () => {
       return BackgroundTask.BackgroundTaskResult.Success;
     }
 
-    await NoteSyncQueueService.drain();
-    await pullAllFromRepos();
+    // ONE cycle spans the drain+pull pair; drain() sees the held cycle and
+    // skips its own acquisition (no self-deadlock).
+    const releaseCycle = await GitSyncGate.acquireCycle();
+    try {
+      await NoteSyncQueueService.drain();
+      await pullAllFromRepos();
+    } finally {
+      releaseCycle();
+    }
 
     return BackgroundTask.BackgroundTaskResult.Success;
   } catch (error) {

--- a/src/services/CanvasGitHubSyncService.ts
+++ b/src/services/CanvasGitHubSyncService.ts
@@ -4,7 +4,7 @@ import { parseRepoPath } from '../utils/gitPathParser';
 import { AuthService } from './AuthService';
 import { SyncEngineService } from './SyncEngineService';
 import { LocalGitWriter } from './git/LocalGitWriter';
-import { resolveBranch } from './git/branchResolver';
+import { resolveBranch } from './git/resolveBranch';
 
 async function resolveToken(accountId?: string): Promise<string | undefined> {
   if (!accountId) return undefined;

--- a/src/services/ForegroundSyncService.ts
+++ b/src/services/ForegroundSyncService.ts
@@ -5,6 +5,7 @@ import { StorageService } from './StorageService';
 import { NoteSyncQueueService } from './NoteSyncQueueService';
 import { pullAllFromRepos } from './RepoPullService';
 import { reconcileThoughtDumps } from './ai/thoughtDumpIndexing';
+import { GitSyncGate } from './git/GitSyncGate';
 
 /**
  * Foreground auto-pull driver: pulls every tracked repo when the app becomes
@@ -113,12 +114,21 @@ async function runPull(reason: string): Promise<void> {
   let success = false;
   const PULL_TIMEOUT_MS = 600_000;
   backgroundWork = (async () => {
+    // ONE cycle acquisition spans the whole drain+pull pair; drain() sees
+    // the held cycle and runs inside it (no self-deadlock). The release
+    // lives with the work itself, not the timeout race below, so a timed-
+    // out pull keeps owning the cycle until it actually settles.
+    const releaseCycle = await GitSyncGate.acquireCycle();
     try {
-      await NoteSyncQueueService.drain();
-    } catch (error) {
-      console.warn(`[ForegroundSync] drain (${reason}) failed:`, error);
+      try {
+        await NoteSyncQueueService.drain();
+      } catch (error) {
+        console.warn(`[ForegroundSync] drain (${reason}) failed:`, error);
+      }
+      await pullAllFromRepos();
+    } finally {
+      releaseCycle();
     }
-    await pullAllFromRepos();
   })().finally(() => {
     pendingBackgroundWork = false;
     backgroundWork = null;
@@ -278,6 +288,7 @@ export async function __runPullForTest(reason = 'test'): Promise<void> {
 
 export function __resetForegroundSyncForTest(): void {
   stopForegroundWatcher();
+  GitSyncGate.__resetForTest();
   inFlight = false;
   pendingBackgroundWork = false;
   backgroundWork = null;

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -208,6 +208,14 @@ export interface GitHubFileCommit {
   commit: { sha: string };
 }
 
+/** Entry of a Git tree listing / explicit `POST /git/trees` payload. */
+export interface GitHubTreeEntry {
+  path: string;
+  mode: string;
+  type: string;
+  sha: string;
+}
+
 export interface GitHubPathCommitDates {
   updatedAt?: number;
   createdAt?: number;
@@ -978,9 +986,130 @@ class GitHubServiceClass {
     return true;
   }
 
+  /**
+   * Git Data API primitives backing `src/services/git/BatchGitOperations`
+   * (single-commit bulk deletes). Strict contract: HTTP errors are rethrown
+   * so the batch driver can apply its own retry/fallback policy — unlike
+   * the Contents-API helpers above, which swallow failures into null/[] .
+   */
+  async getBranchHead(
+    owner: string,
+    repo: string,
+    branch: string,
+    opts?: TokenOpts,
+  ): Promise<{ sha: string }> {
+    const encodedBranch = branch.split('/').map(encodeURIComponent).join('/');
+    const data = await this.request<{ object?: { sha?: string } }>(
+      `https://api.github.com/repos/${owner}/${repo}/git/ref/heads/${encodedBranch}`,
+      'GET',
+      undefined,
+      opts,
+    );
+    if (!data?.object?.sha) {
+      throw new Error(`Branch head not found for ${branch}`);
+    }
+    return { sha: data.object.sha };
+  }
+
+  async getCommit(
+    owner: string,
+    repo: string,
+    sha: string,
+    opts?: TokenOpts,
+  ): Promise<{ treeSha: string }> {
+    const data = await this.request<{ tree?: { sha?: string } }>(
+      `https://api.github.com/repos/${owner}/${repo}/git/commits/${encodeURIComponent(sha)}`,
+      'GET',
+      undefined,
+      opts,
+    );
+    if (!data?.tree?.sha) {
+      throw new Error(`Commit tree not found for ${sha}`);
+    }
+    return { treeSha: data.tree.sha };
+  }
+
+  async getTreeRaw(
+    owner: string,
+    repo: string,
+    treeSha: string,
+    recursive: boolean = true,
+    opts?: TokenOpts,
+  ): Promise<GitHubTreeEntry[]> {
+    const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(treeSha)}` +
+      (recursive ? '?recursive=1' : '');
+    const data = await this.request(url, 'GET', undefined, opts);
+    // Same strictness as `getTreeRecursiveOrThrow`: a 200 with a malformed
+    // body is not evidence of an empty tree.
+    if (!Array.isArray(data?.tree)) {
+      throw new Error('GitHub tree response missing tree array');
+    }
+    return data.tree.map((item: any) => ({
+      path: item.path,
+      mode: item.mode,
+      type: item.type,
+      sha: item.sha,
+    }));
+  }
+
+  async createTree(
+    owner: string,
+    repo: string,
+    tree: GitHubTreeEntry[],
+    opts?: TokenOpts,
+  ): Promise<{ sha: string }> {
+    // Explicit tree (no base_tree): omitting a path from base_tree does NOT
+    // delete it, so batch deletes always send the FULL tree minus deletions.
+    const data = await this.request<{ sha?: string }>(
+      `https://api.github.com/repos/${owner}/${repo}/git/trees`,
+      'POST',
+      { tree },
+      opts,
+    );
+    if (!data?.sha) {
+      throw new Error('GitHub create tree returned no sha');
+    }
+    return { sha: data.sha };
+  }
+
+  async createCommit(
+    owner: string,
+    repo: string,
+    input: { message: string; tree: string; parents: string[] },
+    opts?: TokenOpts,
+  ): Promise<{ sha: string }> {
+    const data = await this.request<{ sha?: string }>(
+      `https://api.github.com/repos/${owner}/${repo}/git/commits`,
+      'POST',
+      input,
+      opts,
+    );
+    if (!data?.sha) {
+      throw new Error('GitHub create commit returned no sha');
+    }
+    return { sha: data.sha };
+  }
+
+  async updateRef(
+    owner: string,
+    repo: string,
+    ref: string,
+    sha: string,
+    force: boolean = false,
+    opts?: TokenOpts,
+  ): Promise<void> {
+    const encodedRef = ref.split('/').map(encodeURIComponent).join('/');
+    await this.request(
+      `https://api.github.com/repos/${owner}/${repo}/git/refs/${encodedRef}`,
+      'PATCH',
+      { sha, force },
+      opts,
+    );
+  }
+
   private async request<T = any>(
     url: string,
-    method: 'GET' | 'PUT' | 'POST' | 'DELETE' = 'GET',
+    method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' = 'GET',
     data?: any,
     opts?: TokenOpts,
   ): Promise<T> {

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -6,7 +6,7 @@ import { AuthService } from './AuthService';
 import { SyncEngineService } from './SyncEngineService';
 import { LocalGitWriter } from './git/LocalGitWriter';
 import { GitFsService } from './git/GitFsService';
-import { resolveBranch } from './git/branchResolver';
+import { resolveBranch } from './git/resolveBranch';
 import { githubActivity } from '../stores/githubActivityStore';
 import { getGitHostService } from './git/gitHostFactory';
 import { FEATURE_USE_MULTI_HOST_WRITE } from './featureFlags';

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -9,6 +9,8 @@ import { SyncEngineService } from './SyncEngineService';
 import { AuthService } from './AuthService';
 import { LocalGitWriter } from './git/LocalGitWriter';
 import { classifyGitHubSyncError, isRetryableFailure, syncStatusForError } from './git/syncFailure';
+import { resolveBranch } from './git/resolveBranch';
+import { clearDeleteFailure, readDeleteFailures, recordDeleteFailure } from './git/deleteFailures';
 import { NoteColor, NoteFormat } from '../models/Note';
 
 const QUEUE_KEY = '@gitnotes:sync_queue_v1';
@@ -72,9 +74,24 @@ export type QueuedMutation =
       params: NoteDeleteParams;
     });
 
+/**
+ * Side-channel notification for mutations the queue gave up on. Emitted
+ * instead of changing `drain()`'s `{succeeded, failed, remaining}`
+ * contract: drops do not count as `failed` in the durable case, and the
+ * return shape stays exactly as callers (and tests) codify it.
+ */
+export interface DroppedMutationEvent {
+  mutation: QueuedMutation;
+  /** 'durable' = non-retryable error; 'exhausted' = retry budget used up. */
+  reason: 'durable' | 'exhausted';
+  error?: string;
+  status?: number;
+}
+
 class NoteSyncQueueServiceClass {
   private isDraining = false;
   private listeners = new Set<() => void>();
+  private droppedListeners = new Set<(event: DroppedMutationEvent) => void>();
 
   subscribe(fn: () => void): () => void {
     this.listeners.add(fn);
@@ -83,10 +100,27 @@ class NoteSyncQueueServiceClass {
     };
   }
 
+  onDroppedMutation(fn: (event: DroppedMutationEvent) => void): () => void {
+    this.droppedListeners.add(fn);
+    return () => {
+      this.droppedListeners.delete(fn);
+    };
+  }
+
   private notify(): void {
     this.listeners.forEach((fn) => {
       try {
         fn();
+      } catch {
+        // ignore listener errors - user callbacks should not break the queue
+      }
+    });
+  }
+
+  private emitDroppedMutation(event: DroppedMutationEvent): void {
+    this.droppedListeners.forEach((fn) => {
+      try {
+        fn(event);
       } catch {
         // ignore listener errors - user callbacks should not break the queue
       }
@@ -128,11 +162,18 @@ class NoteSyncQueueServiceClass {
   }
 
   async isTombstoned(repo: string, branch: string | undefined, filePath: string): Promise<boolean> {
+    const key = this.tombstoneKey(repo, branch || 'main', filePath);
+    try {
+      // A dropped-delete failure entry pins the tombstone indefinitely:
+      // the remote file still exists, so expiry would let the next pull
+      // resurrect the note the user deleted.
+      const failures = await readDeleteFailures();
+      if (failures[key] != null) return true;
+    } catch { /* fall through to the TTL check */ }
     try {
       const raw = await AsyncStorage.getItem(TOMBSTONE_KEY);
       if (!raw) return false;
       const map: Record<string, number> = JSON.parse(raw);
-      const key = this.tombstoneKey(repo, branch || 'main', filePath);
       const ts = map[key];
       if (ts == null) return false;
       if (Date.now() - ts > TOMBSTONE_TTL_MS) {
@@ -145,6 +186,7 @@ class NoteSyncQueueServiceClass {
   }
 
   async removeTombstone(repo: string, branch: string | undefined, filePath: string): Promise<void> {
+    await clearDeleteFailure(repo, branch, filePath);
     try {
       const raw = await AsyncStorage.getItem(TOMBSTONE_KEY);
       if (!raw) return;
@@ -155,24 +197,28 @@ class NoteSyncQueueServiceClass {
   }
 
   async enqueueNoteUpsert(params: NoteUpsertParams, localNoteId?: string): Promise<void> {
+    // Persist the RESOLVED branch so the tombstone key, drain group key,
+    // and clone-mode push all agree with the branch pulls resolve.
+    const branch = await resolveBranch(params.repo, params.branch);
+    const resolvedParams: NoteUpsertParams = { ...params, branch };
     const items = await this.getAll();
     const sameRepoBranchPath = (m: QueuedMutation) =>
-      m.params.repo === params.repo &&
-      (m.params.branch || 'main') === (params.branch || 'main') &&
-      m.params.filePath === params.filePath;
+      m.params.repo === resolvedParams.repo &&
+      (m.params.branch || 'main') === branch &&
+      m.params.filePath === resolvedParams.filePath;
     // Drop prior upserts with the same (repo, branch, filePath, title) —
     // latest wins. Also drop any pending delete for the same path: the
     // user re-created the note, so the delete is wasted (#565 phase B.2).
     const filtered = items.filter((m) => {
       if (m.type === 'note.upsert') {
         return !(
-          sameRepoBranchPath(m) && m.params.title === params.title
+          sameRepoBranchPath(m) && m.params.title === resolvedParams.title
         );
       }
       // note.delete: only drop if filePath matches and is set on both
       // sides — undefined filePath on either side means we can't be
       // sure they refer to the same blob.
-      return !(params.filePath && sameRepoBranchPath(m));
+      return !(resolvedParams.filePath && sameRepoBranchPath(m));
     });
     filtered.push({
       id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -180,17 +226,21 @@ class NoteSyncQueueServiceClass {
       createdAt: Date.now(),
       attempts: 0,
       localNoteId,
-      params,
+      params: resolvedParams,
     });
     await this.saveAll(filtered);
   }
 
   async enqueueNoteDelete(params: NoteDeleteParams): Promise<void> {
+    // Persist the RESOLVED branch so the tombstone key matches what the
+    // pull side checks (RepoPullService resolves the same way).
+    const branch = await resolveBranch(params.repo, params.branch);
+    const resolvedParams: NoteDeleteParams = { ...params, branch };
     const items = await this.getAll();
     const sameRepoBranchPath = (m: QueuedMutation) =>
-      m.params.repo === params.repo &&
-      (m.params.branch || 'main') === (params.branch || 'main') &&
-      m.params.filePath === params.filePath;
+      m.params.repo === resolvedParams.repo &&
+      (m.params.branch || 'main') === branch &&
+      m.params.filePath === resolvedParams.filePath;
     // Drop prior upserts for this file — they're wasted writes since the
     // file is being deleted (#565 phase B.2). Drop prior deletes for the
     // same file too — only one delete is needed.
@@ -200,10 +250,12 @@ class NoteSyncQueueServiceClass {
       type: 'note.delete',
       createdAt: Date.now(),
       attempts: 0,
-      params,
+      params: resolvedParams,
     });
     await this.saveAll(filtered);
-    await this.addTombstone(params.repo, params.branch, params.filePath);
+    // Retry re-enqueue clears any pinned failure from a previous drop.
+    await clearDeleteFailure(resolvedParams.repo, branch, resolvedParams.filePath);
+    await this.addTombstone(resolvedParams.repo, branch, resolvedParams.filePath);
   }
 
   async drain(): Promise<{ succeeded: number; failed: number; remaining: number }> {
@@ -295,12 +347,24 @@ class NoteSyncQueueServiceClass {
     let succeeded = 0;
     let failed = 0;
 
-    const recordFailure = (item: QueuedMutation, error: string | undefined): void => {
+    const recordFailure = async (
+      item: QueuedMutation,
+      error: string | undefined,
+      status?: number,
+    ): Promise<void> => {
       const attempts = item.attempts + 1;
       if (attempts >= MAX_ATTEMPTS) {
         console.warn('[NoteSyncQueue] dropped after max attempts:', error);
         failed++;
         droppedIds.add(item.id);
+        this.emitDroppedMutation({ mutation: item, reason: 'exhausted', error, status });
+        if (item.type === 'note.delete') {
+          await recordDeleteFailure(item.params.repo, item.params.branch, item.params.filePath, {
+            error: error ?? 'Unknown error',
+            kind: 'exhausted',
+            at: Date.now(),
+          });
+        }
       } else {
         updatedById.set(item.id, {
           ...item,
@@ -338,8 +402,21 @@ class NoteSyncQueueServiceClass {
         if (!isRetryableFailure(failure)) {
           console.warn('[NoteSyncQueue] dropped durable failure:', failure.kind);
           droppedIds.add(item.id);
+          this.emitDroppedMutation({
+            mutation: item,
+            reason: 'durable',
+            error: result.error,
+            status: result.status,
+          });
+          if (item.type === 'note.delete') {
+            await recordDeleteFailure(item.params.repo, item.params.branch, item.params.filePath, {
+              error: result.error ?? failure.message,
+              kind: failure.kind,
+              at: Date.now(),
+            });
+          }
         } else {
-          recordFailure(item, result.error);
+          await recordFailure(item, result.error, result.status);
         }
         continue;
       }
@@ -376,7 +453,7 @@ class NoteSyncQueueServiceClass {
         }
       } else {
         console.warn('[NoteSyncQueue] coalesced push failed:', flushResult.error);
-        for (const { item } of pendingFlush) recordFailure(item, flushResult.error);
+        for (const { item } of pendingFlush) await recordFailure(item, flushResult.error);
       }
     }
 

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -10,8 +10,11 @@ import { AuthService } from './AuthService';
 import { LocalGitWriter } from './git/LocalGitWriter';
 import { classifyGitHubSyncError, isRetryableFailure, syncStatusForError } from './git/syncFailure';
 import { resolveBranch } from './git/resolveBranch';
-import { clearDeleteFailure, readDeleteFailures, recordDeleteFailure } from './git/deleteFailures';
+import { clearDeleteFailure, readDeleteFailures, recordDeleteFailure, DELETE_FAILURES_STORAGE_KEY } from './git/deleteFailures';
 import { GitSyncGate } from './git/GitSyncGate';
+import { batchDeleteFiles } from './git/BatchGitOperations';
+import type { BatchDeleteFilesResult } from './git/BatchGitOperations';
+import { parseRepoPath } from '../utils/gitPathParser';
 import { NoteColor, NoteFormat } from '../models/Note';
 
 const QUEUE_KEY = '@gitnotes:sync_queue_v1';
@@ -197,66 +200,150 @@ class NoteSyncQueueServiceClass {
     } catch { /* best-effort */ }
   }
 
-  async enqueueNoteUpsert(params: NoteUpsertParams, localNoteId?: string): Promise<void> {
-    // Persist the RESOLVED branch so the tombstone key, drain group key,
-    // and clone-mode push all agree with the branch pulls resolve.
-    const branch = await resolveBranch(params.repo, params.branch);
-    const resolvedParams: NoteUpsertParams = { ...params, branch };
-    const items = await this.getAll();
-    const sameRepoBranchPath = (m: QueuedMutation) =>
-      m.params.repo === resolvedParams.repo &&
-      (m.params.branch || 'main') === branch &&
-      m.params.filePath === resolvedParams.filePath;
-    // Drop prior upserts with the same (repo, branch, filePath, title) —
-    // latest wins. Also drop any pending delete for the same path: the
-    // user re-created the note, so the delete is wasted (#565 phase B.2).
-    const filtered = items.filter((m) => {
-      if (m.type === 'note.upsert') {
-        return !(
-          sameRepoBranchPath(m) && m.params.title === resolvedParams.title
-        );
+  private newMutationId(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  private branchCacheKey(repo: string, hint: string | undefined): string {
+    return `${repo}\n${hint ?? ''}`;
+  }
+
+  private async resolveBranchesOnce(
+    keys: { repo: string; hint?: string }[],
+  ): Promise<Map<string, string>> {
+    const unique = new Map<string, { repo: string; hint?: string }>();
+    for (const key of keys) {
+      unique.set(this.branchCacheKey(key.repo, key.hint), key);
+    }
+    const resolved = new Map<string, string>();
+    await Promise.all(
+      Array.from(unique.entries()).map(async ([cacheKey, { repo, hint }]) => {
+        resolved.set(cacheKey, await resolveBranch(repo, hint));
+      }),
+    );
+    return resolved;
+  }
+
+  /**
+   * Batch variant of `enqueueNoteDelete`: branches are resolved once per
+   * unique (repo, hint) pair, the queue is rewritten ONCE, and tombstones
+   * plus pinned-failure clears happen in ONE read/modify/write pass per
+   * storage key. Same-path dedup rules apply across the existing queue AND
+   * within the batch (last item for a path wins).
+   */
+  async enqueueNoteDeletes(items: NoteDeleteParams[]): Promise<void> {
+    if (items.length === 0) return;
+    const branches = await this.resolveBranchesOnce(
+      items.map((params) => ({ repo: params.repo, hint: params.branch })),
+    );
+    const resolvedItems = items.map((params) => ({
+      ...params,
+      branch: branches.get(this.branchCacheKey(params.repo, params.branch))!,
+    }));
+
+    let queue = await this.getAll();
+    const batchMutations: QueuedMutation[] = [];
+    for (const params of resolvedItems) {
+      const sameRepoBranchPath = (m: QueuedMutation) =>
+        m.params.repo === params.repo &&
+        (m.params.branch || 'main') === params.branch &&
+        m.params.filePath === params.filePath;
+      queue = queue.filter((m) => !sameRepoBranchPath(m));
+      for (let i = batchMutations.length - 1; i >= 0; i -= 1) {
+        if (sameRepoBranchPath(batchMutations[i])) batchMutations.splice(i, 1);
       }
-      // note.delete: only drop if filePath matches and is set on both
-      // sides — undefined filePath on either side means we can't be
-      // sure they refer to the same blob.
-      return !(resolvedParams.filePath && sameRepoBranchPath(m));
+      batchMutations.push({
+        id: this.newMutationId(),
+        type: 'note.delete',
+        createdAt: Date.now(),
+        attempts: 0,
+        params,
+      });
+    }
+    await this.saveAll([...queue, ...batchMutations]);
+
+    let tombstoneMap: Record<string, number> = {};
+    let failureMap: Record<string, unknown> = {};
+    try {
+      const rawTombstones = await AsyncStorage.getItem(TOMBSTONE_KEY);
+      if (rawTombstones) tombstoneMap = JSON.parse(rawTombstones);
+    } catch { /* best-effort */ }
+    try {
+      const rawFailures = await AsyncStorage.getItem(DELETE_FAILURES_STORAGE_KEY);
+      if (rawFailures) failureMap = JSON.parse(rawFailures);
+    } catch { /* best-effort */ }
+    const now = Date.now();
+    let failuresChanged = false;
+    for (const params of resolvedItems) {
+      const key = this.tombstoneKey(params.repo, params.branch, params.filePath);
+      tombstoneMap[key] = now;
+      if (key in failureMap) {
+        delete failureMap[key];
+        failuresChanged = true;
+      }
+    }
+    try {
+      await AsyncStorage.setItem(TOMBSTONE_KEY, JSON.stringify(tombstoneMap));
+      if (failuresChanged) {
+        await AsyncStorage.setItem(DELETE_FAILURES_STORAGE_KEY, JSON.stringify(failureMap));
+      }
+    } catch { /* best-effort */ }
+  }
+
+  /**
+   * Batch variant of `enqueueNoteUpsert`: ONE queue write for the whole
+   * batch. Dedup mirrors the single-item rules — a new upsert drops
+   * same-path prior upserts with the same title (latest wins) and any
+   * pending same-path delete (the note was re-created, delete wasted).
+   */
+  async enqueueNoteUpserts(
+    items: NoteUpsertParams[],
+    localNoteIds?: (string | undefined)[],
+  ): Promise<void> {
+    if (items.length === 0) return;
+    const branches = await this.resolveBranchesOnce(
+      items.map((params) => ({ repo: params.repo, hint: params.branch })),
+    );
+
+    let queue = await this.getAll();
+    const batchMutations: QueuedMutation[] = [];
+    items.forEach((rawParams, index) => {
+      const branch = branches.get(this.branchCacheKey(rawParams.repo, rawParams.branch))!;
+      const resolvedParams: NoteUpsertParams = { ...rawParams, branch };
+      const sameRepoBranchPath = (m: QueuedMutation) =>
+        m.params.repo === resolvedParams.repo &&
+        (m.params.branch || 'main') === branch &&
+        m.params.filePath === resolvedParams.filePath;
+      // note.delete entries are only dropped when filePath is set on both
+      // sides — undefined on either side means the blob match is unproven.
+      const keepExisting = (m: QueuedMutation): boolean => {
+        if (m.type === 'note.upsert') {
+          return !(sameRepoBranchPath(m) && m.params.title === resolvedParams.title);
+        }
+        return !(resolvedParams.filePath && sameRepoBranchPath(m));
+      };
+      queue = queue.filter(keepExisting);
+      for (let i = batchMutations.length - 1; i >= 0; i -= 1) {
+        if (!keepExisting(batchMutations[i])) batchMutations.splice(i, 1);
+      }
+      batchMutations.push({
+        id: this.newMutationId(),
+        type: 'note.upsert',
+        createdAt: Date.now(),
+        attempts: 0,
+        localNoteId: localNoteIds?.[index],
+        params: resolvedParams,
+      });
     });
-    filtered.push({
-      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      type: 'note.upsert',
-      createdAt: Date.now(),
-      attempts: 0,
-      localNoteId,
-      params: resolvedParams,
-    });
-    await this.saveAll(filtered);
+    await this.saveAll([...queue, ...batchMutations]);
+  }
+
+  async enqueueNoteUpsert(params: NoteUpsertParams, localNoteId?: string): Promise<void> {
+    await this.enqueueNoteUpserts([params], localNoteId === undefined ? undefined : [localNoteId]);
   }
 
   async enqueueNoteDelete(params: NoteDeleteParams): Promise<void> {
-    // Persist the RESOLVED branch so the tombstone key matches what the
-    // pull side checks (RepoPullService resolves the same way).
-    const branch = await resolveBranch(params.repo, params.branch);
-    const resolvedParams: NoteDeleteParams = { ...params, branch };
-    const items = await this.getAll();
-    const sameRepoBranchPath = (m: QueuedMutation) =>
-      m.params.repo === resolvedParams.repo &&
-      (m.params.branch || 'main') === branch &&
-      m.params.filePath === resolvedParams.filePath;
-    // Drop prior upserts for this file — they're wasted writes since the
-    // file is being deleted (#565 phase B.2). Drop prior deletes for the
-    // same file too — only one delete is needed.
-    const filtered = items.filter((m) => !sameRepoBranchPath(m));
-    filtered.push({
-      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      type: 'note.delete',
-      createdAt: Date.now(),
-      attempts: 0,
-      params: resolvedParams,
-    });
-    await this.saveAll(filtered);
-    // Retry re-enqueue clears any pinned failure from a previous drop.
-    await clearDeleteFailure(resolvedParams.repo, branch, resolvedParams.filePath);
-    await this.addTombstone(resolvedParams.repo, branch, resolvedParams.filePath);
+    await this.enqueueNoteDeletes([params]);
   }
 
   async drain(): Promise<{ succeeded: number; failed: number; remaining: number }> {
@@ -407,6 +494,74 @@ class NoteSyncQueueServiceClass {
       }
     };
 
+    // API-mode single-commit bulk: >=2 due deletes in one (repo, branch)
+    // group ship as ONE Git-Data commit instead of N Contents-API deletes.
+    // Subgroups keyed by accountId never share a batch (token ownership);
+    // a group that throws is left for the per-item loop below so its items
+    // get the full deleteNoteFromGitHub classification instead.
+    const handledByBatch = new Set<string>();
+    if (!isClone) {
+      const dueDeletes = items.filter(
+        (m): m is QueuedMutation & { type: 'note.delete' } => m.type === 'note.delete',
+      );
+      if (dueDeletes.length >= 2) {
+        const repoInfo = parseRepoPath(repoPath);
+        if (repoInfo) {
+          const subgroups = new Map<string, (QueuedMutation & { type: 'note.delete' })[]>();
+          for (const item of dueDeletes) {
+            const key = item.params.accountId ?? '';
+            const arr = subgroups.get(key) ?? [];
+            arr.push(item);
+            subgroups.set(key, arr);
+          }
+          for (const [accountId, group] of subgroups) {
+            if (group.length < 2) continue;
+            let tokenOverride: string | undefined;
+            if (accountId) {
+              tokenOverride = (await AuthService.getTokenById(accountId)) ?? undefined;
+            }
+            let batchResult: BatchDeleteFilesResult | null = null;
+            try {
+              batchResult = await batchDeleteFiles({
+                owner: repoInfo.owner,
+                repo: repoInfo.repo,
+                branch,
+                paths: group.map((item) => item.params.filePath),
+                message: `Delete ${group.length} notes`,
+                ...(tokenOverride ? { opts: { tokenOverride } } : {}),
+              });
+            } catch (batchError) {
+              console.warn('[NoteSyncQueue] batch delete threw; group reverts to per-item processing:', batchError);
+            }
+            if (batchResult) {
+              const byPath = new Map(group.map((item) => [item.params.filePath, item]));
+              const deletedPaths = new Set(batchResult.deleted);
+              for (const item of group) {
+                if (deletedPaths.has(item.params.filePath)) {
+                  await this.removeTombstone(item.params.repo, item.params.branch, item.params.filePath);
+                  succeeded += 1;
+                  droppedIds.add(item.id);
+                  handledByBatch.add(item.id);
+                }
+              }
+              for (const failure of batchResult.failed) {
+                const item = byPath.get(failure.path);
+                if (!item) continue;
+                handledByBatch.add(item.id);
+                await this.classifyBatchDeleteFailure(item, failure.error, droppedIds, recordFailure);
+              }
+              for (const item of group) {
+                if (!handledByBatch.has(item.id)) {
+                  handledByBatch.add(item.id);
+                  await recordFailure(item, 'Batch delete returned no outcome for path');
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     // Items whose local write/delete+commit succeeded but whose push is
     // deferred to the group flush. Recorded so we can apply the post-
     // success StorageService.updateNote (upserts only) and drop them
@@ -414,6 +569,7 @@ class NoteSyncQueueServiceClass {
     const pendingFlush: { item: QueuedMutation; result: NoteGitHubSyncResult }[] = [];
 
     for (const item of items) {
+      if (handledByBatch.has(item.id)) continue;
       const result =
         item.type === 'note.upsert'
           ? await syncNoteToGitHub({
@@ -489,6 +645,28 @@ class NoteSyncQueueServiceClass {
     }
 
     return { succeeded, failed, droppedIds, updatedById };
+  }
+
+  private async classifyBatchDeleteFailure(
+    item: QueuedMutation & { type: 'note.delete' },
+    error: string,
+    droppedIds: Set<string>,
+    recordFailure: (item: QueuedMutation, error: string | undefined, status?: number) => Promise<void>,
+  ): Promise<void> {
+    const status = syncStatusForError(error);
+    const failure = classifyGitHubSyncError(new Error(error), status);
+    if (isRetryableFailure(failure)) {
+      await recordFailure(item, error, status);
+      return;
+    }
+    console.warn('[NoteSyncQueue] dropped durable batch-delete failure:', failure.kind);
+    droppedIds.add(item.id);
+    this.emitDroppedMutation({ mutation: item, reason: 'durable', error, status });
+    await recordDeleteFailure(item.params.repo, item.params.branch, item.params.filePath, {
+      error: error || failure.message,
+      kind: failure.kind,
+      at: Date.now(),
+    });
   }
 
   private async applyPostSyncStorageUpdate(

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -11,6 +11,7 @@ import { LocalGitWriter } from './git/LocalGitWriter';
 import { classifyGitHubSyncError, isRetryableFailure, syncStatusForError } from './git/syncFailure';
 import { resolveBranch } from './git/resolveBranch';
 import { clearDeleteFailure, readDeleteFailures, recordDeleteFailure } from './git/deleteFailures';
+import { GitSyncGate } from './git/GitSyncGate';
 import { NoteColor, NoteFormat } from '../models/Note';
 
 const QUEUE_KEY = '@gitnotes:sync_queue_v1';
@@ -265,6 +266,12 @@ class NoteSyncQueueServiceClass {
     }
     this.isDraining = true;
 
+    // Serialize against app-wide drain+pull cycles (foreground/startup/
+    // background/manual sync). When this drain runs INSIDE a held cycle
+    // the cycle owner already owns the mutex — acquiring again here would
+    // self-deadlock, so the short-circuit is mandatory.
+    const releaseCycle = GitSyncGate.isCycleHeld() ? null : await GitSyncGate.acquireCycle();
+
     try {
       const initial = await this.getAll();
       const now = Date.now();
@@ -324,6 +331,7 @@ class NoteSyncQueueServiceClass {
       return { succeeded, failed, remaining: next.length };
     } finally {
       this.isDraining = false;
+      if (releaseCycle) releaseCycle();
     }
   }
 
@@ -340,6 +348,29 @@ class NoteSyncQueueServiceClass {
     const sep = key.indexOf('\n');
     const repoPath = key.slice(0, sep);
     const branch = key.slice(sep + 1);
+
+    // Push marker spans the whole group flight (per-mutation HTTP calls and
+    // the clone-mode coalesced push). A pull reading origin mid-push is the
+    // resurrection window, so pull steps must wait for this marker to clear.
+    GitSyncGate.markPushActive(repoPath, branch);
+    try {
+      return await this.processDrainGroup(repoPath, branch, items, now);
+    } finally {
+      GitSyncGate.clearPushActive(repoPath, branch);
+    }
+  }
+
+  private async processDrainGroup(
+    repoPath: string,
+    branch: string,
+    items: QueuedMutation[],
+    now: number,
+  ): Promise<{
+    succeeded: number;
+    failed: number;
+    droppedIds: Set<string>;
+    updatedById: Map<string, QueuedMutation>;
+  }> {
     const isClone = (await SyncEngineService.getMode(repoPath)) === 'clone';
 
     const droppedIds = new Set<string>();

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -52,6 +52,8 @@ export interface NoteDeleteParams {
   filePath: string;
   title?: string;
   accountId?: string;
+  /** Local note id carried for success events + entity locks; the sync itself ignores it. */
+  localNoteId?: string;
 }
 
 interface MutationCommon {
@@ -92,10 +94,21 @@ export interface DroppedMutationEvent {
   status?: number;
 }
 
+/**
+ * Side-channel notification for mutations that reached the remote
+ * successfully. `noteStore` listens for `note.delete` events to complete
+ * the local delete (storage + state + registry) — the row stays
+ * visible-but-locked until this fires.
+ */
+export interface MutationSucceededEvent {
+  mutation: QueuedMutation;
+}
+
 class NoteSyncQueueServiceClass {
   private isDraining = false;
   private listeners = new Set<() => void>();
   private droppedListeners = new Set<(event: DroppedMutationEvent) => void>();
+  private succeededListeners = new Set<(event: MutationSucceededEvent) => void>();
 
   subscribe(fn: () => void): () => void {
     this.listeners.add(fn);
@@ -111,6 +124,13 @@ class NoteSyncQueueServiceClass {
     };
   }
 
+  onMutationSucceeded(fn: (event: MutationSucceededEvent) => void): () => void {
+    this.succeededListeners.add(fn);
+    return () => {
+      this.succeededListeners.delete(fn);
+    };
+  }
+
   private notify(): void {
     this.listeners.forEach((fn) => {
       try {
@@ -123,6 +143,16 @@ class NoteSyncQueueServiceClass {
 
   private emitDroppedMutation(event: DroppedMutationEvent): void {
     this.droppedListeners.forEach((fn) => {
+      try {
+        fn(event);
+      } catch {
+        // ignore listener errors - user callbacks should not break the queue
+      }
+    });
+  }
+
+  private emitMutationSucceeded(event: MutationSucceededEvent): void {
+    this.succeededListeners.forEach((fn) => {
       try {
         fn(event);
       } catch {
@@ -541,6 +571,7 @@ class NoteSyncQueueServiceClass {
                   await this.removeTombstone(item.params.repo, item.params.branch, item.params.filePath);
                   succeeded += 1;
                   droppedIds.add(item.id);
+                  this.emitMutationSucceeded({ mutation: item });
                   handledByBatch.add(item.id);
                 }
               }
@@ -618,6 +649,7 @@ class NoteSyncQueueServiceClass {
         }
         succeeded++;
         droppedIds.add(item.id);
+        this.emitMutationSucceeded({ mutation: item });
       }
     }
 
@@ -637,6 +669,7 @@ class NoteSyncQueueServiceClass {
           }
           succeeded++;
           droppedIds.add(item.id);
+          this.emitMutationSucceeded({ mutation: item });
         }
       } else {
         console.warn('[NoteSyncQueue] coalesced push failed:', flushResult.error);

--- a/src/services/TodoGitHubSyncService.ts
+++ b/src/services/TodoGitHubSyncService.ts
@@ -5,6 +5,7 @@ import { AuthService } from './AuthService';
 import { SyncEngineService } from './SyncEngineService';
 import { LocalGitWriter } from './git/LocalGitWriter';
 import { GitFsService } from './git/GitFsService';
+import { resolveBranch } from './git/resolveBranch';
 import { githubActivity } from '../stores/githubActivityStore';
 
 async function resolveToken(accountId?: string): Promise<string | undefined> {
@@ -53,7 +54,7 @@ export async function syncTodoToGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = branch || 'main';
+  const targetBranch = await resolveBranch(repoPath, branch);
   const opts = tokenOverride ? { tokenOverride } : undefined;
 
   let targetPath = filePath;
@@ -163,7 +164,7 @@ export async function deleteTodoFromGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = branch || 'main';
+  const targetBranch = await resolveBranch(repoPath, branch);
   const opts = tokenOverride ? { tokenOverride } : undefined;
 
   const mode = await SyncEngineService.getMode(repoPath);

--- a/src/services/git/BatchGitOperations.ts
+++ b/src/services/git/BatchGitOperations.ts
@@ -1,0 +1,181 @@
+import { GitHubService, GitHubTreeEntry, TokenOpts } from '../GitHubService';
+import { extractHttpErrorDetails } from './syncFailure';
+
+export interface BatchDeleteFilesInput {
+  owner: string;
+  repo: string;
+  branch: string;
+  paths: string[];
+  message: string;
+  opts?: TokenOpts;
+}
+
+export interface BatchDeleteFailedPath {
+  path: string;
+  error: string;
+}
+
+export interface BatchDeleteFilesResult {
+  success: boolean;
+  deleted: string[];
+  failed: BatchDeleteFailedPath[];
+}
+
+/** Initial cycle + up to 2 full retries when updateRef reports the branch moved. */
+const MAX_CYCLE_ATTEMPTS = 3;
+
+type CycleOutcome =
+  | { ok: true }
+  | { ok: false; fromUpdateRef: boolean; error: unknown };
+
+/**
+ * Builds the explicit tree payload for a delete-only commit: the recursive
+ * listing minus every deleted path. A subtree entry survives only when the
+ * deletions neither touch it nor anything below it — a stale subtree sha
+ * after an internal delete would resurrect the very files being removed.
+ * Blobs under a kept (unchanged) subtree are omitted: the subtree sha fully
+ * describes them, and re-listing them risks GitHub rejecting the duplicate
+ * coverage.
+ */
+export function buildTreeMinusPaths(
+  entries: GitHubTreeEntry[],
+  deletePaths: string[],
+): GitHubTreeEntry[] {
+  const deletedSet = new Set(deletePaths);
+  const isDeletedOrUnderDeleted = (path: string): boolean =>
+    deletedSet.has(path) || deletePaths.some((d) => path.startsWith(d + '/'));
+
+  const keptSubtrees = entries
+    .filter(
+      (entry) =>
+        entry.type === 'tree' &&
+        !isDeletedOrUnderDeleted(entry.path) &&
+        !deletePaths.some((d) => d.startsWith(entry.path + '/')),
+    )
+    .map((entry) => entry.path);
+  const underKeptSubtree = (path: string): boolean =>
+    keptSubtrees.some((t) => path.startsWith(t + '/'));
+
+  return entries.filter((entry) => {
+    if (isDeletedOrUnderDeleted(entry.path)) return false;
+    if (entry.type === 'tree') return keptSubtrees.includes(entry.path);
+    return !underKeptSubtree(entry.path);
+  });
+}
+
+async function runDeleteCycle(
+  input: BatchDeleteFilesInput,
+  uniquePaths: string[],
+): Promise<CycleOutcome> {
+  const { owner, repo, branch, message, opts } = input;
+  try {
+    const head = await GitHubService.getBranchHead(owner, repo, branch, opts);
+    const commit = await GitHubService.getCommit(owner, repo, head.sha, opts);
+    const entries = await GitHubService.getTreeRaw(owner, repo, commit.treeSha, true, opts);
+    const tree = buildTreeMinusPaths(entries, uniquePaths);
+    const newTree = await GitHubService.createTree(owner, repo, tree, opts);
+    const newCommit = await GitHubService.createCommit(owner, repo, {
+      message,
+      tree: newTree.sha,
+      parents: [head.sha],
+    }, opts);
+    try {
+      await GitHubService.updateRef(owner, repo, `heads/${branch}`, newCommit.sha, false, opts);
+    } catch (error) {
+      return { ok: false, fromUpdateRef: true, error };
+    }
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, fromUpdateRef: false, error };
+  }
+}
+
+function isBranchMovedError(error: unknown): boolean {
+  const { status } = extractHttpErrorDetails(error);
+  return status === 409 || status === 422;
+}
+
+async function deleteFilesSequentially(
+  owner: string,
+  repo: string,
+  branch: string,
+  paths: string[],
+  message: string,
+  opts?: TokenOpts,
+): Promise<BatchDeleteFilesResult> {
+  const deleted: string[] = [];
+  const failed: BatchDeleteFailedPath[] = [];
+  for (const path of paths) {
+    try {
+      const lookup = await GitHubService.getFileSha(owner, repo, path, branch, opts);
+      if (lookup.kind === 'not-found') {
+        deleted.push(path);
+        continue;
+      }
+      if (lookup.kind === 'error') {
+        failed.push({ path, error: lookup.message });
+        continue;
+      }
+      const result = await GitHubService.deleteFile(owner, repo, path, message, lookup.sha, branch, opts);
+      if (result) {
+        deleted.push(path);
+        continue;
+      }
+      failed.push({ path, error: 'GitHub API returned no result' });
+    } catch (error) {
+      const details = extractHttpErrorDetails(error);
+      if (details.status === 404) {
+        deleted.push(path);
+        continue;
+      }
+      const errorMessage = details.message ?? (error instanceof Error ? error.message : String(error));
+      failed.push({ path, error: errorMessage });
+    }
+  }
+  return { success: failed.length === 0, deleted, failed };
+}
+
+/**
+ * Deletes two or more remote files with ONE commit via the Git Data API:
+ * head → commit → recursive tree → explicit tree minus the deleted paths →
+ * createTree → createCommit(parent=head) → updateRef.
+ *
+ * A 409/422 from updateRef means the branch moved mid-flight; the whole
+ * cycle is retried with a fresh head (up to 2 retries). Any terminal
+ * Git-Data failure degrades to sequential typed-sha `deleteFile` calls and
+ * merges the per-path outcomes — bulk must never be worse than per-file.
+ * Throws for fewer than 2 paths (single files use the Contents API).
+ */
+export async function batchDeleteFiles(
+  input: BatchDeleteFilesInput,
+): Promise<BatchDeleteFilesResult> {
+  const { paths } = input;
+  if (paths.length < 2) {
+    throw new Error('batchDeleteFiles requires at least 2 paths');
+  }
+  const uniquePaths = Array.from(new Set(paths));
+
+  let terminalError: unknown = null;
+  for (let attempt = 0; attempt < MAX_CYCLE_ATTEMPTS; attempt += 1) {
+    const outcome = await runDeleteCycle(input, uniquePaths);
+    if (outcome.ok) {
+      return { success: true, deleted: uniquePaths, failed: [] };
+    }
+    terminalError = outcome.error;
+    const retriable = outcome.fromUpdateRef && isBranchMovedError(outcome.error);
+    if (!retriable || attempt === MAX_CYCLE_ATTEMPTS - 1) break;
+  }
+
+  console.warn(
+    '[BatchGitOperations] batch delete cycle failed, falling back to per-file deletes:',
+    terminalError,
+  );
+  return deleteFilesSequentially(
+    input.owner,
+    input.repo,
+    input.branch,
+    uniquePaths,
+    input.message,
+    input.opts,
+  );
+}

--- a/src/services/git/GitSyncGate.ts
+++ b/src/services/git/GitSyncGate.ts
@@ -1,0 +1,221 @@
+import { gitOperationRegistry, GIT_OP_ALL_REPOS } from '../../stores/gitOperationStore';
+
+/**
+ * App-wide concurrency gate for git sync. Two independent layers:
+ *
+ * Layer 1 — CYCLE mutex: exactly one drain/pull cycle runs app-wide at a
+ * time. Every sync entry (queue drain, foreground pull, startup pull,
+ * background task, manual syncNow) acquires it and releases in a finally.
+ * A drain+pull pair is ONE acquisition — steps inside a held cycle never
+ * re-acquire, so a cycle can never deadlock itself. Callers that drain
+ * inside an existing cycle must check `isCycleHeld()` first and skip the
+ * acquisition (see NoteSyncQueueService.drain).
+ *
+ * Layer 2 — PUSH markers per `${repo}@${branch || 'main'}`: set around
+ * mutation flights (drain groups, repo-tree writes) so pull steps can wait
+ * for in-flight pushes on the repo they are about to read — pulling origin
+ * mid-push is the resurrection window for deleted notes. `waitForIdle`
+ * polls until the repo's markers clear (or timeout); unrelated repos are
+ * never blocked.
+ *
+ * Every held cycle/marker publishes a running op into the git-operation
+ * registry so lock UI and guards observe the gate; the op is removed on
+ * release (succeed) or watchdog expiry (fail). Watchdogs: a leaked cycle
+ * auto-expires after 10 minutes, and markers older than 10 minutes are
+ * swept on the next markPushActive.
+ */
+
+const CYCLE_WATCHDOG_MS = 10 * 60 * 1_000;
+const MARKER_MAX_AGE_MS = 10 * 60 * 1_000;
+const WAIT_FOR_IDLE_POLL_MS = 250;
+const WAIT_FOR_IDLE_TIMEOUT_MS = 60_000;
+const DEFAULT_MARKER_BRANCH = 'main';
+
+interface PushMarker {
+  repo: string;
+  branch: string;
+  since: number;
+  registryOpId: string;
+}
+
+class GitSyncGateClass {
+  private cycleHeld = false;
+  private cycleToken = 0;
+  private cycleRegistryOpId: string | null = null;
+  private cycleWatchdog: ReturnType<typeof setTimeout> | null = null;
+  private cycleWaiters: Array<() => void> = [];
+  private pushMarkers = new Map<string, PushMarker>();
+
+  /**
+   * Acquire the app-wide cycle mutex. Resolves immediately when free,
+   * otherwise queues FIFO behind the current holder. The returned release
+   * is idempotent and becomes a no-op once the watchdog force-expires the
+   * acquisition. Pair every call with a release in a finally.
+   */
+  acquireCycle(): Promise<() => void> {
+    if (!this.cycleHeld) {
+      this.grantCycle();
+      return Promise.resolve(this.makeCycleReleaser(this.cycleToken));
+    }
+    return new Promise<() => void>((resolve) => {
+      this.cycleWaiters.push(() => resolve(this.makeCycleReleaser(this.cycleToken)));
+    });
+  }
+
+  isCycleHeld(): boolean {
+    return this.cycleHeld;
+  }
+
+  markPushActive(repo: string, branch?: string): void {
+    this.sweepStuckMarkers();
+    const key = this.markerKey(repo, branch);
+    const existing = this.pushMarkers.get(key);
+    if (existing) {
+      existing.since = Date.now();
+      return;
+    }
+    const normalizedBranch = branch || DEFAULT_MARKER_BRANCH;
+    const registryOpId = gitOperationRegistry.begin({
+      kind: 'push',
+      repo,
+      branch: normalizedBranch,
+      entityIds: [],
+      attempts: 0,
+      status: 'running',
+    });
+    this.pushMarkers.set(key, {
+      repo,
+      branch: normalizedBranch,
+      since: Date.now(),
+      registryOpId,
+    });
+  }
+
+  clearPushActive(repo: string, branch?: string): void {
+    const key = this.markerKey(repo, branch);
+    const marker = this.pushMarkers.get(key);
+    if (!marker) return;
+    this.pushMarkers.delete(key);
+    gitOperationRegistry.succeed(marker.registryOpId);
+  }
+
+  /** True if any marker is held; with a repo arg, only that repo's markers count. */
+  isPushActive(repo?: string): boolean {
+    for (const marker of this.pushMarkers.values()) {
+      if (repo === undefined || marker.repo === repo) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Resolve once no push markers remain for the repo (or app-wide when
+   * omitted). Resolves false instead of waiting past timeoutMs.
+   */
+  async waitForIdle(repo?: string, timeoutMs: number = WAIT_FOR_IDLE_TIMEOUT_MS): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (this.isPushActive(repo)) {
+      if (Date.now() >= deadline) return false;
+      await new Promise<void>((resolve) => setTimeout(resolve, WAIT_FOR_IDLE_POLL_MS));
+    }
+    return true;
+  }
+
+  __resetForTest(): void {
+    if (this.cycleWatchdog !== null) {
+      clearTimeout(this.cycleWatchdog);
+      this.cycleWatchdog = null;
+    }
+    for (const marker of this.pushMarkers.values()) {
+      gitOperationRegistry.succeed(marker.registryOpId);
+    }
+    this.pushMarkers.clear();
+    this.cycleWaiters = [];
+    this.cycleHeld = false;
+    this.cycleToken += 1;
+    if (this.cycleRegistryOpId) {
+      gitOperationRegistry.succeed(this.cycleRegistryOpId);
+      this.cycleRegistryOpId = null;
+    }
+  }
+
+  private markerKey(repo: string, branch?: string): string {
+    return `${repo}@${branch || DEFAULT_MARKER_BRANCH}`;
+  }
+
+  private grantCycle(): void {
+    this.cycleHeld = true;
+    this.cycleToken += 1;
+    this.publishCycleOp();
+    this.armCycleWatchdog();
+  }
+
+  private publishCycleOp(): void {
+    this.cycleRegistryOpId = gitOperationRegistry.begin({
+      kind: 'pull',
+      repo: GIT_OP_ALL_REPOS,
+      entityIds: [],
+      attempts: 0,
+      status: 'running',
+    });
+  }
+
+  private armCycleWatchdog(): void {
+    if (this.cycleWatchdog !== null) clearTimeout(this.cycleWatchdog);
+    this.cycleWatchdog = setTimeout(() => this.expireCycle(), CYCLE_WATCHDOG_MS);
+  }
+
+  private expireCycle(): void {
+    this.cycleWatchdog = null;
+    if (!this.cycleHeld) return;
+    console.warn(`[GitSyncGate] cycle held for ${CYCLE_WATCHDOG_MS}ms; force-releasing leaked acquisition`);
+    const opId = this.cycleRegistryOpId;
+    this.cycleRegistryOpId = null;
+    // Invalidate any outstanding release token from the leaked holder.
+    this.cycleToken += 1;
+    if (opId) gitOperationRegistry.fail(opId, 'Sync cycle watchdog expired');
+    this.handOffOrReleaseCycle();
+  }
+
+  private handOffOrReleaseCycle(): void {
+    const next = this.cycleWaiters.shift();
+    if (next) {
+      // Still held — the next FIFO waiter becomes the holder with a fresh
+      // token, registry op, and watchdog window.
+      this.cycleToken += 1;
+      this.publishCycleOp();
+      this.armCycleWatchdog();
+      next();
+      return;
+    }
+    this.cycleHeld = false;
+  }
+
+  private makeCycleReleaser(token: number): () => void {
+    let used = false;
+    return () => {
+      if (used) return;
+      used = true;
+      if (!this.cycleHeld || token !== this.cycleToken) return;
+      if (this.cycleWatchdog !== null) {
+        clearTimeout(this.cycleWatchdog);
+        this.cycleWatchdog = null;
+      }
+      const opId = this.cycleRegistryOpId;
+      this.cycleRegistryOpId = null;
+      if (opId) gitOperationRegistry.succeed(opId);
+      this.handOffOrReleaseCycle();
+    };
+  }
+
+  private sweepStuckMarkers(): void {
+    const now = Date.now();
+    for (const [key, marker] of this.pushMarkers) {
+      if (now - marker.since <= MARKER_MAX_AGE_MS) continue;
+      this.pushMarkers.delete(key);
+      console.warn(`[GitSyncGate] clearing stuck push marker ${key} after ${MARKER_MAX_AGE_MS}ms`);
+      gitOperationRegistry.fail(marker.registryOpId, 'Push marker watchdog expired');
+    }
+  }
+}
+
+export const GitSyncGate = new GitSyncGateClass();

--- a/src/services/git/deleteFailures.ts
+++ b/src/services/git/deleteFailures.ts
@@ -1,0 +1,72 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * Durable record of dropped note-delete mutations.
+ *
+ * When the sync queue drops a `note.delete` (non-retryable error or
+ * retry budget exhausted) the delete never reached the remote, so the
+ * upstream file still exists. This map keeps one entry per dropped
+ * delete so surfaces can treat the tombstone as permanent (pinned past
+ * the 24h TTL) until the user retries — otherwise the tombstone expires
+ * and the next pull resurrects the note the user deleted.
+ *
+ * Contract shared with `gitOperationStore` hydration: key/shape here are
+ * canonical — do not change without updating the registry reader.
+ */
+export const DELETE_FAILURES_STORAGE_KEY = '@gitnotes:delete_failures_v1';
+
+export interface DeleteFailureEntry {
+  error: string;
+  kind: string;
+  at: number;
+}
+
+export type DeleteFailureMap = Record<string, DeleteFailureEntry>;
+
+/** Key format mirrors the delete-tombstone key: `repo::resolvedBranch::path`. */
+export function deleteFailureKey(
+  repo: string,
+  branch: string | undefined,
+  filePath: string,
+): string {
+  return `${repo}::${branch || 'main'}::${filePath}`;
+}
+
+export async function readDeleteFailures(): Promise<DeleteFailureMap> {
+  try {
+    const raw = await AsyncStorage.getItem(DELETE_FAILURES_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return parsed as DeleteFailureMap;
+  } catch {
+    return {};
+  }
+}
+
+export async function recordDeleteFailure(
+  repo: string,
+  branch: string | undefined,
+  filePath: string,
+  entry: DeleteFailureEntry,
+): Promise<void> {
+  try {
+    const map = await readDeleteFailures();
+    map[deleteFailureKey(repo, branch, filePath)] = entry;
+    await AsyncStorage.setItem(DELETE_FAILURES_STORAGE_KEY, JSON.stringify(map));
+  } catch { /* best-effort persistence */ }
+}
+
+export async function clearDeleteFailure(
+  repo: string,
+  branch: string | undefined,
+  filePath: string,
+): Promise<void> {
+  try {
+    const map = await readDeleteFailures();
+    const key = deleteFailureKey(repo, branch, filePath);
+    if (!(key in map)) return;
+    delete map[key];
+    await AsyncStorage.setItem(DELETE_FAILURES_STORAGE_KEY, JSON.stringify(map));
+  } catch { /* best-effort persistence */ }
+}

--- a/src/services/git/manualSync.ts
+++ b/src/services/git/manualSync.ts
@@ -1,0 +1,134 @@
+import { NoteSyncQueueService } from '../NoteSyncQueueService';
+import { pullAllFromRepos, pullFromSingleRepo } from '../RepoPullService';
+import { useCanvasStore } from '../../stores/canvasStore';
+import { useNoteStore } from '../../stores/noteStore';
+import { useTodoStore } from '../../stores/todoStore';
+import { GitSyncGate } from './GitSyncGate';
+
+/**
+ * Single manual-sync entry point ("sync now") for user-facing pulls:
+ * pull-to-refresh swipes and the cloud-icon sync button. Acquires the
+ * app-wide gate cycle, drains queued mutations, waits for in-flight push
+ * markers to settle, pulls remote state, and refreshes all three stores
+ * before releasing the cycle.
+ *
+ * Reentrancy: exactly one syncNow runs at a time. Overlapping manual
+ * calls return `{ok:false, error:'already-running'}` immediately instead
+ * of queueing — the gesture already ran once, and stacking another pull
+ * behind a long drain only adds latency. (Auto paths — ForegroundSync
+ * runPull / BackgroundSyncService — keep their own gate-wrapped internals
+ * and never route through here.)
+ *
+ * Callers MUST NOT hold a gate cycle before calling syncNow: it acquires
+ * the cycle itself, and a held cycle would make that acquisition queue
+ * behind the caller's own lock forever.
+ *
+ * Timeout: the 60s race rejects with 'Sync timed out', but the cycle work
+ * keeps running and holds the cycle until it actually settles — the
+ * release lives with the work (mirroring ForegroundSyncService.runPull),
+ * never with the race, so a timed-out pull cannot interleave with the
+ * next cycle.
+ */
+
+export interface SyncNowOptions {
+  /** Pull exactly one repo path instead of every tracked repo. */
+  repos?: string[];
+}
+
+export interface SyncNowResult {
+  ok: boolean;
+  error?: string;
+}
+
+const SYNC_TIMEOUT_MS = 60_000;
+
+let running = false;
+
+/** Observable manual-sync activity flag (used by UI guards). */
+export function isSyncNowRunning(): boolean {
+  return running;
+}
+
+/**
+ * Wait for in-flight push markers before reading origin. Single-repo syncs
+ * wait only on that repo — a push on an unrelated repo never blocks a
+ * targeted pull. The all-repos path waits app-wide on ANY marker because
+ * it is about to read every repo, and pulling any repo mid-push opens the
+ * deleted-note resurrection window. `waitForIdle(false)` (its own 60s
+ * budget elapsed) logs and proceeds: a manual sync must remain bounded,
+ * and the marker watchdog clears stuck markers within 10 minutes.
+ */
+async function waitForPushesToSettle(repos?: string[]): Promise<void> {
+  const idle =
+    repos?.length === 1
+      ? await GitSyncGate.waitForIdle(repos[0])
+      : await GitSyncGate.waitForIdle();
+  if (!idle) {
+    console.warn('[Sync] push markers still active after waitForIdle budget; pulling anyway');
+  }
+}
+
+async function refreshAllStores(): Promise<void> {
+  await Promise.all([
+    useNoteStore.getState().refreshNotes(),
+    useCanvasStore.getState().refreshCanvases(),
+    useTodoStore.getState().refreshTodos(),
+  ]);
+}
+
+async function runSyncCycle(repos?: string[]): Promise<void> {
+  // ONE cycle acquisition spans drain + pull + refresh. drain() sees the
+  // held cycle via isCycleHeld() and runs inside it (no self-deadlock).
+  const releaseCycle = await GitSyncGate.acquireCycle();
+  try {
+    try {
+      await NoteSyncQueueService.drain();
+    } catch (error) {
+      // A drain failure must not block the remote pull (same recovery
+      // semantics as ForegroundSyncService.runPull).
+      console.warn('[Sync] drain failed:', error);
+    }
+    await waitForPushesToSettle(repos);
+    if (repos?.length === 1) {
+      await pullFromSingleRepo(repos[0]);
+    } else {
+      // A multi-repo selection falls back to the all-repos pull — the
+      // pull service has no subset path, and pulling everything is the
+      // safe superset of any selection.
+      await pullAllFromRepos();
+    }
+  } finally {
+    // Refresh even when the pull failed so the UI reflects whatever made
+    // it into storage (partial pulls land before the failure).
+    try {
+      await refreshAllStores();
+    } catch (error) {
+      console.warn('[Sync] store refresh failed:', error);
+    }
+    releaseCycle();
+  }
+}
+
+export async function syncNow(options?: SyncNowOptions): Promise<SyncNowResult> {
+  if (running) {
+    return { ok: false, error: 'already-running' };
+  }
+  running = true;
+
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  try {
+    await Promise.race([
+      runSyncCycle(options?.repos),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error('Sync timed out')), SYNC_TIMEOUT_MS);
+      }),
+    ]);
+    return { ok: true };
+  } catch (error) {
+    console.warn('[Sync] syncNow failed:', error);
+    return { ok: false, error: error instanceof Error ? error.message : 'Sync failed' };
+  } finally {
+    if (timeoutId !== null) clearTimeout(timeoutId);
+    running = false;
+  }
+}

--- a/src/services/git/resolveBranch.ts
+++ b/src/services/git/resolveBranch.ts
@@ -1,0 +1,17 @@
+/**
+ * Canonical branch-resolution entry point for the sync-write paths
+ * (NoteSyncQueueService enqueue + note/todo/canvas GitHub sync services).
+ *
+ * Resolution order (implemented in `branchResolver`):
+ *   1. Explicit branch from the caller — short-circuits with NO network
+ *      or filesystem access.
+ *   2. Session cache → local clone HEAD (clone-mode repos).
+ *   3. Host default-branch lookup (GitHub API `default_branch`).
+ *   4. Hard fallback 'main'.
+ *
+ * Enqueueing a mutation with the RESOLVED branch (instead of the raw,
+ * possibly-undefined caller hint) keeps the delete-tombstone key, the
+ * drain group key, and the clone-mode coalesced push all targeting the
+ * same branch the pull side resolves.
+ */
+export { resolveBranch } from './branchResolver';

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -33,9 +33,9 @@ export function clearAuthToken(): void {
 
 function labelForMethod(method?: string): string {
   const m = (method ?? 'get').toLowerCase();
-  if (m === 'delete') return 'Deleting on GitHub…';
-  if (m === 'put' || m === 'post' || m === 'patch') return 'Saving to GitHub…';
-  return 'Syncing with GitHub…';
+  if (m === 'delete') return 'Deleting on GitHub';
+  if (m === 'put' || m === 'post' || m === 'patch') return 'Saving to GitHub';
+  return 'Syncing with GitHub';
 }
 
 type TrackedConfig = InternalAxiosRequestConfig & {

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -4,6 +4,7 @@ import { StorageService } from '../services/StorageService';
 import { GitHubService } from '../services/GitHubService';
 import { deleteCanvasFromGitHub } from '../services/CanvasGitHubSyncService';
 import { formatSyncError } from '../services/git/formatSyncError';
+import { gitOperationRegistry } from './gitOperationStore';
 
 interface CanvasState {
   canvases: Canvas[];
@@ -73,33 +74,54 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()((set, get) =
       set({ error: null });
       const canvas = get().canvases.find((c) => c.id === id);
 
-      // Repo-backed canvases must purge the remote file first; otherwise the
-      // next pull re-imports the row. The sync helper treats a missing remote
-      // (sha null / 404) as success.
+      let opId: string | null = null;
       if (canvas?.repo && canvas.filePath) {
-        if (!GitHubService.isAuthenticated()) {
-          set({ error: 'Sign in to GitHub to delete synced canvases' });
-          return false;
-        }
-        const remote = await deleteCanvasFromGitHub({
+        opId = gitOperationRegistry.begin({
+          kind: 'delete',
           repo: canvas.repo,
           branch: canvas.branch,
-          filePath: canvas.filePath,
-          title: canvas.title,
-          accountId: canvas.accountId,
+          path: canvas.filePath,
+          entityIds: [id],
+          status: 'running',
+          attempts: 0,
         });
-        if (!remote.success) {
-          if (remote.error) console.warn('[CanvasStore] delete sync failed:', remote.error);
-          set({ error: formatSyncError(remote.error, 'delete') });
-          return false;
-        }
       }
 
-      const success = await StorageService.deleteCanvas(id);
-      if (success) {
-        set((state) => ({ canvases: state.canvases.filter((c) => c.id !== id) }));
+      try {
+        // Repo-backed canvases must purge the remote file first; otherwise the
+        // next pull re-imports the row. The sync helper treats a missing remote
+        // (sha null / 404) as success.
+        if (canvas?.repo && canvas.filePath) {
+          if (!GitHubService.isAuthenticated()) {
+            set({ error: 'Sign in to GitHub to delete synced canvases' });
+            if (opId) gitOperationRegistry.fail(opId, 'Sign in to GitHub to delete synced canvases');
+            return false;
+          }
+          const remote = await deleteCanvasFromGitHub({
+            repo: canvas.repo,
+            branch: canvas.branch,
+            filePath: canvas.filePath,
+            title: canvas.title,
+            accountId: canvas.accountId,
+          });
+          if (!remote.success) {
+            if (remote.error) console.warn('[CanvasStore] delete sync failed:', remote.error);
+            set({ error: formatSyncError(remote.error, 'delete') });
+            if (opId) gitOperationRegistry.fail(opId, remote.error ?? 'Delete failed');
+            return false;
+          }
+        }
+
+        const success = await StorageService.deleteCanvas(id);
+        if (success) {
+          if (opId) gitOperationRegistry.succeed(opId);
+          set((state) => ({ canvases: state.canvases.filter((c) => c.id !== id) }));
+        }
+        return success;
+      } catch (err) {
+        if (opId) gitOperationRegistry.fail(opId, err instanceof Error ? err.message : 'Delete failed');
+        throw err;
       }
-      return success;
     } catch (err) {
       set({ error: 'Failed to delete canvas' });
       console.error('Error deleting canvas:', err);

--- a/src/stores/gitOperationStore.ts
+++ b/src/stores/gitOperationStore.ts
@@ -1,0 +1,294 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
+import type { QueuedMutation } from '../services/NoteSyncQueueService';
+
+/**
+ * Central registry of git operations (saves, deletes, pushes, pulls, ...).
+ * Drives the app-wide locked/busy UI. The store never invents persistent
+ * truth: queued and failed ops are re-derived from the durable sync queue
+ * and the delete-failure map via hydrate(), so locks survive app restarts
+ * and the StartupSyncGate refresh cascade that re-reads AsyncStorage.
+ */
+
+export type GitOpKind = 'upsert' | 'delete' | 'rename' | 'move' | 'pull' | 'push';
+
+export type GitOpStatus = 'queued' | 'running' | 'failed';
+
+export interface GitOp {
+  id: string;
+  kind: GitOpKind;
+  repo: string;
+  branch?: string;
+  path?: string;
+  entityIds: string[];
+  status: GitOpStatus;
+  error?: string;
+  attempts: number;
+  createdAt: number;
+}
+
+export type GitOpBeginInput = Omit<GitOp, 'id' | 'createdAt'> & { status?: 'queued' | 'running' };
+
+/** Parsed entry from the durable delete-failure map (`@gitnotes:delete_failures_v1`). */
+export interface FailedDeleteEntry {
+  /** Raw map key `${repo}::${resolvedBranch}::${path}`; doubles as the derived op id. */
+  key: string;
+  repo: string;
+  branch: string;
+  path: string;
+  error: string;
+  kind: string;
+  at: number;
+}
+
+interface GitOperationState {
+  ops: Record<string, GitOp>;
+}
+
+interface GitOperationActions {
+  begin: (input: GitOpBeginInput) => string;
+  setRunning: (id: string) => void;
+  succeed: (id: string) => void;
+  fail: (id: string, error: string) => void;
+  retry: (id: string) => void;
+  replaceFromDurable: (queued: QueuedMutation[], failed: FailedDeleteEntry[]) => void;
+}
+
+const GIT_OP_KINDS: readonly GitOpKind[] = ['upsert', 'delete', 'rename', 'move', 'pull', 'push'];
+const DELETE_FAILURES_KEY = '@gitnotes:delete_failures_v1';
+
+/** Ids of ops derived from durable sources on the last replaceFromDurable pass. */
+let durableOpIds = new Set<string>();
+let queueSubscription: (() => void) | null = null;
+
+function normalizeBranch(branch: string | undefined): string {
+  return branch || 'main';
+}
+
+function isActiveStatus(status: GitOpStatus): boolean {
+  return status === 'queued' || status === 'running';
+}
+
+function generateOpId(): string {
+  return `gitop-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function toGitOpKind(value: string): GitOpKind {
+  return GIT_OP_KINDS.includes(value as GitOpKind) ? (value as GitOpKind) : 'delete';
+}
+
+function opFromQueuedMutation(mutation: QueuedMutation): GitOp | null {
+  if (!mutation || typeof mutation.id !== 'string' || !mutation.params || typeof mutation.params.repo !== 'string') {
+    return null;
+  }
+  const base = {
+    id: mutation.id,
+    repo: mutation.params.repo,
+    branch: mutation.params.branch,
+    path: mutation.params.filePath,
+    entityIds: [] as string[],
+    status: 'queued' as const,
+    error: mutation.lastError,
+    attempts: typeof mutation.attempts === 'number' ? mutation.attempts : 0,
+    createdAt: typeof mutation.createdAt === 'number' ? mutation.createdAt : 0,
+  };
+  if (mutation.type === 'note.upsert') {
+    return { ...base, kind: 'upsert', entityIds: mutation.localNoteId ? [mutation.localNoteId] : [] };
+  }
+  if (mutation.type === 'note.delete') {
+    return { ...base, kind: 'delete' };
+  }
+  return null;
+}
+
+function parseDeleteFailureKey(key: string): { repo: string; branch: string; path: string } | null {
+  const firstSep = key.indexOf('::');
+  const secondSep = firstSep >= 0 ? key.indexOf('::', firstSep + 2) : -1;
+  if (firstSep <= 0 || secondSep === -1) return null;
+  const repo = key.slice(0, firstSep);
+  const branch = key.slice(firstSep + 2, secondSep);
+  const path = key.slice(secondSep + 2);
+  if (!repo || !path) return null;
+  return { repo, branch, path };
+}
+
+function opFromFailedEntry(entry: FailedDeleteEntry): GitOp | null {
+  if (!entry || !entry.key || !entry.repo || !entry.path) return null;
+  return {
+    id: entry.key,
+    kind: toGitOpKind(entry.kind),
+    repo: entry.repo,
+    branch: entry.branch,
+    path: entry.path,
+    entityIds: [],
+    status: 'failed',
+    error: entry.error || 'Delete failed',
+    attempts: 0,
+    createdAt: entry.at || 0,
+  };
+}
+
+function buildDurableOps(queued: QueuedMutation[], failed: FailedDeleteEntry[]): Record<string, GitOp> {
+  const ops: Record<string, GitOp> = {};
+  for (const entry of Array.isArray(failed) ? failed : []) {
+    const op = opFromFailedEntry(entry);
+    if (op) ops[op.id] = op;
+  }
+  for (const mutation of Array.isArray(queued) ? queued : []) {
+    const op = opFromQueuedMutation(mutation);
+    if (op) ops[op.id] = op;
+  }
+  return ops;
+}
+
+async function readDeleteFailures(): Promise<FailedDeleteEntry[]> {
+  try {
+    const raw = await AsyncStorage.getItem(DELETE_FAILURES_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+    const entries: FailedDeleteEntry[] = [];
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      const parts = parseDeleteFailureKey(key);
+      if (!parts || !value || typeof value !== 'object') continue;
+      const record = value as { error?: unknown; kind?: unknown; at?: unknown };
+      entries.push({
+        key,
+        repo: parts.repo,
+        branch: parts.branch,
+        path: parts.path,
+        error: typeof record.error === 'string' ? record.error : 'Delete failed',
+        kind: typeof record.kind === 'string' ? record.kind : 'delete',
+        at: typeof record.at === 'number' ? record.at : 0,
+      });
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+function ensureQueueSubscription(): void {
+  if (queueSubscription) return;
+  queueSubscription = NoteSyncQueueService.subscribe(() => {
+    void hydrate();
+  });
+}
+
+export const useGitOperationStore = create<GitOperationState & GitOperationActions>()((set) => ({
+  ops: {},
+
+  begin: (input) => {
+    const id = generateOpId();
+    const op: GitOp = {
+      id,
+      kind: input.kind,
+      repo: input.repo,
+      branch: input.branch,
+      path: input.path,
+      entityIds: input.entityIds,
+      status: input.status ?? 'queued',
+      error: input.error,
+      attempts: input.attempts,
+      createdAt: Date.now(),
+    };
+    set((state) => ({ ops: { ...state.ops, [id]: op } }));
+    return id;
+  },
+
+  setRunning: (id) =>
+    set((state) => {
+      const op = state.ops[id];
+      if (!op) return state;
+      return { ops: { ...state.ops, [id]: { ...op, status: 'running', error: undefined } } };
+    }),
+
+  succeed: (id) =>
+    set((state) => {
+      if (!state.ops[id]) return state;
+      const ops = { ...state.ops };
+      delete ops[id];
+      return { ops };
+    }),
+
+  fail: (id, error) =>
+    set((state) => {
+      const op = state.ops[id];
+      if (!op) return state;
+      return { ops: { ...state.ops, [id]: { ...op, status: 'failed', error } } };
+    }),
+
+  retry: (id) =>
+    set((state) => {
+      const op = state.ops[id];
+      if (!op) return state;
+      return { ops: { ...state.ops, [id]: { ...op, status: 'queued', error: undefined } } };
+    }),
+
+  replaceFromDurable: (queued, failed) =>
+    set((state) => {
+      const durable = buildDurableOps(queued, failed);
+      const ops: Record<string, GitOp> = {};
+      // Non-durable ops (running push/pull markers, in-flight repo mutations)
+      // are caller-owned and not re-derivable from storage — preserve them.
+      for (const [id, op] of Object.entries(state.ops)) {
+        if (!durableOpIds.has(id)) ops[id] = op;
+      }
+      Object.assign(ops, durable);
+      durableOpIds = new Set(Object.keys(durable));
+      return { ops };
+    }),
+}));
+
+/**
+ * Re-derive the registry from durable sources: the persisted sync queue
+ * plus the delete-failure map. Called from App bootstrap right after
+ * bootstrapStorage(), and re-runs live on queue churn via the guarded
+ * subscription below.
+ */
+export async function hydrate(): Promise<void> {
+  try {
+    const [queued, failed] = await Promise.all([NoteSyncQueueService.getAll(), readDeleteFailures()]);
+    useGitOperationStore.getState().replaceFromDurable(queued, failed);
+  } catch (error) {
+    console.warn('[gitOperationStore] hydrate failed:', error);
+  }
+  ensureQueueSubscription();
+}
+
+export const isPathLocked = (
+  ops: Record<string, GitOp>,
+  repo: string,
+  branch: string | undefined,
+  path: string | undefined,
+): boolean =>
+  Object.values(ops).some(
+    (op) =>
+      isActiveStatus(op.status) &&
+      op.repo === repo &&
+      normalizeBranch(op.branch) === normalizeBranch(branch) &&
+      (op.path === undefined || op.path === path),
+  );
+
+export const isEntityLocked = (ops: Record<string, GitOp>, entityId: string): boolean =>
+  Object.values(ops).some((op) => isActiveStatus(op.status) && op.entityIds.includes(entityId));
+
+export const isRepoBusy = (ops: Record<string, GitOp>, repo: string): boolean =>
+  Object.values(ops).some((op) => isActiveStatus(op.status) && op.repo === repo);
+
+export const hasActivePull = (ops: Record<string, GitOp>, repo: string): boolean =>
+  Object.values(ops).some((op) => isActiveStatus(op.status) && op.kind === 'pull' && op.repo === repo);
+
+export const pendingRunningCount = (ops: Record<string, GitOp>): number =>
+  Object.values(ops).filter((op) => isActiveStatus(op.status)).length;
+
+/** Non-hook facade for service-layer callers (sync gate, repo-tree, stores). */
+export const gitOperationRegistry = {
+  begin: (input: GitOpBeginInput) => useGitOperationStore.getState().begin(input),
+  setRunning: (id: string) => useGitOperationStore.getState().setRunning(id),
+  succeed: (id: string) => useGitOperationStore.getState().succeed(id),
+  fail: (id: string, error: string) => useGitOperationStore.getState().fail(id, error),
+  retry: (id: string) => useGitOperationStore.getState().retry(id),
+  hydrate: () => hydrate(),
+};

--- a/src/stores/gitOperationStore.ts
+++ b/src/stores/gitOperationStore.ts
@@ -103,7 +103,8 @@ function opFromQueuedMutation(mutation: QueuedMutation): GitOp | null {
     return { ...base, kind: 'upsert', entityIds: mutation.localNoteId ? [mutation.localNoteId] : [] };
   }
   if (mutation.type === 'note.delete') {
-    return { ...base, kind: 'delete' };
+    const localNoteId = mutation.params.localNoteId;
+    return { ...base, kind: 'delete', entityIds: localNoteId ? [localNoteId] : [] };
   }
   return null;
 }

--- a/src/stores/gitOperationStore.ts
+++ b/src/stores/gitOperationStore.ts
@@ -58,6 +58,12 @@ interface GitOperationActions {
 const GIT_OP_KINDS: readonly GitOpKind[] = ['upsert', 'delete', 'rename', 'move', 'pull', 'push'];
 const DELETE_FAILURES_KEY = '@gitnotes:delete_failures_v1';
 
+/**
+ * Repo sentinel for app-wide ops. The sync gate publishes its cycle op as a
+ * pull against every repo; selectors below treat it as matching all repos.
+ */
+export const GIT_OP_ALL_REPOS = '*';
+
 /** Ids of ops derived from durable sources on the last replaceFromDurable pass. */
 let durableOpIds = new Set<string>();
 let queueSubscription: (() => void) | null = null;
@@ -275,10 +281,19 @@ export const isEntityLocked = (ops: Record<string, GitOp>, entityId: string): bo
   Object.values(ops).some((op) => isActiveStatus(op.status) && op.entityIds.includes(entityId));
 
 export const isRepoBusy = (ops: Record<string, GitOp>, repo: string): boolean =>
-  Object.values(ops).some((op) => isActiveStatus(op.status) && op.repo === repo);
+  Object.values(ops).some(
+    (op) =>
+      isActiveStatus(op.status) &&
+      (op.repo === repo || (op.repo === GIT_OP_ALL_REPOS && op.kind === 'pull')),
+  );
 
 export const hasActivePull = (ops: Record<string, GitOp>, repo: string): boolean =>
-  Object.values(ops).some((op) => isActiveStatus(op.status) && op.kind === 'pull' && op.repo === repo);
+  Object.values(ops).some(
+    (op) =>
+      isActiveStatus(op.status) &&
+      op.kind === 'pull' &&
+      (op.repo === repo || op.repo === GIT_OP_ALL_REPOS),
+  );
 
 export const pendingRunningCount = (ops: Record<string, GitOp>): number =>
   Object.values(ops).filter((op) => isActiveStatus(op.status)).length;

--- a/src/stores/githubActivityStore.ts
+++ b/src/stores/githubActivityStore.ts
@@ -48,7 +48,7 @@ export const useGitHubActivityStore = create<GitHubActivityState & GitHubActivit
     const timer = get().hideTimer;
     if (timer !== null) clearTimeout(timer);
     const newInflight = get().inflight + 1;
-    const newLabel = label ?? get().label ?? 'Syncing with GitHub…';
+    const newLabel = label ?? get().label ?? 'Syncing with GitHub';
     if (!get().visible) {
       const existing = get().visibilityChangeTimer;
       if (existing !== null) clearTimeout(existing);

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -3,6 +3,9 @@ import { create } from 'zustand';
 import { Note, NoteCreateInput, NoteUpdateInput, sortNotesWithPinnedFirst, filterNotesBySearch } from '../models/Note';
 import { StorageService } from '../services/StorageService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
+import type { MutationSucceededEvent, DroppedMutationEvent } from '../services/NoteSyncQueueService';
+import { gitOperationRegistry, useGitOperationStore } from './gitOperationStore';
+import type { GitOp } from './gitOperationStore';
 import { slugifyLocal, getExtensionForFormat } from '../components/editor/editorShared';
 
 interface NoteState {
@@ -102,33 +105,39 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
       set({ error: null });
 
       const note = get().notes.find((n) => n.id === id);
-      if (note?.repo) {
-        // Recover from the case where the note synced but the response
-        // never landed (so `filePath` is unset locally) by deriving the
-        // canonical path from title + folder + format. The same shape is
-        // produced by `useNoteEditorDocument` when first uploading; if no
-        // such file exists upstream, deleteNoteFromGitHub treats sha-null
-        // as success and the row drops cleanly.
+      if (!note) return false;
+
+      if (note.repo) {
         const filePath = note.filePath ?? deriveDefaultNotePath(note);
         if (filePath) {
-          // Optimistic delete (#565 phase A): enqueue the remote delete
-          // and let the next drain ship it. The UI removes the row
-          // immediately below — no spinner on the GitHub round-trip.
-          // Auth/network failures stay queued and retry on foreground/
-          // online triggers.
+          // The note stays in storage and renders locked until the queue
+          // reports success (row removed) or a drop (Retry shown).
+          armDeleteCompletionHandlers();
           await NoteSyncQueueService.enqueueNoteDelete({
             repo: note.repo,
             branch: note.branch,
             filePath,
             title: note.title,
             accountId: note.accountId,
+            localNoteId: id,
           });
-          // Fire-and-forget drain so the typical online case still pushes
-          // immediately. Reentrancy guard inside drain handles overlap.
+          gitOperationRegistry.begin({
+            kind: 'delete',
+            repo: note.repo,
+            branch: note.branch,
+            path: filePath,
+            entityIds: [id],
+            status: 'running',
+            attempts: 0,
+          });
           void NoteSyncQueueService.drain();
+          return true;
         }
+        // Repo-backed note with no derivable path: nothing to enqueue, so
+        // fall through to the instant local delete below.
       }
 
+      // Local-only notes delete instantly.
       const success = await StorageService.deleteNote(id);
       if (success) {
         set((state) => ({ notes: state.notes.filter((n) => n.id !== id) }));
@@ -205,3 +214,114 @@ export const useFilteredNotes = () => {
     [notes, searchQuery],
   );
 };
+
+// ── Delete-completion handlers ────────────────────────────────────────
+// The registry never removes a note's local row itself — queued deletes
+// complete asynchronously, so noteStore listens ONCE for the queue's
+// success/drop side channels and finishes the job there.
+
+let deleteHandlersArmed = false;
+
+function normalizeBranchForMatch(branch: string | undefined): string {
+  return branch || 'main';
+}
+
+function findNoteForDelete(mutation: {
+  repo?: string;
+  branch?: string;
+  filePath?: string;
+  localNoteId?: string;
+}): Note | undefined {
+  const { repo, branch, filePath, localNoteId } = mutation;
+  if (!repo || !filePath) return undefined;
+  const notes = useNoteStore.getState().notes;
+  if (localNoteId) return notes.find((n) => n.id === localNoteId);
+  return notes.find(
+    (n) =>
+      n.repo === repo &&
+      normalizeBranchForMatch(n.branch) === normalizeBranchForMatch(branch) &&
+      (n.filePath === filePath || deriveDefaultNotePath(n) === filePath),
+  );
+}
+
+function deleteOpMatches(
+  op: GitOp,
+  repo: string,
+  branch: string | undefined,
+  filePath: string,
+  localNoteId: string | undefined,
+): boolean {
+  if (op.kind !== 'delete') return false;
+  const pathMatch =
+    op.repo === repo && normalizeBranchForMatch(op.branch) === normalizeBranchForMatch(branch) && op.path === filePath;
+  const entityMatch = !!localNoteId && op.entityIds.includes(localNoteId);
+  return pathMatch || entityMatch;
+}
+
+function succeedDeleteOps(
+  repo: string,
+  branch: string | undefined,
+  filePath: string,
+  localNoteId: string | undefined,
+): void {
+  const { ops } = useGitOperationStore.getState();
+  for (const [id, op] of Object.entries(ops)) {
+    if (deleteOpMatches(op, repo, branch, filePath, localNoteId)) {
+      useGitOperationStore.getState().succeed(id);
+    }
+  }
+}
+
+function failDeleteOps(
+  repo: string,
+  branch: string | undefined,
+  filePath: string,
+  localNoteId: string | undefined,
+  error: string,
+): void {
+  const { ops } = useGitOperationStore.getState();
+  for (const [id, op] of Object.entries(ops)) {
+    if (deleteOpMatches(op, repo, branch, filePath, localNoteId)) {
+      useGitOperationStore.getState().fail(id, error);
+    }
+  }
+}
+
+function onDeleteMutationSucceeded(event: MutationSucceededEvent): void {
+  const mutation = event.mutation;
+  if (mutation.type !== 'note.delete') return;
+  const note = findNoteForDelete(mutation.params);
+  if (note) {
+    void StorageService.deleteNote(note.id).catch(() => undefined);
+    useNoteStore.setState((state) => ({ notes: state.notes.filter((n) => n.id !== note.id) }));
+  }
+  succeedDeleteOps(mutation.params.repo, mutation.params.branch, mutation.params.filePath, mutation.params.localNoteId);
+}
+
+function onDeleteMutationDropped(event: DroppedMutationEvent): void {
+  const mutation = event.mutation;
+  if (mutation.type !== 'note.delete') return;
+  failDeleteOps(
+    mutation.params.repo,
+    mutation.params.branch,
+    mutation.params.filePath,
+    mutation.params.localNoteId,
+    event.error ?? 'Delete failed',
+  );
+}
+
+/**
+ * Registers the success/drop handlers exactly once. Guarded so test suites
+ * that mock NoteSyncQueueService without the side-channel methods can still
+ * import this store without crashing.
+ */
+function armDeleteCompletionHandlers(): void {
+  if (deleteHandlersArmed) return;
+  if (typeof NoteSyncQueueService.onMutationSucceeded !== 'function') return;
+  if (typeof NoteSyncQueueService.onDroppedMutation !== 'function') return;
+  NoteSyncQueueService.onMutationSucceeded(onDeleteMutationSucceeded);
+  NoteSyncQueueService.onDroppedMutation(onDeleteMutationDropped);
+  deleteHandlersArmed = true;
+}
+
+armDeleteCompletionHandlers();

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -7,6 +7,11 @@ import type { MutationSucceededEvent, DroppedMutationEvent } from '../services/N
 import { gitOperationRegistry, useGitOperationStore } from './gitOperationStore';
 import type { GitOp } from './gitOperationStore';
 import { slugifyLocal, getExtensionForFormat } from '../components/editor/editorShared';
+import { parseRepoPath } from '../utils/gitPathParser';
+
+function pathsEqual(a: { owner: string; repo: string } | null, b: { owner: string; repo: string }): boolean {
+  return !!a && a.owner === b.owner && a.repo === b.repo;
+}
 
 interface NoteState {
   notes: Note[];
@@ -21,6 +26,7 @@ interface NoteActions {
   createNote: (input: NoteCreateInput) => Promise<Note | null>;
   updateNote: (input: NoteUpdateInput) => Promise<Note | null>;
   deleteNote: (id: string) => Promise<boolean>;
+  dropByFilePaths: (repo: string, paths: string[]) => Promise<number>;
   clearAllNotes: () => Promise<boolean>;
   getNoteById: (id: string) => Note | undefined;
   togglePin: (id: string) => Promise<boolean>;
@@ -147,6 +153,32 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
       set({ error: 'Failed to delete note' });
       console.error('Error deleting note:', err);
       return false;
+    }
+  },
+
+  dropByFilePaths: async (repo, paths) => {
+    try {
+      set({ error: null });
+      const pathSet = new Set(paths);
+      const repoPaths = parseRepoPath(repo);
+      const matches = get().notes.filter((note) => {
+        if (!note.repo) return false;
+        const sameRepo =
+          note.repo === repo ||
+          (!!repoPaths && pathsEqual(parseRepoPath(note.repo), repoPaths));
+        if (!sameRepo) return false;
+        const filePath = note.filePath ?? deriveDefaultNotePath(note);
+        return !!filePath && pathSet.has(filePath);
+      });
+      if (matches.length === 0) return 0;
+      await Promise.all(matches.map((note) => StorageService.deleteNote(note.id)));
+      const ids = new Set(matches.map((n) => n.id));
+      set((state) => ({ notes: state.notes.filter((n) => !ids.has(n.id)) }));
+      return matches.length;
+    } catch (err) {
+      set({ error: 'Failed to drop notes' });
+      console.error('Error dropping notes:', err);
+      return 0;
     }
   },
 

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -25,7 +25,7 @@ interface NoteActions {
   clearError: () => void;
 }
 
-function deriveDefaultNotePath(note: Note): string | null {
+export function deriveDefaultNotePath(note: Note): string | null {
   const title = (note.title ?? '').trim();
   if (!title) return null;
   const slug = slugifyLocal(title);

--- a/src/stores/todoStore.ts
+++ b/src/stores/todoStore.ts
@@ -4,6 +4,7 @@ import { StorageService } from '../services/StorageService';
 import { GitHubService } from '../services/GitHubService';
 import { deleteTodoFromGitHub } from '../services/TodoGitHubSyncService';
 import { formatSyncError } from '../services/git/formatSyncError';
+import { gitOperationRegistry } from './gitOperationStore';
 
 interface TodoState {
   todos: Todo[];
@@ -73,33 +74,54 @@ export const useTodoStore = create<TodoState & TodoActions>()((set, get) => ({
       const todoToDelete = get().todos.find((t) => t.id === id);
       const isRepoBacked = !!(todoToDelete?.repo && todoToDelete.filePath);
 
-      // Repo-backed todos must purge the remote file first; otherwise the next
-      // pull re-imports the row (#489). The sync helper already treats a
-      // missing remote (sha null / 404) as success so a stale local row can
-      // still be cleaned up.
+      let opId: string | null = null;
       if (isRepoBacked) {
-        if (!GitHubService.isAuthenticated()) {
-          set({ error: 'Cannot delete repo-backed todo while signed out of GitHub' });
-          return false;
-        }
-        const remote = await deleteTodoFromGitHub({
+        opId = gitOperationRegistry.begin({
+          kind: 'delete',
           repo: todoToDelete!.repo!,
           branch: todoToDelete!.branch,
-          filePath: todoToDelete!.filePath!,
-          text: todoToDelete!.text,
+          path: todoToDelete!.filePath!,
+          entityIds: [id],
+          status: 'running',
+          attempts: 0,
         });
-        if (!remote.success) {
-          if (remote.error) console.warn('[TodoStore] delete sync failed:', remote.error);
-          set({ error: formatSyncError(remote.error, 'delete') });
-          return false;
-        }
       }
 
-      const success = await StorageService.deleteTodo(id);
-      if (success) {
-        set((state) => ({ todos: state.todos.filter((t) => t.id !== id) }));
+      try {
+        // Repo-backed todos must purge the remote file first; otherwise the next
+        // pull re-imports the row (#489). The sync helper already treats a
+        // missing remote (sha null / 404) as success so a stale local row can
+        // still be cleaned up.
+        if (isRepoBacked) {
+          if (!GitHubService.isAuthenticated()) {
+            set({ error: 'Cannot delete repo-backed todo while signed out of GitHub' });
+            if (opId) gitOperationRegistry.fail(opId, 'Cannot delete repo-backed todo while signed out of GitHub');
+            return false;
+          }
+          const remote = await deleteTodoFromGitHub({
+            repo: todoToDelete!.repo!,
+            branch: todoToDelete!.branch,
+            filePath: todoToDelete!.filePath!,
+            text: todoToDelete!.text,
+          });
+          if (!remote.success) {
+            if (remote.error) console.warn('[TodoStore] delete sync failed:', remote.error);
+            set({ error: formatSyncError(remote.error, 'delete') });
+            if (opId) gitOperationRegistry.fail(opId, remote.error ?? 'Delete failed');
+            return false;
+          }
+        }
+
+        const success = await StorageService.deleteTodo(id);
+        if (success) {
+          if (opId) gitOperationRegistry.succeed(opId);
+          set((state) => ({ todos: state.todos.filter((t) => t.id !== id) }));
+        }
+        return success;
+      } catch (err) {
+        if (opId) gitOperationRegistry.fail(opId, err instanceof Error ? err.message : 'Delete failed');
+        throw err;
       }
-      return success;
     } catch (err) {
       set({ error: 'Failed to delete todo' });
       console.error('Error deleting todo:', err);


### PR DESCRIPTION
## What
Fixes the "deleted file comes back until it finally sticks" bug at its roots, plus the app-wide treatment requested:

**Delete-resurrection root causes**
- Repo-tree file delete never silently skips on SHA-lookup failure (typed sha: error → alert+row intact, not-found → soft success, found → delete with sha)
- Folder-delete partial failures aggregate into one report; failed rows stay visible
- Note-delete tombstones key on the RESOLVED branch; durable queue drops (auth/permission/conflict/not_found, 8-attempt exhaustion) surface as visible failed-with-Retry items instead of silent loss

**Deadlock-free push/pull gate**
- Global sync CYCLE mutex (one drain/pull cycle at a time; drain+pull atomic, no self-deadlock) + per-repo push markers that make pull steps wait
- Unified `syncNow` manual-sync helper — every manual entry point (pull-to-refresh, cloud icon, TodoList refresh, StartupSyncGate) routes through ONE gate-wrapped path

**Delete-state UI (the headline)**
- Items stay visible-but-locked during git ops: grayed (0.45 opacity), non-interactive (swipe/long-press/context-menu disabled), trailing spinner
- Durable failures show error + Retry (re-enqueues, clears failure entry)
- Editor save blocked while a delete is queued on that path (Alert) — no silent upsert-cancels-delete
- Restart-safe: hydrate restores locks from persisted queue/failure map before first drain
- Applies to notes (list + home), todos, canvases, thought dumps, repo-tree files/folders

**Single-commit bulk ops**
- Bulk note/todo deletes + folder deletes batch through ONE Git-Data-API commit in API mode; clone mode keeps one coalesced push
- Batch enqueue = one queue write

**Busy-state design language**
- NO ellipsis busy-text anywhere; busy = disabled control + spinner (23 files cleaned)
- Persistent cloud badge = queue source of truth; pill = transient HTTP activity; pull controls disabled while gate busy
- i18n keys in all 6 locales

## Tests
- New: gitOperationStore (19), GitSyncGate (11), manualSync (5), BatchGitOperations (6), deleteFailures, repo-tree-delete (4), repo-tree-lock (5), notes-delete-lock (6), git-state-ui (6), sync-locking integration S1–S8 (9)
- Full suite: **2049 passed / 0 failed** · `yarn ts:check` exit 0 · `yarn eslint` 0 errors
- Confirmed no scope intrusion: conflict resolver, background scheduling, AI/chat, importers untouched; NoteSyncQueueService mechanics (backoff/MAX_ATTEMPTS/grouping/reentrancy/drain contract) preserved; no new dependencies

## Verification
Final wave F1–F4 all approved (plan compliance, code quality, headless manual QA via integration suite, scope fidelity).