### PR TITLE
fix(chat): guard thread-card timestamp crash + make stage-then-push the default (remove FEATURE_STAGE_PUSH)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -47,7 +47,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { reconcileThoughtDumps } from './src/services/ai/thoughtDumpIndexing';
 import { LastSelectionPreferenceService } from './src/services/LastSelectionPreferenceService';
 import * as PushNotificationService from './src/services/PushNotificationService';
-import { FEATURE_STAGE_PUSH } from './src/services/featureFlags';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -114,10 +113,8 @@ export default function App() {
     } catch (error) {
       console.warn('[App] foreground sync watcher start failed:', error);
     }
-    if (FEATURE_STAGE_PUSH) {
-      PushNotificationService.attachToScheduler();
-      PushNotificationService.subscribeToPushProgress();
-    }
+    PushNotificationService.attachToScheduler();
+    PushNotificationService.subscribeToPushProgress();
     void reconcileThoughtDumps().catch(() => {});
     void LastSelectionPreferenceService.migrateFromLegacy();
   }, []);

--- a/__tests__/ai-chat-tools-expansion.test.ts
+++ b/__tests__/ai-chat-tools-expansion.test.ts
@@ -522,7 +522,7 @@ describe('chat-tools expansion — chatRepoSync behavior', () => {
     expect(createInput.repo).toBe('me/notes-repo');
     expect(createInput.branch).toBe('dev');
     expect(NoteSyncQueueService.enqueueNoteUpsert).toHaveBeenCalledTimes(1);
-    expect(NoteSyncQueueService.drain).toHaveBeenCalled();
+    expect(NoteSyncQueueService.drain).not.toHaveBeenCalled();
   });
 
   test('write tools skip the sync queue when no chat repo is selected', async () => {
@@ -555,7 +555,7 @@ describe('chat-tools expansion — chatRepoSync behavior', () => {
     expect(firstUpdate.content).toContain('## Sequence');
     expect(firstUpdate.content).toContain('[[Second]]');
     expect(NoteSyncQueueService.enqueueNoteUpsert).toHaveBeenCalledTimes(2);
-    expect(NoteSyncQueueService.drain).toHaveBeenCalled();
+    expect(NoteSyncQueueService.drain).not.toHaveBeenCalled();
     expect((result.data as { linked: number }).linked).toBe(2);
   });
 });

--- a/__tests__/chat-thread-card-crash.test.tsx
+++ b/__tests__/chat-thread-card-crash.test.tsx
@@ -1,0 +1,93 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Regression: "AI chat crashes instantly on open".
+ *
+ * The chat-thread list renders a summary card for every thread, and
+ * ChatThreadCard called `formatDistanceToNow(thread.updatedAt)` unguarded.
+ * date-fns throws `RangeError: Invalid time value` for a missing/NaN
+ * updatedAt (e.g. a thread persisted before timestamps were uniformly
+ * applied, or a partially-synced summary), and since this is a render error
+ * the whole chat screen crashes the moment the list opens. This is the same
+ * crash class #864 fixed for message bubbles but missed for thread cards.
+ *
+ * buildThreadSummary also copied `updatedAt` through unnormalized, so a bad
+ * value reached the card. Both sites are fixed and locked here.
+ */
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (value: string) => value }),
+}));
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { ChatThreadCard } from '../src/components/chat/ChatThreadCard';
+import type { ChatThread, ChatThreadSummary } from '../src/models/Chat';
+import { buildThreadSummary } from '../src/utils/chatThreadSummary';
+import { TestThemeProvider } from './ui/testThemeProvider';
+
+function makeThread(overrides?: Partial<ChatThread>): ChatThread {
+  return {
+    id: 'thread-1',
+    title: 'Test thread',
+    messages: [],
+    createdAt: 1,
+    updatedAt: 2,
+    repoOwner: 'o',
+    repoName: 'r',
+    branch: 'main',
+    filePath: 'chat/thread-1.json',
+    ...overrides,
+  };
+}
+
+function renderCard(thread: ChatThreadSummary) {
+  return render(
+    React.createElement(
+      TestThemeProvider,
+      null,
+      React.createElement(ChatThreadCard, {
+        thread,
+        onPress: () => undefined,
+        onLongPress: () => undefined,
+      }),
+    ),
+  );
+}
+
+describe('chat thread card crash regression', () => {
+  test('card with NaN updatedAt renders without crashing', () => {
+    // Previously: `formatDistanceToNow(NaN)` threw `RangeError: Invalid time
+    // value`, an uncaught render error that killed the chat screen on open.
+    expect(() =>
+      renderCard({ id: 'legacy-1', title: 'Legacy', updatedAt: NaN, messageCount: 0 }),
+    ).not.toThrow();
+  });
+
+  test('card with missing updatedAt renders without crashing', () => {
+    expect(() =>
+      renderCard({ id: 'legacy-2', title: 'Legacy', messageCount: 0 } as ChatThreadSummary),
+    ).not.toThrow();
+  });
+
+  test('card with valid updatedAt renders the ago label', () => {
+    const { getByText } = renderCard({
+      id: 'ok-1',
+      title: 'Fine',
+      updatedAt: Date.now(),
+      messageCount: 3,
+    });
+    expect(getByText(/ago/i)).toBeTruthy();
+  });
+
+  test('buildThreadSummary with NaN updatedAt returns a finite timestamp', () => {
+    const summary = buildThreadSummary(makeThread({ updatedAt: NaN }));
+    expect(Number.isFinite(summary.updatedAt)).toBe(true);
+  });
+
+  test('buildThreadSummary with missing updatedAt returns a finite timestamp', () => {
+    const thread = makeThread() as any;
+    delete thread.updatedAt;
+    const summary = buildThreadSummary(thread);
+    expect(Number.isFinite(summary.updatedAt)).toBe(true);
+  });
+});

--- a/__tests__/components/useNoteEditorDocument.notFound.test.ts
+++ b/__tests__/components/useNoteEditorDocument.notFound.test.ts
@@ -16,6 +16,10 @@ jest.mock('../../src/services/NoteGitHubSyncService', () => ({
   syncNoteToGitHub: jest.fn(),
 }));
 
+jest.mock('../../src/services/git/StagingService', () => ({
+  StagingService: { stageUpsert: jest.fn() },
+}));
+
 jest.mock('../../src/services/NoteSyncQueueService', () => ({
   NoteSyncQueueService: { enqueue: jest.fn(), enqueueNoteUpsert: jest.fn() },
 }));
@@ -25,8 +29,8 @@ jest.mock('../../src/utils/haptics', () => ({
 }));
 
 import { useNoteEditorDocument } from '../../src/components/editor/useNoteEditorDocument';
-import { syncNoteToGitHub } from '../../src/services/NoteGitHubSyncService';
 import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
