### PR TITLE
feat(ui): floating buttons never overlap + stage button hold animation matches AI button

### DIFF
--- a/__tests__/components/FloatingStageButton.test.tsx
+++ b/__tests__/components/FloatingStageButton.test.tsx
@@ -134,6 +134,28 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
+const mockHandlePressIn = jest.fn();
+const mockHandlePressOut = jest.fn();
+const mockHandleHoldComplete = jest.fn();
+
+jest.mock('../../src/components/ai/useFloatingAIButtonAffordances', () => ({
+  FLOATING_AI_BUTTON_LONG_PRESS_MS: 450,
+  PRESS_SCALE_FACTOR: 0.08,
+  useFloatingAIButtonAffordances: () => ({
+    entranceProgress: { value: 1 },
+    pressProgress: { value: 0 },
+    holdProgress: { value: 0 },
+    hintProgress: { value: 0 },
+    hubDiscovered: false,
+    discoveryChecked: true,
+    handlePressIn: mockHandlePressIn,
+    handlePressOut: mockHandlePressOut,
+    handleHoldComplete: mockHandleHoldComplete,
+    cancelAffordances: jest.fn(),
+    markHubDiscovered: jest.fn(),
+  }),
+}));
+
 import { FloatingAIButton } from '../../src/components/ai/FloatingAIButton';
 
 describe('FloatingStageButton', () => {
@@ -146,6 +168,9 @@ describe('FloatingStageButton', () => {
     mockNavigate.mockClear();
     mockPushAll.mockClear();
     mockRequestPush.mockClear();
+    mockHandlePressIn.mockClear();
+    mockHandlePressOut.mockClear();
+    mockHandleHoldComplete.mockClear();
     jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(false);
   });
 
@@ -171,6 +196,7 @@ describe('FloatingStageButton', () => {
 
     fireEvent(getByTestId('floating-stage.button.navigate-stage'), 'longPress');
 
+    expect(mockHandleHoldComplete).toHaveBeenCalledTimes(1);
     expect(mockPushAll).toHaveBeenCalledTimes(1);
     jest.useRealTimers();
   });

--- a/__tests__/floatingButtonLayout.test.ts
+++ b/__tests__/floatingButtonLayout.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  COLLISION_GAP,
+  getButtonRect,
+  publishButtonRect,
+  rectsOverlap,
+  resolveNonOverlapping,
+  resolveNonOverlappingWithRect,
+  subscribeButtonRects,
+  type FloatingButtonGeometry,
+} from '../src/components/floatingButtonLayout';
+
+const STANDARD_GEOMETRY: FloatingButtonGeometry = {
+  viewportWidth: 320,
+  viewportHeight: 480,
+  leftClearance: 16,
+  rightClearance: 16,
+  topBound: 60,
+  tabBarHeight: 0,
+  minimumBottomClearance: 100,
+};
+
+const SHORT_GEOMETRY: FloatingButtonGeometry = {
+  ...STANDARD_GEOMETRY,
+  viewportHeight: 220,
+};
+
+describe('rectsOverlap', () => {
+  it('returns true when the rects intersect', () => {
+    expect(rectsOverlap(
+      { x: 0, y: 0, size: 50 },
+      { x: 10, y: 10, size: 50 },
+      COLLISION_GAP,
+    )).toBe(true);
+  });
+
+  it('returns true when the rects are within the gap', () => {
+    expect(rectsOverlap(
+      { x: 0, y: 0, size: 50 },
+      { x: 58, y: 0, size: 50 },
+      COLLISION_GAP,
+    )).toBe(true);
+  });
+
+  it('returns false when the rects are farther apart than the gap', () => {
+    expect(rectsOverlap(
+      { x: 0, y: 0, size: 50 },
+      { x: 100, y: 0, size: 50 },
+      COLLISION_GAP,
+    )).toBe(false);
+  });
+});
+
+describe('resolveNonOverlapping', () => {
+  it('returns the desired position unchanged when the other rect is absent', () => {
+    const desired = { x: 248, y: 216 };
+
+    const resolved = resolveNonOverlappingWithRect(
+      desired,
+      56,
+      STANDARD_GEOMETRY,
+      null,
+    );
+
+    expect(resolved).toEqual(desired);
+  });
+
+  it('returns the desired position unchanged when it does not overlap', () => {
+    publishButtonRect('stage', { x: 16, y: 300, size: 52 });
+    const desired = { x: 248, y: 216 };
+
+    const resolved = resolveNonOverlapping('ai', desired, 56, STANDARD_GEOMETRY);
+
+    expect(resolved).toEqual(desired);
+  });
+
+  it('stacks above the other button on the same edge', () => {
+    publishButtonRect('stage', { x: 248, y: 260, size: 52 });
+
+    const resolved = resolveNonOverlapping('ai', { x: 248, y: 260 }, 56, STANDARD_GEOMETRY);
+
+    expect(resolved).toEqual({ x: 248, y: 192 });
+  });
+
+  it('stacks below the other button on the same edge when above is blocked', () => {
+    publishButtonRect('stage', { x: 248, y: 60, size: 52 });
+
+    const resolved = resolveNonOverlapping('ai', { x: 248, y: 60 }, 56, STANDARD_GEOMETRY);
+
+    expect(resolved).toEqual({ x: 248, y: 124 });
+  });
+
+  it('flips to the opposite edge when both vertical stack slots are clamped and blocked', () => {
+    publishButtonRect('stage', { x: 248, y: 60, size: 52 });
+
+    const resolved = resolveNonOverlapping('ai', { x: 248, y: 60 }, 56, SHORT_GEOMETRY);
+
+    expect(resolved).toEqual({ x: 16, y: 60 });
+  });
+
+  it('never returns a position outside the safe bounds', () => {
+    const collidingStageRects = [
+      { x: 248, y: 60, size: 52 },
+      { x: 248, y: 260, size: 52 },
+      { x: 16, y: 60, size: 52 },
+      { x: 16, y: 300, size: 52 },
+    ];
+
+    for (const stageRect of collidingStageRects) {
+      publishButtonRect('stage', stageRect);
+      const safeBottom = STANDARD_GEOMETRY.viewportHeight - 100;
+
+      const resolved = resolveNonOverlapping('ai', { x: stageRect.x, y: stageRect.y }, 56, STANDARD_GEOMETRY);
+
+      expect(resolved.y).toBeGreaterThanOrEqual(STANDARD_GEOMETRY.topBound);
+      expect(resolved.y + 56).toBeLessThanOrEqual(safeBottom);
+      expect(resolved.x).toBeGreaterThanOrEqual(STANDARD_GEOMETRY.leftClearance);
+      expect(resolved.x + 56).toBeLessThanOrEqual(
+        STANDARD_GEOMETRY.viewportWidth - STANDARD_GEOMETRY.rightClearance,
+      );
+    }
+  });
+});
+
+describe('button rect registry', () => {
+  it('stores and returns published rects per button id', () => {
+    publishButtonRect('ai', { x: 248, y: 216, size: 56 });
+
+    expect(getButtonRect('ai')).toEqual({ x: 248, y: 216, size: 56 });
+  });
+
+  it('notifies subscribers on every publish and stops after unsubscribe', () => {
+    const seenRects: unknown[] = [];
+    const unsubscribe = subscribeButtonRects(() => {
+      seenRects.push(getButtonRect('ai'));
+    });
+
+    publishButtonRect('ai', { x: 248, y: 216, size: 56 });
+    publishButtonRect('ai', { x: 16, y: 168, size: 56 });
+
+    expect(seenRects).toEqual([
+      { x: 248, y: 216, size: 56 },
+      { x: 16, y: 168, size: 56 },
+    ]);
+
+    unsubscribe();
+    publishButtonRect('ai', { x: 248, y: 96, size: 56 });
+
+    expect(seenRects).toHaveLength(2);
+  });
+});

--- a/src/components/ai/FloatingAIButton.tsx
+++ b/src/components/ai/FloatingAIButton.tsx
@@ -27,6 +27,7 @@ import {
 } from './FloatingAIHubMenu';
 import { useFloatingAIButtonPosition } from './useFloatingAIButtonPosition';
 import { useFloatingAIButtonPanGesture } from './useFloatingAIButtonPanGesture';
+import { useFloatingButtonCollision } from '../floatingButtonLayout';
 import {
   FLOATING_AI_BUTTON_LONG_PRESS_MS,
   PRESS_SCALE_FACTOR,
@@ -47,6 +48,13 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
   const [verticalDirection, setVerticalDirection] = useState<MenuDirection>(-1);
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const position = useFloatingAIButtonPosition();
+  useFloatingButtonCollision('ai', {
+    translateX: position.translateX,
+    translateY: position.translateY,
+    dragActive: position.dragActive,
+    size: FLOATING_AI_BUTTON_SIZE,
+    geometry: position.geometry,
+  });
   const {
     geometry,
     translateX,

--- a/src/components/ai/FloatingAIHubMenu.tsx
+++ b/src/components/ai/FloatingAIHubMenu.tsx
@@ -5,7 +5,6 @@ import {
   Canvas,
   Circle,
   ColorMatrix,
-  DashPathEffect,
   Group,
   Paint,
 } from '@shopify/react-native-skia';
@@ -15,6 +14,7 @@ import Animated, {
   type SharedValue,
 } from 'react-native-reanimated';
 import { RADII } from '../../theme/tokens';
+import { HoldProgressRing } from '../ui/HoldProgressRing';
 import {
   FLOATING_AI_BUTTON_SIZE,
   FLOATING_AI_HUB_ITEMS,
@@ -29,9 +29,6 @@ const LIQUID_CANVAS_INSET = (
   LIQUID_CANVAS_SIZE - FLOATING_AI_BUTTON_SIZE
 ) / 2;
 const LIQUID_CENTER = LIQUID_CANVAS_SIZE / 2;
-export const HOLD_RING_RADIUS = FLOATING_AI_BUTTON_SIZE / 2 + 6;
-const HOLD_RING_STROKE_WIDTH = 3.5;
-export const HOLD_RING_CIRCUMFERENCE = 2 * Math.PI * HOLD_RING_RADIUS;
 const GOOEY_ALPHA_MATRIX = [
   1, 0, 0, 0, 0,
   0, 1, 0, 0, 0,
@@ -45,6 +42,8 @@ export const MENU_SPRING = {
   stiffness: 210,
   overshootClamping: true,
 } as const;
+
+export { HOLD_RING_CIRCUMFERENCE, HOLD_RING_RADIUS } from '../ui/HoldProgressRing';
 
 interface HubItemContent {
   readonly label: string;
@@ -168,7 +167,7 @@ interface FloatingAIHubMenuProps {
   readonly horizontalDirection: MenuDirection;
   readonly verticalDirection: MenuDirection;
   readonly progress: SharedValue<number>;
-  readonly holdProgress?: SharedValue<number>;
+  readonly holdProgress: SharedValue<number>;
   readonly hintProgress?: SharedValue<number>;
   readonly primaryColor: string;
   readonly iconColor: string;
@@ -195,15 +194,6 @@ export function FloatingAIHubMenu({
 }: FloatingAIHubMenuProps) {
   const canvasProgress = useDerivedValue(
     () => Math.max(progress.value, hintProgress?.value ?? 0),
-  );
-  const ringIntervals = useDerivedValue(
-    () => [
-      (holdProgress?.value ?? 0) * HOLD_RING_CIRCUMFERENCE,
-      HOLD_RING_CIRCUMFERENCE,
-    ],
-  );
-  const ringOpacity = useDerivedValue(
-    () => Math.min(1, (holdProgress?.value ?? 0) * 3),
   );
 
   return (
@@ -238,23 +228,15 @@ export function FloatingAIHubMenu({
               />
             ))}
           </Group>
-
-          <Circle
-            cx={LIQUID_CENTER}
-            cy={LIQUID_CENTER}
-            r={HOLD_RING_RADIUS}
-            color={primaryColor}
-            style="stroke"
-            strokeWidth={HOLD_RING_STROKE_WIDTH}
-            strokeCap="round"
-            opacity={ringOpacity}
-            origin={{ x: LIQUID_CENTER, y: LIQUID_CENTER }}
-            transform={[{ rotate: -Math.PI / 2 }]}
-          >
-            <DashPathEffect intervals={ringIntervals} />
-          </Circle>
         </Canvas>
       )}
+
+      <HoldProgressRing
+        progress={holdProgress}
+        size={FLOATING_AI_BUTTON_SIZE}
+        color={primaryColor}
+        reduceMotionEnabled={reduceMotionEnabled}
+      />
 
       {menuOpen && FLOATING_AI_HUB_ITEMS.map((item) => (
         <HubMenuItem

--- a/src/components/ai/useFloatingAIButtonPanGesture.ts
+++ b/src/components/ai/useFloatingAIButtonPanGesture.ts
@@ -1,10 +1,19 @@
+import { useEffect } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
-import { runOnJS, withSpring } from 'react-native-reanimated';
+import { runOnJS, useSharedValue, withSpring } from 'react-native-reanimated';
 import type { FloatingAIButtonPositionState } from './useFloatingAIButtonPosition';
 import {
+  FLOATING_AI_BUTTON_SIZE,
   resolveFloatingAIButtonPlacement,
   type MenuDirection,
 } from './floatingAIButtonGeometry';
+import {
+  getButtonRect,
+  publishButtonRect,
+  resolveNonOverlappingWithRect,
+  subscribeButtonRects,
+  type FloatingButtonRect,
+} from '../floatingButtonLayout';
 
 const POSITION_SPRING = {
   mass: 1,
@@ -34,6 +43,14 @@ export function useFloatingAIButtonPanGesture(
     markPositionInteractionStarted,
     savePosition,
   } = position;
+  const otherRect = useSharedValue<FloatingButtonRect | null>(null);
+
+  useEffect(() => {
+    otherRect.value = getButtonRect('stage');
+    return subscribeButtonRects(() => {
+      otherRect.value = getButtonRect('stage');
+    });
+  }, [otherRect]);
 
   return Gesture.Pan()
     .onBegin(() => {
@@ -56,15 +73,26 @@ export function useFloatingAIButtonPanGesture(
         latestGeometry.value,
       );
       const normalizedPosition = placement.position;
+      const collisionFreePosition = resolveNonOverlappingWithRect(
+        normalizedPosition,
+        FLOATING_AI_BUTTON_SIZE,
+        latestGeometry.value,
+        otherRect.value,
+      );
 
-      translateX.value = withSpring(normalizedPosition.x, POSITION_SPRING);
-      translateY.value = withSpring(normalizedPosition.y, POSITION_SPRING);
-      savedTranslateX.value = normalizedPosition.x;
-      savedTranslateY.value = normalizedPosition.y;
+      translateX.value = withSpring(collisionFreePosition.x, POSITION_SPRING);
+      translateY.value = withSpring(collisionFreePosition.y, POSITION_SPRING);
+      savedTranslateX.value = collisionFreePosition.x;
+      savedTranslateY.value = collisionFreePosition.y;
 
       runOnJS(actions.setHorizontalDirection)(placement.horizontalDirection);
       runOnJS(actions.setVerticalDirection)(placement.verticalDirection);
-      runOnJS(savePosition)(normalizedPosition);
+      runOnJS(savePosition)(collisionFreePosition);
+      runOnJS(publishButtonRect)('ai', {
+        x: collisionFreePosition.x,
+        y: collisionFreePosition.y,
+        size: FLOATING_AI_BUTTON_SIZE,
+      });
     })
     .onFinalize((_event, successful) => {
       dragActive.value = false;
@@ -78,16 +106,27 @@ export function useFloatingAIButtonPanGesture(
         savedPosition,
         latestGeometry.value,
       ).position;
-      translateX.value = withSpring(normalizedPosition.x, POSITION_SPRING);
-      translateY.value = withSpring(normalizedPosition.y, POSITION_SPRING);
-      savedTranslateX.value = normalizedPosition.x;
-      savedTranslateY.value = normalizedPosition.y;
+      const collisionFreePosition = resolveNonOverlappingWithRect(
+        normalizedPosition,
+        FLOATING_AI_BUTTON_SIZE,
+        latestGeometry.value,
+        otherRect.value,
+      );
+      translateX.value = withSpring(collisionFreePosition.x, POSITION_SPRING);
+      translateY.value = withSpring(collisionFreePosition.y, POSITION_SPRING);
+      savedTranslateX.value = collisionFreePosition.x;
+      savedTranslateY.value = collisionFreePosition.y;
 
       if (
-        normalizedPosition.x !== savedPosition.x
-        || normalizedPosition.y !== savedPosition.y
+        collisionFreePosition.x !== savedPosition.x
+        || collisionFreePosition.y !== savedPosition.y
       ) {
-        runOnJS(savePosition)(normalizedPosition);
+        runOnJS(savePosition)(collisionFreePosition);
       }
+      runOnJS(publishButtonRect)('ai', {
+        x: collisionFreePosition.x,
+        y: collisionFreePosition.y,
+        size: FLOATING_AI_BUTTON_SIZE,
+      });
     });
 }

--- a/src/components/ai/useFloatingAIButtonPosition.ts
+++ b/src/components/ai/useFloatingAIButtonPosition.ts
@@ -4,7 +4,9 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSharedValue, type SharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTabBarHeight } from '../ui/TabBar';
+import { publishButtonRect, resolveNonOverlapping } from '../floatingButtonLayout';
 import {
+  FLOATING_AI_BUTTON_SIZE,
   resolveFloatingAIButtonPlacement,
   type FloatingButtonGeometry,
   type FloatingButtonPosition,
@@ -82,6 +84,7 @@ export function useFloatingAIButtonPosition(): FloatingAIButtonPositionState {
     translateY.value = position.y;
     savedTranslateX.value = position.x;
     savedTranslateY.value = position.y;
+    publishButtonRect('ai', { x: position.x, y: position.y, size: FLOATING_AI_BUTTON_SIZE });
   }, [savedTranslateX, savedTranslateY, translateX, translateY]);
 
   const savePosition = useCallback((position: FloatingButtonPosition) => {
@@ -137,6 +140,14 @@ export function useFloatingAIButtonPosition(): FloatingAIButtonPositionState {
   }, [applyPosition, dragActive, savePosition]);
 
   useEffect(() => {
+    publishButtonRect('ai', {
+      x: initialPosition.x,
+      y: initialPosition.y,
+      size: FLOATING_AI_BUTTON_SIZE,
+    });
+  }, [initialPosition.x, initialPosition.y]);
+
+  useEffect(() => {
     latestGeometry.value = geometry;
   }, [geometry, latestGeometry]);
 
@@ -151,15 +162,21 @@ export function useFloatingAIButtonPosition(): FloatingAIButtonPositionState {
       currentPosition,
       geometry,
     ).position;
+    const resolvedPosition = resolveNonOverlapping(
+      'ai',
+      normalizedPosition,
+      FLOATING_AI_BUTTON_SIZE,
+      geometry,
+    );
     if (
-      normalizedPosition.x === currentPosition.x
-      && normalizedPosition.y === currentPosition.y
+      resolvedPosition.x === currentPosition.x
+      && resolvedPosition.y === currentPosition.y
     ) {
       return;
     }
 
-    applyPosition(normalizedPosition);
-    savePosition(normalizedPosition);
+    applyPosition(resolvedPosition);
+    savePosition(resolvedPosition);
   }, [
     applyPosition,
     dragActive,

--- a/src/components/floatingButtonLayout.ts
+++ b/src/components/floatingButtonLayout.ts
@@ -1,0 +1,194 @@
+import { useEffect } from 'react';
+import { withSpring, type SharedValue } from 'react-native-reanimated';
+import type { FloatingButtonGeometry } from './ai/floatingAIButtonGeometry';
+
+export type FloatingButtonId = 'ai' | 'stage';
+
+export interface FloatingButtonRect {
+  readonly x: number;
+  readonly y: number;
+  readonly size: number;
+}
+
+export const COLLISION_GAP = 12;
+
+const COLLISION_SPRING = {
+  mass: 1,
+  damping: 15,
+  stiffness: 120,
+  overshootClamping: true,
+} as const;
+
+const rects: Record<FloatingButtonId, FloatingButtonRect | null> = {
+  ai: null,
+  stage: null,
+};
+
+const listeners = new Set<() => void>();
+
+export function publishButtonRect(
+  id: FloatingButtonId,
+  rect: FloatingButtonRect,
+): void {
+  rects[id] = rect;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function getButtonRect(id: FloatingButtonId): FloatingButtonRect | null {
+  return rects[id];
+}
+
+export function subscribeButtonRects(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function rectsOverlap(
+  a: FloatingButtonRect,
+  b: FloatingButtonRect,
+  gap: number,
+): boolean {
+  'worklet';
+
+  return (
+    a.x < b.x + b.size + gap
+    && b.x < a.x + a.size + gap
+    && a.y < b.y + b.size + gap
+    && b.y < a.y + a.size + gap
+  );
+}
+
+function overlapAmount(a: FloatingButtonRect, b: FloatingButtonRect): number {
+  'worklet';
+
+  const xOverlap = Math.max(
+    0,
+    Math.min(a.x + a.size + COLLISION_GAP, b.x + b.size)
+      - Math.max(a.x - COLLISION_GAP, b.x),
+  );
+  const yOverlap = Math.max(
+    0,
+    Math.min(a.y + a.size + COLLISION_GAP, b.y + b.size)
+      - Math.max(a.y - COLLISION_GAP, b.y),
+  );
+  return xOverlap * yOverlap;
+}
+
+/**
+ * Worklet-safe collision resolution against an explicit other rect. Prefers
+ * stacking vertically on the same edge, then flips edges, then falls back to
+ * the least-overlapping candidate.
+ */
+export function resolveNonOverlappingWithRect(
+  desired: { readonly x: number; readonly y: number },
+  size: number,
+  geometry: FloatingButtonGeometry,
+  other: FloatingButtonRect | null,
+): { x: number; y: number } {
+  'worklet';
+
+  if (other === null) {
+    return { x: desired.x, y: desired.y };
+  }
+
+  const desiredRect: FloatingButtonRect = { x: desired.x, y: desired.y, size };
+  if (!rectsOverlap(desiredRect, other, COLLISION_GAP)) {
+    return { x: desired.x, y: desired.y };
+  }
+
+  const safeBottom = geometry.viewportHeight
+    - Math.max(geometry.tabBarHeight, geometry.minimumBottomClearance);
+  const leftX = geometry.leftClearance;
+  const rightX = geometry.viewportWidth - size - geometry.rightClearance;
+  const desiredOnLeft = Math.abs(desired.x - leftX) <= Math.abs(desired.x - rightX);
+
+  const candidates = [
+    { x: desired.x, y: Math.max(geometry.topBound, other.y - size - COLLISION_GAP) },
+    { x: desired.x, y: Math.min(safeBottom - size, other.y + other.size + COLLISION_GAP) },
+    {
+      x: desiredOnLeft ? rightX : leftX,
+      y: Math.min(Math.max(desired.y, geometry.topBound), safeBottom - size),
+    },
+  ];
+
+  for (const candidate of candidates) {
+    const candidateRect: FloatingButtonRect = {
+      x: candidate.x,
+      y: candidate.y,
+      size,
+    };
+    if (!rectsOverlap(candidateRect, other, COLLISION_GAP)) {
+      return candidate;
+    }
+  }
+
+  let leastOverlapping = candidates[0];
+  for (const candidate of candidates) {
+    const candidateAmount = overlapAmount(
+      { x: candidate.x, y: candidate.y, size },
+      other,
+    );
+    const leastAmount = overlapAmount(
+      { x: leastOverlapping.x, y: leastOverlapping.y, size },
+      other,
+    );
+    if (candidateAmount < leastAmount) {
+      leastOverlapping = candidate;
+    }
+  }
+  return leastOverlapping;
+}
+
+/**
+ * Resolves a desired position against the other button's current registered
+ * rect. Runs on the JS thread (position hooks, collision nudges).
+ */
+export function resolveNonOverlapping(
+  myId: FloatingButtonId,
+  desired: { readonly x: number; readonly y: number },
+  size: number,
+  geometry: FloatingButtonGeometry,
+): { x: number; y: number } {
+  const otherId: FloatingButtonId = myId === 'ai' ? 'stage' : 'ai';
+  return resolveNonOverlappingWithRect(desired, size, geometry, rects[otherId]);
+}
+
+interface UseFloatingButtonCollisionOptions {
+  readonly translateX: SharedValue<number>;
+  readonly translateY: SharedValue<number>;
+  readonly dragActive: SharedValue<boolean>;
+  readonly size: number;
+  readonly geometry: FloatingButtonGeometry;
+}
+
+/**
+ * Subscribes to the shared rect registry. Only the stage button yields to the
+ * other while at rest; the AI button resolves collisions at its own drag-end
+ * and geometry normalization.
+ */
+export function useFloatingButtonCollision(
+  id: FloatingButtonId,
+  options: UseFloatingButtonCollisionOptions,
+): void {
+  const { translateX, translateY, dragActive, size, geometry } = options;
+
+  useEffect(() => {
+    const otherId: FloatingButtonId = id === 'ai' ? 'stage' : 'ai';
+    if (id !== 'stage') return;
+    return subscribeButtonRects(() => {
+      const other = getButtonRect(otherId);
+      if (other === null || dragActive.value) return;
+      const current = { x: translateX.value, y: translateY.value };
+      const currentRect: FloatingButtonRect = { x: current.x, y: current.y, size };
+      if (!rectsOverlap(currentRect, other, COLLISION_GAP)) return;
+      const resolved = resolveNonOverlapping(id, current, size, geometry);
+      translateX.value = withSpring(resolved.x, COLLISION_SPRING);
+      translateY.value = withSpring(resolved.y, COLLISION_SPRING);
+      publishButtonRect(id, { x: resolved.x, y: resolved.y, size });
+    });
+  }, [dragActive, geometry, id, size, translateX, translateY]);
+}

--- a/src/components/git/FloatingStageButton.tsx
+++ b/src/components/git/FloatingStageButton.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo } from 'react';
-import { ActivityIndicator, Pressable, StyleSheet } from 'react-native';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AccessibilityInfo, ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
@@ -9,12 +9,16 @@ import { useStageStore } from '../../stores/stageStore';
 import { useTheme } from '../../contexts/ThemeContext';
 import { HapticService } from '../../utils/haptics';
 import type { RootStackParamList } from '../../navigation/types';
-import {
-  STAGE_BUTTON_SIZE,
-  STAGE_BUTTON_LONG_PRESS_MS,
-} from './stageButtonGeometry';
+import { useFloatingButtonCollision } from '../floatingButtonLayout';
+import { HoldProgressRing } from '../ui/HoldProgressRing';
+import { STAGE_BUTTON_SIZE } from './stageButtonGeometry';
 import { useStageButtonPosition } from './useStageButtonPosition';
 import { useStageButtonPanGesture } from './useStageButtonPanGesture';
+import {
+  FLOATING_AI_BUTTON_LONG_PRESS_MS,
+  PRESS_SCALE_FACTOR,
+  useFloatingAIButtonAffordances,
+} from '../ai/useFloatingAIButtonAffordances';
 
 interface FloatingStageButtonProps {
   readonly currentRouteName?: string;
@@ -27,11 +31,56 @@ export function FloatingStageButton({ currentRouteName }: FloatingStageButtonPro
   const globalPushing = useStageStore((s) => s.globalPushing);
   const isPushing = useStageStore((s) => s.isPushing);
   const position = useStageButtonPosition();
+  const [reduceMotionEnabled, setReduceMotionEnabled] = useState(true);
+  const [reduceMotionResolved, setReduceMotionResolved] = useState(false);
+
+  useFloatingButtonCollision('stage', {
+    translateX: position.translateX,
+    translateY: position.translateY,
+    dragActive: position.dragActive,
+    size: STAGE_BUTTON_SIZE,
+    geometry: position.geometry,
+  });
+
+  const affordances = useFloatingAIButtonAffordances({
+    reduceMotionEnabled,
+    reduceMotionResolved,
+    menuOpen: false,
+  });
 
   const anyPushing = useMemo(
     () => globalPushing || Object.values(isPushing).some(Boolean),
     [globalPushing, isPushing],
   );
+
+  useEffect(() => {
+    let isMounted = true;
+    AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
+      if (!isMounted) return;
+      setReduceMotionEnabled(enabled);
+      setReduceMotionResolved(true);
+    });
+    const subscription = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      (enabled) => {
+        setReduceMotionEnabled(enabled);
+        setReduceMotionResolved(true);
+      },
+    );
+
+    return () => {
+      isMounted = false;
+      subscription.remove();
+    };
+  }, []);
+
+  const triggerAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        scale: 1 - PRESS_SCALE_FACTOR * affordances.pressProgress.value,
+      },
+    ],
+  }));
 
   const handleTap = useCallback(() => {
     HapticService.selection();
@@ -40,9 +89,10 @@ export function FloatingStageButton({ currentRouteName }: FloatingStageButtonPro
 
   const handleLongPress = useCallback(() => {
     if (anyPushing) return;
+    affordances.handleHoldComplete();
     HapticService.selection();
     useStageStore.getState().pushAll();
-  }, [anyPushing]);
+  }, [affordances, anyPushing]);
 
   const panGesture = useStageButtonPanGesture(position);
 
@@ -63,32 +113,42 @@ export function FloatingStageButton({ currentRouteName }: FloatingStageButtonPro
 
   return (
     <Animated.View style={[styles.container, animatedStyle]} pointerEvents="box-none">
+      <HoldProgressRing
+        progress={affordances.holdProgress}
+        size={STAGE_BUTTON_SIZE}
+        color={colors.primary}
+        reduceMotionEnabled={reduceMotionEnabled}
+      />
       <GestureDetector gesture={panGesture}>
-        <Pressable
-          testID="floating-stage.button.navigate-stage"
-          accessibilityRole="button"
-          accessibilityLabel="View staged changes"
-          accessibilityHint="Tap to view staged changes. Press and hold to push all staged changes."
-          accessibilityState={{ disabled: anyPushing }}
-          onPress={handleTap}
-          onLongPress={handleLongPress}
-          delayLongPress={STAGE_BUTTON_LONG_PRESS_MS}
-          style={({ pressed }) => [
-            styles.button,
-            { backgroundColor: colors.primary },
-            pressed ? styles.pressed : null,
-          ]}
-        >
-          {anyPushing ? (
-            <ActivityIndicator
-              testID="floating-stage.button.progress"
-              size="small"
-              color="#FFFFFF"
-            />
-          ) : (
-            <Ionicons name="cloud-upload" size={24} color="#FFFFFF" />
-          )}
-        </Pressable>
+        <Animated.View style={triggerAnimatedStyle}>
+          <Pressable
+            testID="floating-stage.button.navigate-stage"
+            accessibilityRole="button"
+            accessibilityLabel="View staged changes"
+            accessibilityHint="Tap to view staged changes. Press and hold to push all staged changes."
+            accessibilityState={{ disabled: anyPushing }}
+            onPress={handleTap}
+            onLongPress={handleLongPress}
+            onPressIn={affordances.handlePressIn}
+            onPressOut={affordances.handlePressOut}
+            delayLongPress={FLOATING_AI_BUTTON_LONG_PRESS_MS}
+            style={({ pressed }) => [
+              styles.button,
+              { backgroundColor: colors.primary },
+              pressed ? styles.pressed : null,
+            ]}
+          >
+            {anyPushing ? (
+              <ActivityIndicator
+                testID="floating-stage.button.progress"
+                size="small"
+                color="#FFFFFF"
+              />
+            ) : (
+              <Ionicons name="cloud-upload" size={24} color="#FFFFFF" />
+            )}
+          </Pressable>
+        </Animated.View>
       </GestureDetector>
     </Animated.View>
   );

--- a/src/components/git/stageButtonGeometry.ts
+++ b/src/components/git/stageButtonGeometry.ts
@@ -3,9 +3,10 @@ import {
   type FloatingButtonGeometry,
   type FloatingButtonPosition,
 } from '../ai/floatingAIButtonGeometry';
+import { FLOATING_AI_BUTTON_LONG_PRESS_MS } from '../ai/useFloatingAIButtonAffordances';
 
 export const STAGE_BUTTON_SIZE = 52;
-export const STAGE_BUTTON_LONG_PRESS_MS = 500;
+export const STAGE_BUTTON_LONG_PRESS_MS = FLOATING_AI_BUTTON_LONG_PRESS_MS;
 export const STAGE_BUTTON_VERTICAL_GAP = 12;
 
 /**

--- a/src/components/git/useStageButtonPanGesture.ts
+++ b/src/components/git/useStageButtonPanGesture.ts
@@ -1,7 +1,15 @@
+import { useEffect } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
-import { runOnJS, withSpring } from 'react-native-reanimated';
+import { runOnJS, useSharedValue, withSpring } from 'react-native-reanimated';
 import type { StageButtonPositionState } from './useStageButtonPosition';
-import { resolveStageButtonPlacement } from './stageButtonGeometry';
+import { resolveStageButtonPlacement, STAGE_BUTTON_SIZE } from './stageButtonGeometry';
+import {
+  getButtonRect,
+  publishButtonRect,
+  resolveNonOverlappingWithRect,
+  subscribeButtonRects,
+  type FloatingButtonRect,
+} from '../floatingButtonLayout';
 
 const POSITION_SPRING = {
   mass: 1,
@@ -21,6 +29,14 @@ export function useStageButtonPanGesture(position: StageButtonPositionState) {
     markPositionInteractionStarted,
     savePosition,
   } = position;
+  const otherRect = useSharedValue<FloatingButtonRect | null>(null);
+
+  useEffect(() => {
+    otherRect.value = getButtonRect('ai');
+    return subscribeButtonRects(() => {
+      otherRect.value = getButtonRect('ai');
+    });
+  }, [otherRect]);
 
   return Gesture.Pan()
     .onBegin(() => {
@@ -39,13 +55,24 @@ export function useStageButtonPanGesture(position: StageButtonPositionState) {
         latestGeometry.value,
       );
       const normalizedPosition = placement.position;
+      const collisionFreePosition = resolveNonOverlappingWithRect(
+        normalizedPosition,
+        STAGE_BUTTON_SIZE,
+        latestGeometry.value,
+        otherRect.value,
+      );
 
-      translateX.value = withSpring(normalizedPosition.x, POSITION_SPRING);
-      translateY.value = withSpring(normalizedPosition.y, POSITION_SPRING);
-      savedTranslateX.value = normalizedPosition.x;
-      savedTranslateY.value = normalizedPosition.y;
+      translateX.value = withSpring(collisionFreePosition.x, POSITION_SPRING);
+      translateY.value = withSpring(collisionFreePosition.y, POSITION_SPRING);
+      savedTranslateX.value = collisionFreePosition.x;
+      savedTranslateY.value = collisionFreePosition.y;
 
-      runOnJS(savePosition)(normalizedPosition);
+      runOnJS(savePosition)(collisionFreePosition);
+      runOnJS(publishButtonRect)('stage', {
+        x: collisionFreePosition.x,
+        y: collisionFreePosition.y,
+        size: STAGE_BUTTON_SIZE,
+      });
     })
     .onFinalize((_event, successful) => {
       dragActive.value = false;
@@ -59,16 +86,27 @@ export function useStageButtonPanGesture(position: StageButtonPositionState) {
         savedPosition,
         latestGeometry.value,
       ).position;
-      translateX.value = withSpring(normalizedPosition.x, POSITION_SPRING);
-      translateY.value = withSpring(normalizedPosition.y, POSITION_SPRING);
-      savedTranslateX.value = normalizedPosition.x;
-      savedTranslateY.value = normalizedPosition.y;
+      const collisionFreePosition = resolveNonOverlappingWithRect(
+        normalizedPosition,
+        STAGE_BUTTON_SIZE,
+        latestGeometry.value,
+        otherRect.value,
+      );
+      translateX.value = withSpring(collisionFreePosition.x, POSITION_SPRING);
+      translateY.value = withSpring(collisionFreePosition.y, POSITION_SPRING);
+      savedTranslateX.value = collisionFreePosition.x;
+      savedTranslateY.value = collisionFreePosition.y;
 
       if (
-        normalizedPosition.x !== savedPosition.x
-        || normalizedPosition.y !== savedPosition.y
+        collisionFreePosition.x !== savedPosition.x
+        || collisionFreePosition.y !== savedPosition.y
       ) {
-        runOnJS(savePosition)(normalizedPosition);
+        runOnJS(savePosition)(collisionFreePosition);
       }
+      runOnJS(publishButtonRect)('stage', {
+        x: collisionFreePosition.x,
+        y: collisionFreePosition.y,
+        size: STAGE_BUTTON_SIZE,
+      });
     });
 }

--- a/src/components/git/useStageButtonPosition.ts
+++ b/src/components/git/useStageButtonPosition.ts
@@ -4,11 +4,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSharedValue, type SharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTabBarHeight } from '../ui/TabBar';
+import { publishButtonRect, resolveNonOverlapping } from '../floatingButtonLayout';
 import type {
   FloatingButtonGeometry,
   FloatingButtonPosition,
 } from '../ai/floatingAIButtonGeometry';
-import { resolveStageButtonPlacement } from './stageButtonGeometry';
+import { resolveStageButtonPlacement, STAGE_BUTTON_SIZE } from './stageButtonGeometry';
 
 const EDGE_INSET = 16;
 const MINIMUM_TOP_BOUND = 60;
@@ -82,6 +83,7 @@ export function useStageButtonPosition(): StageButtonPositionState {
     translateY.value = position.y;
     savedTranslateX.value = position.x;
     savedTranslateY.value = position.y;
+    publishButtonRect('stage', { x: position.x, y: position.y, size: STAGE_BUTTON_SIZE });
   }, [savedTranslateX, savedTranslateY, translateX, translateY]);
 
   const savePosition = useCallback((position: FloatingButtonPosition) => {
@@ -137,6 +139,14 @@ export function useStageButtonPosition(): StageButtonPositionState {
   }, [applyPosition, dragActive, savePosition]);
 
   useEffect(() => {
+    publishButtonRect('stage', {
+      x: initialPosition.x,
+      y: initialPosition.y,
+      size: STAGE_BUTTON_SIZE,
+    });
+  }, [initialPosition.x, initialPosition.y]);
+
+  useEffect(() => {
     latestGeometry.value = geometry;
   }, [geometry, latestGeometry]);
 
@@ -151,15 +161,21 @@ export function useStageButtonPosition(): StageButtonPositionState {
       currentPosition,
       geometry,
     ).position;
+    const resolvedPosition = resolveNonOverlapping(
+      'stage',
+      normalizedPosition,
+      STAGE_BUTTON_SIZE,
+      geometry,
+    );
     if (
-      normalizedPosition.x === currentPosition.x
-      && normalizedPosition.y === currentPosition.y
+      resolvedPosition.x === currentPosition.x
+      && resolvedPosition.y === currentPosition.y
     ) {
       return;
     }
 
-    applyPosition(normalizedPosition);
-    savePosition(normalizedPosition);
+    applyPosition(resolvedPosition);
+    savePosition(resolvedPosition);
   }, [
     applyPosition,
     dragActive,

--- a/src/components/ui/HoldProgressRing.tsx
+++ b/src/components/ui/HoldProgressRing.tsx
@@ -1,0 +1,74 @@
+import { StyleSheet } from 'react-native';
+import { Canvas, Circle, DashPathEffect } from '@shopify/react-native-skia';
+import { useDerivedValue, type SharedValue } from 'react-native-reanimated';
+import { FLOATING_AI_BUTTON_SIZE } from '../ai/floatingAIButtonGeometry';
+
+export const HOLD_RING_STROKE_WIDTH = 3.5;
+export const HOLD_RING_RADIUS_OFFSET = 6;
+const HOLD_RING_PADDING = 2;
+export const HOLD_RING_RADIUS = FLOATING_AI_BUTTON_SIZE / 2 + HOLD_RING_RADIUS_OFFSET;
+export const HOLD_RING_CIRCUMFERENCE = 2 * Math.PI * HOLD_RING_RADIUS;
+
+interface HoldProgressRingProps {
+  readonly progress: SharedValue<number>;
+  readonly size: number;
+  readonly color: string;
+  readonly reduceMotionEnabled: boolean;
+}
+
+export function HoldProgressRing({
+  progress,
+  size,
+  color,
+  reduceMotionEnabled,
+}: HoldProgressRingProps) {
+  const ringRadius = size / 2 + HOLD_RING_RADIUS_OFFSET;
+  const ringCircumference = 2 * Math.PI * ringRadius;
+  const ringCanvasSize = ringRadius * 2 + HOLD_RING_STROKE_WIDTH * 2 + HOLD_RING_PADDING * 2;
+  const ringCenter = ringCanvasSize / 2;
+  const ringIntervals = useDerivedValue(() => [
+    progress.value * ringCircumference,
+    ringCircumference,
+  ]);
+  const ringOpacity = useDerivedValue(() => Math.min(1, progress.value * 3));
+
+  if (reduceMotionEnabled) {
+    return null;
+  }
+
+  return (
+    <Canvas
+      pointerEvents="none"
+      style={[
+        styles.canvas,
+        {
+          width: ringCanvasSize,
+          height: ringCanvasSize,
+          top: -(ringCanvasSize - size) / 2,
+          left: -(ringCanvasSize - size) / 2,
+        },
+      ]}
+    >
+      <Circle
+        cx={ringCenter}
+        cy={ringCenter}
+        r={ringRadius}
+        color={color}
+        style="stroke"
+        strokeWidth={HOLD_RING_STROKE_WIDTH}
+        strokeCap="round"
+        opacity={ringOpacity}
+        origin={{ x: ringCenter, y: ringCenter }}
+        transform={[{ rotate: -Math.PI / 2 }]}
+      >
+        <DashPathEffect intervals={ringIntervals} />
+      </Circle>
+    </Canvas>
+  );
+}
+
+const styles = StyleSheet.create({
+  canvas: {
+    position: 'absolute',
+  },
+});


### PR DESCRIPTION
**Collision avoidance:** the AI button and stage button were fully independent (own position hooks, own AsyncStorage) and could overlap. Added a shared module-singleton registry (`src/components/floatingButtonLayout.ts`): both buttons publish their rects, and `resolveNonOverlapping` stacks vertically (then flips edge) with a spring animation when they collide. The stage button yields while at rest; the AI button resolves at its own drag-end. Worklet-safe so it works in gesture worklets.

**Hold animation parity:** the stage button now uses the same `useFloatingAIButtonAffordances` as the AI button — press-scale (PRESS_SCALE_FACTOR), 450ms hold ring (extracted into a shared `HoldProgressRing` Skia component used by both buttons), and long-press fires pushAll after the hold completes. Byte-identical ring output for the AI hub.

Verification: ts:check, full jest (2180 passed / 0 failed), eslint 0 errors, format check clean.