### PR TITLE
fix(git): wire StagePushScheduler into bootstrap so floating stage button appears

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -47,6 +47,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { reconcileThoughtDumps } from './src/services/ai/thoughtDumpIndexing';
 import { LastSelectionPreferenceService } from './src/services/LastSelectionPreferenceService';
 import * as PushNotificationService from './src/services/PushNotificationService';
+import * as StagePushScheduler from './src/services/StagePushScheduler';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -115,6 +116,7 @@ export default function App() {
     }
     PushNotificationService.attachToScheduler();
     PushNotificationService.subscribeToPushProgress();
+    StagePushScheduler.startScheduler();
     void reconcileThoughtDumps().catch(() => {});
     void LastSelectionPreferenceService.migrateFromLegacy();
   }, []);

--- a/__tests__/services/StagePushScheduler.test.ts
+++ b/__tests__/services/StagePushScheduler.test.ts
@@ -61,6 +61,9 @@ const flushAsync = async (rounds = 20): Promise<void> => {
 };
 
 describe('StagePushScheduler', () => {
+  let loadStagedSpy: jest.SpiedFunction<() => Promise<void>>;
+  let registerQueueSubscriptionSpy: jest.SpiedFunction<() => void>;
+
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
@@ -73,6 +76,14 @@ describe('StagePushScheduler', () => {
       pushQueue: [],
       pendingCount: 0,
     });
+    // No-op the store actions startScheduler() triggers so the real async
+    // loadStaged cannot clobber fixture state mid-test.
+    loadStagedSpy = jest
+      .spyOn(useStageStore.getState(), 'loadStaged')
+      .mockResolvedValue(undefined);
+    registerQueueSubscriptionSpy = jest
+      .spyOn(useStageStore.getState(), 'registerQueueSubscription')
+      .mockImplementation(() => undefined);
     (StorageService.getSavedRepositories as jest.Mock).mockImplementation(async () => [
       { path: REPO_A },
       { path: REPO_B },
@@ -206,5 +217,13 @@ describe('StagePushScheduler', () => {
     expect(failures).toEqual([{ key: 'a/repo::main', error: 'boom' }]);
     expect(useStageStore.getState().isPushing['a/repo::main']).toBe(false);
     expect(useStageStore.getState().pushQueue).toHaveLength(0);
+  });
+
+  test('startScheduler() loads staged state once and registers the queue subscription', async () => {
+    startScheduler();
+    await flushAsync();
+
+    expect(loadStagedSpy).toHaveBeenCalledTimes(1);
+    expect(registerQueueSubscriptionSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/StagePushScheduler.ts
+++ b/src/services/StagePushScheduler.ts
@@ -134,6 +134,9 @@ export function startScheduler(): void {
   if (schedulerRunning) return;
   schedulerRunning = true;
   useStageStore.getState().registerQueueSubscription();
+  // Seed pendingCount at boot so the staged-changes UI reflects the current
+  // state immediately, not only after later queue-churn notifications.
+  void useStageStore.getState().loadStaged();
   unsubscribeStaged = useStageStore.subscribe(onStagedChanged);
   resetIdleTimer();
 }


### PR DESCRIPTION
Fixes the missing push button. The floating stage button was mounted but hid itself when `pendingCount === 0` — and `pendingCount` was only populated on Stage-screen mount or queue-churn, because `startScheduler()` was never called at boot. This wires it into `App.tsx` bootstrap and seeds an initial `loadStaged()`.

Verification: ts:check, full jest (2168+ pass, 0 fail), eslint 0 errors.