### PR TITLE
fix(chat): inset empty-state title, description and hint chips from screen edges

### DIFF
--- a/__tests__/ChatHintChips.test.tsx
+++ b/__tests__/ChatHintChips.test.tsx
@@ -106,7 +106,7 @@ describe('ChatHintChips', () => {
     expect(getByTestId('chat-hints-scroller')).toHaveProp('horizontal', true);
   });
 
-  test('outer container has no horizontal padding so chips sit flush to screen edges', () => {
+  test('outer container has no horizontal padding (side inset lives on the scroller content)', () => {
     const { UNSAFE_root } = render(<ChatHintChips onPressHint={jest.fn()} />);
 
     const scroller = UNSAFE_root.findByProps({ testID: 'chat-hints-scroller' });
@@ -118,13 +118,13 @@ describe('ChatHintChips', () => {
     expect(style.paddingRight).toBeUndefined();
   });
 
-  test('in empty-chat context the first chip starts at x=0 (no leading padding)', () => {
+  test('in empty-chat context the scroll content has symmetric side padding so the first chip is inset on load', () => {
     const { UNSAFE_root } = render(<ChatHintChips onPressHint={jest.fn()} />);
 
     const scroller = UNSAFE_root.findByProps({ testID: 'chat-hints-scroller' });
-    expect(scroller.props.contentContainerStyle.paddingHorizontal).toBeUndefined();
+    expect(scroller.props.contentContainerStyle.paddingHorizontal).toBe(8);
     expect(scroller.props.contentContainerStyle.paddingLeft).toBeUndefined();
-    expect(scroller.props.contentContainerStyle.paddingRight).toBe(8);
+    expect(scroller.props.contentContainerStyle.paddingRight).toBeUndefined();
 
     const outerContainer = scroller.parent;
     expect(outerContainer?.props.style.paddingHorizontal).toBeUndefined();

--- a/docs/wiki/ai-integration.md
+++ b/docs/wiki/ai-integration.md
@@ -285,6 +285,17 @@ async function safeChat(messages: Message[], provider: AIProviderConfig) {
 }
 ```
 
+## Chat Empty State UI
+
+The empty (new chat) screen in `ChatScreen.tsx` shows a start-conversation title, a body description, and a horizontally scrolling hint chip row (`ChatHintChips`).
+
+Layout rules:
+
+- **Title & description** (`ChatScreen.tsx`, `ListEmptyComponent`) use `marginHorizontal: spacing[4]` so text never touches the screen edges.
+- **Hint chip row** (`ChatHintChips.tsx`) uses `paddingHorizontal: spacing[2]` on the `ScrollView` `contentContainerStyle`. On load the first chip is inset from the left edge; the row remains scrollable so the user can swipe chips to the screen edges.
+
+Tests: `__tests__/ChatHintChips.test.tsx` asserts the scroller carries symmetric side padding while the outer container stays padding-free.
+
 ## Testing
 
 ```typescript

--- a/src/components/ai/ChatHintChips.tsx
+++ b/src/components/ai/ChatHintChips.tsx
@@ -105,7 +105,7 @@ export function ChatHintChips({ onPressHint }: ChatHintChipsProps) {
         testID="chat-hints-scroller"
         horizontal
         showsHorizontalScrollIndicator={false}
-        contentContainerStyle={{ gap: spacing[2], paddingRight: spacing[2] }}
+        contentContainerStyle={{ gap: spacing[2], paddingHorizontal: spacing[2] }}
       >
         {HINTS.map((hint) => (
           <TouchableOpacity

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -146,8 +146,10 @@ export default function ChatScreen() {
                 className="flex-1 justify-center items-center"
                 style={{ paddingVertical: spacing[6], paddingHorizontal: 0 }}
               >
-                <Text className="text-xl font-bold mb-2 text-text">{t('chat.startConversation')}</Text>
-                <Text className="text-md text-center text-text-secondary">
+                <Text className="text-xl font-bold mb-2 text-text" style={{ marginHorizontal: spacing[4] }}>
+                  {t('chat.startConversation')}
+                </Text>
+                <Text className="text-md text-center text-text-secondary" style={{ marginHorizontal: spacing[4] }}>
                   {t('chat.emptyStateBody')}
                 </Text>
                 <ChatHintChips onPressHint={handleHintPress} />


### PR DESCRIPTION
## Summary

Fixes the default layout of the empty (New Chat) page in `ChatScreen`:

- **Title & description** now use `marginHorizontal: spacing[4]` (16px) so the text has breathing room from both screen edges instead of touching them.
- **Hint chip slider** (`ChatHintChips`) now uses symmetric `paddingHorizontal: spacing[2]` on the `ScrollView` content container. On load the first chip is inset from the left edge; the row stays fully scrollable so the user can swipe chips to the screen edges.

## Changes

| File | Change |
|------|--------|
| `src/screens/ChatScreen.tsx` | Added horizontal margin to empty-state title + description |
| `src/components/ai/ChatHintChips.tsx` | `paddingRight` → `paddingHorizontal` (symmetric side inset) |
| `__tests__/ChatHintChips.test.tsx` | Updated assertions to expect symmetric side padding |
| `docs/wiki/ai-integration.md` | Documented empty chat state layout |

## Verification

- `yarn ts:check` ✅
- `yarn jest` — 245 suites / 2178 tests pass ✅
- `yarn eslint` on changed files ✅