+import { StagingService } from '../../src/services/git/StagingService';
 
 const baseParams = {
   initialFormat: 'markdown' as const,
@@ -92,7 +96,7 @@ describe('useNoteEditorDocument notFound (issue #669)', () => {
 
   test('shows actionable auth failure and does not enqueue the locally saved note', async () => {
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
-    (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: false, error: 'GitHub not authenticated' });
+    (StagingService.stageUpsert as jest.Mock).mockRejectedValue(new Error('GitHub not authenticated'));
     const createNote = jest.fn(async () => ({ id: 'new-note-1' }));
 
     const { result } = renderHook(() =>
@@ -118,13 +122,11 @@ describe('useNoteEditorDocument notFound (issue #669)', () => {
     alertSpy.mockRestore();
   });
 
-  test('shows the repository permission alert for a generic 403 sync failure', async () => {
+  test('shows the repository permission alert for a generic 403 stage failure', async () => {
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
-    (syncNoteToGitHub as jest.Mock).mockResolvedValue({
-      success: false,
-      error: 'Permission denied',
-      status: 403,
-    });
+    (StagingService.stageUpsert as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('Permission denied'), { status: 403 }),
+    );
     const createNote = jest.fn(async () => ({ id: 'new-note-1' }));
 
     const { result } = renderHook(() =>

--- a/__tests__/components/useNoteEditorDocument.stage.test.tsx
+++ b/__tests__/components/useNoteEditorDocument.stage.test.tsx
@@ -27,7 +27,6 @@ jest.mock('../../src/services/git/StagingService', () => ({
 }));
 
 jest.mock('../../src/services/featureFlags', () => ({
-  FEATURE_STAGE_PUSH: false,
   FEATURE_USE_MULTI_HOST_WRITE: false,
 }));
 
@@ -39,10 +38,6 @@ import { useNoteEditorDocument } from '../../src/components/editor/useNoteEditor
 import { syncNoteToGitHub } from '../../src/services/NoteGitHubSyncService';
 import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
 import { StagingService } from '../../src/services/git/StagingService';
-
-const featureFlagsMock = jest.requireMock('../../src/services/featureFlags') as {
-  FEATURE_STAGE_PUSH: boolean;
-};
 
 const navigation = {
   navigate: jest.fn(),
@@ -70,15 +65,13 @@ function editorParams(overrides: Record<string, unknown>) {
 describe('useNoteEditorDocument stage-push rework', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('with FEATURE_STAGE_PUSH ON: stages the upsert and never calls syncNoteToGitHub', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('stages the upsert and never calls syncNoteToGitHub', async () => {
     jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
     (StagingService.stageUpsert as jest.Mock).mockResolvedValue({ success: true });
     const createNote = jest.fn(async () => ({ id: 'new-note-1' }));
@@ -121,53 +114,7 @@ describe('useNoteEditorDocument stage-push rework', () => {
     );
   });
 
-  it('with FEATURE_STAGE_PUSH OFF: old path is unchanged (syncNoteToGitHub called, stageUpsert not)', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
-    jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
-    (syncNoteToGitHub as jest.Mock).mockResolvedValue({
-      success: true,
-      filePath: 'notes/my-note.md',
-      finalContent: null,
-    });
-    const createNote = jest.fn(async () => ({ id: 'new-note-1' }));
-    const updateNote = jest.fn(async () => true);
-
-    const { result } = renderHook(() =>
-      useNoteEditorDocument(
-        editorParams({
-          initialRepo: 'owner/repo',
-          initialBranch: 'main',
-          initialTitle: 'My Note',
-          initialContent: 'body',
-          initialFolderPath: '/notes',
-          createNote,
-          updateNote,
-          getNoteById: () => undefined,
-        }),
-      ),
-    );
-
-    await act(async () => {
-      await result.current.handleSave();
-    });
-
-    expect(syncNoteToGitHub).toHaveBeenCalledTimes(1);
-    expect(syncNoteToGitHub).toHaveBeenCalledWith(
-      expect.objectContaining({
-        repo: 'owner/repo',
-        branch: 'main',
-        filePath: '/notes/my-note.md',
-        title: 'My Note',
-      }),
-    );
-    expect(StagingService.stageUpsert).not.toHaveBeenCalled();
-    expect(updateNote).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'new-note-1', filePath: 'notes/my-note.md' }),
-    );
-  });
-
-  it('with FEATURE_STAGE_PUSH ON and a failing stage: falls back to the sync queue with the "Note Saved Locally" alert', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('a failing stage falls back to the sync queue with the "Note Saved Locally" alert', async () => {
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
     (StagingService.stageUpsert as jest.Mock).mockResolvedValue({ success: false, error: 'staging boom' });
     const createNote = jest.fn(async () => ({ id: 'new-note-1' }));

--- a/__tests__/screens/HomeScreen.color-select.test.tsx
+++ b/__tests__/screens/HomeScreen.color-select.test.tsx
@@ -7,11 +7,11 @@
  * tests:
  *
  *   1. A source-level regression test confirming the broken `'color' in
- *      item.data` guard has been removed and the sync call has been added.
- *   2. A behavioural test of the sync helper used by `handleColorSelect`,
+ *      item.data` guard has been removed and the stage call has been added.
+ *   2. A behavioural test of the stage helper used by `handleColorSelect`,
  *      mirroring the same logic used in `useNotesListNoteActions`.
  *
- * The sync logic is shared by design (HomeScreen and Notes-list perform
+ * The stage logic is shared by design (HomeScreen and Notes-list perform
  * the same side effect after `updateNote`), so verifying it once here is
  * sufficient.
  */
@@ -22,7 +22,7 @@ import * as path from 'path';
 // ----- Sync helper (mirrors HomeScreen.handleColorSelect) -----
 type NoteColorValue = import('../../src/models/Note').NoteColor;
 
-interface SyncInput {
+interface StageInput {
   repo?: string;
   branch?: string;
   filePath?: string;
@@ -33,19 +33,18 @@ interface SyncInput {
   color: NoteColorValue | null;
 }
 
-async function colorSyncAfterUpdateNote(
-  updated: { id: string } & Partial<SyncInput>,
+async function colorStageAfterUpdateNote(
+  updated: { id: string } & Partial<StageInput>,
   color: NoteColorValue | null,
   deps: {
-    syncNoteToGitHub: (params: SyncInput) => Promise<{ success: boolean; finalContent?: string | null }>;
-    enqueueNoteUpsert: (params: SyncInput, id: string) => Promise<void>;
-    updateNoteContent: (id: string, content: string) => Promise<void>;
+    stageUpsert: (params: StageInput) => Promise<{ success: boolean }>;
+    enqueueNoteUpsert: (params: StageInput, id: string) => Promise<void>;
   },
 ): Promise<void> {
   if (!updated.repo || !updated.filePath || !(updated.content ?? '').trim()) {
     return;
   }
-  const syncParams: SyncInput = {
+  const syncParams: StageInput = {
     repo: updated.repo!,
     branch: updated.branch,
     filePath: updated.filePath!,
@@ -56,12 +55,7 @@ async function colorSyncAfterUpdateNote(
     color,
   };
   try {
-    const result = await deps.syncNoteToGitHub(syncParams);
-    if (!result.success) {
-      await deps.enqueueNoteUpsert(syncParams, updated.id);
-    } else if (result.finalContent && result.finalContent !== updated.content) {
-      await deps.updateNoteContent(updated.id, result.finalContent);
-    }
+    await deps.stageUpsert(syncParams);
   } catch (error) {
     await deps.enqueueNoteUpsert(syncParams, updated.id);
   }
@@ -82,15 +76,16 @@ describe('HomeScreen color-tag fix (issue #794)', () => {
       expect(hasBrokenGuard).toBe(false);
     });
 
-    test('handleColorSelect syncs via syncNoteToGitHub', () => {
-      expect(homeScreenSrc).toContain('syncNoteToGitHub');
+    test('handleColorSelect stages via StagingService and never calls syncNoteToGitHub', () => {
+      expect(homeScreenSrc).toContain('StagingService.stageUpsert');
       expect(homeScreenSrc).toContain('NoteSyncQueueService');
       expect(homeScreenSrc).toContain('enqueueNoteUpsert');
+      expect(homeScreenSrc).not.toContain('syncNoteToGitHub');
     });
 
-    test('imports the sync services', () => {
+    test('imports the stage services', () => {
       expect(homeScreenSrc).toMatch(
-        /import\s*\{\s*syncNoteToGitHub\s*\}\s*from\s*['"]\.\.\/services\/NoteGitHubSyncService['"]/,
+        /import\s*\{\s*StagingService\s*\}\s*from\s*['"]\.\.\/services\/git\/StagingService['"]/,
       );
       expect(homeScreenSrc).toMatch(
         /import\s*\{\s*NoteSyncQueueService\s*\}\s*from\s*['"]\.\.\/services\/NoteSyncQueueService['"]/,
@@ -98,25 +93,23 @@ describe('HomeScreen color-tag fix (issue #794)', () => {
     });
   });
 
-  describe('sync behaviour after color update', () => {
-    test('Case A: skips sync for a note without a repo or filePath', async () => {
-      const sync = jest.fn();
+  describe('stage behaviour after color update', () => {
+    test('Case A: skips staging for a note without a repo or filePath', async () => {
+      const stage = jest.fn();
       const enqueue = jest.fn();
-      const updateContent = jest.fn();
-      await colorSyncAfterUpdateNote(
+      await colorStageAfterUpdateNote(
         { id: 'n1', content: 'body' },
         'red',
-        { syncNoteToGitHub: sync, enqueueNoteUpsert: enqueue, updateNoteContent: updateContent },
+        { stageUpsert: stage, enqueueNoteUpsert: enqueue },
       );
-      expect(sync).not.toHaveBeenCalled();
+      expect(stage).not.toHaveBeenCalled();
       expect(enqueue).not.toHaveBeenCalled();
     });
 
-    test('Case B: syncs and updates content when syncNoteToGitHub returns finalContent', async () => {
-      const sync = jest.fn().mockResolvedValue({ success: true, finalContent: 'NEW CONTENT' });
+    test('Case B: stages the upsert with the selected color', async () => {
+      const stage = jest.fn().mockResolvedValue({ success: true });
       const enqueue = jest.fn();
-      const updateContent = jest.fn();
-      await colorSyncAfterUpdateNote(
+      await colorStageAfterUpdateNote(
         {
           id: 'n1',
           repo: 'o/r',
@@ -125,20 +118,18 @@ describe('HomeScreen color-tag fix (issue #794)', () => {
           content: 'body',
         },
         'blue',
-        { syncNoteToGitHub: sync, enqueueNoteUpsert: enqueue, updateNoteContent: updateContent },
+        { stageUpsert: stage, enqueueNoteUpsert: enqueue },
       );
-      expect(sync).toHaveBeenCalledWith(
+      expect(stage).toHaveBeenCalledWith(
         expect.objectContaining({ repo: 'o/r', filePath: 'notes/a.md', color: 'blue' }),
       );
-      expect(updateContent).toHaveBeenCalledWith('n1', 'NEW CONTENT');
       expect(enqueue).not.toHaveBeenCalled();
     });
 
-    test('Case C: enqueues via NoteSyncQueueService when syncNoteToGitHub throws', async () => {
-      const sync = jest.fn().mockRejectedValue(new Error('network down'));
+    test('Case C: enqueues via NoteSyncQueueService when stageUpsert throws', async () => {
+      const stage = jest.fn().mockRejectedValue(new Error('network down'));
       const enqueue = jest.fn();
-      const updateContent = jest.fn();
-      await colorSyncAfterUpdateNote(
+      await colorStageAfterUpdateNote(
         {
           id: 'n1',
           repo: 'o/r',
@@ -147,20 +138,18 @@ describe('HomeScreen color-tag fix (issue #794)', () => {
           content: 'body',
         },
         'green',
-        { syncNoteToGitHub: sync, enqueueNoteUpsert: enqueue, updateNoteContent: updateContent },
+        { stageUpsert: stage, enqueueNoteUpsert: enqueue },
       );
       expect(enqueue).toHaveBeenCalledWith(
         expect.objectContaining({ color: 'green' }),
         'n1',
       );
-      expect(updateContent).not.toHaveBeenCalled();
     });
 
-    test('Case C (variant): enqueues when sync returns success:false', async () => {
-      const sync = jest.fn().mockResolvedValue({ success: false });
+    test('Case C (variant): a failed stage does not enqueue (only a throw does)', async () => {
+      const stage = jest.fn().mockResolvedValue({ success: false });
       const enqueue = jest.fn();
-      const updateContent = jest.fn();
-      await colorSyncAfterUpdateNote(
+      await colorStageAfterUpdateNote(
         {
           id: 'n1',
           repo: 'o/r',
@@ -169,12 +158,10 @@ describe('HomeScreen color-tag fix (issue #794)', () => {
           content: 'body',
         },
         'purple',
-        { syncNoteToGitHub: sync, enqueueNoteUpsert: enqueue, updateNoteContent: updateContent },
+        { stageUpsert: stage, enqueueNoteUpsert: enqueue },
       );
-      expect(enqueue).toHaveBeenCalledWith(
-        expect.objectContaining({ color: 'purple' }),
-        'n1',
-      );
+      expect(stage).toHaveBeenCalled();
+      expect(enqueue).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/services/StagePushScheduler.test.ts
+++ b/__tests__/services/StagePushScheduler.test.ts
@@ -1,14 +1,6 @@
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import type { StagedItem } from '../../src/services/git/StagingService';
 
-const mockFlagState: { FEATURE_STAGE_PUSH: boolean } = { FEATURE_STAGE_PUSH: true };
-jest.mock('../../src/services/featureFlags', () => ({
-  get FEATURE_STAGE_PUSH(): boolean {
-    return mockFlagState.FEATURE_STAGE_PUSH;
-  },
-  FEATURE_USE_MULTI_HOST_WRITE: false,
-}));
-
 jest.mock('../../src/services/git/StagingService', () => ({
   StagingService: {
     listStaged: jest.fn(async () => []),
@@ -72,7 +64,6 @@ describe('StagePushScheduler', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
-    mockFlagState.FEATURE_STAGE_PUSH = true;
     stopScheduler();
     setOnPushFailure(null);
     useStageStore.setState({
@@ -158,22 +149,6 @@ describe('StagePushScheduler', () => {
     const state = useStageStore.getState();
     expect(state.pushQueue).toHaveLength(0);
     expect(Object.values(state.isPushing).every((p) => !p)).toBe(true);
-  });
-
-  test('FEATURE_STAGE_PUSH off makes startScheduler a no-op', async () => {
-    mockFlagState.FEATURE_STAGE_PUSH = false;
-    useStageStore.setState({
-      staged: [item(REPO_A, 'main', 'notes/a.md')],
-      pendingCount: 1,
-    });
-    const registerSpy = jest.spyOn(useStageStore.getState(), 'registerQueueSubscription');
-
-    startScheduler();
-
-    expect(registerSpy).not.toHaveBeenCalled();
-    jest.advanceTimersByTime(10 * 60 * 1000);
-    await flushAsync();
-    expect(StagingService.pushStaged).not.toHaveBeenCalled();
   });
 
   test('background flush honors the ≤10-files-per-repo cap', async () => {

--- a/__tests__/services/ThoughtDumpService.test.ts
+++ b/__tests__/services/ThoughtDumpService.test.ts
@@ -51,6 +51,10 @@ jest.mock('../../src/services/git/gitHostFactory', () => ({
   })),
 }));
 
+jest.mock('../../src/services/git/StagingService', () => ({
+  StagingService: { stageUpsert: jest.fn(), stageDelete: jest.fn() },
+}));
+
 jest.mock('../../src/services/featureFlags', () => ({
   FEATURE_USE_MULTI_HOST_WRITE: false,
 }));
@@ -58,17 +62,19 @@ jest.mock('../../src/services/featureFlags', () => ({
 import { ThoughtDumpService } from '../../src/services/ThoughtDumpService';
 import { GitHubService } from '../../src/services/GitHubService';
 import { SyncEngineService } from '../../src/services/SyncEngineService';
-import { LocalGitWriter } from '../../src/services/git/LocalGitWriter';
+import { StagingService } from '../../src/services/git/StagingService';
 import { parseThoughtDump, serializeThoughtDump, createThoughtDump } from '../../src/models/ThoughtDump';
 
 beforeEach(() => {
   jest.clearAllMocks();
   (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
   (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
+  (StagingService.stageUpsert as jest.Mock).mockResolvedValue({ success: true });
+  (StagingService.stageDelete as jest.Mock).mockResolvedValue({ success: true });
 });
 
 describe('ThoughtDumpService.create', () => {
-  it('creates a thought dump via API mode', async () => {
+  it('stages the upsert for the new dump', async () => {
     const dump = await ThoughtDumpService.create('my random thought', {
       repoPath: 'org/repo',
       branch: 'main',
@@ -80,30 +86,25 @@ describe('ThoughtDumpService.create', () => {
     expect(dump!.id).toBeTruthy();
     expect(dump!.createdAt).toBeTruthy();
 
-    expect(GitHubService.updateFile).toHaveBeenCalledTimes(1);
-    const call = (GitHubService.updateFile as jest.Mock).mock.calls[0];
-    expect(call[2]).toBe(dump!.filePath);
-    expect(call[3]).toContain('<!-- thought-dump');
-    expect(call[3]).toContain('my random thought');
+    expect(StagingService.stageUpsert).toHaveBeenCalledTimes(1);
+    expect(StagingService.stageUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: dump!.filePath,
+        title: 'Thought dump',
+      }),
+    );
+    const arg = (StagingService.stageUpsert as jest.Mock).mock.calls[0][0] as { content: string };
+    expect(arg.content).toContain('<!-- thought-dump');
+    expect(arg.content).toContain('my random thought');
+    expect(GitHubService.updateFile).not.toHaveBeenCalled();
   });
 
   it('returns null when not authenticated', async () => {
     (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(false);
     const dump = await ThoughtDumpService.create('test', { repoPath: 'org/repo' });
     expect(dump).toBeNull();
-  });
-
-  it('uses clone mode when configured', async () => {
-    (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
-
-    const dump = await ThoughtDumpService.create('clone thought', {
-      repoPath: 'org/repo',
-      branch: 'main',
-    });
-
-    expect(dump).not.toBeNull();
-    expect(LocalGitWriter.writeAndCommit).toHaveBeenCalledTimes(1);
-    expect(GitHubService.updateFile).not.toHaveBeenCalled();
   });
 });
 
@@ -155,7 +156,7 @@ describe('ThoughtDumpService.list', () => {
 });
 
 describe('ThoughtDumpService.delete', () => {
-  it('deletes a thought dump via API mode', async () => {
+  it('stages the delete', async () => {
     const result = await ThoughtDumpService.delete('some-id', {
       repoPath: 'org/repo',
       branch: 'main',
@@ -163,23 +164,15 @@ describe('ThoughtDumpService.delete', () => {
     });
 
     expect(result).toBe(true);
-    expect(GitHubService.getFileSha).toHaveBeenCalledWith(
-      'org', 'repo', 'thoughts/20240101-120000-some-id.md', 'main',
+    expect(StagingService.stageDelete).toHaveBeenCalledTimes(1);
+    expect(StagingService.stageDelete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: 'thoughts/20240101-120000-some-id.md',
+        title: 'Thought dump',
+      }),
     );
-    expect(GitHubService.deleteFile).toHaveBeenCalledTimes(1);
-  });
-
-  it('uses clone mode for delete when configured', async () => {
-    (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
-
-    const result = await ThoughtDumpService.delete('some-id', {
-      repoPath: 'org/repo',
-      branch: 'main',
-      filePath: 'thoughts/20240101-120000-some-id.md',
-    });
-
-    expect(result).toBe(true);
-    expect(LocalGitWriter.deleteAndCommit).toHaveBeenCalledTimes(1);
     expect(GitHubService.deleteFile).not.toHaveBeenCalled();
   });
 

--- a/__tests__/services/git/cloneMigration.test.ts
+++ b/__tests__/services/git/cloneMigration.test.ts
@@ -95,15 +95,15 @@ describe('CloneMigrationService.migrateRepo', () => {
     expect(report.success).toBe(true);
 
     expect(getLgwMocks().writeAndCommit).toHaveBeenCalledTimes(3);
-    // All writeAndCommit calls must be staged-only (push:false) so the final
-    // push flushes everything in one round-trip.
+    // All writeAndCommit calls must be staged-only (push:false) — the
+    // stage/push engine owns the flush.
     for (const call of getLgwMocks().writeAndCommit.mock.calls) {
       expect(call[0].push).toBe(false);
     }
-    expect(getLgwMocks().push).toHaveBeenCalledTimes(1);
+    expect(getLgwMocks().push).not.toHaveBeenCalled();
   });
 
-  test('reports failures and still pushes the successful commits', async () => {
+  test('reports failures without pushing (the engine owns the flush)', async () => {
     getLgwMocks().writeAndCommit.mockResolvedValueOnce({
       success: false,
       error: 'disk full',
@@ -116,8 +116,7 @@ describe('CloneMigrationService.migrateRepo', () => {
     expect(report.failures).toEqual([
       { kind: 'note', filePath: 'notes/local.md', error: 'disk full' },
     ]);
-    // Two successes → push still runs.
-    expect(getLgwMocks().push).toHaveBeenCalledTimes(1);
+    expect(getLgwMocks().push).not.toHaveBeenCalled();
   });
 
   test('skips push when nothing migrated', async () => {

--- a/__tests__/staging-delete-rewire.test.ts
+++ b/__tests__/staging-delete-rewire.test.ts
@@ -15,7 +15,6 @@ import { renderWithTheme } from './helpers/renderWithTheme';
 import ConflictResolverScreen from '../src/screens/ConflictResolverScreen';
 
 jest.mock('../src/services/featureFlags', () => ({
-  FEATURE_STAGE_PUSH: false,
   FEATURE_USE_MULTI_HOST_WRITE: false,
 }));
 
@@ -153,11 +152,6 @@ jest.mock('@react-navigation/native', () => {
 
 jest.mock('@react-navigation/native-stack', () => ({}));
 
-const featureFlagsMock = jest.requireMock('../src/services/featureFlags') as {
-  FEATURE_STAGE_PUSH: boolean;
-  FEATURE_USE_MULTI_HOST_WRITE: boolean;
-};
-
 interface ConflictApi {
   getConflict: jest.Mock;
   updateConflict: jest.Mock;
@@ -216,13 +210,11 @@ async function pressCommitAndPushButton(): Promise<void> {
 describe('noteStore.deleteNote staging rewire', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
     useNoteStore.setState({ notes: [], isLoading: false, error: null, searchQuery: '' });
     useGitOperationStore.setState({ ops: {} });
   });
 
-  it('with FEATURE_STAGE_PUSH ON (api mode): stages the delete, keeps the row locked, never drains directly', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('api mode: stages the delete, keeps the row locked, never drains directly', async () => {
     (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
     (StagingService.stageDelete as jest.Mock).mockResolvedValue({ success: true });
     useNoteStore.setState({
@@ -262,8 +254,7 @@ describe('noteStore.deleteNote staging rewire', () => {
     expect(ops[0].status).toBe('running');
   });
 
-  it('with FEATURE_STAGE_PUSH ON (clone mode): completes the local delete immediately (no queue mutation exists)', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('clone mode: completes the local delete immediately (no queue mutation exists)', async () => {
     (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
     (StagingService.stageDelete as jest.Mock).mockResolvedValue({ success: true });
     useNoteStore.setState({
@@ -300,28 +291,7 @@ describe('noteStore.deleteNote staging rewire', () => {
     expect(NoteSyncQueueService.drain).not.toHaveBeenCalled();
   });
 
-  it('with FEATURE_STAGE_PUSH OFF: old path is unchanged (enqueue + drain)', async () => {
-    useNoteStore.setState({
-      notes: [
-        makeNote({
-          id: 'n2',
-          repo: 'owner/repo',
-          branch: 'main',
-          filePath: 'notes/two.md',
-        }),
-      ],
-    });
-
-    const ok = await useNoteStore.getState().deleteNote('n2');
-
-    expect(ok).toBe(true);
-    expect(StagingService.stageDelete).not.toHaveBeenCalled();
-    expect(NoteSyncQueueService.enqueueNoteDelete).toHaveBeenCalledTimes(1);
-    expect(NoteSyncQueueService.drain).toHaveBeenCalledTimes(1);
-  });
-
-  it('with FEATURE_STAGE_PUSH ON and a failing stage: surfaces the error and does not enqueue/drain', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('a failing stage surfaces the error and does not enqueue/drain', async () => {
     (StagingService.stageDelete as jest.Mock).mockResolvedValue({ success: false, error: 'staging boom' });
     useNoteStore.setState({
       notes: [
@@ -346,12 +316,10 @@ describe('noteStore.deleteNote staging rewire', () => {
 describe('AI tool saves staging rewire', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
     useNoteStore.setState({ notes: [], isLoading: false, error: null, searchQuery: '' });
   });
 
-  it('create_note with FEATURE_STAGE_PUSH ON: enqueues without calling drain directly', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('create_note enqueues without calling drain directly', async () => {
     useNoteStore.setState({
       createNote: jest.fn(async (input: unknown) => ({ id: 'new-note', ...(input as object) })),
     });
@@ -367,20 +335,7 @@ describe('AI tool saves staging rewire', () => {
     expect(NoteSyncQueueService.drain).not.toHaveBeenCalled();
   });
 
-  it('create_note with FEATURE_STAGE_PUSH OFF: enqueues then drains (old path)', async () => {
-    useNoteStore.setState({
-      createNote: jest.fn(async (input: unknown) => ({ id: 'new-note', ...(input as object) })),
-    });
-
-    const result = await executeToolCall('create_note', { title: 'T', content: 'C' }, 'auto');
-
-    expect(result.success).toBe(true);
-    expect(NoteSyncQueueService.enqueueNoteUpsert).toHaveBeenCalledTimes(1);
-    expect(NoteSyncQueueService.drain).toHaveBeenCalledTimes(1);
-  });
-
-  it('link_notes with FEATURE_STAGE_PUSH ON: enqueues each link without draining', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('link_notes enqueues each link without draining', async () => {
     useNoteStore.setState({
       notes: [
         makeNote({ id: 'a', title: 'A', repo: 'owner/repo', branch: 'main', filePath: 'notes/a.md' }),
@@ -400,8 +355,7 @@ describe('AI tool saves staging rewire', () => {
     expect(NoteSyncQueueService.drain).not.toHaveBeenCalled();
   });
 
-  it('grade_questioner_answers with FEATURE_STAGE_PUSH ON: enqueues without draining', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('grade_questioner_answers enqueues without draining', async () => {
     useNoteStore.setState({
       notes: [
         makeNote({
@@ -432,7 +386,6 @@ describe('AI tool saves staging rewire', () => {
 describe('ConflictResolverScreen commitAndPush staging rewire', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
     conflictApi.getConflict.mockReturnValue(conflictFixture);
     (GitFsService.mergeCommit as jest.Mock).mockResolvedValue({ sha: 'merged-sha' });
   });
@@ -441,8 +394,7 @@ describe('ConflictResolverScreen commitAndPush staging rewire', () => {
     jest.restoreAllMocks();
   });
 
-  it('with FEATURE_STAGE_PUSH ON: mergeCommit is called with push:false and no immediate push happens', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('mergeCommit is called with push:false and no immediate push happens', async () => {
     jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
 
     const screen = renderWithTheme(React.createElement(ConflictResolverScreen));
@@ -459,20 +411,6 @@ describe('ConflictResolverScreen commitAndPush staging rewire', () => {
         push: false,
       }),
     );
-    expect(conflictApi.removeConflict).toHaveBeenCalledWith('owner/repo', 'main');
-    expect(navMock).toHaveBeenCalled();
-  });
-
-  it('with FEATURE_STAGE_PUSH OFF: mergeCommit keeps the old push behavior (no push key)', async () => {
-    jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
-
-    const screen = renderWithTheme(React.createElement(ConflictResolverScreen));
-    fireEvent.press(screen.getByText('Save merged'));
-    await pressCommitAndPushButton();
-
-    expect(GitFsService.mergeCommit).toHaveBeenCalledTimes(1);
-    const mergeOpts = (GitFsService.mergeCommit as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
-    expect(mergeOpts).not.toHaveProperty('push');
     expect(conflictApi.removeConflict).toHaveBeenCalledWith('owner/repo', 'main');
     expect(navMock).toHaveBeenCalled();
   });

--- a/__tests__/staging-rewire.test.ts
+++ b/__tests__/staging-rewire.test.ts
@@ -11,7 +11,6 @@ import { render, fireEvent, renderHook, act } from '@testing-library/react-nativ
 // ---------------------------------------------------------------------------
 
 jest.mock('../src/services/featureFlags', () => ({
-  FEATURE_STAGE_PUSH: false,
   FEATURE_USE_MULTI_HOST_WRITE: false,
 }));
 
@@ -349,7 +348,6 @@ import { syncTodoToGitHub, deleteTodoFromGitHub } from '../src/services/TodoGitH
 import { deleteCanvasFromGitHub } from '../src/services/CanvasGitHubSyncService';
 import { syncTemplateToGitHub, deleteTemplateFromGitHub } from '../src/services/TemplateGitHubSyncService';
 import { syncNoteToGitHub } from '../src/services/NoteGitHubSyncService';
-import { NoteSyncQueueService } from '../src/services/NoteSyncQueueService';
 import { GitHubService } from '../src/services/GitHubService';
 import { StorageService } from '../src/services/StorageService';
 import { TemplateRepoPreferenceService } from '../src/services/TemplateRepoPreferenceService';
@@ -357,11 +355,6 @@ import type { Todo } from '../src/models/Todo';
 import type { Canvas } from '../src/models/Canvas';
 import type { NoteTemplate } from '../src/services/TemplateService';
 import type { Note } from '../src/models/Note';
-
-const featureFlagsMock = jest.requireMock('../src/services/featureFlags') as {
-  FEATURE_STAGE_PUSH: boolean;
-  FEATURE_USE_MULTI_HOST_WRITE: boolean;
-};
 
 const stageUpsertMock = StagingService.stageUpsert as jest.Mock;
 const stageDeleteMock = StagingService.stageDelete as jest.Mock;
@@ -415,8 +408,7 @@ describe('staging rewire — todoStore.deleteTodo', () => {
     useTodoStore.setState({ todos: [repoTodo], error: null });
   });
 
-  it('flag ON: stages the delete and never calls deleteTodoFromGitHub', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('stages the delete and never calls deleteTodoFromGitHub', async () => {
     const ok = await useTodoStore.getState().deleteTodo('t1');
 
     expect(ok).toBe(true);
@@ -431,18 +423,6 @@ describe('staging rewire — todoStore.deleteTodo', () => {
     expect(deleteTodoFromGitHub).not.toHaveBeenCalled();
     expect(StorageService.deleteTodo).toHaveBeenCalledWith('t1');
   });
-
-  it('flag OFF: old path unchanged (deleteTodoFromGitHub called, no stage)', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
-    (deleteTodoFromGitHub as jest.Mock).mockResolvedValue({ success: true });
-    const ok = await useTodoStore.getState().deleteTodo('t1');
-
-    expect(ok).toBe(true);
-    expect(deleteTodoFromGitHub).toHaveBeenCalledWith(
-      expect.objectContaining({ repo: 'owner/repo', filePath: 'todos/buy-milk.json' }),
-    );
-    expect(stageDeleteMock).not.toHaveBeenCalled();
-  });
 });
 
 describe('staging rewire — canvasStore.deleteCanvas', () => {
@@ -452,8 +432,7 @@ describe('staging rewire — canvasStore.deleteCanvas', () => {
     useCanvasStore.setState({ canvases: [repoCanvas], error: null });
   });
 
-  it('flag ON: stages the delete and never calls deleteCanvasFromGitHub', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('stages the delete and never calls deleteCanvasFromGitHub', async () => {
     const ok = await useCanvasStore.getState().deleteCanvas('c1');
 
     expect(ok).toBe(true);
@@ -468,18 +447,6 @@ describe('staging rewire — canvasStore.deleteCanvas', () => {
     expect(deleteCanvasFromGitHub).not.toHaveBeenCalled();
     expect(StorageService.deleteCanvas).toHaveBeenCalledWith('c1');
   });
-
-  it('flag OFF: old path unchanged (deleteCanvasFromGitHub called, no stage)', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
-    (deleteCanvasFromGitHub as jest.Mock).mockResolvedValue({ success: true });
-    const ok = await useCanvasStore.getState().deleteCanvas('c1');
-
-    expect(ok).toBe(true);
-    expect(deleteCanvasFromGitHub).toHaveBeenCalledWith(
-      expect.objectContaining({ repo: 'owner/repo', filePath: 'canvases/my-canvas.json' }),
-    );
-    expect(stageDeleteMock).not.toHaveBeenCalled();
-  });
 });
 
 describe('staging rewire — templateStore', () => {
@@ -492,8 +459,7 @@ describe('staging rewire — templateStore', () => {
     useTemplateStore.setState({ customTemplates: [], pinnedIds: [], isLoading: false });
   });
 
-  it('createTemplate flag ON: stages the upsert and never calls syncTemplateToGitHub', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('createTemplate stages the upsert and never calls syncTemplateToGitHub', async () => {
     stageUpsertMock.mockResolvedValue({ success: true });
 
     const created = await useTemplateStore.getState().createTemplate({
@@ -513,8 +479,7 @@ describe('staging rewire — templateStore', () => {
     expect(syncTemplateToGitHub).not.toHaveBeenCalled();
   });
 
-  it('updateTemplate flag ON: stages the upsert and never calls syncTemplateToGitHub', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('updateTemplate stages the upsert and never calls syncTemplateToGitHub', async () => {
     stageUpsertMock.mockResolvedValue({ success: true });
     useTemplateStore.setState({ customTemplates: [repoTemplate], pinnedIds: [] });
 
@@ -530,8 +495,7 @@ describe('staging rewire — templateStore', () => {
     expect(syncTemplateToGitHub).not.toHaveBeenCalled();
   });
 
-  it('deleteTemplate flag ON: stages the delete and never calls deleteTemplateFromGitHub', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('deleteTemplate stages the delete and never calls deleteTemplateFromGitHub', async () => {
     stageDeleteMock.mockResolvedValue({ success: true });
     useTemplateStore.setState({ customTemplates: [repoTemplate], pinnedIds: [] });
 
@@ -546,16 +510,6 @@ describe('staging rewire — templateStore', () => {
       }),
     );
     expect(deleteTemplateFromGitHub).not.toHaveBeenCalled();
-  });
-
-  it('createTemplate flag OFF: old path unchanged', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
-    (syncTemplateToGitHub as jest.Mock).mockResolvedValue({ success: true, filePath: 'templates/my-template.md' });
-
-    await useTemplateStore.getState().createTemplate({ name: 'My Template', content: 'body' });
-
-    expect(syncTemplateToGitHub).toHaveBeenCalledTimes(1);
-    expect(stageUpsertMock).not.toHaveBeenCalled();
   });
 });
 
@@ -572,8 +526,7 @@ describe('staging rewire — TodoContext.toggleTodo', () => {
     useTodoStore.setState({ todos: [repoTodo], error: null });
   });
 
-  it('flag ON: stages the upsert and never calls syncTodoToGitHub', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('stages the upsert and never calls syncTodoToGitHub', async () => {
     const { result } = renderHook(() => useTodos());
 
     let ok = false;
@@ -594,19 +547,6 @@ describe('staging rewire — TodoContext.toggleTodo', () => {
     expect(JSON.parse(arg.content)).toMatchObject({ text: 'Buy milk', completed: true });
     expect(syncTodoToGitHub).not.toHaveBeenCalled();
   });
-
-  it('flag OFF: old path unchanged (syncTodoToGitHub called, no stage)', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
-    (syncTodoToGitHub as jest.Mock).mockResolvedValue({ success: true });
-    const { result } = renderHook(() => useTodos());
-
-    await act(async () => {
-      await result.current.toggleTodo('t1');
-    });
-
-    expect(syncTodoToGitHub).toHaveBeenCalledTimes(1);
-    expect(stageUpsertMock).not.toHaveBeenCalled();
-  });
 });
 
 describe('staging rewire — ThoughtDumpService', () => {
@@ -617,8 +557,7 @@ describe('staging rewire — ThoughtDumpService', () => {
     (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
   });
 
-  it('create flag ON: stages the upsert, no GitHubService/LocalGitWriter write', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('create stages the upsert, no GitHubService/LocalGitWriter write', async () => {
     const dump = await ThoughtDumpService.create('hello dump', {
       repoPath: 'owner/repo',
       branch: 'main',
@@ -636,8 +575,7 @@ describe('staging rewire — ThoughtDumpService', () => {
     expect(GitHubService.updateFile).not.toHaveBeenCalled();
   });
 
-  it('delete flag ON: stages the delete, no GitHubService delete', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('delete stages the delete, no GitHubService delete', async () => {
     const ok = await ThoughtDumpService.delete('id1', {
       repoPath: 'owner/repo',
       branch: 'main',
@@ -655,18 +593,6 @@ describe('staging rewire — ThoughtDumpService', () => {
     );
     expect(GitHubService.getFileSha).not.toHaveBeenCalled();
     expect(GitHubService.deleteFile).not.toHaveBeenCalled();
-  });
-
-  it('create flag OFF: old path unchanged (GitHubService.updateFile called, no stage)', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
-    const dump = await ThoughtDumpService.create('hello dump', {
-      repoPath: 'owner/repo',
-      branch: 'main',
-    });
-
-    expect(dump).not.toBeNull();
-    expect(GitHubService.updateFile).toHaveBeenCalledTimes(1);
-    expect(stageUpsertMock).not.toHaveBeenCalled();
   });
 });
 
@@ -705,8 +631,7 @@ describe('staging rewire — useNotesListNoteActions.handleColorSelect', () => {
     stageUpsertMock.mockResolvedValue({ success: true });
   });
 
-  it('flag ON: stages the upsert and never calls syncNoteToGitHub', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('stages the upsert and never calls syncNoteToGitHub', async () => {
     const updateNote = jest.fn(async () => makeColorNote());
     const { result } = renderActions(updateNote);
 
@@ -725,33 +650,6 @@ describe('staging rewire — useNotesListNoteActions.handleColorSelect', () => {
     );
     expect(syncNoteToGitHub).not.toHaveBeenCalled();
   });
-
-  it('flag OFF: old path unchanged (syncNoteToGitHub called, no stage)', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
-    (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: true });
-    const updateNote = jest.fn(async () => makeColorNote());
-    const { result } = renderActions(updateNote);
-
-    await act(async () => {
-      await result.current.handleColorSelect(makeColorNote(), 'blue');
-    });
-
-    expect(syncNoteToGitHub).toHaveBeenCalledTimes(1);
-    expect(stageUpsertMock).not.toHaveBeenCalled();
-  });
-
-  it('flag OFF: queue fallback preserved when syncNoteToGitHub fails', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
-    (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: false });
-    const updateNote = jest.fn(async () => makeColorNote());
-    const { result } = renderActions(updateNote);
-
-    await act(async () => {
-      await result.current.handleColorSelect(makeColorNote(), 'green');
-    });
-
-    expect(NoteSyncQueueService.enqueueNoteUpsert).toHaveBeenCalledTimes(1);
-  });
 });
 
 describe('staging rewire — TodoListScreen handleAddTodo / handleUpdateTodo', () => {
@@ -766,8 +664,7 @@ describe('staging rewire — TodoListScreen handleAddTodo / handleUpdateTodo', (
     jest.restoreAllMocks();
   });
 
-  it('add-todo flag ON: stages the upsert and never calls syncTodoToGitHub', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('add-todo stages the upsert and never calls syncTodoToGitHub', async () => {
     (StorageService.createTodo as jest.Mock).mockResolvedValue({
       ...repoTodo,
       id: 'new-todo-1',
@@ -794,8 +691,7 @@ describe('staging rewire — TodoListScreen handleAddTodo / handleUpdateTodo', (
     expect(syncTodoToGitHub).not.toHaveBeenCalled();
   });
 
-  it('update-todo flag ON: stages the upsert and never calls syncTodoToGitHub', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = true;
+  it('update-todo stages the upsert and never calls syncTodoToGitHub', async () => {
     (StorageService.updateTodo as jest.Mock).mockImplementation(
       async (_input: { id: string }) => ({ ...repoTodo, text: 'Buy oat milk' }),
     );
@@ -818,26 +714,6 @@ describe('staging rewire — TodoListScreen handleAddTodo / handleUpdateTodo', (
     );
     expect(syncTodoToGitHub).not.toHaveBeenCalled();
   });
-
-  it('add-todo flag OFF: old path unchanged (syncTodoToGitHub called, no stage)', async () => {
-    featureFlagsMock.FEATURE_STAGE_PUSH = false;
-    (StorageService.createTodo as jest.Mock).mockResolvedValue({
-      ...repoTodo,
-      id: 'new-todo-1',
-      accountId: undefined,
-    });
-    (syncTodoToGitHub as jest.Mock).mockResolvedValue({ success: true });
-
-    const { getByTestId } = render(React.createElement(TodoListScreen));
-    await fireEvent.press(getByTestId('icon-btn-Add todo'));
-    await fireEvent.changeText(getByTestId('modal-todo-text'), 'Buy milk');
-    await fireEvent.press(getByTestId('modal-todo-repo'));
-    await fireEvent.press(getByTestId('modal-todo-branch'));
-    await fireEvent.press(getByTestId('modal-todo-submit'));
-
-    expect(syncTodoToGitHub).toHaveBeenCalledTimes(1);
-    expect(stageUpsertMock).not.toHaveBeenCalled();
-  });
 });
 
 describe('staging rewire — heavy screens (source-level)', () => {
@@ -848,28 +724,25 @@ describe('staging rewire — heavy screens (source-level)', () => {
   const homeSrc = fs.readFileSync(path.join(__dirname, '../src/screens/HomeScreen.tsx'), 'utf-8');
   const settingsSrc = fs.readFileSync(path.join(__dirname, '../src/screens/SettingsScreen.tsx'), 'utf-8');
 
-  it('CanvasEditorContent.saveCanvas imports the flag + StagingService and calls stageUpsert', () => {
-    expect(canvasSrc).toMatch(/import\s*\{\s*FEATURE_STAGE_PUSH\s*\}\s*from\s*['"].*featureFlags['"]/);
+  it('CanvasEditorContent.saveCanvas calls stageUpsert and no longer references the flag or syncCanvasToGitHub', () => {
     expect(canvasSrc).toMatch(/import\s*\{\s*StagingService\s*\}\s*from\s*['"].*StagingService['"]/);
     expect(canvasSrc).toContain('StagingService.stageUpsert');
     expect(canvasSrc).toContain('JSON.stringify(scene, null, 2)');
-    // flag-OFF path retained
-    expect(canvasSrc).toContain('syncCanvasToGitHub');
+    expect(canvasSrc).not.toContain('FEATURE_STAGE_PUSH');
+    expect(canvasSrc).not.toContain('syncCanvasToGitHub');
   });
 
-  it('HomeScreen.handleColorSelect imports the flag + StagingService and calls stageUpsert', () => {
-    expect(homeSrc).toMatch(/import\s*\{\s*FEATURE_STAGE_PUSH\s*\}\s*from\s*['"].*featureFlags['"]/);
+  it('HomeScreen.handleColorSelect calls stageUpsert and no longer references the flag or syncNoteToGitHub', () => {
     expect(homeSrc).toMatch(/import\s*\{\s*StagingService\s*\}\s*from\s*['"].*StagingService['"]/);
     expect(homeSrc).toContain('StagingService.stageUpsert');
-    // flag-OFF path retained
-    expect(homeSrc).toContain('syncNoteToGitHub');
+    expect(homeSrc).not.toContain('FEATURE_STAGE_PUSH');
+    expect(homeSrc).not.toContain('syncNoteToGitHub');
   });
 
-  it('SettingsScreen.handleSyncExistingTemplates imports the flag + StagingService and calls stageUpsert', () => {
-    expect(settingsSrc).toMatch(/import\s*\{\s*FEATURE_STAGE_PUSH\s*\}\s*from\s*['"].*featureFlags['"]/);
+  it('SettingsScreen.handleSyncExistingTemplates calls stageUpsert and no longer references the flag or syncTemplateToGitHub', () => {
     expect(settingsSrc).toMatch(/import\s*\{\s*StagingService\s*\}\s*from\s*['"].*StagingService['"]/);
     expect(settingsSrc).toContain('StagingService.stageUpsert');
-    // flag-OFF path retained
-    expect(settingsSrc).toContain('syncTemplateToGitHub');
+    expect(settingsSrc).not.toContain('FEATURE_STAGE_PUSH');
+    expect(settingsSrc).not.toContain('syncTemplateToGitHub');
   });
 });

--- a/__tests__/stores/noteStore.test.ts
+++ b/__tests__/stores/noteStore.test.ts
@@ -16,6 +16,14 @@ jest.mock('../../src/services/NoteSyncQueueService', () => ({
   },
 }));
 
+jest.mock('../../src/services/SyncEngineService', () => ({
+  SyncEngineService: { getMode: jest.fn(async () => 'api') },
+}));
+
+jest.mock('../../src/services/git/StagingService', () => ({
+  StagingService: { stageDelete: jest.fn(), stageUpsert: jest.fn() },
+}));
+
 jest.mock('../../src/components/editor/editorShared', () => ({
   slugifyLocal: jest.fn((s: string) => s.toLowerCase().replace(/\s+/g, '-')),
   getExtensionForFormat: jest.fn(() => '.md'),
@@ -24,6 +32,7 @@ jest.mock('../../src/components/editor/editorShared', () => ({
 import { useNoteStore } from '../../src/stores/noteStore';
 import { StorageService } from '../../src/services/StorageService';
 import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
+import { StagingService } from '../../src/services/git/StagingService';
 import type { Note } from '../../src/models/Note';
 
 const makeNote = (id: string, overrides: Partial<Note> = {}): Note => ({
@@ -103,18 +112,22 @@ describe('useNoteStore', () => {
   });
 
   describe('deleteNote', () => {
-    it('enqueues remote delete for repo-backed notes', async () => {
+    it('stages the delete for repo-backed notes (api mode keeps the row locked)', async () => {
       const note = makeNote('1', { repo: 'me/repo', branch: 'main', filePath: 'notes/test.md' });
       useNoteStore.setState({ notes: [note] });
+      (StagingService.stageDelete as jest.Mock).mockResolvedValue({ success: true });
       (StorageService.deleteNote as jest.Mock).mockResolvedValue(true);
 
       await useNoteStore.getState().deleteNote('1');
 
-      expect(NoteSyncQueueService.enqueueNoteDelete).toHaveBeenCalled();
-      expect(NoteSyncQueueService.drain).toHaveBeenCalled();
+      expect(StagingService.stageDelete).toHaveBeenCalled();
+      expect(NoteSyncQueueService.enqueueNoteDelete).not.toHaveBeenCalled();
+      expect(NoteSyncQueueService.drain).not.toHaveBeenCalled();
+      // Api mode keeps the row until the queue reports the delete succeeded.
+      expect(useNoteStore.getState().notes).toHaveLength(1);
     });
 
-    it('removes note from list after successful delete', async () => {
+    it('removes note from list after successful local delete', async () => {
       useNoteStore.setState({ notes: [makeNote('1')] });
       (StorageService.deleteNote as jest.Mock).mockResolvedValue(true);
 

--- a/__tests__/stores/todoStore.test.ts
+++ b/__tests__/stores/todoStore.test.ts
@@ -14,8 +14,8 @@ jest.mock('../../src/services/GitHubService', () => ({
   },
 }));
 
-jest.mock('../../src/services/TodoGitHubSyncService', () => ({
-  deleteTodoFromGitHub: jest.fn(),
+jest.mock('../../src/services/git/StagingService', () => ({
+  StagingService: { stageDelete: jest.fn(), stageUpsert: jest.fn() },
 }));
 
 jest.mock('../../src/services/git/formatSyncError', () => ({
@@ -25,7 +25,7 @@ jest.mock('../../src/services/git/formatSyncError', () => ({
 import { useTodoStore } from '../../src/stores/todoStore';
 import { StorageService } from '../../src/services/StorageService';
 import { GitHubService } from '../../src/services/GitHubService';
-import { deleteTodoFromGitHub } from '../../src/services/TodoGitHubSyncService';
+import { StagingService } from '../../src/services/git/StagingService';
 import type { Todo } from '../../src/models/Todo';
 
 const makeTodo = (id: string, overrides: Partial<Todo> = {}): Todo => ({
@@ -94,24 +94,24 @@ describe('useTodoStore', () => {
       await useTodoStore.getState().deleteTodo('1');
 
       expect(StorageService.deleteTodo).toHaveBeenCalledWith('1');
-      expect(deleteTodoFromGitHub).not.toHaveBeenCalled();
+      expect(StagingService.stageDelete).not.toHaveBeenCalled();
       expect(useTodoStore.getState().todos).toHaveLength(0);
     });
 
-    it('calls deleteTodoFromGitHub for repo-backed todos before local delete', async () => {
+    it('stages the delete for repo-backed todos before local delete', async () => {
       const repoTodo = makeTodo('1', { repo: 'me/repo', branch: 'main', filePath: 'todos/test.json', text: 'test' });
       useTodoStore.setState({ todos: [repoTodo] });
       (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
-      (deleteTodoFromGitHub as jest.Mock).mockResolvedValue({ success: true });
+      (StagingService.stageDelete as jest.Mock).mockResolvedValue({ success: true });
       (StorageService.deleteTodo as jest.Mock).mockResolvedValue(true);
 
       await useTodoStore.getState().deleteTodo('1');
 
-      expect(deleteTodoFromGitHub).toHaveBeenCalled();
+      expect(StagingService.stageDelete).toHaveBeenCalled();
       expect(StorageService.deleteTodo).toHaveBeenCalledWith('1');
     });
 
-    it('returns false without calling GitHub for unauthenticated repo-backed delete', async () => {
+    it('returns false without staging for unauthenticated repo-backed delete', async () => {
       const repoTodo = makeTodo('1', { repo: 'me/repo', branch: 'main', filePath: 'todos/test.json' });
       useTodoStore.setState({ todos: [repoTodo] });
       (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(false);
@@ -119,7 +119,7 @@ describe('useTodoStore', () => {
       const result = await useTodoStore.getState().deleteTodo('1');
 
       expect(result).toBe(false);
-      expect(deleteTodoFromGitHub).not.toHaveBeenCalled();
+      expect(StagingService.stageDelete).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/sync-locking.integration.test.ts
+++ b/__tests__/sync-locking.integration.test.ts
@@ -17,6 +17,7 @@
 jest.mock('../src/services/GitHubService', () => ({
   GitHubService: {
     isAuthenticated: jest.fn(() => true),
+    getUser: jest.fn(() => ({ login: 'me', name: 'Me', email: 'me@example.com' })),
     getTreeRecursive: jest.fn(),
     getTreeRecursiveOrThrow: jest.fn(),
     getFileContent: jest.fn(),
@@ -66,7 +67,10 @@ jest.mock('../src/services/StorageService', () => ({
 }));
 
 jest.mock('../src/services/SyncEngineService', () => ({
-  SyncEngineService: { getMode: jest.fn(async () => 'api') },
+  SyncEngineService: {
+    getMode: jest.fn(async () => 'api'),
+    listOverrides: jest.fn(async () => ({})),
+  },
 }));
 
 jest.mock('../src/services/AuthService', () => ({
@@ -344,6 +348,7 @@ import { LocalGitWriter } from '../src/services/git/LocalGitWriter';
 import { batchDeleteFiles } from '../src/services/git/BatchGitOperations';
 import { SyncEngineService } from '../src/services/SyncEngineService';
 import { GitFsService } from '../src/services/git/GitFsService';
+import { StagingService } from '../src/services/git/StagingService';
 import { GitSyncGate } from '../src/services/git/GitSyncGate';
 import { syncNow } from '../src/services/git/manualSync';
 import { pullFromSingleRepo, pullAllFromRepos } from '../src/services/RepoPullService';
@@ -552,6 +557,10 @@ describe('sync-locking integration scenarios S1–S8', () => {
     expect(screen.getByText('Second')).toBeTruthy();
     expect(screen.getByTestId('swipeable-select-n2').props.accessibilityState.disabled).toBe(true);
 
+    // The stage path enqueues but never drains — the push engine owns the
+    // flush. Trigger it here the way the scheduler would.
+    void NoteSyncQueueService.drain();
+
     // Let the drain reach its transport, then report success.
     await act(async () => {
       await flushMicrotasks();
@@ -584,6 +593,12 @@ describe('sync-locking integration scenarios S1–S8', () => {
     const screen = renderNotesList();
     fireEvent(screen.getByTestId('notes-card-n3'), 'longPress');
     fireEvent.press(screen.getByTestId('notes-context-menu.delete'));
+
+    // The stage path enqueues but never drains — simulate the push engine.
+    await waitFor(() => {
+      expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy();
+    });
+    void NoteSyncQueueService.drain();
 
     // Durable drop -> failed row (error affordance, row still present).
     await waitFor(() => {
@@ -711,6 +726,9 @@ describe('sync-locking integration scenarios S1–S8', () => {
     fireEvent.press(screen.getByTestId('bulk-action-bar.delete'));
     await pressAlertButtonAsync('Delete');
 
+    // The stage path enqueues but never drains — simulate the push engine.
+    void NoteSyncQueueService.drain();
+
     // The whole batch is enqueued in ONE queue write...
     const queueWrites = (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
       ([key]: [string]) => key === QUEUE_KEY,
@@ -781,6 +799,9 @@ describe('sync-locking integration scenarios S1–S8', () => {
     }
     fireEvent.press(screen.getByTestId('bulk-action-bar.delete'));
     await pressAlertButtonAsync('Delete');
+
+    // The stage path enqueues but never drains — simulate the push engine.
+    void NoteSyncQueueService.drain();
 
     const queueWrites = (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
       ([key]: [string]) => key === QUEUE_KEY,
@@ -872,13 +893,20 @@ describe('sync-locking integration scenarios S1–S8', () => {
     expect(Object.values(ops).some((op) => op.status !== 'failed' && op.kind === 'delete' && op.path === 'notes/sixth.md')).toBe(true);
   });
 
-  it('S7 — clone divergence lifecycle: push {success:false,error:"Push failed: diverged"} is retryable, exhausts at MAX_ATTEMPTS, drops with reason "exhausted", pins the tombstone, fails the registry op, and the conflict store keeps the local-deleted-remote-modified entry unresolved', async () => {
+  it('S7 — clone divergence lifecycle: the delete commits locally (push:false) and the row is removed immediately; a diverged engine push surfaces without resurrecting the row, and the conflict store keeps the local-deleted-remote-modified entry unresolved', async () => {
     (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
-    (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({ success: true });
+    (SyncEngineService.listOverrides as jest.Mock).mockResolvedValue({ 'owner/repo': 'clone' });
+    (LocalGitWriter.deleteAndCommit as jest.Mock).mockResolvedValue({ success: true });
     (LocalGitWriter.push as jest.Mock).mockResolvedValue({
       success: false,
       error: 'Push failed: diverged',
     });
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([
+      { path: 'owner/repo', branch: 'main' },
+    ]);
+    (GitFsService.getCommitOid as jest.Mock).mockImplementation(async ({ ref }: { ref: string }) =>
+      ref.includes('remotes/origin') ? 'remote-oid' : 'local-oid',
+    );
 
     // The divergence read (RepoPullService:108) already persisted this entry;
     // autoResolve leaves local-deleted-remote-modified unresolved by design.
@@ -908,66 +936,32 @@ describe('sync-locking integration scenarios S1–S8', () => {
     const note = createNote({ id: 'n7', title: 'Diverged', repo: 'owner/repo', branch: 'main', filePath: 'notes/diverged.md' });
     useNoteStore.setState({ notes: [note], isLoading: false, error: null });
 
-    const dropped: Array<{ reason?: string; error?: string; mutation: { type: string } }> = [];
-    const unsub = NoteSyncQueueService.onDroppedMutation((e) => dropped.push(e as never));
-
     await useNoteStore.getState().deleteNote('n7');
     await flushMicrotasks();
 
-    // First attempt: delete commit ok (push:false), coalesced push diverges.
-    expect(LocalGitWriter.push).toHaveBeenCalledTimes(1);
-    const queued = await NoteSyncQueueService.getAll();
-    expect(queued).toHaveLength(1);
-    expect(queued[0].attempts).toBe(1);
-    expect(queued[0].lastError).toBe('Push failed: diverged');
-    // Row still visible and locked (no silent loss).
-    expect(useNoteStore.getState().notes.some((n) => n.id === 'n7')).toBe(true);
-
-    // Exhaust the retry budget.
-    let virtualNow = Date.now();
-    const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => virtualNow);
-    let lastResult = { succeeded: 0, failed: 0, remaining: 1 };
-    try {
-      for (let i = 0; i < 8; i += 1) {
-        lastResult = await NoteSyncQueueService.drain();
-        virtualNow += 60_000;
-      }
-    } finally {
-      nowSpy.mockRestore();
-    }
-
-    expect(lastResult.failed).toBe(1);
-    expect(lastResult.remaining).toBe(0);
-    expect(LocalGitWriter.push).toHaveBeenCalledTimes(8);
-
-    // Dropped event, NOT silent.
-    expect(dropped).toHaveLength(1);
-    expect(dropped[0].reason).toBe('exhausted');
-    expect(dropped[0].error).toBe('Push failed: diverged');
-    expect(dropped[0].mutation.type).toBe('note.delete');
-
-    // Failure entry persisted + tombstone pinned past the TTL.
-    const failures = await readDeleteFailures();
-    expect(failures['owner/repo::main::notes/diverged.md']).toMatchObject({
-      error: 'Push failed: diverged',
-      kind: 'exhausted',
-    });
-    const futureSpy = jest
-      .spyOn(Date, 'now')
-      .mockImplementation(() => virtualNow + TOMBSTONE_TTL_MS + 60_000);
-    try {
-      expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'main', 'notes/diverged.md')).toBe(true);
-    } finally {
-      futureSpy.mockRestore();
-    }
-
-    // Registry: the delete op for the path is FAILED with the diverged error.
-    const ops = useGitOperationStore.getState().ops;
-    const failedOp = Object.values(ops).find(
-      (op) => op.kind === 'delete' && op.path === 'notes/diverged.md' && op.status === 'failed',
+    // Clone-mode stageDelete commits the delete locally; the row is removed
+    // immediately and no queue mutation is created.
+    expect(LocalGitWriter.deleteAndCommit).toHaveBeenCalledTimes(1);
+    expect(LocalGitWriter.deleteAndCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoPath: 'owner/repo',
+        branch: 'main',
+        filePath: 'notes/diverged.md',
+        push: false,
+      }),
     );
-    expect(failedOp).toBeDefined();
-    expect(failedOp?.error).toContain('diverged');
+    expect(useNoteStore.getState().notes.some((n) => n.id === 'n7')).toBe(false);
+    expect(Object.values(useGitOperationStore.getState().ops).some(
+      (op) => op.kind === 'delete' && op.path === 'notes/diverged.md' && op.status === 'failed',
+    )).toBe(false);
+    expect(await NoteSyncQueueService.getAll()).toHaveLength(0);
+
+    // The engine's coalesced push is where divergence surfaces: the flush
+    // fails, but the local row stays deleted (no resurrection).
+    const pushResult = await StagingService.pushStaged('owner/repo', 'main');
+    expect(pushResult.success).toBe(false);
+    expect(pushResult.error).toContain('diverged');
+    expect(useNoteStore.getState().notes.some((n) => n.id === 'n7')).toBe(false);
 
     // Linkage with the conflict store: the local-deleted-remote-modified
     // entry is still there and NOT auto-resolved.
@@ -977,8 +971,6 @@ describe('sync-locking integration scenarios S1–S8', () => {
     expect(file?.kind).toBe('local-deleted-remote-modified');
     expect(file?.autoResolved).toBe(false);
     expect(useConflictStore.getState().totalUnresolvedFiles()).toBeGreaterThanOrEqual(1);
-
-    unsub();
   });
 
   it('S8 — restart: seeded AsyncStorage queue + failure map hydrate into the registry; rows render locked (queued) and failed BEFORE any drain runs', async () => {

--- a/__tests__/template-repo-sync.test.ts
+++ b/__tests__/template-repo-sync.test.ts
@@ -11,15 +11,15 @@ jest.mock('../src/services/TemplateRepoPreferenceService', () => ({
     get: jest.fn(async () => ({ repoPath: 'me/repo', branch: 'main' })),
   },
 }));
-type SyncResult = { success: boolean; filePath?: string; error?: string };
-const mockSyncTemplateToGitHub = jest.fn(async (..._args: any[]): Promise<SyncResult> => ({ success: true, filePath: 'templates/x.md' }));
-const mockDeleteTemplateFromGitHub = jest.fn(async (..._args: any[]): Promise<SyncResult> => ({ success: true }));
-jest.mock('../src/services/TemplateGitHubSyncService', () => ({
-  syncTemplateToGitHub: (...a: any[]) => mockSyncTemplateToGitHub(...a),
-  deleteTemplateFromGitHub: (...a: any[]) => mockDeleteTemplateFromGitHub(...a),
+jest.mock('../src/services/git/StagingService', () => ({
+  StagingService: {
+    stageUpsert: jest.fn(async () => ({ success: true })),
+    stageDelete: jest.fn(async () => ({ success: true })),
+  },
 }));
 
 import { useTemplateStore } from '../src/stores/templateStore';
+import { StagingService } from '../src/services/git/StagingService';
 
 describe('templateStore repo sync', () => {
   beforeEach(() => {
@@ -27,40 +27,58 @@ describe('templateStore repo sync', () => {
     useTemplateStore.setState({ customTemplates: [], pinnedIds: [], isLoading: false });
   });
 
-  test('createTemplate writes to GitHub and stores returned filePath', async () => {
+  test('createTemplate stages the upsert to the templates repo', async () => {
     const t = await useTemplateStore.getState().createTemplate({
       name: 'X', icon: 'document-outline', description: '', content: 'body', tags: [],
     });
-    expect(mockSyncTemplateToGitHub).toHaveBeenCalledTimes(1);
-    expect(useTemplateStore.getState().customTemplates[0].filePath).toBe('templates/x.md');
-    expect(t.filePath).toBe('templates/x.md');
+    expect(StagingService.stageUpsert).toHaveBeenCalledTimes(1);
+    expect(StagingService.stageUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: 'me/repo',
+        branch: 'main',
+        filePath: 'templates/x.md',
+        title: 'X',
+      }),
+    );
+    expect(useTemplateStore.getState().customTemplates).toHaveLength(1);
+    expect(t.isCustom).toBe(true);
   });
 
-  test('updateTemplate calls sync with merged template', async () => {
+  test('updateTemplate stages the upsert with the merged template', async () => {
     await useTemplateStore.getState().createTemplate({
       name: 'X', icon: 'document-outline', description: '', content: 'body', tags: [],
     });
-    mockSyncTemplateToGitHub.mockClear();
+    (StagingService.stageUpsert as jest.Mock).mockClear();
     const id = useTemplateStore.getState().customTemplates[0].id;
     await useTemplateStore.getState().updateTemplate(id, { content: 'new body' });
-    expect(mockSyncTemplateToGitHub).toHaveBeenCalledTimes(1);
-    const arg = mockSyncTemplateToGitHub.mock.calls[0][0];
-    expect(arg.template.content).toBe('new body');
+    expect(StagingService.stageUpsert).toHaveBeenCalledTimes(1);
+    const arg = (StagingService.stageUpsert as jest.Mock).mock.calls[0][0] as { content: string };
+    expect(arg.content).toContain('new body');
   });
 
-  test('deleteTemplate calls deleteTemplateFromGitHub when filePath is known', async () => {
-    await useTemplateStore.getState().createTemplate({
-      name: 'X', icon: 'document-outline', description: '', content: 'body', tags: [],
+  test('deleteTemplate stages the delete when filePath is known', async () => {
+    useTemplateStore.setState({
+      customTemplates: [
+        {
+          id: 'tpl-x',
+          name: 'X',
+          content: 'body',
+          filePath: 'templates/x.md',
+          isCustom: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      pinnedIds: [],
     });
-    const id = useTemplateStore.getState().customTemplates[0].id;
-    await useTemplateStore.getState().deleteTemplate(id);
-    expect(mockDeleteTemplateFromGitHub).toHaveBeenCalledWith(expect.objectContaining({
-      repoPath: 'me/repo', branch: 'main', filePath: 'templates/x.md', name: 'X',
+    await useTemplateStore.getState().deleteTemplate('tpl-x');
+    expect(StagingService.stageDelete).toHaveBeenCalledWith(expect.objectContaining({
+      repo: 'me/repo', branch: 'main', filePath: 'templates/x.md', title: 'X',
     }));
   });
 
-  test('createTemplate persists locally without filePath when sync fails', async () => {
-    mockSyncTemplateToGitHub.mockResolvedValueOnce({ success: false, error: 'GitHub unavailable' });
+  test('createTemplate persists locally without filePath when staging fails', async () => {
+    (StagingService.stageUpsert as jest.Mock).mockResolvedValueOnce({ success: false, error: 'GitHub unavailable' });
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const t = await useTemplateStore.getState().createTemplate({
@@ -69,7 +87,7 @@ describe('templateStore repo sync', () => {
     expect(t.filePath).toBeUndefined();
     expect(useTemplateStore.getState().customTemplates).toHaveLength(1);
     expect(useTemplateStore.getState().customTemplates[0].filePath).toBeUndefined();
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Failed to sync template'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Failed to stage template'));
     warn.mockRestore();
   });
 });

--- a/__tests__/todo-completion.test.ts
+++ b/__tests__/todo-completion.test.ts
@@ -25,8 +25,8 @@ jest.mock('../src/services/GitHubService', () => ({
   },
 }));
 
-jest.mock('../src/services/TodoGitHubSyncService', () => ({
-  syncTodoToGitHub: jest.fn(() => Promise.resolve({ success: true })),
+jest.mock('../src/services/git/StagingService', () => ({
+  StagingService: { stageUpsert: jest.fn(() => Promise.resolve({ success: true })) },
 }));
 
 import { act, renderHook } from '@testing-library/react-native';
@@ -34,7 +34,7 @@ import { useTodos } from '../src/contexts/TodoContext';
 import { Todo } from '../src/models/Todo';
 import { StorageService } from '../src/services/StorageService';
 import { NotificationService } from '../src/services/NotificationService';
-import { syncTodoToGitHub } from '../src/services/TodoGitHubSyncService';
+import { StagingService } from '../src/services/git/StagingService';
 import { useTodoStore } from '../src/stores/todoStore';
 
 const makeTodo = (overrides: Partial<Todo>): Todo => ({
@@ -106,13 +106,14 @@ describe('todo completion ordering and refresh', () => {
     expect(useTodoStore.getState().todos[0]?.id).toBe('todo-2');
     expect(useTodoStore.getState().todos[2]).toMatchObject({ id: 'todo-1', completed: true });
     expect(StorageService.saveAllTodos).toHaveBeenCalled();
-    expect(syncTodoToGitHub).toHaveBeenCalledWith(expect.objectContaining({
+    expect(StagingService.stageUpsert).toHaveBeenCalledWith(expect.objectContaining({
       repo: 'owner/repo',
       branch: 'main',
       filePath: 'todos/top-todo.json',
-      text: 'Top todo',
-      todo: expect.objectContaining({ completed: true }),
+      title: 'Top todo',
     }));
+    const stageArg = (StagingService.stageUpsert as jest.Mock).mock.calls[0][0] as { content: string };
+    expect(JSON.parse(stageArg.content)).toMatchObject({ text: 'Top todo', completed: true });
 
     await act(async () => {
       await result.current.refreshTodos();

--- a/__tests__/todo-delete-sync.test.ts
+++ b/__tests__/todo-delete-sync.test.ts
@@ -20,6 +20,10 @@ jest.mock('../src/services/SyncEngineService', () => ({
   },
 }));
 
+jest.mock('../src/services/git/StagingService', () => ({
+  StagingService: { stageDelete: jest.fn(), stageUpsert: jest.fn() },
+}));
+
 jest.mock('../src/services/AuthService', () => ({
   AuthService: {
     getTokenById: jest.fn(async () => null),
@@ -30,6 +34,7 @@ jest.mock('../src/services/AuthService', () => ({
 import { useTodoStore } from '../src/stores/todoStore';
 import { StorageService } from '../src/services/StorageService';
 import { GitHubService } from '../src/services/GitHubService';
+import { StagingService } from '../src/services/git/StagingService';
 
 describe('todo delete GitHub sync', () => {
   let storageTodos: Array<{
@@ -58,10 +63,11 @@ describe('todo delete GitHub sync', () => {
       content: { sha: 'deleted-sha' },
       commit: { sha: 'commit-sha' },
     });
+    (StagingService.stageDelete as jest.Mock).mockResolvedValue({ success: true });
     useTodoStore.setState({ todos: [], isLoading: false, error: null });
   });
 
-  test('deletes the remote todo file and keeps it gone after refresh', async () => {
+  test('stages the delete, removes the local row, and keeps it gone after refresh', async () => {
     const syncedTodo = {
       id: 'todo-1',
       text: 'Ship it',
@@ -78,23 +84,16 @@ describe('todo delete GitHub sync', () => {
 
     await useTodoStore.getState().deleteTodo('todo-1');
 
+    expect(StagingService.stageDelete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: 'owner/repo',
+        branch: 'main',
+        filePath: 'todos/ship-it.json',
+        title: 'Ship it',
+      }),
+    );
+    expect(GitHubService.deleteFile).not.toHaveBeenCalled();
     expect(StorageService.deleteTodo).toHaveBeenCalledWith('todo-1');
-    expect(GitHubService.getFileSha).toHaveBeenCalledWith(
-      'owner',
-      'repo',
-      'todos/ship-it.json',
-      'main',
-      undefined,
-    );
-    expect(GitHubService.deleteFile).toHaveBeenCalledWith(
-      'owner',
-      'repo',
-      'todos/ship-it.json',
-      'Delete todo: Ship it',
-      'todo-sha-123',
-      'main',
-      undefined,
-    );
     expect(useTodoStore.getState().todos).toEqual([]);
 
     await useTodoStore.getState().refreshTodos();
@@ -102,7 +101,7 @@ describe('todo delete GitHub sync', () => {
     expect(useTodoStore.getState().todos).toEqual([]);
   });
 
-  test('keeps the todo locally when GitHub delete fails so pull does not re-import it', async () => {
+  test('keeps the todo locally when the delete stage fails so pull does not re-import it', async () => {
     const syncedTodo = {
       id: 'todo-2',
       text: 'Keep on failure',
@@ -117,12 +116,15 @@ describe('todo delete GitHub sync', () => {
     storageTodos = [syncedTodo];
     useTodoStore.setState({ todos: [syncedTodo], isLoading: false, error: null });
 
-    (GitHubService.deleteFile as jest.Mock).mockResolvedValueOnce(null);
+    (StagingService.stageDelete as jest.Mock).mockResolvedValueOnce({
+      success: false,
+      error: 'staging boom',
+    });
 
     const ok = await useTodoStore.getState().deleteTodo('todo-2');
 
     expect(ok).toBe(false);
-    // Local storage MUST NOT be mutated when remote delete fails — otherwise
+    // Local storage MUST NOT be mutated when staging fails — otherwise
     // the next pull-to-refresh would re-create the todo (issue #489).
     expect(StorageService.deleteTodo).not.toHaveBeenCalled();
     expect(useTodoStore.getState().todos).toEqual([syncedTodo]);
@@ -155,12 +157,7 @@ describe('todo delete GitHub sync', () => {
     expect(useTodoStore.getState().error).toBeTruthy();
   });
 
-  test('treats a missing remote (sha null) as success so local row can still be removed', async () => {
-    // Reproduces the "Cannot delete todo: failed to look up remote file" bug —
-    // a stale local row whose remote was already deleted should not be stuck
-    // forever. Pull won't re-import a file that doesn't exist anymore.
-    (GitHubService.getFileSha as jest.Mock).mockResolvedValueOnce({ kind: 'not-found' });
-
+  test('a successful stage clears a stale local row (missing remote handled by the stage engine)', async () => {
     const stale = {
       id: 'todo-stale',
       text: 'Already gone remotely',
@@ -177,6 +174,7 @@ describe('todo delete GitHub sync', () => {
     const ok = await useTodoStore.getState().deleteTodo('todo-stale');
 
     expect(ok).toBe(true);
+    expect(StagingService.stageDelete).toHaveBeenCalledTimes(1);
     expect(GitHubService.deleteFile).not.toHaveBeenCalled();
     expect(StorageService.deleteTodo).toHaveBeenCalledWith('todo-stale');
     expect(useTodoStore.getState().todos).toEqual([]);

--- a/src/components/canvas/CanvasEditorContent.tsx
+++ b/src/components/canvas/CanvasEditorContent.tsx
@@ -47,8 +47,6 @@ import {
   slugifyCanvasTitle,
 } from '../../models/Canvas';
 import GitContextPicker from '../GitContextPicker';
-import { syncCanvasToGitHub } from '../../services/CanvasGitHubSyncService';
-import { FEATURE_STAGE_PUSH } from '../../services/featureFlags';
 import { StagingService } from '../../services/git/StagingService';
 import { useAuth } from '../../contexts/AuthContext';
 import { renderSceneToPng } from '../../utils/canvasPngExport';
@@ -1271,30 +1269,15 @@ export default function CanvasEditorContent() {
     }
 
     if (repo) {
-      if (FEATURE_STAGE_PUSH) {
-        const stageResult = await StagingService.stageUpsert({
-          repo,
-          branch,
-          filePath: canvasFilePath,
-          title: title.trim(),
-          content: JSON.stringify(scene, null, 2),
-        });
-        if (!stageResult.success) {
-          console.warn('[CanvasEditorContent] stage canvas failed:', stageResult.error);
-        }
-      } else {
-        const syncResult = await syncCanvasToGitHub({
-          repo,
-          branch,
-          filePath: canvasFilePath,
-          title: title.trim(),
-          scene,
-          accountId,
-        });
-
-        if (!syncResult.success) {
-          Alert.alert('Sync Failed', syncResult.error || 'Canvas changes were saved locally but could not sync to GitHub.');
-        }
+      const stageResult = await StagingService.stageUpsert({
+        repo,
+        branch,
+        filePath: canvasFilePath,
+        title: title.trim(),
+        content: JSON.stringify(scene, null, 2),
+      });
+      if (!stageResult.success) {
+        console.warn('[CanvasEditorContent] stage canvas failed:', stageResult.error);
       }
     }
 

--- a/src/components/chat/ChatThreadCard.tsx
+++ b/src/components/chat/ChatThreadCard.tsx
@@ -18,7 +18,11 @@ function ChatThreadCardImpl({ thread, onPress, onLongPress }: ChatThreadCardProp
   const { colors, type } = useTokens();
   const typography = type ?? TYPE;
 
-  const timeAgo = formatDistanceToNow(thread.updatedAt, { addSuffix: true });
+  // formatDistanceToNow throws RangeError on a missing/NaN timestamp; never let a
+  // persisted thread summary with an invalid updatedAt crash the whole chat render.
+  const timeAgo = Number.isFinite(thread.updatedAt)
+    ? formatDistanceToNow(thread.updatedAt, { addSuffix: true })
+    : '';
 
   return (
     <TouchableOpacity activeOpacity={0.7} onPress={onPress} onLongPress={onLongPress}>

--- a/src/components/editor/useNoteEditorDocument.ts
+++ b/src/components/editor/useNoteEditorDocument.ts
@@ -12,10 +12,8 @@ import { GitService } from '../../services/GitService';
 import { LastSelectionPreferenceService } from '../../services/LastSelectionPreferenceService';
 import { HapticService } from '../../utils/haptics';
 import { useUndo } from '../../utils/useUndo';
-import { syncNoteToGitHub } from '../../services/NoteGitHubSyncService';
 import { NoteSyncQueueService } from '../../services/NoteSyncQueueService';
 import { classifyGitHubSyncError, isRetryableFailure, syncStatusForError } from '../../services/git/syncFailure';
-import { FEATURE_STAGE_PUSH } from '../../services/featureFlags';
 import { StagingService } from '../../services/git/StagingService';
 import { githubActivity } from '../../stores/githubActivityStore';
 import { useGitOperationStore, gitOperationRegistry } from '../../stores/gitOperationStore';
@@ -390,82 +388,37 @@ export function useNoteEditorDocument({
             knownSha: commit,
           };
 
-          if (FEATURE_STAGE_PUSH) {
-            const stageResult = await StagingService.stageUpsert(syncParams);
-            if (stageResult.success && syncPath) {
-              const updated = await updateNote({
-                id: savedNoteId,
-                filePath: syncPath,
-              });
-              if (!updated) {
-                Alert.alert(
-                  'Partial Save',
-                  'Your note was staged but local metadata could not be updated.',
-                  [{ text: 'OK' }],
-                );
-              }
-            } else {
-              try {
-                await NoteSyncQueueService.enqueueNoteUpsert(syncParams, savedNoteId);
-                Alert.alert(
-                  'Note Saved Locally',
-                  'Your note was saved but could not be pushed to GitHub yet. It will sync automatically when connection is restored.',
-                  [{ text: 'OK' }],
-                );
-              } catch {
-                Alert.alert(
-                  'Save Failed',
-                  'Your note was saved locally but could not be queued for sync. Please try again.',
-                  [{ text: 'OK' }],
-                );
-              }
+          const stageResult = await StagingService.stageUpsert(syncParams);
+          if (stageResult.success && syncPath) {
+            const updated = await updateNote({
+              id: savedNoteId,
+              filePath: syncPath,
+            });
+            if (!updated) {
+              Alert.alert(
+                'Partial Save',
+                'Your note was staged but local metadata could not be updated.',
+                [{ text: 'OK' }],
+              );
             }
           } else {
-            const syncResult = await syncNoteToGitHub(syncParams);
-
-            if (syncResult.success && syncResult.filePath) {
-              const updated = await updateNote({
-                id: savedNoteId,
-                filePath: syncResult.filePath,
-                ...(syncResult.finalContent != null && syncResult.finalContent !== finalContent
-                  ? { content: syncResult.finalContent }
-                  : {}),
-              });
-              if (!updated) {
-                Alert.alert(
-                  'Partial Save',
-                  'Your note was pushed to GitHub but local metadata could not be updated.',
-                  [{ text: 'OK' }],
-                );
-              }
-            } else {
-              const error = syncResult.error!;
-              const failure = classifyGitHubSyncError(
-                new Error(error),
-                syncResult.status ?? syncStatusForError(error),
+            try {
+              await NoteSyncQueueService.enqueueNoteUpsert(syncParams, savedNoteId);
+              Alert.alert(
+                'Note Saved Locally',
+                'Your note was saved but could not be pushed to GitHub yet. It will sync automatically when connection is restored.',
+                [{ text: 'OK' }],
               );
-              if (isRetryableFailure(failure)) {
-                try {
-                  await NoteSyncQueueService.enqueueNoteUpsert(syncParams, savedNoteId);
-                  Alert.alert(
-                    'Note Saved Locally',
-                    'Your note was saved but could not be pushed to GitHub yet. It will sync automatically when connection is restored.',
-                    [{ text: 'OK' }],
-                  );
-                } catch {
-                  Alert.alert(
-                    'Save Failed',
-                    'Your note was saved locally but could not be queued for sync. Please try again.',
-                    [{ text: 'OK' }],
-                  );
-                }
-              } else {
-                showDurableSyncFailureAlert(failure.kind);
-              }
+            } catch {
+              Alert.alert(
+                'Save Failed',
+                'Your note was saved locally but could not be queued for sync. Please try again.',
+                [{ text: 'OK' }],
+              );
             }
           }
         } catch (error) {
-          console.warn('[useNoteEditorDocument] syncNoteToGitHub threw:', error);
+          console.warn('[useNoteEditorDocument] note sync threw:', error);
           const existingForColor = getNoteByIdRef.current(savedNoteId);
           const syncParams = {
             repo,

--- a/src/components/notes/useNotesListNoteActions.ts
+++ b/src/components/notes/useNotesListNoteActions.ts
@@ -7,8 +7,6 @@ import { parseRepoPath } from '../../utils/gitPathParser';
 import { HapticService } from '../../utils/haptics';
 import { ShareFormat, ShareService } from '../../services/ShareService';
 import { NoteSyncQueueService } from '../../services/NoteSyncQueueService';
-import { syncNoteToGitHub } from '../../services/NoteGitHubSyncService';
-import { FEATURE_STAGE_PUSH } from '../../services/featureFlags';
 import { StagingService } from '../../services/git/StagingService';
 import { githubActivity } from '../../stores/githubActivityStore';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -93,28 +91,14 @@ export function useNotesListNoteActions({
             tags: updated.tags,
             color,
           };
-          if (FEATURE_STAGE_PUSH) {
-            try {
-              const staged = await StagingService.stageUpsert(syncParams);
-              if (!staged.success) {
-                console.warn('[useNotesListNoteActions] stage after color update failed:', staged.error);
-              }
-            } catch (error) {
-              console.warn('[useNotesListNoteActions] stage after color update failed:', error);
-              await NoteSyncQueueService.enqueueNoteUpsert(syncParams, updated.id);
+          try {
+            const staged = await StagingService.stageUpsert(syncParams);
+            if (!staged.success) {
+              console.warn('[useNotesListNoteActions] stage after color update failed:', staged.error);
             }
-          } else {
-            try {
-              const result = await syncNoteToGitHub(syncParams);
-              if (!result.success) {
-                await NoteSyncQueueService.enqueueNoteUpsert(syncParams, updated.id);
-              } else if (result.finalContent && result.finalContent !== updated.content) {
-                await updateNote({ id: updated.id, content: result.finalContent });
-              }
-            } catch (error) {
-              console.warn('[useNotesListNoteActions] sync after color update failed:', error);
-              await NoteSyncQueueService.enqueueNoteUpsert(syncParams, updated.id);
-            }
+          } catch (error) {
+            console.warn('[useNotesListNoteActions] stage after color update failed:', error);
+            await NoteSyncQueueService.enqueueNoteUpsert(syncParams, updated.id);
           }
         }
       } catch {

--- a/src/components/repo/repoTreeShared.ts
+++ b/src/components/repo/repoTreeShared.ts
@@ -3,7 +3,6 @@ import { GitHubContent, GitHubService } from '../../services/GitHubService';
 import { AuthService } from '../../services/AuthService';
 import { SyncEngineService } from '../../services/SyncEngineService';
 import { LocalGitWriter } from '../../services/git/LocalGitWriter';
-import { FEATURE_STAGE_PUSH } from '../../services/featureFlags';
 import { batchDeleteFiles } from '../../services/git/BatchGitOperations';
 import { getGitHostService } from '../../services/git/gitHostFactory';
 
@@ -135,10 +134,8 @@ async function resolveCloneAuthor(): Promise<{ name: string; email: string }> {
 
 /**
  * Clone-mode folder delete: one local `deleteAndCommit(push:false)` per
- * leaf file, then ONE trailing `LocalGitWriter.push` flushes the whole
- * folder (mirrors `NoteSyncQueueService.processDrainGroup`'s coalesced
- * push). A failed flush strands every locally-committed delete, so they
- * all surface as failures.
+ * leaf file. Pushes are owned by the stage/push engine, so nothing is
+ * flushed here.
  */
 async function deleteDirectoryClone(
   owner: string,
@@ -170,22 +167,14 @@ async function deleteDirectoryClone(
     }
   }
 
-  if (deleted.length > 0 && !FEATURE_STAGE_PUSH) {
-    const flushResult = await LocalGitWriter.push({ repoPath, branch: targetBranch, token });
-    if (!flushResult.success) {
-      const pushError = flushResult.error ?? 'Push failed';
-      for (const path of deleted) failed.push({ path, error: pushError });
-      return { deleted: [], failed };
-    }
-  }
   return { deleted, failed };
 }
 
 /**
  * Mode-aware folder delete. API mode batches every collected path into ONE
  * `batchDeleteFiles` commit (>= 2 paths; a single-path folder falls back to
- * per-file deletes). Clone mode commits locally with push deferred and
- * flushes with one trailing push.
+ * per-file deletes). Clone mode commits locally with push deferred to the
+ * stage/push engine.
  */
 export async function deleteDirectoryModeAware(
   owner: string,

--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -3,9 +3,6 @@ import { Todo, TodoCreateInput, TodoUpdateInput, reorderTodos } from '../models/
 import { StorageService } from '../services/StorageService';
 import { NotificationService } from '../services/NotificationService';
 import { useTodoStore } from '../stores/todoStore';
-import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
-import { formatSyncError } from '../services/git/formatSyncError';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 import { StagingService } from '../services/git/StagingService';
 
 /** Mirrors TodoGitHubSyncService.serializeTodo so staged todos keep the on-disk shape. */
@@ -131,28 +128,15 @@ export function useTodos(): TodoContextValue {
     }
 
     if (todo.repo) {
-      if (FEATURE_STAGE_PUSH) {
-        const stageResult = await StagingService.stageUpsert({
-          repo: todo.repo,
-          branch: todo.branch,
-          filePath: todo.filePath,
-          title: finalTodo.text,
-          content: serializeTodoForStage(finalTodo),
-        });
-        if (!stageResult.success) {
-          console.warn('[TodoContext] GitHub stage failed:', stageResult.error);
-        }
-      } else {
-        const syncResult = await syncTodoToGitHub({
-          repo: todo.repo,
-          branch: todo.branch,
-          filePath: todo.filePath,
-          text: finalTodo.text,
-          todo: finalTodo,
-        });
-        if (!syncResult.success) {
-          console.warn('[TodoContext] GitHub sync failed:', formatSyncError(syncResult.error, 'upsert'));
-        }
+      const stageResult = await StagingService.stageUpsert({
+        repo: todo.repo,
+        branch: todo.branch,
+        filePath: todo.filePath,
+        title: finalTodo.text,
+        content: serializeTodoForStage(finalTodo),
+      });
+      if (!stageResult.success) {
+        console.warn('[TodoContext] GitHub stage failed:', stageResult.error);
       }
     }
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -32,7 +32,6 @@ import { RootStackParamList } from './types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAIStore } from '../stores/aiStore';
 import { useAIHubStore } from '../stores/aiHubStore';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -237,7 +236,7 @@ export default function AppNavigator() {
             )}
           </Stack.Navigator>
           <FloatingAIButton currentRouteName={currentRouteName} />
-          {FEATURE_STAGE_PUSH && <FloatingStageButton currentRouteName={currentRouteName} />}
+          <FloatingStageButton currentRouteName={currentRouteName} />
         </View>
       </NavigationContainer>
         <ChatRepoPickerModal

--- a/src/screens/ConflictResolverScreen.tsx
+++ b/src/screens/ConflictResolverScreen.tsx
@@ -10,7 +10,6 @@ import { ConflictResolverService } from '../services/conflict/ConflictResolverSe
 import { proposeMerge } from '../services/conflict/AiConflictResolver';
 import { GitFsService } from '../services/git/GitFsService';
 import { LocalGitWriter } from '../services/git/LocalGitWriter';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 import { AuthService } from '../services/AuthService';
 import type { FileConflict } from '../services/conflict/types';
 import type { RootStackParamList } from '../navigation/types';
@@ -175,7 +174,7 @@ export default function ConflictResolverScreen() {
           message: `Merge remote changes into ${branch}`,
           author: { name: authorName, email: authorEmail },
           token,
-          ...(FEATURE_STAGE_PUSH ? { push: false } : {}),
+          push: false,
         });
 
         if ('error' in result) {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -30,9 +30,7 @@ import { buildPinnedFeed, buildRecentFeed, RecentItem } from '../utils/recentIte
 import { HomeNoteContextMenu } from '../components/home/HomeNoteContextMenu';
 import ColorPicker from '../components/ColorPicker';
 import { ShareFormat } from '../services/ShareService';
-import { syncNoteToGitHub } from '../services/NoteGitHubSyncService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 import { StagingService } from '../services/git/StagingService';
 import { useGitOperationStore } from '../stores/gitOperationStore';
 import { useTranslation } from 'react-i18next';
@@ -246,28 +244,14 @@ export default function HomeScreen() {
             tags: updated.tags,
             color,
           };
-          if (FEATURE_STAGE_PUSH) {
-            try {
-              const staged = await StagingService.stageUpsert(syncParams);
-              if (!staged.success) {
-                console.warn('[HomeScreen] stage after color update failed:', staged.error);
-              }
-            } catch (error) {
-              console.warn('[HomeScreen] stage after color update failed:', error);
-              await NoteSyncQueueService.enqueueNoteUpsert(syncParams, updated.id);
+          try {
+            const staged = await StagingService.stageUpsert(syncParams);
+            if (!staged.success) {
+              console.warn('[HomeScreen] stage after color update failed:', staged.error);
             }
-          } else {
-            try {
-              const result = await syncNoteToGitHub(syncParams);
-              if (!result.success) {
-                await NoteSyncQueueService.enqueueNoteUpsert(syncParams, updated.id);
-              } else if (result.finalContent && result.finalContent !== updated.content) {
-                await updateNote({ id: updated.id, content: result.finalContent });
-              }
-            } catch (error) {
-              console.warn('[HomeScreen] sync after color update failed:', error);
-              await NoteSyncQueueService.enqueueNoteUpsert(syncParams, updated.id);
-            }
+          } catch (error) {
+            console.warn('[HomeScreen] stage after color update failed:', error);
+            await NoteSyncQueueService.enqueueNoteUpsert(syncParams, updated.id);
           }
         }
       } catch {

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -15,7 +15,6 @@ import { Note } from '../models/Note';
 import { GitHubService } from '../services/GitHubService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
 import type { NoteDeleteParams } from '../services/NoteSyncQueueService';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 import { gitOperationRegistry, useGitOperationStore } from '../stores/gitOperationStore';
 import { GitSyncGate } from '../services/git/GitSyncGate';
 import { deriveDefaultNotePath, useNoteStore } from '../stores/noteStore';
@@ -393,9 +392,6 @@ export default function NotesListScreen() {
                   localNoteId: note.id,
                 }));
                 await NoteSyncQueueService.enqueueNoteDeletes(params);
-                if (!FEATURE_STAGE_PUSH) {
-                  void NoteSyncQueueService.drain();
-                }
               }
               let localFailure = false;
               for (const id of localOnlyIds) {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -18,9 +18,7 @@ import { GitHubService, type GitHubRepository } from '../services/GitHubService'
 import { RepoFileSyncService } from '../services/RepoFileSyncService';
 import { pullFromSingleRepo } from '../services/RepoPullService';
 import { TemplateRepoPreferenceService, type TemplateRepoPreference } from '../services/TemplateRepoPreferenceService';
-import { syncTemplateToGitHub } from '../services/TemplateGitHubSyncService';
 import { serializeTemplate, templateSlug } from '../services/TemplateMarkdownService';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 import { StagingService } from '../services/git/StagingService';
 import { SyncEngineService, type SyncEngineMode } from '../services/SyncEngineService';
 import { GitFsService } from '../services/git/GitFsService';
@@ -414,29 +412,19 @@ export default function SettingsScreen() {
     let failed = 0;
     try {
       for (const template of unsynced) {
-        if (FEATURE_STAGE_PUSH) {
-          const filePath = `templates/${templateSlug(template.name)}.md`;
-          const staged = await StagingService.stageUpsert({
-            repo: templatesRepoPref.repoPath,
-            branch: templatesRepoPref.branch,
-            filePath,
-            title: template.name,
-            content: serializeTemplate({ ...template, filePath: undefined }),
-          });
-          if (staged.success) {
-            await useTemplateStore.getState().updateTemplate(template.id, { filePath });
-            synced++;
-          } else {
-            failed++;
-          }
+        const filePath = `templates/${templateSlug(template.name)}.md`;
+        const staged = await StagingService.stageUpsert({
+          repo: templatesRepoPref.repoPath,
+          branch: templatesRepoPref.branch,
+          filePath,
+          title: template.name,
+          content: serializeTemplate({ ...template, filePath: undefined }),
+        });
+        if (staged.success) {
+          await useTemplateStore.getState().updateTemplate(template.id, { filePath });
+          synced++;
         } else {
-          const result = await syncTemplateToGitHub({ repoPath: templatesRepoPref.repoPath, branch: templatesRepoPref.branch, template });
-          if (result.success && result.filePath) {
-            await useTemplateStore.getState().updateTemplate(template.id, { filePath: result.filePath });
-            synced++;
-          } else {
-            failed++;
-          }
+          failed++;
         }
       }
     } finally {

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -13,8 +13,6 @@ import { useTheme } from '../contexts/ThemeContext';
 import { slugifyTodoText, Todo, TodoPriority } from '../models/Todo';
 import { SortMode } from '../types/SortTypes';
 import { HapticService } from '../utils/haptics';
-import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 import { StagingService } from '../services/git/StagingService';
 import { syncNow } from '../services/git/manualSync';
 import { batchDeleteFiles } from '../services/git/BatchGitOperations';
@@ -424,29 +422,15 @@ export default function TodoListScreen() {
     });
 
     if (todoRepo && newTodo) {
-      if (FEATURE_STAGE_PUSH) {
-        const stageResult = await StagingService.stageUpsert({
-          repo: todoRepo,
-          branch: todoBranch,
-          filePath: todoFilePath,
-          title: todoText.trim(),
-          content: serializeTodoForStage(newTodo),
-        });
-        if (!stageResult.success) {
-          console.warn('[TodoList] GitHub stage failed:', stageResult.error);
-        }
-      } else {
-        const syncResult = await syncTodoToGitHub({
-          repo: todoRepo,
-          branch: todoBranch,
-          filePath: todoFilePath,
-          text: todoText.trim(),
-          todo: newTodo,
-          accountId: newTodo.accountId,
-        });
-        if (!syncResult.success) {
-          console.warn('[TodoList] GitHub sync failed:', syncResult.error);
-        }
+      const stageResult = await StagingService.stageUpsert({
+        repo: todoRepo,
+        branch: todoBranch,
+        filePath: todoFilePath,
+        title: todoText.trim(),
+        content: serializeTodoForStage(newTodo),
+      });
+      if (!stageResult.success) {
+        console.warn('[TodoList] GitHub stage failed:', stageResult.error);
       }
     }
 
@@ -491,47 +475,24 @@ export default function TodoListScreen() {
       accountId: editAccountId,
     });
 
-    if (FEATURE_STAGE_PUSH) {
-      const stageResult = await StagingService.stageUpsert({
-        repo: todoRepo,
-        branch: todoBranch,
-        filePath: todoFilePath,
-        title: todoText.trim(),
-        content: serializeTodoForStage({
-          text: todoText.trim(),
-          completed: editingTodo.completed,
-          priority: todoPriority,
-          notes: todoNotes.trim() || undefined,
-          tags: editingTodo.tags,
-          dueDate: todoDueDate,
-          createdAt: editingTodo.createdAt,
-          updatedAt: Date.now(),
-        }),
-      });
-      if (!stageResult.success) {
-        console.warn('[TodoList] GitHub stage failed:', stageResult.error);
-      }
-    } else {
-      const syncResult = await syncTodoToGitHub({
-        repo: todoRepo,
-        branch: todoBranch,
-        filePath: todoFilePath,
+    const stageResult = await StagingService.stageUpsert({
+      repo: todoRepo,
+      branch: todoBranch,
+      filePath: todoFilePath,
+      title: todoText.trim(),
+      content: serializeTodoForStage({
         text: todoText.trim(),
-        todo: {
-          text: todoText.trim(),
-          completed: editingTodo.completed,
-          priority: todoPriority,
-          notes: todoNotes.trim() || undefined,
-          tags: editingTodo.tags,
-          dueDate: todoDueDate,
-          createdAt: editingTodo.createdAt,
-          updatedAt: Date.now(),
-        },
-        accountId: editAccountId,
-      });
-      if (!syncResult.success) {
-        console.warn('[TodoList] GitHub sync failed:', syncResult.error);
-      }
+        completed: editingTodo.completed,
+        priority: todoPriority,
+        notes: todoNotes.trim() || undefined,
+        tags: editingTodo.tags,
+        dueDate: todoDueDate,
+        createdAt: editingTodo.createdAt,
+        updatedAt: Date.now(),
+      }),
+    });
+    if (!stageResult.success) {
+      console.warn('[TodoList] GitHub stage failed:', stageResult.error);
     }
 
     resetForm();

--- a/src/services/BackgroundSyncService.ts
+++ b/src/services/BackgroundSyncService.ts
@@ -6,7 +6,6 @@ import { NoteSyncQueueService } from './NoteSyncQueueService';
 import { pullAllFromRepos } from './RepoPullService';
 import { GitSyncGate } from './git/GitSyncGate';
 import { StagingService } from './git/StagingService';
-import { FEATURE_STAGE_PUSH } from './featureFlags';
 
 const TASK_NAME = 'background-sync';
 
@@ -36,9 +35,7 @@ TaskManager.defineTask(TASK_NAME, async () => {
     try {
       await NoteSyncQueueService.drain();
       await pullAllFromRepos();
-      if (FEATURE_STAGE_PUSH) {
-        await flushStagedSetsForBackgroundTask();
-      }
+      await flushStagedSetsForBackgroundTask();
     } finally {
       releaseCycle();
     }

--- a/src/services/StagePushScheduler.ts
+++ b/src/services/StagePushScheduler.ts
@@ -1,7 +1,6 @@
 import { StagingService } from './git/StagingService';
 import { GitSyncGate } from './git/GitSyncGate';
 import { useStageStore } from '../stores/stageStore';
-import { FEATURE_STAGE_PUSH } from './featureFlags';
 
 /**
  * Foreground idle-timeout auto-push for staged changes.
@@ -130,9 +129,9 @@ export function onStagedChanged(): void {
   resetIdleTimer();
 }
 
-/** Start the scheduler. No-op behind `FEATURE_STAGE_PUSH`. */
+/** Start the scheduler. */
 export function startScheduler(): void {
-  if (!FEATURE_STAGE_PUSH || schedulerRunning) return;
+  if (schedulerRunning) return;
   schedulerRunning = true;
   useStageStore.getState().registerQueueSubscription();
   unsubscribeStaged = useStageStore.subscribe(onStagedChanged);

--- a/src/services/ThoughtDumpService.ts
+++ b/src/services/ThoughtDumpService.ts
@@ -3,11 +3,9 @@ import { StorageService } from './StorageService';
 import { ThoughtDump, createThoughtDump, serializeThoughtDump, parseThoughtDump } from '../models/ThoughtDump';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { SyncEngineService } from './SyncEngineService';
-import { LocalGitWriter } from './git/LocalGitWriter';
-import { AuthService } from './AuthService';
 import { resolveBranch } from './git/branchResolver';
 import { getGitHostService } from './git/gitHostFactory';
-import { FEATURE_USE_MULTI_HOST_WRITE, FEATURE_STAGE_PUSH } from './featureFlags';
+import { FEATURE_USE_MULTI_HOST_WRITE } from './featureFlags';
 import { StagingService } from './git/StagingService';
 import type { GitHostProvider } from './git/GitHost';
 
@@ -37,18 +35,6 @@ async function enqueueRepoWrite<T>(
   return next;
 }
 
-async function resolveAuthor(): Promise<{ name: string; email: string }> {
-  const host = getGitHostService('github');
-  const user = await host.getAuthenticatedUser();
-  const name = user?.login || 'gitnotes';
-  const email = user?.email || `${name}@users.noreply.gitnotes`;
-  return { name, email };
-}
-
-async function resolveToken(): Promise<string | undefined> {
-  return (await AuthService.getToken()) ?? undefined;
-}
-
 export interface ThoughtDumpCreateOptions {
   repoPath: string;
   branch?: string;
@@ -76,18 +62,15 @@ export class ThoughtDumpService {
 
     let repoPath: string;
     let branch: string;
-    let provider: GitHostProvider | undefined;
 
     if (options?.repoPath) {
       repoPath = options.repoPath;
       branch = await resolveBranch(repoPath, options.branch);
-      provider = options.provider;
     } else {
       const repo = await getFirstRepo();
       if (!repo) return null;
       repoPath = repo.repoPath;
       branch = repo.branch ?? 'main';
-      provider = repo.provider;
     }
 
     const repoInfo = parseRepoPath(repoPath);
@@ -96,52 +79,15 @@ export class ThoughtDumpService {
     const dump = createThoughtDump(text);
     const content = serializeThoughtDump(dump);
 
-    const mode = await SyncEngineService.getMode(repoPath);
-
-    const writeResult = await enqueueRepoWrite(repoInfo.owner, repoInfo.repo, branch, async () => {
-      if (FEATURE_STAGE_PUSH) {
-        return StagingService.stageUpsert({
-          repo: repoPath,
-          branch,
-          filePath: dump.filePath,
-          title: 'Thought dump',
-          content,
-        });
-      }
-
-      if (mode === 'clone') {
-        const author = await resolveAuthor();
-        const token = await resolveToken();
-        return LocalGitWriter.writeAndCommit({
-          repoPath,
-          branch,
-          filePath: dump.filePath,
-          content,
-          message: `Add thought dump`,
-          author,
-          token,
-        });
-      }
-
-      if (FEATURE_USE_MULTI_HOST_WRITE) {
-        const host = getGitHostService(provider);
-        await host.updateFile(
-          repoInfo.owner, repoInfo.repo, dump.filePath, content,
-          `Add thought dump`, branch,
-        );
-        return { success: true, filePath: dump.filePath };
-      }
-
-      const result = await GitHubService.updateFile(
-        repoInfo.owner,
-        repoInfo.repo,
-        dump.filePath,
-        content,
-        `Add thought dump`,
+    const writeResult = await enqueueRepoWrite(repoInfo.owner, repoInfo.repo, branch, async () =>
+      StagingService.stageUpsert({
+        repo: repoPath,
         branch,
-      );
-      return { success: !!result, filePath: dump.filePath };
-    });
+        filePath: dump.filePath,
+        title: 'Thought dump',
+        content,
+      }),
+    );
 
     if (!writeResult.success) {
       console.warn('[ThoughtDumpService] create failed:', writeResult.error);
@@ -230,61 +176,17 @@ export class ThoughtDumpService {
 
     const repoPath = options.repoPath;
     const branch = await resolveBranch(repoPath, options.branch);
-    const provider = options.provider;
     const repoInfo = parseRepoPath(repoPath);
     if (!repoInfo) return false;
 
-    const mode = await SyncEngineService.getMode(repoPath);
-
-    const result = await enqueueRepoWrite(repoInfo.owner, repoInfo.repo, branch, async () => {
-      if (FEATURE_STAGE_PUSH) {
-        return StagingService.stageDelete({
-          repo: repoPath,
-          branch,
-          filePath: options.filePath,
-          title: 'Thought dump',
-        });
-      }
-
-      if (mode === 'clone') {
-        const author = await resolveAuthor();
-        const token = await resolveToken();
-        return LocalGitWriter.deleteAndCommit({
-          repoPath,
-          branch,
-          filePath: options.filePath,
-          message: `Delete thought dump`,
-          author,
-          token,
-        });
-      }
-
-      if (FEATURE_USE_MULTI_HOST_WRITE) {
-        const host = getGitHostService(provider);
-        const lookup = await host.getFileSha(repoInfo.owner, repoInfo.repo, options.filePath, branch);
-        if (lookup.kind === 'not-found') return { success: true, filePath: options.filePath };
-        if (lookup.kind === 'error') return { success: false, error: lookup.message };
-        await host.deleteFile(
-          repoInfo.owner, repoInfo.repo, options.filePath,
-          `Delete thought dump`, lookup.sha!, branch,
-        );
-        return { success: true, filePath: options.filePath };
-      }
-
-      const lookup = await GitHubService.getFileSha(repoInfo.owner, repoInfo.repo, options.filePath, branch);
-      if (lookup.kind === 'not-found') return { success: true, filePath: options.filePath };
-      if (lookup.kind === 'error') return { success: false, error: lookup.message };
-
-      const deleteResult = await GitHubService.deleteFile(
-        repoInfo.owner,
-        repoInfo.repo,
-        options.filePath,
-        `Delete thought dump`,
-        lookup.sha,
+    const result = await enqueueRepoWrite(repoInfo.owner, repoInfo.repo, branch, async () =>
+      StagingService.stageDelete({
+        repo: repoPath,
         branch,
-      );
-      return { success: !!deleteResult, filePath: options.filePath };
-    });
+        filePath: options.filePath,
+        title: 'Thought dump',
+      }),
+    );
 
     return result.success;
   }

--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -7,7 +7,6 @@ import { useAIStore } from '../../stores/aiStore';
 import { initializeModel } from '../AIService';
 import { GITHUB_ITEM_STATES, GitHubItemState, GitHubService } from '../GitHubService';
 import { NoteSyncQueueService } from '../NoteSyncQueueService';
-import { FEATURE_STAGE_PUSH } from '../featureFlags';
 
 export interface ProposedChange {
   type: string;
@@ -205,9 +204,6 @@ async function enqueueNoteSync(
       },
       noteId,
     );
-    if (!FEATURE_STAGE_PUSH) {
-      void NoteSyncQueueService.drain();
-    }
   } catch (error) {
     console.warn('[actionExecutor] enqueueNoteUpsert failed:', error);
   }
@@ -401,9 +397,6 @@ export async function executeToolCall(
               },
               gradedNote.id,
             );
-            if (!FEATURE_STAGE_PUSH) {
-              void NoteSyncQueueService.drain();
-            }
           } catch (error) {
             console.warn('[actionExecutor] grade_questioner_answers sync enqueue failed:', error);
           }
@@ -707,14 +700,6 @@ export async function executeToolCall(
             }
           }
           linked += 1;
-        }
-
-        if (repoPath && !FEATURE_STAGE_PUSH) {
-          try {
-            void NoteSyncQueueService.drain();
-          } catch {
-            // Drain is best-effort — the queue retries on its next trigger.
-          }
         }
 
         return buildSuccessResult({

--- a/src/services/featureFlags.ts
+++ b/src/services/featureFlags.ts
@@ -1,2 +1,1 @@
 export const FEATURE_USE_MULTI_HOST_WRITE = false;
-export const FEATURE_STAGE_PUSH = false;

--- a/src/services/git/CloneMigrationService.ts
+++ b/src/services/git/CloneMigrationService.ts
@@ -1,8 +1,6 @@
 import { StorageService } from '../StorageService';
 import { GitHubService } from '../GitHubService';
-import { AuthService } from '../AuthService';
 import { LocalGitWriter } from './LocalGitWriter';
-import { FEATURE_STAGE_PUSH } from '../featureFlags';
 import { TemplateRepoPreferenceService } from '../TemplateRepoPreferenceService';
 import { useTemplateStore } from '../../stores/templateStore';
 import { serializeTemplate, templateSlug } from '../TemplateMarkdownService';
@@ -48,11 +46,11 @@ function serializeTodo(todo: Partial<Todo>): string {
 
 /**
  * One-shot import that copies every locally-tracked file with `repo ===
- * repoPath` into the cloned working tree, stages + commits each one without
- * pushing, then pushes the whole batch in a single round-trip. The point is
- * to lift offline edits (notes the user wrote in API mode that never reached
- * the remote) into the new clone before the first pull-fast-forward — without
- * this step the next pull would fast-forward over them.
+ * repoPath` into the cloned working tree, staging + committing each one
+ * without pushing. The point is to lift offline edits (notes the user wrote
+ * in API mode that never reached the remote) into the new clone before the
+ * first pull-fast-forward — without this step the next pull would fast-forward
+ * over them. Pushes are owned by the stage/push engine.
  *
  * Safe to re-run: writeAndCommit is idempotent at the working-tree level
  * (overwrites + git-add will produce a no-op commit if content matches HEAD).
@@ -72,7 +70,6 @@ export class CloneMigrationService {
     };
 
     const author = authorFromUser();
-    const token = (await AuthService.getToken()) ?? undefined;
 
     const allNotes = await StorageService.getAllNotes();
     const localNotes = allNotes.filter((n: Note) => n.repo === repoPath && n.filePath);
@@ -168,19 +165,6 @@ export class CloneMigrationService {
             filePath: targetPath,
             error: result.error ?? 'unknown',
           });
-      }
-    }
-
-    const total = report.notes + report.todos + report.canvases + report.templates;
-    if (total > 0 && !FEATURE_STAGE_PUSH) {
-      const pushResult = await LocalGitWriter.push({ repoPath, branch, token });
-      if (!pushResult.success) {
-        report.success = false;
-        report.failures.push({
-          kind: 'push',
-          filePath: '',
-          error: pushResult.error ?? 'unknown',
-        });
       }
     }
 

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -2,9 +2,7 @@ import { create } from 'zustand';
 import { Canvas, CanvasCreateInput, CanvasUpdateInput, sortCanvasesByUpdated } from '../models/Canvas';
 import { StorageService } from '../services/StorageService';
 import { GitHubService } from '../services/GitHubService';
-import { deleteCanvasFromGitHub } from '../services/CanvasGitHubSyncService';
 import { formatSyncError } from '../services/git/formatSyncError';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 import { StagingService } from '../services/git/StagingService';
 import { gitOperationRegistry } from './gitOperationStore';
 
@@ -99,33 +97,17 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()((set, get) =
             if (opId) gitOperationRegistry.fail(opId, 'Sign in to GitHub to delete synced canvases');
             return false;
           }
-          if (FEATURE_STAGE_PUSH) {
-            const staged = await StagingService.stageDelete({
-              repo: canvas.repo,
-              branch: canvas.branch,
-              filePath: canvas.filePath,
-              title: canvas.title,
-            });
-            if (!staged.success) {
-              if (staged.error) console.warn('[CanvasStore] delete stage failed:', staged.error);
-              set({ error: formatSyncError(staged.error, 'delete') });
-              if (opId) gitOperationRegistry.fail(opId, staged.error ?? 'Delete failed');
-              return false;
-            }
-          } else {
-            const remote = await deleteCanvasFromGitHub({
-              repo: canvas.repo,
-              branch: canvas.branch,
-              filePath: canvas.filePath,
-              title: canvas.title,
-              accountId: canvas.accountId,
-            });
-            if (!remote.success) {
-              if (remote.error) console.warn('[CanvasStore] delete sync failed:', remote.error);
-              set({ error: formatSyncError(remote.error, 'delete') });
-              if (opId) gitOperationRegistry.fail(opId, remote.error ?? 'Delete failed');
-              return false;
-            }
+          const staged = await StagingService.stageDelete({
+            repo: canvas.repo,
+            branch: canvas.branch,
+            filePath: canvas.filePath,
+            title: canvas.title,
+          });
+          if (!staged.success) {
+            if (staged.error) console.warn('[CanvasStore] delete stage failed:', staged.error);
+            set({ error: formatSyncError(staged.error, 'delete') });
+            if (opId) gitOperationRegistry.fail(opId, staged.error ?? 'Delete failed');
+            return false;
           }
         }
 

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -5,7 +5,6 @@ import { StorageService } from '../services/StorageService';
 import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
 import type { MutationSucceededEvent, DroppedMutationEvent, NoteDeleteParams } from '../services/NoteSyncQueueService';
 import { SyncEngineService } from '../services/SyncEngineService';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 import { StagingService } from '../services/git/StagingService';
 import { gitOperationRegistry, useGitOperationStore } from './gitOperationStore';
 import type { GitOp } from './gitOperationStore';
@@ -141,34 +140,27 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
               status: 'running',
               attempts: 0,
             });
-          if (FEATURE_STAGE_PUSH) {
-            const mode = await SyncEngineService.getMode(repoPath);
-            const stageResult = await StagingService.stageDelete(deleteParams);
-            if (!stageResult.success) {
-              set({ error: stageResult.error ?? 'Failed to delete note' });
-              return false;
+          const mode = await SyncEngineService.getMode(repoPath);
+          const stageResult = await StagingService.stageDelete(deleteParams);
+          if (!stageResult.success) {
+            set({ error: stageResult.error ?? 'Failed to delete note' });
+            return false;
+          }
+          if (mode === 'clone') {
+            // Clone-mode stageDelete commits the delete locally with no
+            // queue mutation, so the side-channel completion handlers
+            // never fire — finish the local delete right here.
+            const opId = beginDeleteOp();
+            const success = await StorageService.deleteNote(id);
+            if (success) {
+              set((state) => ({ notes: state.notes.filter((n) => n.id !== id) }));
+              gitOperationRegistry.succeed(opId);
+            } else {
+              gitOperationRegistry.fail(opId, 'Failed to delete note locally');
             }
-            if (mode === 'clone') {
-              // Clone-mode stageDelete commits the delete locally with no
-              // queue mutation, so the side-channel completion handlers
-              // never fire — finish the local delete right here.
-              const opId = beginDeleteOp();
-              const success = await StorageService.deleteNote(id);
-              if (success) {
-                set((state) => ({ notes: state.notes.filter((n) => n.id !== id) }));
-                gitOperationRegistry.succeed(opId);
-              } else {
-                gitOperationRegistry.fail(opId, 'Failed to delete note locally');
-              }
-              return success;
-            }
-          } else {
-            await NoteSyncQueueService.enqueueNoteDelete(deleteParams);
+            return success;
           }
           beginDeleteOp();
-          if (!FEATURE_STAGE_PUSH) {
-            void NoteSyncQueueService.drain();
-          }
           return true;
         }
         // Repo-backed note with no derivable path: nothing to enqueue, so

--- a/src/stores/templateStore.ts
+++ b/src/stores/templateStore.ts
@@ -2,14 +2,9 @@ import { create } from 'zustand';
 import { NoteTemplate, NOTE_TEMPLATES } from '../services/TemplateService';
 import { StorageService } from '../services/StorageService';
 import { TemplateRepoPreferenceService } from '../services/TemplateRepoPreferenceService';
-import {
-  syncTemplateToGitHub,
-  deleteTemplateFromGitHub,
-} from '../services/TemplateGitHubSyncService';
 import { serializeTemplate, templateSlug } from '../services/TemplateMarkdownService';
 import { generateId } from '../utils/ids';
 import { formatSyncError } from '../services/git/formatSyncError';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 import { StagingService } from '../services/git/StagingService';
 
 interface TemplateState {
@@ -47,31 +42,18 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
       updatedAt: Date.now(),
     };
 
-    let synced = template;
+    const synced = template;
     const pref = await TemplateRepoPreferenceService.get();
     if (pref) {
-      if (FEATURE_STAGE_PUSH) {
-        const staged = await StagingService.stageUpsert({
-          repo: pref.repoPath,
-          branch: pref.branch,
-          filePath: template.filePath ?? `templates/${templateSlug(template.name)}.md`,
-          title: template.name,
-          content: serializeTemplate({ ...template, filePath: undefined }),
-        });
-        if (!staged.success) {
-          console.warn(`[templateStore] Failed to stage template "${template.name}" to GitHub: ${formatSyncError(staged.error, 'upsert')}`);
-        }
-      } else {
-        const result = await syncTemplateToGitHub({
-          repoPath: pref.repoPath,
-          branch: pref.branch,
-          template,
-        });
-        if (result.success && result.filePath) {
-          synced = { ...template, filePath: result.filePath };
-        } else if (!result.success) {
-          console.warn(`[templateStore] Failed to sync template "${template.name}" to GitHub: ${formatSyncError(result.error, 'upsert')}`);
-        }
+      const staged = await StagingService.stageUpsert({
+        repo: pref.repoPath,
+        branch: pref.branch,
+        filePath: template.filePath ?? `templates/${templateSlug(template.name)}.md`,
+        title: template.name,
+        content: serializeTemplate({ ...template, filePath: undefined }),
+      });
+      if (!staged.success) {
+        console.warn(`[templateStore] Failed to stage template "${template.name}" to GitHub: ${formatSyncError(staged.error, 'upsert')}`);
       }
     }
 
@@ -89,28 +71,15 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
 
     const pref = await TemplateRepoPreferenceService.get();
     if (pref) {
-      if (FEATURE_STAGE_PUSH) {
-        const staged = await StagingService.stageUpsert({
-          repo: pref.repoPath,
-          branch: pref.branch,
-          filePath: merged.filePath ?? `templates/${templateSlug(merged.name)}.md`,
-          title: merged.name,
-          content: serializeTemplate({ ...merged, filePath: undefined }),
-        });
-        if (!staged.success) {
-          console.warn(`[templateStore] Failed to stage template "${merged.name}" to GitHub: ${formatSyncError(staged.error, 'upsert')}`);
-        }
-      } else {
-        const result = await syncTemplateToGitHub({
-          repoPath: pref.repoPath,
-          branch: pref.branch,
-          template: merged,
-        });
-        if (result.success && result.filePath) {
-          merged.filePath = result.filePath;
-        } else if (!result.success) {
-          console.warn(`[templateStore] Failed to sync template "${merged.name}" to GitHub: ${formatSyncError(result.error, 'upsert')}`);
-        }
+      const staged = await StagingService.stageUpsert({
+        repo: pref.repoPath,
+        branch: pref.branch,
+        filePath: merged.filePath ?? `templates/${templateSlug(merged.name)}.md`,
+        title: merged.name,
+        content: serializeTemplate({ ...merged, filePath: undefined }),
+      });
+      if (!staged.success) {
+        console.warn(`[templateStore] Failed to stage template "${merged.name}" to GitHub: ${formatSyncError(staged.error, 'upsert')}`);
       }
     }
 
@@ -125,26 +94,14 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
 
     const pref = await TemplateRepoPreferenceService.get();
     if (pref && template.filePath) {
-      if (FEATURE_STAGE_PUSH) {
-        const staged = await StagingService.stageDelete({
-          repo: pref.repoPath,
-          branch: pref.branch,
-          filePath: template.filePath,
-          title: template.name,
-        });
-        if (!staged.success) {
-          console.warn(`[templateStore] Failed to stage template "${template.name}" deletion: ${formatSyncError(staged.error, 'delete')}`);
-        }
-      } else {
-        const delResult = await deleteTemplateFromGitHub({
-          repoPath: pref.repoPath,
-          branch: pref.branch,
-          filePath: template.filePath,
-          name: template.name,
-        });
-        if (!delResult.success) {
-          console.warn(`[templateStore] Failed to delete template "${template.name}" from GitHub: ${formatSyncError(delResult.error, 'delete')}`);
-        }
+      const staged = await StagingService.stageDelete({
+        repo: pref.repoPath,
+        branch: pref.branch,
+        filePath: template.filePath,
+        title: template.name,
+      });
+      if (!staged.success) {
+        console.warn(`[templateStore] Failed to stage template "${template.name}" deletion: ${formatSyncError(staged.error, 'delete')}`);
       }
     }
 

--- a/src/stores/todoStore.ts
+++ b/src/stores/todoStore.ts
@@ -2,9 +2,7 @@ import { create } from 'zustand';
 import { Todo, TodoCreateInput, TodoUpdateInput, reorderTodos } from '../models/Todo';
 import { StorageService } from '../services/StorageService';
 import { GitHubService } from '../services/GitHubService';
-import { deleteTodoFromGitHub } from '../services/TodoGitHubSyncService';
 import { formatSyncError } from '../services/git/formatSyncError';
-import { FEATURE_STAGE_PUSH } from '../services/featureFlags';
 import { StagingService } from '../services/git/StagingService';
 import { gitOperationRegistry } from './gitOperationStore';
 
@@ -100,32 +98,17 @@ export const useTodoStore = create<TodoState & TodoActions>()((set, get) => ({
             if (opId) gitOperationRegistry.fail(opId, 'Cannot delete repo-backed todo while signed out of GitHub');
             return false;
           }
-          if (FEATURE_STAGE_PUSH) {
-            const staged = await StagingService.stageDelete({
-              repo: todoToDelete!.repo!,
-              branch: todoToDelete!.branch,
-              filePath: todoToDelete!.filePath!,
-              title: todoToDelete!.text,
-            });
-            if (!staged.success) {
-              if (staged.error) console.warn('[TodoStore] delete stage failed:', staged.error);
-              set({ error: formatSyncError(staged.error, 'delete') });
-              if (opId) gitOperationRegistry.fail(opId, staged.error ?? 'Delete failed');
-              return false;
-            }
-          } else {
-            const remote = await deleteTodoFromGitHub({
-              repo: todoToDelete!.repo!,
-              branch: todoToDelete!.branch,
-              filePath: todoToDelete!.filePath!,
-              text: todoToDelete!.text,
-            });
-            if (!remote.success) {
-              if (remote.error) console.warn('[TodoStore] delete sync failed:', remote.error);
-              set({ error: formatSyncError(remote.error, 'delete') });
-              if (opId) gitOperationRegistry.fail(opId, remote.error ?? 'Delete failed');
-              return false;
-            }
+          const staged = await StagingService.stageDelete({
+            repo: todoToDelete!.repo!,
+            branch: todoToDelete!.branch,
+            filePath: todoToDelete!.filePath!,
+            title: todoToDelete!.text,
+          });
+          if (!staged.success) {
+            if (staged.error) console.warn('[TodoStore] delete stage failed:', staged.error);
+            set({ error: formatSyncError(staged.error, 'delete') });
+            if (opId) gitOperationRegistry.fail(opId, staged.error ?? 'Delete failed');
+            return false;
           }
         }
 

--- a/src/utils/chatThreadSummary.ts
+++ b/src/utils/chatThreadSummary.ts
@@ -97,7 +97,7 @@ export function buildThreadSummary(thread: ChatThread): ChatThreadSummary {
   return {
     id: thread.id,
     title: deriveThreadTitle(thread),
-    updatedAt: thread.updatedAt,
+    updatedAt: Number.isFinite(thread.updatedAt) ? thread.updatedAt : Date.now(),
     messageCount: thread.messages.length,
     ...(preview ? { preview } : {}),
   };


### PR DESCRIPTION
## Summary

Two changes:

**1. fix(chat): guard thread-card timestamp render to stop instant crash**
The AI chat crashed instantly on open when a persisted thread summary had a missing/NaN `updatedAt`. `ChatThreadCard` called `formatDistanceToNow(thread.updatedAt)` unguarded — `date-fns` throws `RangeError: Invalid time value`, a render error that kills the whole chat screen (the same crash class previously fixed for message bubbles, missed for thread cards). Reproduced with a test, then fixed:
- `ChatThreadCard` guards the render (`Number.isFinite` → empty label).
- `buildThreadSummary` normalizes a bad `updatedAt` to `Date.now()` instead of propagating NaN.
- Regression test `__tests__/chat-thread-card-crash.test.tsx` (NaN renders, missing renders, valid renders "ago", summary normalization).

**2. feat(git): make stage-then-push the default, remove FEATURE_STAGE_PUSH flag**
The stage-then-push workflow (PR #863) is now the only behavior. Removed the `FEATURE_STAGE_PUSH` compile-time flag and deleted every old inline-push branch across all rewire sites (editor save, todos, canvases, templates, thought dumps, color changes, deletes, AI saves, conflict merges, folder deletes, clone migration, scheduler, background task, floating button mount, notifications). Net −583 lines of dead code.

## Verification

- `yarn ts:check` ✅
- `yarn jest` — 2168 passed, 0 failed (7 pre-existing skips) ✅
- `yarn eslint . --ext .ts,.tsx` — 0 errors ✅
- `yarn format:check` ✅
- `grep -rn "FEATURE_STAGE_PUSH"` — zero matches ✅
