### PR TITLE
fix(sync): complete the stage-push migration (pull-only sync, per-item locks, notification fixes)

### DIFF
--- a/__tests__/ForegroundSyncService.test.ts
+++ b/__tests__/ForegroundSyncService.test.ts
@@ -19,12 +19,6 @@ jest.mock('../src/services/StorageService', () => ({
   },
 }));
 
-jest.mock('../src/services/NoteSyncQueueService', () => ({
-  NoteSyncQueueService: {
-    drain: jest.fn(),
-  },
-}));
-
 jest.mock('../src/services/RepoPullService', () => ({
   pullAllFromRepos: jest.fn(),
 }));
@@ -45,7 +39,6 @@ import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globa
 import NetInfo, { NetInfoStateType, type NetInfoState } from '@react-native-community/netinfo';
 import type { AppStateStatus } from 'react-native';
 import { GitHubService } from '../src/services/GitHubService';
-import { NoteSyncQueueService } from '../src/services/NoteSyncQueueService';
 import {
   __resetForegroundSyncForTest,
   __runPullForTest,
@@ -60,7 +53,6 @@ import type { GitRepository } from '../src/services/GitService';
 const authMock = jest.mocked(GitHubService.isAuthenticated);
 const reposMock = jest.mocked(StorageService.getSavedRepositories);
 const netInfoFetchMock = jest.mocked(NetInfo.fetch);
-const drainMock = jest.mocked(NoteSyncQueueService.drain);
 const pullMock = jest.mocked(pullAllFromRepos);
 
 const repository: GitRepository = { id: 'repo-id', name: 'repo', path: 'owner/repo' };
@@ -99,7 +91,6 @@ describe('ForegroundSyncService', () => {
     authMock.mockReturnValue(true);
     reposMock.mockResolvedValue([repository]);
     netInfoFetchMock.mockResolvedValue(reachableState);
-    drainMock.mockResolvedValue({ succeeded: 0, failed: 0, remaining: 0 });
     pullMock.mockResolvedValue(pullResult);
   });
 
@@ -108,12 +99,8 @@ describe('ForegroundSyncService', () => {
     jest.useRealTimers();
   });
 
-  test('drains queued mutations before pulling remote state', async () => {
+  test('pulls remote state without draining queued mutations', async () => {
     const order: string[] = [];
-    drainMock.mockImplementation(async () => {
-      order.push('drain');
-      return { succeeded: 1, failed: 0, remaining: 0 };
-    });
     pullMock.mockImplementation(async () => {
       order.push('pull');
       return pullResult;
@@ -121,15 +108,14 @@ describe('ForegroundSyncService', () => {
 
     await __runPullForTest();
 
-    expect(order).toEqual(['drain', 'pull']);
+    expect(order).toEqual(['pull']);
   });
 
-  test('does not drain or pull while offline', async () => {
+  test('does not pull while offline', async () => {
     netInfoFetchMock.mockResolvedValue(offlineState);
 
     await __runPullForTest();
 
-    expect(drainMock).not.toHaveBeenCalled();
     expect(pullMock).not.toHaveBeenCalled();
   });
 
@@ -150,7 +136,6 @@ describe('ForegroundSyncService', () => {
     const secondPull = __runPullForTest('second');
 
     await secondPull;
-    expect(drainMock).toHaveBeenCalledTimes(1);
     expect(pullMock).toHaveBeenCalledTimes(1);
 
     resolvePull?.();
@@ -162,18 +147,16 @@ describe('ForegroundSyncService', () => {
     jest.setSystemTime(11000);
     await __runPullForTest('second');
 
-    expect(drainMock).toHaveBeenCalledTimes(1);
     expect(pullMock).toHaveBeenCalledTimes(1);
   });
 
-  test('recovers when draining fails without entering pull backoff', async () => {
-    drainMock.mockRejectedValueOnce(new Error('drain failed'));
+  test('recovers after a pull failure once backoff elapses', async () => {
+    pullMock.mockRejectedValueOnce(new Error('pull failed'));
 
     await __runPullForTest('first');
     jest.setSystemTime(40000);
     await __runPullForTest('second');
 
-    expect(drainMock).toHaveBeenCalledTimes(2);
     expect(pullMock).toHaveBeenCalledTimes(2);
   });
 

--- a/__tests__/components/useNoteEditorDocument.stage.test.tsx
+++ b/__tests__/components/useNoteEditorDocument.stage.test.tsx
@@ -62,6 +62,10 @@ function editorParams(overrides: Record<string, unknown>) {
   };
 }
 
+const SAVED_LOCALLY_TITLE = 'Note Saved Locally';
+const SAVED_LOCALLY_BODY =
+  'Your note was saved but could not be pushed to GitHub yet. It will sync automatically when connection is restored.';
+
 describe('useNoteEditorDocument stage-push rework', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -108,15 +112,63 @@ describe('useNoteEditorDocument stage-push rework', () => {
       }),
     );
     expect(syncNoteToGitHub).not.toHaveBeenCalled();
+    // A successful stage must not re-enqueue or show the fallback toast.
+    expect(NoteSyncQueueService.enqueueNoteUpsert).not.toHaveBeenCalled();
+    expect(Alert.alert).not.toHaveBeenCalledWith(SAVED_LOCALLY_TITLE, SAVED_LOCALLY_BODY, [
+      { text: 'OK' },
+    ]);
     // On success the staged path is persisted back to the local note.
     expect(updateNote).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'new-note-1', filePath: '/notes/my-note.md' }),
     );
   });
 
-  it('a failing stage falls back to the sync queue with the "Note Saved Locally" alert', async () => {
+  it('stages a new root-level note with a real path and no fallback toast', async () => {
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
-    (StagingService.stageUpsert as jest.Mock).mockResolvedValue({ success: false, error: 'staging boom' });
+    (StagingService.stageUpsert as jest.Mock).mockResolvedValue({ success: true });
+    const createNote = jest.fn(async () => ({ id: 'new-root-note' }));
+    const updateNote = jest.fn(async () => true);
+
+    const { result } = renderHook(() =>
+      useNoteEditorDocument(
+        editorParams({
+          initialRepo: 'owner/repo',
+          initialBranch: 'main',
+          initialTitle: 'My Note',
+          initialContent: 'body',
+          createNote,
+          updateNote,
+          getNoteById: () => undefined,
+        }),
+      ),
+    );
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(StagingService.stageUpsert).toHaveBeenCalledTimes(1);
+    expect(StagingService.stageUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: 'my-note.md', repo: 'owner/repo', branch: 'main' }),
+    );
+    // A root note now gets a real syncPath, so metadata is persisted and nothing re-enqueues.
+    expect(updateNote).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'new-root-note', filePath: 'my-note.md' }),
+    );
+    expect(NoteSyncQueueService.enqueueNoteUpsert).not.toHaveBeenCalled();
+    expect(alertSpy).not.toHaveBeenCalledWith(SAVED_LOCALLY_TITLE, SAVED_LOCALLY_BODY, [
+      { text: 'OK' },
+    ]);
+    alertSpy.mockRestore();
+  });
+
+  it('a stage returning success:false shows the failure alert and does not enqueue', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    (StagingService.stageUpsert as jest.Mock).mockResolvedValue({
+      success: false,
+      error: 'staging boom',
+    });
     const createNote = jest.fn(async () => ({ id: 'new-note-1' }));
 
     const { result } = renderHook(() =>
@@ -140,12 +192,53 @@ describe('useNoteEditorDocument stage-push rework', () => {
 
     expect(StagingService.stageUpsert).toHaveBeenCalledTimes(1);
     expect(syncNoteToGitHub).not.toHaveBeenCalled();
-    expect(NoteSyncQueueService.enqueueNoteUpsert).toHaveBeenCalledTimes(1);
+    // Staging owns the enqueue; a non-throw failure means nothing was staged, so
+    // surfacing it as "Save Failed" must not trigger a second enqueue.
+    expect(NoteSyncQueueService.enqueueNoteUpsert).not.toHaveBeenCalled();
     expect(alertSpy).toHaveBeenCalledWith(
-      'Note Saved Locally',
-      'Your note was saved but could not be pushed to GitHub yet. It will sync automatically when connection is restored.',
+      'Save Failed',
+      'Your note was saved locally but could not be staged for sync. Please try again.',
       [{ text: 'OK' }],
     );
+    expect(alertSpy).not.toHaveBeenCalledWith(SAVED_LOCALLY_TITLE, SAVED_LOCALLY_BODY, [
+      { text: 'OK' },
+    ]);
+    expect(warnSpy).toHaveBeenCalled();
+    alertSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('a throwing stage falls back to the sync queue with the "Note Saved Locally" alert', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    (StagingService.stageUpsert as jest.Mock).mockRejectedValue(new Error('network down'));
+    const createNote = jest.fn(async () => ({ id: 'new-note-1' }));
+
+    const { result } = renderHook(() =>
+      useNoteEditorDocument(
+        editorParams({
+          initialRepo: 'owner/repo',
+          initialBranch: 'main',
+          initialTitle: 'My Note',
+          initialContent: 'body',
+          initialFolderPath: '/notes',
+          createNote,
+          updateNote: jest.fn(async () => true),
+          getNoteById: () => undefined,
+        }),
+      ),
+    );
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(StagingService.stageUpsert).toHaveBeenCalledTimes(1);
+    expect(syncNoteToGitHub).not.toHaveBeenCalled();
+    // A thrown error means staging never enqueued, so one fallback enqueue is correct.
+    expect(NoteSyncQueueService.enqueueNoteUpsert).toHaveBeenCalledTimes(1);
+    expect(alertSpy).toHaveBeenCalledWith(SAVED_LOCALLY_TITLE, SAVED_LOCALLY_BODY, [
+      { text: 'OK' },
+    ]);
     alertSpy.mockRestore();
   });
 });

--- a/__tests__/hooks/useGitOpLock.test.ts
+++ b/__tests__/hooks/useGitOpLock.test.ts
@@ -1,0 +1,44 @@
+import { opMatchesContext, type UseEntityLockOptions } from '../../src/hooks/useGitOpLock';
+import type { GitOp } from '../../src/stores/gitOperationStore';
+
+function makeOp(overrides: Partial<GitOp> = {}): GitOp {
+  return {
+    id: 'op-1',
+    kind: 'upsert',
+    repo: 'owner/repo',
+    branch: 'main',
+    path: undefined,
+    entityIds: [],
+    status: 'running',
+    attempts: 0,
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+const rowContext: UseEntityLockOptions = { repo: 'owner/repo', branch: 'main', path: 'notes/a.md' };
+
+describe('opMatchesContext', () => {
+  it('does not match a row for a repo-wide push op with no path', () => {
+    const op = makeOp({ kind: 'push', path: undefined, entityIds: [] });
+    expect(opMatchesContext(op, undefined, rowContext)).toBe(false);
+    // Even a row that knows its own id must not lock for a path-less push.
+    expect(opMatchesContext(op, 'n1', rowContext)).toBe(false);
+  });
+
+  it('matches a row for an upsert op with the same repo/branch/path', () => {
+    const op = makeOp({ kind: 'upsert', path: 'notes/a.md' });
+    expect(opMatchesContext(op, undefined, rowContext)).toBe(true);
+  });
+
+  it('does not match a row for an op with a different path', () => {
+    const op = makeOp({ kind: 'upsert', path: 'notes/b.md' });
+    expect(opMatchesContext(op, undefined, rowContext)).toBe(false);
+  });
+
+  it('matches by entityIds even when path is undefined', () => {
+    const op = makeOp({ kind: 'delete', path: undefined, entityIds: ['n1'] });
+    expect(opMatchesContext(op, 'n1', rowContext)).toBe(true);
+    expect(opMatchesContext(op, 'n2', rowContext)).toBe(false);
+  });
+});

--- a/__tests__/notes-delete-lock.test.tsx
+++ b/__tests__/notes-delete-lock.test.tsx
@@ -564,7 +564,7 @@ describe('notes delete lock', () => {
     await waitFor(() => {
       expect(NoteSyncQueueService.enqueueNoteDelete).toHaveBeenCalled();
       expect(clearDeleteFailure).toHaveBeenCalledWith('owner/repo', 'main', 'notes/third.md');
-      expect(NoteSyncQueueService.drain).toHaveBeenCalled();
+      expect(NoteSyncQueueService.drain).not.toHaveBeenCalled();
     });
     // The queue notify → hydrate path (real app) re-derives the queued op,
     // which takes the row straight back to locked.

--- a/__tests__/services/BackgroundSyncService.test.ts
+++ b/__tests__/services/BackgroundSyncService.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+jest.mock('expo-background-task', () => ({
+  registerTaskAsync: jest.fn(async () => undefined),
+  unregisterTaskAsync: jest.fn(async () => undefined),
+  BackgroundTaskResult: { Success: 0, Failed: 1 },
+  BackgroundTaskStatus: { Available: 'Available' },
+}));
+
+jest.mock('expo-task-manager', () => ({
+  defineTask: jest.fn(),
+  isTaskDefined: jest.fn(() => true),
+  unregisterTaskAsync: jest.fn(async () => undefined),
+}));
+
+jest.mock('../../src/services/RepoPullService', () => ({
+  pullAllFromRepos: jest.fn(async () => ({
+    repos: 0, notes: 0, canvases: 0, todos: 0, templates: 0,
+  })),
+}));
+
+jest.mock('../../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    drain: jest.fn(async () => ({ succeeded: 0, failed: 0, remaining: 0 })),
+  },
+}));
+
+jest.mock('../../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('../../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+  },
+}));
+
+jest.mock('../../src/services/git/GitSyncGate', () => ({
+  GitSyncGate: {
+    acquireCycle: jest.fn(async () => jest.fn()),
+    isCycleHeld: jest.fn(() => false),
+  },
+}));
+
+jest.mock('../../src/services/NotificationService', () => ({
+  NotificationService: {
+    schedulePushProgress: jest.fn(async () => null),
+  },
+}));
+
+jest.mock('../../src/services/git/StagingService', () => ({
+  StagingService: {
+    listStaged: jest.fn(async () => []),
+    pushStaged: jest.fn(async () => ({ success: true })),
+  },
+}));
+
+import * as BackgroundTask from 'expo-background-task';
+import * as TaskManager from 'expo-task-manager';
+import { GitHubService } from '../../src/services/GitHubService';
+import { StorageService } from '../../src/services/StorageService';
+import { NotificationService } from '../../src/services/NotificationService';
+import { pullAllFromRepos } from '../../src/services/RepoPullService';
+import '../../src/services/BackgroundSyncService';
+
+// defineTask registers the handler once at module load; capture it before
+// clearAllMocks() wipes the call log in beforeEach.
+const backgroundTaskHandler = (TaskManager.defineTask as jest.Mock).mock
+  .calls[0][1] as () => Promise<number>;
+
+const runTask = (): Promise<number> => backgroundTaskHandler();
+
+describe('BackgroundSyncService notification decision', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([
+      { path: 'a/repo' },
+    ]);
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
+    (pullAllFromRepos as jest.Mock).mockResolvedValue({
+      repos: 1, notes: 3, canvases: 0, todos: 0, templates: 0,
+    });
+  });
+
+  test('schedules one notification when the pull had changes', async () => {
+    const result = await runTask();
+
+    expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
+    expect(NotificationService.schedulePushProgress).toHaveBeenCalledTimes(1);
+    expect(NotificationService.schedulePushProgress).toHaveBeenCalledWith(
+      'Synced with origin',
+      expect.stringContaining('3'),
+      { kind: 'background-pull' },
+    );
+  });
+
+  test('stays silent when the pull had zero changes', async () => {
+    (pullAllFromRepos as jest.Mock).mockResolvedValue({
+      repos: 1, notes: 0, canvases: 0, todos: 0, templates: 0,
+    });
+
+    const result = await runTask();
+
+    expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
+    expect(pullAllFromRepos).toHaveBeenCalledTimes(1);
+    expect(NotificationService.schedulePushProgress).not.toHaveBeenCalled();
+  });
+
+  test('returns Success without pulling or notifying when unauthenticated', async () => {
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(false);
+
+    const result = await runTask();
+
+    expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
+    expect(pullAllFromRepos).not.toHaveBeenCalled();
+    expect(NotificationService.schedulePushProgress).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/NotificationService.test.ts
+++ b/__tests__/services/NotificationService.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const mockSetNotificationHandler = jest.fn();
+const mockGetPermissionsAsync = jest.fn(async () => ({ status: 'granted' as const }));
+const mockRequestPermissionsAsync = jest.fn(async () => ({ status: 'granted' as const }));
+const mockScheduleNotificationAsync = jest.fn(async () => 'notification-id');
+const mockCancelScheduledNotificationAsync = jest.fn();
+
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: mockSetNotificationHandler,
+  getPermissionsAsync: mockGetPermissionsAsync,
+  requestPermissionsAsync: mockRequestPermissionsAsync,
+  scheduleNotificationAsync: mockScheduleNotificationAsync,
+  cancelScheduledNotificationAsync: mockCancelScheduledNotificationAsync,
+  SchedulableTriggerInputTypes: {
+    DATE: 'date',
+    TIME_INTERVAL: 'timeInterval',
+  },
+}));
+
+import { Todo } from '../../src/models/Todo';
+
+const NotificationService = require('../../src/services/NotificationService')
+  .NotificationService as typeof import('../../src/services/NotificationService').NotificationService;
+
+describe('NotificationService', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1000);
+    jest.resetAllMocks();
+    mockGetPermissionsAsync.mockImplementation(async () => ({ status: 'granted' }));
+    mockRequestPermissionsAsync.mockImplementation(async () => ({ status: 'granted' }));
+    mockScheduleNotificationAsync.mockImplementation(async () => 'notification-id');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('schedulePushProgress schedules with TIME_INTERVAL seconds:1 and returns the id', async () => {
+    const id = await NotificationService.schedulePushProgress('Pushing changes…', 'Pushing', {
+      kind: 'push-progress',
+    });
+
+    expect(id).toBe('notification-id');
+    expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+    const call = mockScheduleNotificationAsync.mock.calls[0][0] as {
+      content: Record<string, unknown>;
+      trigger: { type: string; seconds?: number; date?: Date };
+    };
+    expect(call.trigger.type).toBe('timeInterval');
+    expect(call.trigger.seconds).toBe(1);
+    expect(call.trigger.type).not.toBe('date');
+    expect(call.trigger.date).toBeUndefined();
+  });
+
+  test('schedulePushFailure schedules with TIME_INTERVAL seconds:1 and returns the id', async () => {
+    const id = await NotificationService.schedulePushFailure(
+      'Push failed',
+      'Could not push',
+      { kind: 'push-failure', repoPath: '/repo', branch: 'main', conflict: false },
+    );
+
+    expect(id).toBe('notification-id');
+    expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+    const call = mockScheduleNotificationAsync.mock.calls[0][0] as {
+      content: Record<string, unknown>;
+      trigger: { type: string; seconds?: number; date?: Date };
+    };
+    expect(call.trigger.type).toBe('timeInterval');
+    expect(call.trigger.seconds).toBe(1);
+    expect(call.trigger.date).toBeUndefined();
+  });
+
+  test('scheduleLearningNotification with a future trigger schedules a DATE trigger', async () => {
+    const trigger = new Date(5000);
+    const id = await NotificationService.scheduleLearningNotification({
+      title: 'Learn',
+      body: 'Body',
+      data: { noteId: 'n1' },
+      trigger,
+    });
+
+    expect(id).toBe('notification-id');
+    const call = mockScheduleNotificationAsync.mock.calls[0][0] as {
+      trigger: { type: string; date: Date };
+    };
+    expect(call.trigger.type).toBe('date');
+    expect(call.trigger.date).toBe(trigger);
+  });
+
+  test('scheduleLearningNotification returns null without scheduling when trigger lapses during permission await', async () => {
+    const trigger = new Date(1500);
+    mockGetPermissionsAsync.mockImplementation(async () => {
+      jest.advanceTimersByTime(600);
+      return { status: 'granted' };
+    });
+
+    const id = await NotificationService.scheduleLearningNotification({
+      title: 'Learn',
+      body: 'Body',
+      data: {},
+      trigger,
+    });
+
+    expect(id).toBeNull();
+    expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  test('scheduleReminder returns undefined for a past trigger without scheduling', async () => {
+    const todo: Todo = {
+      id: 't1',
+      text: 'Buy milk',
+      completed: false,
+      createdAt: 0,
+      updatedAt: 0,
+      dueDate: 500,
+      reminderBeforeMinutes: 0,
+    };
+
+    const result = await NotificationService.scheduleReminder(todo);
+
+    expect(result).toBeUndefined();
+    expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  test('scheduleReminder returns undefined when the trigger lapses during permission await', async () => {
+    const todo: Todo = {
+      id: 't2',
+      text: 'Call back',
+      completed: false,
+      createdAt: 0,
+      updatedAt: 0,
+      dueDate: 1500,
+      reminderBeforeMinutes: 0,
+    };
+    mockGetPermissionsAsync.mockImplementation(async () => {
+      jest.advanceTimersByTime(600);
+      return { status: 'granted' };
+    });
+
+    const result = await NotificationService.scheduleReminder(todo);
+
+    expect(result).toBeUndefined();
+    expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  test('scheduleReminder returns undefined when permission is denied', async () => {
+    const todo: Todo = {
+      id: 't3',
+      text: 'Denied reminder',
+      completed: false,
+      createdAt: 0,
+      updatedAt: 0,
+      dueDate: 5000,
+      reminderBeforeMinutes: 0,
+    };
+    mockGetPermissionsAsync.mockImplementation(async () => ({ status: 'denied' as const }));
+    mockRequestPermissionsAsync.mockImplementation(async () => ({ status: 'denied' as const }));
+
+    const result = await NotificationService.scheduleReminder(todo);
+
+    expect(result).toBeUndefined();
+    expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  test('a scheduleNotificationAsync rejection resolves to null without throwing', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockScheduleNotificationAsync.mockRejectedValueOnce(new Error('ERR_NOTIFICATIONS_FAILED_TO_SCHEDULE'));
+
+    const id = await NotificationService.schedulePushProgress('Pushing', 'Pushing', {
+      kind: 'push-progress',
+    });
+
+    expect(id).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/__tests__/services/StagePushScheduler.test.ts
+++ b/__tests__/services/StagePushScheduler.test.ts
@@ -195,6 +195,27 @@ describe('StagePushScheduler', () => {
     expect(useStageStore.getState().pushQueue).toHaveLength(0);
   });
 
+  test('drainPushQueue resets globalPushing once the queue empties', async () => {
+    useStageStore.setState({
+      staged: [],
+      isPushing: {},
+      globalPushing: true,
+      pushQueue: ['a/repo::main'],
+      pendingCount: 0,
+    });
+
+    const setGlobalPushingSpy = jest.spyOn(useStageStore.getState(), 'setGlobalPushing');
+
+    await drainPushQueue();
+    await flushAsync();
+
+    expect(setGlobalPushingSpy).toHaveBeenCalledWith(false);
+    expect(useStageStore.getState().globalPushing).toBe(false);
+    expect(useStageStore.getState().pushQueue).toHaveLength(0);
+
+    setGlobalPushingSpy.mockRestore();
+  });
+
   test('failed push invokes the registered push-failure callback with {key, error}', async () => {
     useStageStore.setState({
       staged: [item(REPO_A, 'main', 'notes/a.md')],

--- a/__tests__/services/manualSync.test.ts
+++ b/__tests__/services/manualSync.test.ts
@@ -1,7 +1,3 @@
-jest.mock('../../src/services/NoteSyncQueueService', () => ({
-  NoteSyncQueueService: { drain: jest.fn() },
-}));
-
 jest.mock('../../src/services/RepoPullService', () => ({
   pullAllFromRepos: jest.fn(),
   pullFromSingleRepo: jest.fn(),
@@ -24,13 +20,11 @@ jest.mock('../../src/stores/todoStore', () => ({
 }));
 
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
-import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
 import { pullAllFromRepos, pullFromSingleRepo } from '../../src/services/RepoPullService';
 import type { PullResult } from '../../src/services/RepoPullService';
 import { GitSyncGate } from '../../src/services/git/GitSyncGate';
 import { isSyncNowRunning, syncNow } from '../../src/services/git/manualSync';
 
-const drainMock = jest.mocked(NoteSyncQueueService.drain);
 const pullAllMock = jest.mocked(pullAllFromRepos);
 const pullSingleMock = jest.mocked(pullFromSingleRepo);
 
@@ -46,7 +40,6 @@ describe('manualSync.syncNow', () => {
     jest.useFakeTimers();
     jest.clearAllMocks();
     GitSyncGate.__resetForTest();
-    drainMock.mockResolvedValue({ succeeded: 0, failed: 0, remaining: 0 });
     pullAllMock.mockResolvedValue(pullResult);
     pullSingleMock.mockResolvedValue(pullResult);
     mockRefreshNotes.mockResolvedValue(undefined);
@@ -59,12 +52,8 @@ describe('manualSync.syncNow', () => {
     jest.useRealTimers();
   });
 
-  test('runs drain → pull → store refresh inside one held gate cycle (case 1)', async () => {
+  test('runs pull → store refresh inside one held gate cycle (case 1)', async () => {
     const events: string[] = [];
-    drainMock.mockImplementation(async () => {
-      events.push(`drain:held=${GitSyncGate.isCycleHeld()}`);
-      return { succeeded: 1, failed: 0, remaining: 0 };
-    });
     pullAllMock.mockImplementation(async () => {
       events.push(`pull:held=${GitSyncGate.isCycleHeld()}`);
       return pullResult;
@@ -86,7 +75,6 @@ describe('manualSync.syncNow', () => {
 
     expect(result).toEqual({ ok: true });
     expect(events).toEqual([
-      'drain:held=true',
       'pull:held=true',
       'refreshNotes:held=true',
       'refreshCanvases:held=true',
@@ -110,12 +98,10 @@ describe('manualSync.syncNow', () => {
     const first = syncNow();
     await flushMicrotasks();
     expect(isSyncNowRunning()).toBe(true);
-    expect(drainMock).toHaveBeenCalledTimes(1);
     expect(pullAllMock).toHaveBeenCalledTimes(1);
 
     const second = await syncNow();
     expect(second).toEqual({ ok: false, error: 'already-running' });
-    expect(drainMock).toHaveBeenCalledTimes(1);
     expect(pullAllMock).toHaveBeenCalledTimes(1);
     expect(mockRefreshNotes).not.toHaveBeenCalled();
     expect(mockRefreshCanvases).not.toHaveBeenCalled();

--- a/__tests__/stores/gitOperationStore.test.ts
+++ b/__tests__/stores/gitOperationStore.test.ts
@@ -204,9 +204,14 @@ describe('gitOperationStore', () => {
       expect(isPathLocked(opsState(), REPO, BRANCH, 'notes/other.md')).toBe(false);
     });
 
-    it('ops without a path lock every path on their repo+branch (pull/push)', () => {
+    it('repo-wide ops without a path do not lock any specific path (pull/push)', () => {
       beginOp({ kind: 'pull', branch: BRANCH, status: 'running' });
-      expect(isPathLocked(opsState(), REPO, BRANCH, 'any/file.md')).toBe(true);
+      expect(isPathLocked(opsState(), REPO, BRANCH, 'any/file.md')).toBe(false);
+    });
+
+    it('isPathLocked false for an active op with undefined path on the same repo+branch', () => {
+      beginOp({ kind: 'push', branch: BRANCH, status: 'running' });
+      expect(isPathLocked(opsState(), REPO, BRANCH, PATH)).toBe(false);
     });
 
     it('failed ops do not lock paths or entities', () => {

--- a/__tests__/stores/stageStore.test.ts
+++ b/__tests__/stores/stageStore.test.ts
@@ -102,6 +102,17 @@ describe('stageStore', () => {
     expect(state.pushQueue).toEqual(['a/repo::main', 'b/repo::main']);
   });
 
+  it('setGlobalPushing toggles the globalPushing flag (reset after drain)', () => {
+    useStageStore.getState().pushAll();
+    expect(useStageStore.getState().globalPushing).toBe(true);
+
+    useStageStore.getState().setGlobalPushing(false);
+    expect(useStageStore.getState().globalPushing).toBe(false);
+
+    useStageStore.getState().setGlobalPushing(true);
+    expect(useStageStore.getState().globalPushing).toBe(true);
+  });
+
   it('requestPush(key) during globalPushing still enqueues behind', () => {
     useStageStore.setState({ globalPushing: true, pushQueue: ['x/repo::main'] });
 

--- a/__tests__/sync-locking.integration.test.ts
+++ b/__tests__/sync-locking.integration.test.ts
@@ -634,8 +634,9 @@ describe('sync-locking integration scenarios S1–S8', () => {
     );
     pressAlertButton('Retry');
 
-    // The retry drain holds on the transport, so the row is observable LOCKED
-    // again (failure entry cleared, fresh tombstone, one queued delete).
+    // Retry stages the delete (re-enqueues, clears the failure entry) WITHOUT
+    // draining, so the row is observable LOCKED again (fresh tombstone, one
+    // queued delete).
     await waitFor(() => {
       expect(screen.getByTestId('note-row.lock-spinner')).toBeTruthy();
     });
@@ -643,7 +644,9 @@ describe('sync-locking integration scenarios S1–S8', () => {
     expect(await NoteSyncQueueService.pendingCount()).toBe(1);
     expect(await NoteSyncQueueService.isTombstoned('owner/repo', 'main', 'notes/third.md')).toBe(true);
 
-    // Retry drain succeeds -> succeeded event -> storage delete + row removed.
+    // The stage path enqueues but never drains — the push engine owns the
+    // flush. Trigger it here the way the scheduler would, then report success.
+    void NoteSyncQueueService.drain();
     await act(async () => {
       await flushMicrotasks();
     });

--- a/docs/wiki/sync-engine.md
+++ b/docs/wiki/sync-engine.md
@@ -296,12 +296,36 @@ async function processQueue() {
 
 While a git operation is in flight for a file, the row cards in the Notes and Todo lists gray out and show a small spinner in the card's top-right corner (`note-row.lock-spinner` / `todo-row.lock-spinner`). The state comes from `useEntityLock` (`src/hooks/useGitOpLock.ts`), which mirrors ops from the `gitOperationStore` registry.
 
+Locks are per-item. Only ops that carry a concrete `path` or matching `entityIds` gray out a row. Repo-wide ops do not match any row: push markers published with `path: undefined` and the all-repos pull-cycle op (`repo: GIT_OP_ALL_REPOS`) leave every row interactive, so a repo-wide push or pull never dims the whole list. `opMatchesContext` (`src/hooks/useGitOpLock.ts`) and `isPathLocked` (`src/stores/gitOperationStore.ts`) both require `op.path !== undefined && op.path === ctx.path`; an `entityIds` match on a queued delete/upsert still locks its row. Repo-level guards (`gateBusy`, `isRepoBusy`, `hasActivePull`, RefreshControl) are separate and unchanged.
+
 Layout rule:
 
 - The spinner overlay is positioned `absolute` with `right: 24, top: 24` relative to the row wrapper (`LockedNoteRow` / `LockedTodoRow`). The 24px offsets keep the spinner inside the card's bounds, clear of the 12px rounded card corner.
-- Do not lower the offsets below 24 — the note card is inset by `marginHorizontal: 16` and both cards use `borderRadius: 12`, so smaller offsets make the spinner overhang the card edge.
+- Do not lower the offsets below 24. The note card is inset by `marginHorizontal: 16` and both cards use `borderRadius: 12`, so smaller offsets make the spinner overhang the card edge.
 
 Tests: `__tests__/notes-delete-lock.test.tsx` asserts the spinner wrapper sits at least 24px from the row wrapper's right/top edges.
+
+## Push model
+
+Refresh, startup, and manual sync entry points are pull-only. They pull remote state and refresh the stores, but they never push staged changes:
+
+- `ForegroundSyncService.runPull` (`src/services/ForegroundSyncService.ts`) pulls every tracked repo on app focus, online transitions, and the foreground interval. No queue drain.
+- `manualSync.runSyncCycle` (`src/services/git/manualSync.ts`) backs pull-to-refresh, the cloud-icon sync button, and startup sync via `syncNow`. Pull and store refresh only.
+- `useGitOpLock.retry` (`src/hooks/useGitOpLock.ts`) clears the failure entry and re-enqueues the delete; it does not drain the sync queue.
+
+Pushes flow only through three paths: the stage scheduler (`StagePushScheduler`, a 3-minute idle window that resets on staged changes), the explicit Push / Push-all buttons on the Stage screen, or the OS background task. The sync queue drains only when one of those push paths runs. Saving or deleting a note by itself never starts a push.
+
+## Push progress & failure notifications
+
+Immediate local notifications (push progress, push failure, background-pull) use a `TIME_INTERVAL` trigger with `seconds: 1` instead of a near-future date, which avoids expo-notifications rejecting past dates. Date-trigger scheduling (`scheduleDateTrigger` in `src/services/NotificationService.ts`) re-checks the trigger against `Date.now()` after the permission round-trip, so a date that lapses while the permission prompt is open is skipped rather than rejected. Native scheduling failures never throw: they log with `console.warn`, return `null`, and callers fire-and-forget.
+
+## Background pull notification
+
+The OS background sync task (`BackgroundSyncService`) schedules a local notification only when a pull changed something. After `pullAllFromRepos()`, the task sums the `PullResult` counts (`notes + canvases + todos + templates`) and, when the sum is greater than zero, calls `NotificationService.schedulePushProgress('Synced with origin', ...)` with `{ kind: 'background-pull' }`. A background pull that changed nothing stays silent.
+
+## `globalPushing` reset
+
+The stage store's `globalPushing` flag resets to `false` once the push queue drains. `StagePushScheduler.drainPushQueue` calls `setGlobalPushing(false)` after the FIFO loop ends and `dequeueNext()` returns `null`, so the Stage screen "Push all" button and the floating stage button stop spinning as soon as a push completes. While any key is still in flight (`isPushing[key]` true), the flag stays `true`.
 
 ## Testing
 

--- a/src/components/editor/useNoteEditorDocument.ts
+++ b/src/components/editor/useNoteEditorDocument.ts
@@ -360,7 +360,7 @@ export function useNoteEditorDocument({
 
       if (repo && savedNoteId) {
         const syncPath =
-          existingFilePath ?? (folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : undefined);
+          existingFilePath ?? (folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : `${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}`);
         const upsertOpId = syncPath
           ? gitOperationRegistry.begin({
               kind: 'upsert',
@@ -389,7 +389,7 @@ export function useNoteEditorDocument({
           };
 
           const stageResult = await StagingService.stageUpsert(syncParams);
-          if (stageResult.success && syncPath) {
+          if (stageResult.success) {
             const updated = await updateNote({
               id: savedNoteId,
               filePath: syncPath,
@@ -402,20 +402,12 @@ export function useNoteEditorDocument({
               );
             }
           } else {
-            try {
-              await NoteSyncQueueService.enqueueNoteUpsert(syncParams, savedNoteId);
-              Alert.alert(
-                'Note Saved Locally',
-                'Your note was saved but could not be pushed to GitHub yet. It will sync automatically when connection is restored.',
-                [{ text: 'OK' }],
-              );
-            } catch {
-              Alert.alert(
-                'Save Failed',
-                'Your note was saved locally but could not be queued for sync. Please try again.',
-                [{ text: 'OK' }],
-              );
-            }
+            console.warn('[useNoteEditorDocument] stage failed:', stageResult.error);
+            Alert.alert(
+              'Save Failed',
+              'Your note was saved locally but could not be staged for sync. Please try again.',
+              [{ text: 'OK' }],
+            );
           }
         } catch (error) {
           console.warn('[useNoteEditorDocument] note sync threw:', error);

--- a/src/hooks/useGitOpLock.ts
+++ b/src/hooks/useGitOpLock.ts
@@ -23,14 +23,19 @@ function normalizeBranch(branch: string | undefined): string {
   return branch || 'main';
 }
 
-function opMatchesContext(op: GitOp, entityId: string | undefined, ctx?: UseEntityLockOptions): boolean {
+export function opMatchesContext(
+  op: GitOp,
+  entityId: string | undefined,
+  ctx?: UseEntityLockOptions,
+): boolean {
   const entityMatch = !!entityId && op.entityIds.includes(entityId);
   const pathMatch =
     !!ctx?.repo &&
     !!ctx.path &&
     op.repo === ctx.repo &&
     normalizeBranch(op.branch) === normalizeBranch(ctx.branch) &&
-    (op.path === undefined || op.path === ctx.path);
+    op.path !== undefined &&
+    op.path === ctx.path;
   return entityMatch || pathMatch;
 }
 
@@ -41,8 +46,9 @@ function opMatchesContext(op: GitOp, entityId: string | undefined, ctx?: UseEnti
  * entityIds as a secondary index (cover for calls that only know the id).
  *
  * `retry()` clears the durable failure entry, drops every registry op on
- * this path (volatile row-locks included), re-enqueues the delete and
- * drains once so the failed row goes straight back to locked.
+ * this path (volatile row-locks included) and re-enqueues the delete. The
+ * queue notifies and re-derives the queued op, which takes the row straight
+ * back to locked.
  */
 export function useEntityLock(
   entityId?: string,
@@ -91,7 +97,6 @@ export function useEntityLock(
         accountId: note?.accountId,
         localNoteId: note?.id ?? entityId,
       });
-      void NoteSyncQueueService.drain();
     })();
   }, [failedOp, entityId]);
 

--- a/src/services/BackgroundSyncService.ts
+++ b/src/services/BackgroundSyncService.ts
@@ -6,6 +6,7 @@ import { NoteSyncQueueService } from './NoteSyncQueueService';
 import { pullAllFromRepos } from './RepoPullService';
 import { GitSyncGate } from './git/GitSyncGate';
 import { StagingService } from './git/StagingService';
+import { NotificationService } from './NotificationService';
 
 const TASK_NAME = 'background-sync';
 
@@ -34,8 +35,21 @@ TaskManager.defineTask(TASK_NAME, async () => {
     const releaseCycle = await GitSyncGate.acquireCycle();
     try {
       await NoteSyncQueueService.drain();
-      await pullAllFromRepos();
+      const result = await pullAllFromRepos();
       await flushStagedSetsForBackgroundTask();
+
+      const pulled = result.notes + result.canvases + result.todos + result.templates;
+      if (pulled > 0) {
+        try {
+          await NotificationService.schedulePushProgress(
+            'Synced with origin',
+            `Pulled ${pulled} changed item(s)`,
+            { kind: 'background-pull' },
+          );
+        } catch (error) {
+          console.warn('[BackgroundSync] push-progress notification failed:', error);
+        }
+      }
     } finally {
       releaseCycle();
     }

--- a/src/services/ForegroundSyncService.ts
+++ b/src/services/ForegroundSyncService.ts
@@ -2,7 +2,6 @@ import { AppState, type AppStateStatus, type NativeEventSubscription } from 'rea
 import NetInfo, { type NetInfoSubscription } from '@react-native-community/netinfo';
 import { GitHubService } from './GitHubService';
 import { StorageService } from './StorageService';
-import { NoteSyncQueueService } from './NoteSyncQueueService';
 import { pullAllFromRepos } from './RepoPullService';
 import { reconcileThoughtDumps } from './ai/thoughtDumpIndexing';
 import { GitSyncGate } from './git/GitSyncGate';
@@ -114,17 +113,11 @@ async function runPull(reason: string): Promise<void> {
   let success = false;
   const PULL_TIMEOUT_MS = 600_000;
   backgroundWork = (async () => {
-    // ONE cycle acquisition spans the whole drain+pull pair; drain() sees
-    // the held cycle and runs inside it (no self-deadlock). The release
-    // lives with the work itself, not the timeout race below, so a timed-
-    // out pull keeps owning the cycle until it actually settles.
+    // ONE cycle acquisition spans the pull; the release lives with the work
+    // itself, not the timeout race below, so a timed-out pull keeps owning
+    // the cycle until it actually settles.
     const releaseCycle = await GitSyncGate.acquireCycle();
     try {
-      try {
-        await NoteSyncQueueService.drain();
-      } catch (error) {
-        console.warn(`[ForegroundSync] drain (${reason}) failed:`, error);
-      }
       await pullAllFromRepos();
     } finally {
       releaseCycle();

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -20,6 +20,49 @@ export class NotificationService {
     return status === 'granted';
   }
 
+  private static async scheduleImmediate(
+    content: Notifications.NotificationContentInput,
+  ): Promise<string | null> {
+    const hasPermission = await this.requestPermissions();
+    if (!hasPermission) return null;
+
+    try {
+      return await Notifications.scheduleNotificationAsync({
+        content,
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+          seconds: 1,
+        },
+      });
+    } catch (error) {
+      console.warn('[NotificationService] failed to schedule notification:', error);
+      return null;
+    }
+  }
+
+  private static async scheduleDateTrigger(
+    content: Notifications.NotificationContentInput,
+    trigger: Date,
+  ): Promise<string | null> {
+    const hasPermission = await this.requestPermissions();
+    if (!hasPermission) return null;
+
+    if (trigger.getTime() <= Date.now()) return null;
+
+    try {
+      return await Notifications.scheduleNotificationAsync({
+        content,
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.DATE,
+          date: trigger,
+        },
+      });
+    } catch (error) {
+      console.warn('[NotificationService] failed to schedule notification:', error);
+      return null;
+    }
+  }
+
   static async scheduleReminder(todo: Todo): Promise<string | undefined> {
     if (!todo.dueDate || todo.completed) return undefined;
 
@@ -28,23 +71,17 @@ export class NotificationService {
 
     if (triggerTime.getTime() <= Date.now()) return undefined;
 
-    const hasPermission = await this.requestPermissions();
-    if (!hasPermission) return undefined;
-
-    const notificationId = await Notifications.scheduleNotificationAsync({
-      content: {
+    const notificationId = await this.scheduleDateTrigger(
+      {
         title: 'Todo Reminder',
         body: todo.text,
         data: { todoId: todo.id },
         sound: true,
       },
-      trigger: {
-        type: Notifications.SchedulableTriggerInputTypes.DATE,
-        date: triggerTime,
-      },
-    });
+      triggerTime,
+    );
 
-    return notificationId;
+    return notificationId ?? undefined;
   }
 
   static async cancelReminder(notificationId: string): Promise<void> {
@@ -74,18 +111,7 @@ export class NotificationService {
 
     if (trigger.getTime() <= Date.now()) return null;
 
-    const hasPermission = await this.requestPermissions();
-    if (!hasPermission) return null;
-
-    const notificationId = await Notifications.scheduleNotificationAsync({
-      content: { title, body, data, sound: true },
-      trigger: {
-        type: Notifications.SchedulableTriggerInputTypes.DATE,
-        date: trigger,
-      },
-    });
-
-    return notificationId;
+    return this.scheduleDateTrigger({ title, body, data, sound: true }, trigger);
   }
 
   /**
@@ -97,12 +123,7 @@ export class NotificationService {
     body: string,
     data: Record<string, unknown>,
   ): Promise<string | null> {
-    return this.scheduleLearningNotification({
-      title,
-      body,
-      data,
-      trigger: new Date(Date.now() + 100),
-    });
+    return this.scheduleImmediate({ title, body, data, sound: true });
   }
 
   static async schedulePushFailure(
@@ -110,11 +131,6 @@ export class NotificationService {
     body: string,
     data: { kind: 'push-failure'; repoPath?: string; branch?: string; conflict: boolean },
   ): Promise<string | null> {
-    return this.scheduleLearningNotification({
-      title,
-      body,
-      data,
-      trigger: new Date(Date.now() + 100),
-    });
+    return this.scheduleImmediate({ title, body, data, sound: true });
   }
 }

--- a/src/services/StagePushScheduler.ts
+++ b/src/services/StagePushScheduler.ts
@@ -119,6 +119,12 @@ export async function drainPushQueue(): Promise<void> {
         useStageStore.getState().shiftQueue();
       }
     }
+
+    if (useStageStore.getState().dequeueNext() === null) {
+      if (useStageStore.getState().globalPushing) {
+        useStageStore.getState().setGlobalPushing(false);
+      }
+    }
   } finally {
     draining = false;
   }

--- a/src/services/git/manualSync.ts
+++ b/src/services/git/manualSync.ts
@@ -1,4 +1,3 @@
-import { NoteSyncQueueService } from '../NoteSyncQueueService';
 import { pullAllFromRepos, pullFromSingleRepo } from '../RepoPullService';
 import { useCanvasStore } from '../../stores/canvasStore';
 import { useNoteStore } from '../../stores/noteStore';
@@ -8,14 +7,13 @@ import { GitSyncGate } from './GitSyncGate';
 /**
  * Single manual-sync entry point ("sync now") for user-facing pulls:
  * pull-to-refresh swipes and the cloud-icon sync button. Acquires the
- * app-wide gate cycle, drains queued mutations, waits for in-flight push
- * markers to settle, pulls remote state, and refreshes all three stores
- * before releasing the cycle.
+ * app-wide gate cycle, waits for in-flight push markers to settle, pulls
+ * remote state, and refreshes all three stores before releasing the cycle.
  *
  * Reentrancy: exactly one syncNow runs at a time. Overlapping manual
  * calls return `{ok:false, error:'already-running'}` immediately instead
  * of queueing — the gesture already ran once, and stacking another pull
- * behind a long drain only adds latency. (Auto paths — ForegroundSync
+ * behind a long one only adds latency. (Auto paths — ForegroundSync
  * runPull / BackgroundSyncService — keep their own gate-wrapped internals
  * and never route through here.)
  *
@@ -77,17 +75,9 @@ async function refreshAllStores(): Promise<void> {
 }
 
 async function runSyncCycle(repos?: string[]): Promise<void> {
-  // ONE cycle acquisition spans drain + pull + refresh. drain() sees the
-  // held cycle via isCycleHeld() and runs inside it (no self-deadlock).
+  // ONE cycle acquisition spans the push-settle wait + pull + refresh.
   const releaseCycle = await GitSyncGate.acquireCycle();
   try {
-    try {
-      await NoteSyncQueueService.drain();
-    } catch (error) {
-      // A drain failure must not block the remote pull (same recovery
-      // semantics as ForegroundSyncService.runPull).
-      console.warn('[Sync] drain failed:', error);
-    }
     await waitForPushesToSettle(repos);
     if (repos?.length === 1) {
       await pullFromSingleRepo(repos[0]);

--- a/src/stores/gitOperationStore.ts
+++ b/src/stores/gitOperationStore.ts
@@ -275,7 +275,8 @@ export const isPathLocked = (
       isActiveStatus(op.status) &&
       op.repo === repo &&
       normalizeBranch(op.branch) === normalizeBranch(branch) &&
-      (op.path === undefined || op.path === path),
+      op.path !== undefined &&
+      op.path === path,
   );
 
 export const isEntityLocked = (ops: Record<string, GitOp>, entityId: string): boolean =>

--- a/src/stores/stageStore.ts
+++ b/src/stores/stageStore.ts
@@ -29,6 +29,7 @@ interface StageActions {
   keyFor: (repoPath: string, branch: string) => string;
   requestPush: (repoPath?: string, branch?: string) => string | null;
   setPushing: (key: string, bool: boolean) => void;
+  setGlobalPushing: (bool: boolean) => void;
   pushAll: () => void;
   dequeueNext: () => string | null;
   shiftQueue: () => void;
@@ -117,6 +118,8 @@ export const useStageStore = create<StageState & StageActions>()((set, get) => (
 
   setPushing: (key, bool) =>
     set((state) => ({ isPushing: { ...state.isPushing, [key]: bool } })),
+
+  setGlobalPushing: (bool) => set({ globalPushing: bool }),
 
   pushAll: () => {
     set({ globalPushing: true });


### PR DESCRIPTION
## Summary

Completes the stage-push migration. Sync is now **pull-only** — saves stage changes and never push them immediately — and push-related lock/notification bugs are fixed.

### Changes
1. **Pull-only sync** — foreground refresh, startup auto-pull, and manual sync no longer push staged changes; they only pull. Saves stage and wait for the explicit Push flow.
2. **Per-item locks** — row locks now scope to path/entity operations so repo-wide push markers don't gray out the entire note list.
3. **globalPushing reset** — resets when the push queue drains, so the stage Push-all button stops spinning.
4. **Root-level new notes** — no longer show the "Note Saved Locally" toast when staging succeeds (single enqueue).
5. **Notification trigger fix** — push notifications now use `TIME_INTERVAL` trigger plus a post-permission date re-check, fixing `ERR_NOTIFICATIONS_FAILED_TO_SCHEDULE`.
6. **Background pull notifications** — background sync notifies only on actual changes/conflicts.

### Verification
- Full Jest suite: 250 suites / 2200 tests passing
- `yarn ts:check` clean
- `yarn eslint . --ext .ts,.tsx` — 0 errors