### PR TITLE
fix(ui): keep git-action lock spinner inside the card bounds

### DIFF
--- a/__tests__/notes-delete-lock.test.tsx
+++ b/__tests__/notes-delete-lock.test.tsx
@@ -485,7 +485,7 @@ describe('notes delete lock', () => {
     expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy();
   });
 
-  it('places the lock spinner inside the card bounds (right/top 16, relative wrapper)', async () => {
+  it('places the lock spinner inside the card bounds (right/top 24, relative wrapper)', async () => {
     const note = createNote({ id: 'n-pos', title: 'Position', repo: 'owner/repo', branch: 'main', filePath: 'notes/position.md' });
     useNoteStore.setState({ notes: [note], isLoading: false, error: null });
 
@@ -499,10 +499,10 @@ describe('notes delete lock', () => {
     expect(lockView).toBeTruthy();
     const lockStyle = (lockView?.props as { style?: Record<string, unknown> }).style;
     expect(lockStyle?.position).toBe('absolute');
-    // The card is inset by marginHorizontal:16, so an in-bounds spinner must be
-    // at least 16px from the wrapper's right/top edges.
-    expect(lockStyle?.right).toBeGreaterThanOrEqual(16);
-    expect(lockStyle?.top).toBeGreaterThanOrEqual(16);
+    // The card is inset by marginHorizontal:16 and rounded by borderRadius:12, so
+    // an in-bounds spinner must sit at least 24px from the wrapper's right/top edges.
+    expect(lockStyle?.right).toBeGreaterThanOrEqual(24);
+    expect(lockStyle?.top).toBeGreaterThanOrEqual(24);
 
     const wrapper = lockView?.parent?.parent;
     expect(wrapper).toBeTruthy();

--- a/docs/wiki/sync-engine.md
+++ b/docs/wiki/sync-engine.md
@@ -292,6 +292,17 @@ async function processQueue() {
 }
 ```
 
+## Per-Row Lock UI
+
+While a git operation is in flight for a file, the row cards in the Notes and Todo lists gray out and show a small spinner in the card's top-right corner (`note-row.lock-spinner` / `todo-row.lock-spinner`). The state comes from `useEntityLock` (`src/hooks/useGitOpLock.ts`), which mirrors ops from the `gitOperationStore` registry.
+
+Layout rule:
+
+- The spinner overlay is positioned `absolute` with `right: 24, top: 24` relative to the row wrapper (`LockedNoteRow` / `LockedTodoRow`). The 24px offsets keep the spinner inside the card's bounds, clear of the 12px rounded card corner.
+- Do not lower the offsets below 24 — the note card is inset by `marginHorizontal: 16` and both cards use `borderRadius: 12`, so smaller offsets make the spinner overhang the card edge.
+
+Tests: `__tests__/notes-delete-lock.test.tsx` asserts the spinner wrapper sits at least 24px from the row wrapper's right/top edges.
+
 ## Testing
 
 ```typescript

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -143,8 +143,8 @@ function LockedNoteRow({
 const styles = StyleSheet.create({
   rowLockTrailing: {
     position: 'absolute',
-    right: 16,
-    top: 16,
+    right: 24,
+    top: 24,
     zIndex: 5,
   },
 });

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -89,7 +89,7 @@ function LockedTodoRow({ item, selected, selectionMode, onToggleSelect, onPress,
             size="small"
             testID="todo-row.lock-spinner"
             color={colors.primary}
-            style={{ position: 'absolute', right: 16, top: 16, zIndex: 5 }}
+            style={{ position: 'absolute', right: 24, top: 24, zIndex: 5 }}
           />
         ) : null}
       </View>


### PR DESCRIPTION
## Summary

When a git action is in flight, the Notes and Todo list cards gray out and show a small spinner in the top-right corner. That spinner was positioned at `right: 16, top: 16` relative to the row wrapper — but the note card is inset by `marginHorizontal: 16` with `borderRadius: 12`, so the spinner sat flush at the card's outer edge and visibly overhung the rounded corner.

**Change:** spinner offsets moved to `right: 24, top: 24` in `LockedNoteRow` (NotesListScreen) and `LockedTodoRow` (TodoListScreen), keeping the spinner fully inside the card's bounds, clear of the 12px rounded corner.

## Changes

| File | Change |
|------|--------|
| `src/screens/NotesListScreen.tsx` | `rowLockTrailing` offsets 16 → 24 |
| `src/screens/TodoListScreen.tsx` | Inline spinner offsets 16 → 24 |
| `__tests__/notes-delete-lock.test.tsx` | Assert spinner sits ≥ 24px from row wrapper edges |
| `docs/wiki/sync-engine.md` | Documented per-row lock UI layout rule |

## Verification

- `yarn ts:check` ✅
- `yarn jest` — 2168 tests pass ✅
- `yarn eslint` — 0 errors (33 pre-existing warnings unrelated to this change) ✅