### PR TITLE
fix(filters): inset filter chip row from screen edge

### DIFF
--- a/__tests__/filter-bar-edge.test.tsx
+++ b/__tests__/filter-bar-edge.test.tsx
@@ -37,7 +37,7 @@ describe('FilterBar edge-to-edge layout', () => {
     expect(wrapStyle.marginBottom).toBe(4);
   });
 
-  it('starts the chip row at x=0 with only a small trailing padding', () => {
+  it('insets the chip row with symmetric side padding so the first chip is not flush on load', () => {
     const { getByTestId } = renderFilterBar();
 
     const scroll = getByTestId('filter-bar.row');
@@ -45,8 +45,7 @@ describe('FilterBar edge-to-edge layout', () => {
 
     expect(rowStyle.marginLeft ?? 0).toBe(0);
     expect(rowStyle.marginRight ?? 0).toBe(0);
-    expect(rowStyle.paddingLeft ?? 0).toBe(0);
-    expect(rowStyle.paddingRight).toBe(12);
+    expect(rowStyle.paddingHorizontal).toBe(12);
     expect(rowStyle.gap).toBe(6);
   });
 });

--- a/docs/wiki/filter-persistence.md
+++ b/docs/wiki/filter-persistence.md
@@ -8,3 +8,11 @@ Notes and todos retain list filters across app restarts with AsyncStorage keys i
 - Todo completed visibility: `@gitnotes:filters:todo-completed`
 
 The filter hooks load persisted values before writing changes, so initial empty state never replaces stored selections during hydration. Invalid stored JSON leaves the configured initial filters in place.
+
+## Filter bar UI
+
+Active filters render as a horizontally scrolling chip row in `FilterBar.tsx` (used by the Todo and Notes screens). Layout rule:
+
+- The `ScrollView` `contentContainerStyle` (`styles.row`) uses `paddingHorizontal: 12` so on load the first chip is inset from the left edge; the row stays scrollable so the user can swipe chips to the screen edges. The outer wrapper keeps `marginHorizontal: 0`.
+
+Tests: `__tests__/filter-bar-edge.test.tsx` asserts the scroller carries symmetric side padding while the outer wrapper stays margin-free.

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -58,7 +58,7 @@ export function FilterBar({ filters, onRemoveFilter, onClearAll }: FilterBarProp
 
 const styles = StyleSheet.create({
   wrap: { marginHorizontal: 0, marginTop: 4, marginBottom: 4 },
-  row: { gap: 6, paddingTop: 6, paddingBottom: 8, paddingRight: 12 },
+  row: { gap: 6, paddingTop: 6, paddingBottom: 8, paddingHorizontal: 12 },
   chip: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
## Summary

Same fix as #865 but for the todo/notes filter chip row.

`FilterBar` (used by the Todo and Notes screens) rendered its horizontally scrollable chip row with only `paddingRight: 12` in the `ScrollView` `contentContainerStyle`, so on load the first chip sat flush against the left screen edge.

**Change:** `styles.row` now uses `paddingHorizontal: 12` — the first chip is inset from the left edge on load, while the row stays fully scrollable so the user can swipe chips to the screen edges.

## Changes

| File | Change |
|------|--------|
| `src/components/FilterBar.tsx` | `paddingRight` → `paddingHorizontal` on the chip row |
| `__tests__/filter-bar-edge.test.tsx` | Assert symmetric side padding |
| `docs/wiki/filter-persistence.md` | Documented filter bar layout |

## Verification

- `yarn ts:check` ✅
- `yarn jest` — 2168 tests pass ✅
- `yarn eslint` on changed files ✅