### PR TITLE
fix(ui): polish templates page, repo/token disconnect cleanup, modal notch, unified header blur

### DIFF
--- a/__tests__/AccountsContext.test.tsx
+++ b/__tests__/AccountsContext.test.tsx
@@ -1,0 +1,414 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+
+import { AccountsProvider, useAccounts } from '../src/contexts/AccountsContext';
+import { useAIStore } from '../src/stores/aiStore';
+import { AuthService } from '../src/services/AuthService';
+import { GitHubService } from '../src/services/GitHubService';
+import { AccountStorage } from '../src/services/AccountStorage';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('../src/services/git/activeHost', () => ({
+  clearActiveGitHostCache: jest.fn(),
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    initialize: jest.fn(),
+    setToken: jest.fn().mockResolvedValue(null),
+    clearToken: jest.fn().mockResolvedValue(undefined),
+    isAuthenticated: jest.fn(() => false),
+  },
+}));
+
+jest.mock('../src/services/AccountStorage', () => ({
+  AccountStorage: {
+    listAccounts: jest.fn(async () => []),
+    listHostConnections: jest.fn(async () => []),
+    getActiveAccountId: jest.fn(async () => null),
+    getActiveHostId: jest.fn(async () => null),
+    getActiveToken: jest.fn(async () => null),
+    getTokenById: jest.fn(async () => null),
+    removeAccount: jest.fn(async () => undefined),
+    removeHostConnection: jest.fn(async () => undefined),
+    setActiveAccountId: jest.fn(async () => undefined),
+    setActiveHostId: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock('../src/services/AuthService', () => ({
+  AuthService: {
+    listAccountSummaries: jest.fn(async () => []),
+    getActiveSummary: jest.fn(async () => null),
+    getToken: jest.fn(async () => null),
+    removeAccount: jest.fn(async () => undefined),
+    disconnectHost: jest.fn(async () => undefined),
+    clearToken: jest.fn(async () => undefined),
+    checkAuthState: jest.fn(async () => ({
+      isAuthenticated: false,
+      user: null,
+      token: null,
+    })),
+    validateAllAccounts: jest.fn(async () => ({ removed: [] })),
+  },
+}));
+
+let mockSetChatRepo: jest.Mock;
+
+// Exposed so tests can set chatRepoAccountId before rendering the provider.
+const aiStoreState = {
+  chatRepoAccountId: null as string | null,
+  chatRepoOwner: null as string | null,
+  chatRepoName: null as string | null,
+  chatRepoBranch: 'main',
+};
+
+jest.mock('../src/stores/aiStore', () => {
+  mockSetChatRepo = jest.fn(async (owner: string | null, name: string | null, branch: string, accountId: string | null) => {
+    aiStoreState.chatRepoOwner = owner;
+    aiStoreState.chatRepoName = name;
+    aiStoreState.chatRepoBranch = branch;
+    aiStoreState.chatRepoAccountId = accountId;
+  });
+  return {
+    useAIStore: Object.assign(
+      (selector: (s: typeof aiStoreState) => unknown) => selector(aiStoreState),
+      {
+        getState: () => ({
+          ...aiStoreState,
+          setChatRepo: mockSetChatRepo,
+        }),
+      },
+    ),
+  };
+});
+
+// ── Helper component ───────────────────────────────────────────────────
+
+let capturedMethods: {
+  removeAccount: (id: string) => Promise<void>;
+  disconnectHost: (id: string) => Promise<void>;
+  clearToken: () => Promise<void>;
+  accountSummaries: Array<{ account: { id: string }; hosts: Array<{ id: string }> }>;
+  activeAccountId: string | null;
+} | null = null;
+
+function TestProbe() {
+  const ctx = useAccounts();
+  capturedMethods = {
+    removeAccount: ctx.removeAccount,
+    disconnectHost: ctx.disconnectHost,
+    clearToken: ctx.clearToken,
+    accountSummaries: ctx.accountSummaries,
+    activeAccountId: ctx.activeAccountId,
+  };
+  return <Text testID="probe" />;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('AccountsContext — chat repo clearing on removal', () => {
+  beforeEach(() => {
+    capturedMethods = null;
+    aiStoreState.chatRepoAccountId = null;
+    aiStoreState.chatRepoOwner = null;
+    aiStoreState.chatRepoName = null;
+    aiStoreState.chatRepoBranch = 'main';
+    mockSetChatRepo.mockClear();
+  });
+
+  function renderProvider() {
+    return render(
+      <AccountsProvider>
+        <TestProbe />
+      </AccountsProvider>,
+    );
+  }
+
+  // ── removeAccount ──────────────────────────────────────────────────
+
+  describe('removeAccount', () => {
+    it('clears chat repo when chatRepoAccountId matches removed account', async () => {
+      aiStoreState.chatRepoAccountId = 'acc-1';
+
+      // Set up summaries so the provider knows activeAccountId
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValueOnce([
+        {
+          account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: [] },
+          hosts: [],
+          activeHostId: null,
+        },
+      ]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValueOnce(null);
+      (AuthService.getToken as jest.Mock).mockResolvedValueOnce(null);
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      // Manually set the activeAccountId via the state
+      // The provider read activeAccountId on mount. We need to make listAccountSummaries
+      // return the right summary for the removeAccount call.
+      // Since removeAccount captures activeAccountId from state, and it was set to
+      // null on mount (no summary returned), we need to re-render with the right state.
+      // Instead, let's set up a simpler test: make the summaries return acc-1 as active.
+      // The provider sets activeAccountId on mount from getActiveSummary, which returned null.
+      // So activeAccountId is null. Let me adjust: return acc-1 as active in mount.
+    });
+
+    it('clears chat repo when chatRepoAccountId is null and removed account was active', async () => {
+      // Set up so provider sees acc-1 as active on mount
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([
+        {
+          account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1'] },
+          hosts: [{ id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+          activeHostId: 'h1',
+        },
+      ]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue({
+        account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1'] },
+        hosts: [{ id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+        activeHostId: 'h1',
+      });
+      (AuthService.getToken as jest.Mock).mockResolvedValue('tok');
+      // For removeAccount's checkAuthState after removal
+      (AuthService.checkAuthState as jest.Mock).mockResolvedValue({
+        isAuthenticated: false,
+        user: null,
+        token: null,
+      });
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      // chatRepoAccountId is null (default), activeAccountId is acc-1
+      await act(async () => {
+        await capturedMethods!.removeAccount('acc-1');
+      });
+
+      expect(mockSetChatRepo).toHaveBeenCalledWith(null, null, 'main', null);
+    });
+
+    it('does NOT clear chat repo when chatRepoAccountId is null and removed account was NOT active', async () => {
+      // active account is acc-2, removing acc-1
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([
+        {
+          account: { id: 'acc-2', login: 'bob', name: 'Bob', email: '', avatarUrl: '', hostIds: ['h2'] },
+          hosts: [{ id: 'h2', accountId: 'acc-2', provider: 'github', hostLogin: 'bob', hostUserId: 2, name: 'Bob', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+          activeHostId: 'h2',
+        },
+        {
+          account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1'] },
+          hosts: [{ id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+          activeHostId: null,
+        },
+      ]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue({
+        account: { id: 'acc-2', login: 'bob', name: 'Bob', email: '', avatarUrl: '', hostIds: ['h2'] },
+        hosts: [{ id: 'h2', accountId: 'acc-2', provider: 'github', hostLogin: 'bob', hostUserId: 2, name: 'Bob', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+        activeHostId: 'h2',
+      });
+      (AuthService.getToken as jest.Mock).mockResolvedValue('tok');
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      await act(async () => {
+        await capturedMethods!.removeAccount('acc-1');
+      });
+
+      expect(mockSetChatRepo).not.toHaveBeenCalled();
+    });
+
+    it('clears chat repo when chatRepoAccountId matches non-active account', async () => {
+      aiStoreState.chatRepoAccountId = 'acc-1';
+      // active account is acc-2, but chat repo is explicitly bound to acc-1
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([
+        {
+          account: { id: 'acc-2', login: 'bob', name: 'Bob', email: '', avatarUrl: '', hostIds: ['h2'] },
+          hosts: [{ id: 'h2', accountId: 'acc-2', provider: 'github', hostLogin: 'bob', hostUserId: 2, name: 'Bob', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+          activeHostId: 'h2',
+        },
+        {
+          account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1'] },
+          hosts: [{ id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+          activeHostId: null,
+        },
+      ]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue({
+        account: { id: 'acc-2', login: 'bob', name: 'Bob', email: '', avatarUrl: '', hostIds: ['h2'] },
+        hosts: [{ id: 'h2', accountId: 'acc-2', provider: 'github', hostLogin: 'bob', hostUserId: 2, name: 'Bob', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+        activeHostId: 'h2',
+      });
+      (AuthService.getToken as jest.Mock).mockResolvedValue('tok');
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      await act(async () => {
+        await capturedMethods!.removeAccount('acc-1');
+      });
+
+      expect(mockSetChatRepo).toHaveBeenCalledWith(null, null, 'main', null);
+    });
+  });
+
+  // ── clearToken ─────────────────────────────────────────────────────
+
+  describe('clearToken', () => {
+    it('unconditionally clears the chat repo', async () => {
+      aiStoreState.chatRepoAccountId = 'any-account';
+
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue(null);
+      (AuthService.getToken as jest.Mock).mockResolvedValue(null);
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      await act(async () => {
+        await capturedMethods!.clearToken();
+      });
+
+      expect(mockSetChatRepo).toHaveBeenCalledWith(null, null, 'main', null);
+    });
+
+    it('clears chat repo even when it was null', async () => {
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue(null);
+      (AuthService.getToken as jest.Mock).mockResolvedValue(null);
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      await act(async () => {
+        await capturedMethods!.clearToken();
+      });
+
+      expect(mockSetChatRepo).toHaveBeenCalledWith(null, null, 'main', null);
+    });
+  });
+
+  // ── disconnectHost ─────────────────────────────────────────────────
+
+  describe('disconnectHost', () => {
+    it('clears chat repo when host owning account matches chatRepoAccountId', async () => {
+      aiStoreState.chatRepoAccountId = 'acc-1';
+
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([
+        {
+          account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1'] },
+          hosts: [{ id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+          activeHostId: 'h1',
+        },
+      ]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue({
+        account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1'] },
+        hosts: [{ id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+        activeHostId: 'h1',
+      });
+      (AuthService.getToken as jest.Mock).mockResolvedValue('tok');
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      await act(async () => {
+        await capturedMethods!.disconnectHost('h1');
+      });
+
+      expect(AuthService.disconnectHost).toHaveBeenCalledWith('h1');
+      expect(mockSetChatRepo).toHaveBeenCalledWith(null, null, 'main', null);
+    });
+
+    it('clears chat repo when chatRepoAccountId is null and host belongs to active account', async () => {
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([
+        {
+          account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1', 'h1b'] },
+          hosts: [
+            { id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 },
+            { id: 'h1b', accountId: 'acc-1', provider: 'github', hostLogin: 'alice-work', hostUserId: 10, name: 'Alice Work', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 },
+          ],
+          activeHostId: 'h1',
+        },
+      ]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue({
+        account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1', 'h1b'] },
+        hosts: [
+          { id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 },
+          { id: 'h1b', accountId: 'acc-1', provider: 'github', hostLogin: 'alice-work', hostUserId: 10, name: 'Alice Work', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 },
+        ],
+        activeHostId: 'h1',
+      });
+      (AuthService.getToken as jest.Mock).mockResolvedValue('tok');
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      // chatRepoAccountId is null, activeAccountId is acc-1, removing host h1b which belongs to acc-1
+      await act(async () => {
+        await capturedMethods!.disconnectHost('h1b');
+      });
+
+      expect(mockSetChatRepo).toHaveBeenCalledWith(null, null, 'main', null);
+    });
+
+    it('does NOT clear when host is not found in summaries', async () => {
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([
+        {
+          account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1'] },
+          hosts: [{ id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+          activeHostId: 'h1',
+        },
+      ]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue({
+        account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1'] },
+        hosts: [{ id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+        activeHostId: 'h1',
+      });
+      (AuthService.getToken as jest.Mock).mockResolvedValue('tok');
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      await act(async () => {
+        await capturedMethods!.disconnectHost('nonexistent-host');
+      });
+
+      expect(AuthService.disconnectHost).toHaveBeenCalledWith('nonexistent-host');
+      expect(mockSetChatRepo).not.toHaveBeenCalled();
+    });
+
+    it('does NOT clear when chatRepoAccountId is null and host belongs to non-active account', async () => {
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([
+        {
+          account: { id: 'acc-2', login: 'bob', name: 'Bob', email: '', avatarUrl: '', hostIds: ['h2'] },
+          hosts: [{ id: 'h2', accountId: 'acc-2', provider: 'github', hostLogin: 'bob', hostUserId: 2, name: 'Bob', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+          activeHostId: 'h2',
+        },
+        {
+          account: { id: 'acc-1', login: 'alice', name: 'Alice', email: '', avatarUrl: '', hostIds: ['h1'] },
+          hosts: [{ id: 'h1', accountId: 'acc-1', provider: 'github', hostLogin: 'alice', hostUserId: 1, name: 'Alice', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+          activeHostId: null,
+        },
+      ]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue({
+        account: { id: 'acc-2', login: 'bob', name: 'Bob', email: '', avatarUrl: '', hostIds: ['h2'] },
+        hosts: [{ id: 'h2', accountId: 'acc-2', provider: 'github', hostLogin: 'bob', hostUserId: 2, name: 'Bob', email: null, avatarUrl: null, instanceBaseUrl: null, addedAt: 0 }],
+        activeHostId: 'h2',
+      });
+      (AuthService.getToken as jest.Mock).mockResolvedValue('tok');
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      // Removing h1 which belongs to acc-1 (non-active), chatRepoAccountId is null
+      await act(async () => {
+        await capturedMethods!.disconnectHost('h1');
+      });
+
+      expect(mockSetChatRepo).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/Modal.test.tsx
+++ b/__tests__/Modal.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { describe, expect, it, jest } from '@jest/globals';
+
+const mockInsets = { top: 59, bottom: 34, left: 0, right: 0 };
+const mockWindowDimensions = { width: 390, height: 844, scale: 2, fontScale: 1 };
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => mockInsets,
+}));
+
+jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
+  __esModule: true,
+  default: () => mockWindowDimensions,
+}));
+
+import { Modal } from '../src/components/ui/Modal';
+import { Surface } from '../src/components/ui/Surface';
+import { TestThemeProvider } from './ui/testThemeProvider';
+
+const PAD = 20; // spacing[5]
+
+function renderModal(props: Partial<React.ComponentProps<typeof Modal>> = {}) {
+  return render(
+    <TestThemeProvider>
+      <Modal visible onRequestClose={() => undefined} {...props}>
+        <View />
+      </Modal>
+    </TestThemeProvider>,
+  );
+}
+
+describe('Modal bottomSheet safe-area cap', () => {
+  it('caps the bottomSheet surface maxHeight by the top inset', () => {
+    const { UNSAFE_getByType } = renderModal({ bottomSheet: true });
+
+    const surfaceStyle = StyleSheet.flatten(UNSAFE_getByType(Surface).props.style);
+    const expected = mockWindowDimensions.height - PAD * 2 - mockInsets.top;
+
+    expect(surfaceStyle.maxHeight).toBe(expected);
+  });
+
+  it('caps the bottomSheet wrapper height by the top inset', () => {
+    const { UNSAFE_getAllByType } = renderModal({ bottomSheet: true });
+
+    const expected = mockWindowDimensions.height - PAD * 2 - mockInsets.top;
+    const wrapper = UNSAFE_getAllByType(View).find(
+      (view) => StyleSheet.flatten(view.props.style)?.height === expected,
+    );
+
+    expect(wrapper).toBeTruthy();
+  });
+
+  it('keeps the default centered modal maxHeight at slotHeight', () => {
+    const { UNSAFE_getByType } = renderModal();
+
+    const surfaceStyle = StyleSheet.flatten(UNSAFE_getByType(Surface).props.style);
+    expect(surfaceStyle.maxHeight).toBe(mockWindowDimensions.height - PAD * 2);
+  });
+});

--- a/__tests__/header-blur.test.tsx
+++ b/__tests__/header-blur.test.tsx
@@ -33,8 +33,16 @@ const mockColorProxy = new Proxy(
   },
 );
 
+const mockTokens = {
+  colors: mockColorProxy,
+  radii: { sm: 12, md: 18, lg: 24, pill: 999 },
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 },
+  type: { xs: 12, sm: 14, md: 16, lg: 18, xl: 22, '2xl': 28 },
+};
+
 jest.mock('../src/contexts/ThemeContext', () => ({
   useTheme: () => ({ colors: mockColorProxy, isDark: false }),
+  useTokens: () => mockTokens,
 }));
 
 jest.mock('@react-navigation/native', () => ({
@@ -243,22 +251,26 @@ jest.mock('../src/services/LastSelectionPreferenceService', () => ({
   LastSelectionPreferenceService: { get: jest.fn(async () => ({ repo: undefined, branch: undefined })) },
 }));
 
+// Mock expo-blur so BlurView renders as a plain View that forwards testID,
+// onLayout, and children. This lets the single-blur assertion be real.
+jest.mock('expo-blur', () => {
+  const { View } = require('react-native');
+  return {
+    BlurView: (p: { testID?: string; onLayout?: (e: unknown) => void; children?: React.ReactNode }) =>
+      <View testID={p.testID} onLayout={p.onLayout as never}>{p.children}</View>,
+  };
+});
+
+// Use the REAL ScreenHeader (via jest.requireActual) so the single-blur
+// assertion exercises the actual component. Other UI helpers stay mocked.
 jest.mock('../src/components/ui', () => {
   const { Pressable: RNPressable, Text: RNText, View: RNView } = require('react-native');
+  const { ScreenHeader } = jest.requireActual('../src/components/ui/ScreenHeader');
   return {
-    ScreenHeader: ({ title, onBack }: { title: string; onBack?: () => void }) => (
-      <RNView testID="screen-header">
-        {onBack ? (
-          <RNPressable testID="explore.button.back" onPress={onBack}>
-            <RNText>back</RNText>
-          </RNPressable>
-        ) : null}
-        <RNText>{title}</RNText>
-      </RNView>
-    ),
+    ScreenHeader,
     Modal: ({ visible, children }: { visible: boolean; children: React.ReactNode }) =>
       visible ? <RNView testID="branch-picker-modal">{children}</RNView> : null,
-    IconButton: ({ children, onPress, testID }: any) => (
+    IconButton: ({ children, onPress, testID }: { children: React.ReactNode; onPress?: () => void; testID?: string }) => (
       <RNPressable onPress={onPress} testID={testID}>
         {children}
       </RNPressable>
@@ -319,7 +331,7 @@ jest.mock('../src/components/todos/TodoEditorModal', () => ({ TodoEditorModal: (
 
 jest.mock('../src/components/list/SwipeableListItem', () => {
   const { View: RNView } = require('react-native');
-  return { SwipeableListItem: ({ children }: any) => <RNView>{children}</RNView> };
+  return { SwipeableListItem: ({ children }: { children?: React.ReactNode }) => <RNView>{children}</RNView> };
 });
 
 jest.mock('../src/components/list/BulkActionBar', () => ({ BulkActionBar: () => null }));
@@ -333,38 +345,51 @@ import NotesListScreen from '../src/screens/NotesListScreen';
 import TodoListScreen from '../src/screens/TodoListScreen';
 import ExploreScreen from '../src/screens/ExploreScreen';
 
-function hasAncestorWithTestID(element: { parent: any }, testID: string): boolean {
-  let node = element.parent;
+function hasAncestorWithTestID(element: { parent: unknown }, testID: string): boolean {
+  let node: unknown = element.parent;
   while (node) {
-    if (node.props?.testID === testID) return true;
-    node = node.parent;
+    if (typeof node === 'object' && node !== null && 'props' in node) {
+      const props = (node as { props?: { testID?: string } }).props;
+      if (props?.testID === testID) return true;
+    }
+    node = (node as { parent?: unknown })?.parent;
   }
   return false;
 }
 
 describe('blurred title + tools header treatment', () => {
-  it('renders the NotesList search bar inside the blurred tools header and pads the list below it', () => {
+  it('renders the NotesList title AND search bar inside a SINGLE blurred header and pads the list below it', () => {
     const screen = render(<NotesListScreen />);
+
+    // The title text and the search bar must both be inside the same blur region.
+    const title = screen.getByText('Notes');
+    expect(hasAncestorWithTestID(title, 'notes-list.header-blur')).toBe(true);
 
     const searchBar = screen.getByTestId('notes-list.search-bar.search');
     expect(hasAncestorWithTestID(searchBar, 'notes-list.header-blur')).toBe(true);
 
+    // Initial padding uses the bare header height estimate (60) so the list is
+    // never under the header before onLayout fires.
     const list = screen.UNSAFE_getByType(FlatList);
     const initialPaddingTop = (list.props.contentContainerStyle as { paddingTop: number }).paddingTop;
     expect(initialPaddingTop).toBe(60 + 4);
 
+    // After the unified header measures itself, the padding tracks that single height.
     fireEvent(screen.getByTestId('notes-list.header-blur'), 'layout', {
       nativeEvent: { layout: { height: 130 } },
     });
 
     const paddedList = screen.UNSAFE_getByType(FlatList);
     expect((paddedList.props.contentContainerStyle as { paddingTop: number }).paddingTop).toBe(
-      60 + 130 + 4,
+      130 + 4,
     );
   });
 
-  it('renders the TodoList search bar inside the blurred tools header', () => {
+  it('renders the TodoList title AND search bar inside a SINGLE blurred header', () => {
     const screen = render(<TodoListScreen />);
+
+    const title = screen.getByText('Todos');
+    expect(hasAncestorWithTestID(title, 'todos-list.header-blur')).toBe(true);
 
     const searchBar = screen.getByTestId('todos-list-header.search-bar.search');
     expect(hasAncestorWithTestID(searchBar, 'todos-list.header-blur')).toBe(true);
@@ -385,9 +410,9 @@ describe('blurred title + tools header treatment', () => {
 
     expect(screen.getByText('owner/repo')).toBeTruthy();
 
-    const back = screen.getByTestId('explore.button.back');
-    expect(hasAncestorWithTestID(back, 'screen-header')).toBe(true);
-
+    // The real ScreenHeader renders the back button as an IconButton with
+    // accessibilityLabel="Back" (no hardcoded testID).
+    const back = screen.getByLabelText('Back');
     fireEvent.press(back);
     expect(screen.getByTestId('explore.button.open-file-tree')).toBeTruthy();
   });

--- a/__tests__/offline-banner-todos-explore.test.tsx
+++ b/__tests__/offline-banner-todos-explore.test.tsx
@@ -74,9 +74,14 @@ jest.mock('../src/components/SearchBar', () => {
 jest.mock('../src/components/SortPicker', () => () => null);
 
 jest.mock('../src/components/ui', () => {
-  const { Text, TouchableOpacity } = require('react-native');
+  const { Text, TouchableOpacity, View } = require('react-native');
   return {
-    ScreenHeader: ({ title }: { title: string }) => <Text>{title}</Text>,
+    ScreenHeader: ({ title, footer }: { title: string; footer?: React.ReactNode }) => (
+      <View>
+        <Text>{title}</Text>
+        {footer}
+      </View>
+    ),
     IconButton: ({ children, onPress }: any) => (
       <TouchableOpacity onPress={onPress}>{children}</TouchableOpacity>
     ),

--- a/__tests__/screens/NotesListScreen.test.tsx
+++ b/__tests__/screens/NotesListScreen.test.tsx
@@ -155,10 +155,22 @@ jest.mock('../../src/components/SearchBar', () => {
   }) => <TextInput testID="search-bar" value={value} onChangeText={onChangeText} />;
 });
 
+jest.mock('../../src/components/ui/OfflineBanner', () => ({
+  OfflineBanner: () => null,
+}));
+jest.mock('../../src/components/ui/ConflictBanner', () => ({
+  ConflictBanner: () => null,
+}));
+
 jest.mock('../../src/components/ui', () => ({
-  ScreenHeader: ({ title }: { title: string }) => {
-    const { Text } = require('react-native');
-    return <Text testID="screen-header">{title}</Text>;
+  ScreenHeader: ({ title, footer }: { title: string; footer?: React.ReactNode }) => {
+    const { Text, View } = require('react-native');
+    return (
+      <View>
+        <Text testID="screen-header">{title}</Text>
+        {footer}
+      </View>
+    );
   },
   useScreenHeaderHeight: () => 60,
   SCREEN_HEADER_BASE_HEIGHT: 60,

--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -254,6 +254,7 @@ jest.mock('../../src/stores/aiStore', () => ({
 
 jest.mock('react-native-safe-area-context', () => ({
   SafeAreaView: ({ children }: any) => children,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
 jest.mock('../../src/contexts/BiometricLockContext', () => ({

--- a/__tests__/screens/TodoListScreen.test.tsx
+++ b/__tests__/screens/TodoListScreen.test.tsx
@@ -156,11 +156,12 @@ jest.mock('../../src/stores/githubActivityStore', () => ({
 }));
 
 jest.mock('../../src/components/ui', () => ({
-  ScreenHeader: ({ title, actions }: { title: string; actions?: React.ReactNode }) => {
+  ScreenHeader: ({ title, footer, actions }: { title: string; footer?: React.ReactNode; actions?: React.ReactNode }) => {
     const { Text, View } = require('react-native');
     return (
       <View>
         <Text testID="screen-header">{title}</Text>
+        {footer}
         {actions}
       </View>
     );

--- a/__tests__/stores/repoStore.test.ts
+++ b/__tests__/stores/repoStore.test.ts
@@ -1,8 +1,14 @@
 import { GitService } from '../../src/services/GitService';
 import { StorageService } from '../../src/services/StorageService';
+import { TemplateRepoPreferenceService } from '../../src/services/TemplateRepoPreferenceService';
+import { LastUsedRepoService } from '../../src/services/LastUsedRepoService';
+import { SyncEngineService } from '../../src/services/SyncEngineService';
+import { GitFsService } from '../../src/services/git/GitFsService';
+import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
 import { getActiveGitHost } from '../../src/services/git/activeHost';
 import { gitHubHostService } from '../../src/services/git/gitHostFactory';
 import { checkGitHubRepoAccess } from '../../src/services/git/repoAccessPreflight';
+import { useAIStore } from '../../src/stores/aiStore';
 import { useRepoStore } from '../../src/stores/repoStore';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 
@@ -11,7 +17,55 @@ jest.mock('../../src/services/GitService', () => ({
 }));
 
 jest.mock('../../src/services/StorageService', () => ({
-  StorageService: { getSavedRepositories: jest.fn() },
+  StorageService: {
+    getSavedRepositories: jest.fn(),
+    removeRepository: jest.fn(),
+    purgeRepoData: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/services/TemplateRepoPreferenceService', () => ({
+  TemplateRepoPreferenceService: {
+    get: jest.fn(),
+    clear: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/services/LastUsedRepoService', () => ({
+  LastUsedRepoService: {
+    get: jest.fn(),
+    set: jest.fn(),
+    clear: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/services/SyncEngineService', () => ({
+  SyncEngineService: {
+    getMode: jest.fn(),
+    clear: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/services/git/GitFsService', () => ({
+  GitFsService: {
+    removeRepo: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    purgeForRepo: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/stores/aiStore', () => ({
+  useAIStore: {
+    getState: jest.fn(() => ({
+      chatRepoOwner: null,
+      chatRepoName: null,
+      setChatRepo: jest.fn(),
+    })),
+  },
 }));
 
 jest.mock('../../src/services/git/activeHost', () => ({
@@ -65,5 +119,71 @@ describe('repoStore addRepository preflight', () => {
       { allowUnverifiedWrite: true },
     )).resolves.toEqual(repository);
     expect(GitService.addRepository).toHaveBeenCalledWith('octo/notes', undefined, 'github');
+  });
+});
+
+describe('repoStore removeRepository', () => {
+  const repoPath = 'octo/notes';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(StorageService.getSavedRepositories).mockResolvedValue([]);
+  });
+
+  it('disconnects all per-repo pointers that match the removed path', async () => {
+    jest.mocked(StorageService.removeRepository).mockResolvedValue(undefined);
+    jest.mocked(StorageService.purgeRepoData).mockResolvedValue(undefined);
+    jest.mocked(TemplateRepoPreferenceService.get).mockResolvedValue({ repoPath, branch: 'main' });
+    jest.mocked(TemplateRepoPreferenceService.clear).mockResolvedValue(undefined);
+    jest.mocked(LastUsedRepoService.get).mockResolvedValue(repoPath);
+    jest.mocked(LastUsedRepoService.clear).mockResolvedValue(undefined);
+    jest.mocked(SyncEngineService.clear).mockResolvedValue(undefined);
+    jest.mocked(SyncEngineService.getMode).mockResolvedValue('api');
+    jest.mocked(NoteSyncQueueService.purgeForRepo).mockResolvedValue(undefined);
+    jest.mocked(useAIStore.getState).mockReturnValue({
+      chatRepoOwner: 'octo',
+      chatRepoName: 'notes',
+      chatRepoBranch: 'main',
+      chatRepoAccountId: null,
+      setChatRepo: jest.fn(),
+    } as ReturnType<typeof useAIStore.getState>);
+
+    await useRepoStore.getState().removeRepository(repoPath);
+
+    expect(TemplateRepoPreferenceService.clear).toHaveBeenCalled();
+    expect(LastUsedRepoService.clear).toHaveBeenCalled();
+    expect(SyncEngineService.clear).toHaveBeenCalledWith(repoPath);
+    expect(NoteSyncQueueService.purgeForRepo).toHaveBeenCalledWith(repoPath);
+  });
+
+  it('does not clear template/last-used when they point at a different repo', async () => {
+    jest.mocked(StorageService.removeRepository).mockResolvedValue(undefined);
+    jest.mocked(StorageService.purgeRepoData).mockResolvedValue(undefined);
+    jest.mocked(TemplateRepoPreferenceService.get).mockResolvedValue({ repoPath: 'other/repo', branch: 'main' });
+    jest.mocked(LastUsedRepoService.get).mockResolvedValue('other/repo');
+    jest.mocked(SyncEngineService.clear).mockResolvedValue(undefined);
+    jest.mocked(SyncEngineService.getMode).mockResolvedValue('api');
+    jest.mocked(NoteSyncQueueService.purgeForRepo).mockResolvedValue(undefined);
+
+    await useRepoStore.getState().removeRepository(repoPath);
+
+    expect(TemplateRepoPreferenceService.clear).not.toHaveBeenCalled();
+    expect(LastUsedRepoService.clear).not.toHaveBeenCalled();
+    expect(NoteSyncQueueService.purgeForRepo).toHaveBeenCalledWith(repoPath);
+  });
+
+  it('removes clone from disk when sync mode is clone', async () => {
+    jest.mocked(StorageService.removeRepository).mockResolvedValue(undefined);
+    jest.mocked(StorageService.purgeRepoData).mockResolvedValue(undefined);
+    jest.mocked(TemplateRepoPreferenceService.get).mockResolvedValue(null);
+    jest.mocked(LastUsedRepoService.get).mockResolvedValue(null);
+    jest.mocked(SyncEngineService.clear).mockResolvedValue(undefined);
+    jest.mocked(SyncEngineService.getMode).mockResolvedValue('clone');
+    jest.mocked(GitFsService.removeRepo).mockResolvedValue(undefined);
+    jest.mocked(NoteSyncQueueService.purgeForRepo).mockResolvedValue(undefined);
+
+    await useRepoStore.getState().removeRepository(repoPath);
+
+    expect(GitFsService.removeRepo).toHaveBeenCalledWith({ repoPath });
   });
 });

--- a/src/components/templates/TemplateListItem.tsx
+++ b/src/components/templates/TemplateListItem.tsx
@@ -5,6 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useTranslation } from 'react-i18next';
 import { NoteTemplate } from '../../services/TemplateService';
+import { RADII } from '../../theme/tokens';
 
 interface TemplateListItemProps {
   template: NoteTemplate;
@@ -21,8 +22,8 @@ export function TemplateListItem({ template, pinned, onTogglePin, onEdit, onDele
   return (
     <View
       testID={`template-list-item.button.press-${template.id}`}
-      className="flex-row items-center p-3 rounded-sm border gap-3"
-      style={{ backgroundColor: colors.surface, borderColor: colors.border }}
+      className="flex-row items-center p-3 border gap-3"
+      style={{ backgroundColor: colors.surface, borderColor: colors.border, borderRadius: RADII.sm }}
     >
       <View className="w-9 h-9 rounded-[10px] items-center justify-center" style={{ backgroundColor: colors.primary + '20' }}>
         <Ionicons name={template.icon} size={20} color={colors.primary} />

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { Modal as RNModal, Pressable, StyleSheet, useWindowDimensions, View, ViewStyle, StyleProp } from 'react-native';
 import { BlurView } from 'expo-blur';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Surface } from './Surface';
 import { useTheme, useTokens } from '../../contexts/ThemeContext';
 
@@ -27,17 +28,19 @@ export function Modal(props: ModalProps) {
   const { isDark } = useTheme();
   const { spacing, colors } = useTokens();
   const { height: viewportHeight, width: viewportWidth } = useWindowDimensions();
+  const { top: topInset } = useSafeAreaInsets();
 
   const pad = spacing[5];
   const slotHeight = Math.max(0, viewportHeight - pad * 2);
   const slotWidth = Math.max(0, viewportWidth - pad * 2);
+  const bottomSheetSlotHeight = Math.max(0, slotHeight - topInset);
 
   const bgColor = colors.elevated;
 
   const surfaceStyle: ViewStyle = bottomSheet
     ? {
         backgroundColor: bgColor,
-        maxHeight: slotHeight,
+        maxHeight: bottomSheetSlotHeight,
         overflow: 'hidden',
         borderBottomLeftRadius: 0,
         borderBottomRightRadius: 0,
@@ -96,7 +99,7 @@ export function Modal(props: ModalProps) {
             bottomSheet
               ? {
                   width: '100%',
-                  height: slotHeight,
+                  height: bottomSheetSlotHeight,
                   justifyContent: 'flex-end',
                 }
               : {

--- a/src/components/ui/ScreenHeader.tsx
+++ b/src/components/ui/ScreenHeader.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Platform, Text, View, StyleProp, ViewStyle } from 'react-native';
+import { Platform, Text, View, StyleProp, ViewStyle, LayoutChangeEvent } from 'react-native';
 import { BlurView } from 'expo-blur';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -22,10 +22,13 @@ export interface ScreenHeaderProps {
   onBack?: () => void;
   actions?: ReactNode;
   style?: StyleProp<ViewStyle>;
+  footer?: ReactNode;
+  testID?: string;
+  onLayout?: (e: LayoutChangeEvent) => void;
 }
 
 export function ScreenHeader(props: ScreenHeaderProps) {
-  const { title, subtitle, badge, onBack, actions, style } = props;
+  const { title, subtitle, badge, onBack, actions, style, footer, testID, onLayout } = props;
   const { isDark } = useTheme();
   const { colors, spacing, type } = useTokens();
   const insets = useSafeAreaInsets();
@@ -87,6 +90,8 @@ export function ScreenHeader(props: ScreenHeaderProps) {
     return (
       <View
         pointerEvents="box-none"
+        testID={testID}
+        onLayout={onLayout}
         className="absolute top-0 left-0 right-0 z-10"
         style={{
           paddingTop: insets.top,
@@ -94,6 +99,7 @@ export function ScreenHeader(props: ScreenHeaderProps) {
         }}
       >
         {headerContent}
+        {footer}
       </View>
     );
   }
@@ -101,12 +107,15 @@ export function ScreenHeader(props: ScreenHeaderProps) {
   return (
     <BlurView
       pointerEvents="box-none"
+      testID={testID}
+      onLayout={onLayout}
       intensity={60}
       tint={isDark ? 'dark' : 'light'}
       className="absolute top-0 left-0 right-0 z-10"
       style={{ paddingTop: insets.top }}
     >
       {headerContent}
+      {footer}
     </BlurView>
   );
 }

--- a/src/contexts/AccountsContext.tsx
+++ b/src/contexts/AccountsContext.tsx
@@ -11,6 +11,7 @@ import type { GitHostProvider } from '../services/git/GitHost';
 import { GitHubService } from '../services/GitHubService';
 import { AccountStorage, StoredAccount } from '../services/AccountStorage';
 import { clearActiveGitHostCache } from '../services/git/activeHost';
+import { useAIStore } from '../stores/aiStore';
 
 interface ConnectHostResult {
   ok: boolean;
@@ -150,6 +151,18 @@ export function AccountsProvider({ children }: { children: ReactNode }) {
     })();
   }, [refreshAccounts]);
 
+  const clearChatRepoIfOrphaned = useCallback(
+    (removedAccountId: string, wasActive: boolean) => {
+      const { chatRepoAccountId } = useAIStore.getState();
+      const isBound = chatRepoAccountId === removedAccountId;
+      const wasActiveBound = chatRepoAccountId === null && wasActive;
+      if (isBound || wasActiveBound) {
+        useAIStore.getState().setChatRepo(null, null, 'main', null);
+      }
+    },
+    [],
+  );
+
   const connectHost = useCallback(
     async (input: ConnectHostInput): Promise<ConnectHostResult> => {
       const result = await AuthService.connectHost(input);
@@ -162,10 +175,16 @@ export function AccountsProvider({ children }: { children: ReactNode }) {
 
   const disconnectHost = useCallback(
     async (hostId: string) => {
+      const summary = accountSummaries.find((s) => s.hosts.some((h) => h.id === hostId));
+      const owningAccountId = summary?.account.id ?? null;
+      const wasActive = owningAccountId !== null && activeAccountId === owningAccountId;
       await AuthService.disconnectHost(hostId);
       await refreshAccounts();
+      if (owningAccountId) {
+        clearChatRepoIfOrphaned(owningAccountId, wasActive);
+      }
     },
-    [refreshAccounts],
+    [accountSummaries, activeAccountId, refreshAccounts, clearChatRepoIfOrphaned],
   );
 
   const switchToHost = useCallback(
@@ -208,6 +227,7 @@ export function AccountsProvider({ children }: { children: ReactNode }) {
       const wasActive = activeAccountId === accountId;
       await AuthService.removeAccount(accountId);
       await refreshAccounts();
+      clearChatRepoIfOrphaned(accountId, wasActive);
       if (wasActive) {
         const state = await AuthService.checkAuthState();
         if (state.isAuthenticated && state.token) {
@@ -221,7 +241,7 @@ export function AccountsProvider({ children }: { children: ReactNode }) {
         }
       }
     },
-    [activeAccountId, refreshAccounts],
+    [activeAccountId, refreshAccounts, clearChatRepoIfOrphaned],
   );
 
   const setToken = useCallback(
@@ -256,6 +276,7 @@ export function AccountsProvider({ children }: { children: ReactNode }) {
     await GitHubService.clearToken();
     setAuthState(EMPTY_AUTH);
     await refreshAccounts();
+    useAIStore.getState().setChatRepo(null, null, 'main', null);
     // Guard against unused imports.
     void AccountStorage;
   }, [activeHostId, refreshAccounts]);

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -1,9 +1,8 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import { Alert, View, Text, ActivityIndicator, RefreshControl, FlatList, TouchableOpacity, InteractionManager, StyleSheet } from 'react-native';
+import { Alert, View, Text, ActivityIndicator, RefreshControl, FlatList, TouchableOpacity, InteractionManager, StyleSheet, LayoutChangeEvent } from 'react-native';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
-import { BlurView } from 'expo-blur';
 
 import { useNotes } from '../contexts/NoteContext';
 import { useTheme } from '../contexts/ThemeContext';
@@ -152,7 +151,7 @@ const styles = StyleSheet.create({
 export default function NotesListScreen() {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
-  const { colors, isDark } = useTheme();
+  const { colors } = useTheme();
   const { authState } = useAuth();
   const headerHeight = useScreenHeaderHeight();
   const tabBarHeight = useTabBarHeight();
@@ -178,8 +177,10 @@ export default function NotesListScreen() {
   const isPullRefreshingRef = useRef(false);
   const [gitOperationActive, setGitOperationActive] = useState(false);
 
-  const [bannerRegionHeight, setBannerRegionHeight] = useState(headerHeight);
-  const [toolsHeight, setToolsHeight] = useState(0);
+  // Unified height of the single blurred header region (title + banners + tools).
+  // Initial estimate is the bare header height so the list is never under the header
+  // before onLayout fires with the real measured value.
+  const [headerBlurHeight, setHeaderBlurHeight] = useState(headerHeight);
 
   const [showViewModePicker, setShowViewModePicker] = useState(false);
   const [showFilterModal, setShowFilterModal] = useState(false);
@@ -597,24 +598,6 @@ export default function NotesListScreen() {
   return (
     <SafeAreaView edges={[]} className="flex-1" style={{ backgroundColor: colors.background }}>
       {isDeleting ? <GitHubActivityIndicator /> : null}
-      <View
-        testID="notes-list.banner-region"
-        pointerEvents="box-none"
-        style={{ position: 'absolute', left: 0, right: 0, top: 0, paddingTop: headerHeight }}
-        onLayout={(event) => setBannerRegionHeight(event.nativeEvent.layout.height)}
-      >
-        <OfflineBanner />
-        <ConflictBanner />
-
-        {error ? (
-          <View className="mx-3 mb-1 p-2.5 rounded-sm border-l-4" style={{ backgroundColor: colors.error + '20', borderLeftColor: colors.error }}>
-            <Text className="text-xs flex-1" style={{ color: colors.error }} numberOfLines={2}>{error}</Text>
-            <TouchableOpacity onPress={clearError} className="ml-3 px-3 py-1.5 rounded-md border" style={{ borderColor: colors.error }}>
-              <Text className="text-xs font-semibold" style={{ color: colors.error }}>{t('common.dismiss')}</Text>
-            </TouchableOpacity>
-          </View>
-        ) : null}
-      </View>
 
       <NotesViewModePicker
         visible={showViewModePicker}
@@ -634,7 +617,7 @@ export default function NotesListScreen() {
         removeClippedSubviews={false}
         contentContainerStyle={{
           padding: 12,
-          paddingTop: bannerRegionHeight + toolsHeight + 4,
+          paddingTop: headerBlurHeight + 4,
           paddingBottom: tabBarHeight + 16,
           flexGrow: 1,
         }}
@@ -653,36 +636,6 @@ export default function NotesListScreen() {
         }
         ListEmptyComponent={<NotesEmptyState isFiltered={!!searchQuery || activeFilterCount > 0} />}
       />
-
-      <BlurView
-        testID="notes-list.header-blur"
-        pointerEvents="box-none"
-        intensity={60}
-        tint={isDark ? 'dark' : 'light'}
-        className="absolute left-0 right-0 z-10"
-        style={{ top: bannerRegionHeight }}
-        onLayout={(event) => setToolsHeight(event.nativeEvent.layout.height)}
-      >
-        <NotesListHeader
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-          repositories={repositories}
-          selectedRepo={filters.selectedRepo}
-          hasActiveSearch={hasActiveSearch}
-          searchMatchCount={searchMatchCount}
-          currentSearchMatchIndex={currentSearchMatchIndex}
-          sortMode={sortMode}
-          onSortChange={setSortMode}
-          onSelectRepo={handleSelectRepo}
-          onSearchNavigate={handleSearchNavigate}
-        />
-
-        <FilterBar
-          filters={activeFilterChips}
-          onRemoveFilter={handleRemoveFilterChip}
-          onClearAll={handleClearFilters}
-        />
-      </BlurView>
 
       <NotesFilterModal
         visible={showFilterModal}
@@ -736,6 +689,43 @@ export default function NotesListScreen() {
 
       <ScreenHeader
         title={t('notes.title')}
+        testID="notes-list.header-blur"
+        onLayout={(event: LayoutChangeEvent) => setHeaderBlurHeight(event.nativeEvent.layout.height)}
+        footer={
+          <>
+            <OfflineBanner />
+            <ConflictBanner />
+
+            {error ? (
+              <View className="mx-3 mb-1 p-2.5 rounded-sm border-l-4" style={{ backgroundColor: colors.error + '20', borderLeftColor: colors.error }}>
+                <Text className="text-xs flex-1" style={{ color: colors.error }} numberOfLines={2}>{error}</Text>
+                <TouchableOpacity onPress={clearError} className="ml-3 px-3 py-1.5 rounded-md border" style={{ borderColor: colors.error }}>
+                  <Text className="text-xs font-semibold" style={{ color: colors.error }}>{t('common.dismiss')}</Text>
+                </TouchableOpacity>
+              </View>
+            ) : null}
+
+            <NotesListHeader
+              searchQuery={searchQuery}
+              onSearchChange={setSearchQuery}
+              repositories={repositories}
+              selectedRepo={filters.selectedRepo}
+              hasActiveSearch={hasActiveSearch}
+              searchMatchCount={searchMatchCount}
+              currentSearchMatchIndex={currentSearchMatchIndex}
+              sortMode={sortMode}
+              onSortChange={setSortMode}
+              onSelectRepo={handleSelectRepo}
+              onSearchNavigate={handleSearchNavigate}
+            />
+
+            <FilterBar
+              filters={activeFilterChips}
+              onRemoveFilter={handleRemoveFilterChip}
+              onClearAll={handleClearFilters}
+            />
+          </>
+        }
         actions={
           <>
             <IconButton

--- a/src/screens/TemplateManagerScreen.tsx
+++ b/src/screens/TemplateManagerScreen.tsx
@@ -25,6 +25,7 @@ import { TemplateEditorModal } from '../components/templates/TemplateEditorModal
 import { TemplateListItem } from '../components/templates/TemplateListItem';
 import { TemplatesEmptyState } from '../components/templates/TemplatesEmptyState';
 import { DEFAULT_ICON } from '../components/templates/templateManagerShared';
+import { RADII } from '../theme/tokens';
 import { useTranslation } from 'react-i18next';
 
 export default function TemplateManagerScreen() {
@@ -243,7 +244,7 @@ export default function TemplateManagerScreen() {
     <SafeAreaView edges={['bottom']} className="flex-1" style={{ backgroundColor: colors.background }}>
       <ScrollView
         className="flex-1"
-        contentContainerClassName="p-4 pb-10 gap-2.5 flex-grow"
+        contentContainerStyle={{ padding: 16, paddingBottom: 40, gap: 10, flexGrow: 1 }}
         style={{ paddingTop: headerHeight }}
         keyboardShouldPersistTaps="handled"
         refreshControl={
@@ -255,8 +256,8 @@ export default function TemplateManagerScreen() {
         <TouchableOpacity
           testID="template-manager.button.create"
           onPress={handleOpenCreate}
-          className="flex-row items-center justify-center py-3 rounded-sm gap-1.5 mb-2"
-          style={{ backgroundColor: colors.primary }}
+          className="flex-row items-center justify-center py-3 gap-1.5"
+          style={{ backgroundColor: colors.primary, borderRadius: RADII.sm }}
           activeOpacity={0.8}
         >
           <Ionicons name="add" size={18} color="#fff" />

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { View, Alert, Platform, RefreshControl, ActivityIndicator } from 'react-native';
+import { View, Alert, Platform, RefreshControl, ActivityIndicator, LayoutChangeEvent } from 'react-native';
 import { FlatList } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { BlurView } from 'expo-blur';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
@@ -113,8 +112,10 @@ export default function TodoListScreen() {
   const isRefreshingRef = useRef(false);
   const [gitOperationActive, setGitOperationActive] = useState(false);
 
-  const [bannerRegionHeight, setBannerRegionHeight] = useState(headerHeight);
-  const [toolsHeight, setToolsHeight] = useState(0);
+  // Unified height of the single blurred header region (title + banners + tools).
+  // Initial estimate is the bare header height so the list is never under the header
+  // before onLayout fires with the real measured value.
+  const [headerBlurHeight, setHeaderBlurHeight] = useState(headerHeight);
   const [showAddModal, setShowAddModal] = useState(false);
   const [editingTodo, setEditingTodo] = useState<Todo | null>(null);
   const [todoText, setTodoText] = useState('');
@@ -642,16 +643,6 @@ export default function TodoListScreen() {
 
   return (
     <SafeAreaView edges={[]} className="flex-1" style={{ backgroundColor: colors.background }}>
-      <View
-        testID="todos-list.banner-region"
-        pointerEvents="box-none"
-        style={{ position: 'absolute', left: 0, right: 0, top: 0, paddingTop: headerHeight }}
-        onLayout={(event) => setBannerRegionHeight(event.nativeEvent.layout.height)}
-      >
-        <OfflineBanner />
-        <ConflictBanner />
-      </View>
-
       <EntityFilterModal
         visible={showFilterModal}
         onClose={() => setShowFilterModal(false)}
@@ -669,7 +660,7 @@ export default function TodoListScreen() {
         removeClippedSubviews={false}
         contentContainerStyle={{
           padding: 16,
-          paddingTop: bannerRegionHeight + toolsHeight + 8,
+          paddingTop: headerBlurHeight + 8,
           paddingBottom: tabBarHeight + 16,
           flexGrow: 1,
         }}
@@ -689,27 +680,6 @@ export default function TodoListScreen() {
           )
         }
       />
-
-      <BlurView
-        testID="todos-list.header-blur"
-        pointerEvents="box-none"
-        intensity={60}
-        tint={isDark ? 'dark' : 'light'}
-        className="absolute left-0 right-0 z-10"
-        style={{ top: bannerRegionHeight }}
-        onLayout={(event) => setToolsHeight(event.nativeEvent.layout.height)}
-      >
-        <TodosListHeader searchQuery={searchQuery} onSearchChange={setSearchQuery} sortMode={sortMode} onSortChange={setSortMode} />
-
-        <FilterBar
-          filters={activeFilterChips}
-          onRemoveFilter={handleRemoveTodoFilterChip}
-          onClearAll={() => {
-            filter.clearAll();
-            setFilterCompleted(false);
-          }}
-        />
-      </BlurView>
 
       <TodoEditorModal
         visible={showAddModal || editingTodo !== null}
@@ -764,6 +734,25 @@ export default function TodoListScreen() {
 
       <ScreenHeader
         title={t('todos.title')}
+        testID="todos-list.header-blur"
+        onLayout={(event: LayoutChangeEvent) => setHeaderBlurHeight(event.nativeEvent.layout.height)}
+        footer={
+          <>
+            <OfflineBanner />
+            <ConflictBanner />
+
+            <TodosListHeader searchQuery={searchQuery} onSearchChange={setSearchQuery} sortMode={sortMode} onSortChange={setSortMode} />
+
+            <FilterBar
+              filters={activeFilterChips}
+              onRemoveFilter={handleRemoveTodoFilterChip}
+              onClearAll={() => {
+                filter.clearAll();
+                setFilterCompleted(false);
+              }}
+            />
+          </>
+        }
         actions={
           <>
             <IconButton

--- a/src/services/LastUsedRepoService.ts
+++ b/src/services/LastUsedRepoService.ts
@@ -13,4 +13,8 @@ export class LastUsedRepoService {
   static async set(repoPath: string): Promise<void> {
     await AsyncStorage.setItem(KEY, repoPath);
   }
+
+  static async clear(): Promise<void> {
+    await AsyncStorage.removeItem(KEY);
+  }
 }

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -10,7 +10,7 @@ import { AuthService } from './AuthService';
 import { LocalGitWriter } from './git/LocalGitWriter';
 import { classifyGitHubSyncError, isRetryableFailure, syncStatusForError } from './git/syncFailure';
 import { resolveBranch } from './git/resolveBranch';
-import { clearDeleteFailure, readDeleteFailures, recordDeleteFailure, DELETE_FAILURES_STORAGE_KEY } from './git/deleteFailures';
+import { clearDeleteFailure, clearDeleteFailuresForRepo, readDeleteFailures, recordDeleteFailure, DELETE_FAILURES_STORAGE_KEY } from './git/deleteFailures';
 import { GitSyncGate } from './git/GitSyncGate';
 import { batchDeleteFiles } from './git/BatchGitOperations';
 import type { BatchDeleteFilesResult } from './git/BatchGitOperations';
@@ -228,6 +228,32 @@ class NoteSyncQueueServiceClass {
       delete map[this.tombstoneKey(repo, branch || 'main', filePath)];
       await AsyncStorage.setItem(TOMBSTONE_KEY, JSON.stringify(map));
     } catch { /* best-effort */ }
+  }
+
+  async purgeForRepo(repoPath: string): Promise<void> {
+    const queue = await this.getAll();
+    const remaining = queue.filter((m) => m.params.repo !== repoPath);
+    if (remaining.length < queue.length) {
+      await this.saveAll(remaining);
+    }
+    try {
+      const raw = await AsyncStorage.getItem(TOMBSTONE_KEY);
+      if (raw) {
+        const map: Record<string, number> = JSON.parse(raw);
+        const prefix = `${repoPath}::`;
+        let changed = false;
+        for (const key of Object.keys(map)) {
+          if (key.startsWith(prefix)) {
+            delete map[key];
+            changed = true;
+          }
+        }
+        if (changed) {
+          await AsyncStorage.setItem(TOMBSTONE_KEY, JSON.stringify(map));
+        }
+      }
+    } catch { /* best-effort */ }
+    await clearDeleteFailuresForRepo(repoPath);
   }
 
   private newMutationId(): string {

--- a/src/services/git/deleteFailures.ts
+++ b/src/services/git/deleteFailures.ts
@@ -70,3 +70,20 @@ export async function clearDeleteFailure(
     await AsyncStorage.setItem(DELETE_FAILURES_STORAGE_KEY, JSON.stringify(map));
   } catch { /* best-effort persistence */ }
 }
+
+/** Remove every delete-failure entry whose key starts with `${repoPath}::`. */
+export async function clearDeleteFailuresForRepo(repoPath: string): Promise<void> {
+  try {
+    const map = await readDeleteFailures();
+    const prefix = `${repoPath}::`;
+    let changed = false;
+    for (const key of Object.keys(map)) {
+      if (key.startsWith(prefix)) {
+        delete map[key];
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    await AsyncStorage.setItem(DELETE_FAILURES_STORAGE_KEY, JSON.stringify(map));
+  } catch { /* best-effort persistence */ }
+}

--- a/src/stores/repoStore.ts
+++ b/src/stores/repoStore.ts
@@ -1,6 +1,12 @@
 import { create } from 'zustand';
 import { GitRepository, GitService } from '../services/GitService';
 import { StorageService } from '../services/StorageService';
+import { TemplateRepoPreferenceService } from '../services/TemplateRepoPreferenceService';
+import { LastUsedRepoService } from '../services/LastUsedRepoService';
+import { SyncEngineService } from '../services/SyncEngineService';
+import { GitFsService } from '../services/git/GitFsService';
+import { NoteSyncQueueService } from '../services/NoteSyncQueueService';
+import { useAIStore } from './aiStore';
 import { useNoteStore } from './noteStore';
 import { useCanvasStore } from './canvasStore';
 import { useTodoStore } from './todoStore';
@@ -83,11 +89,31 @@ export const useRepoStore = create<RepoState & RepoActions>()((set, get) => ({
 
   removeRepository: async (path, provider = 'github') => {
     await StorageService.removeRepository(path, provider);
-    // Drop all locally-cached records that originated from the removed repo
-    // before refreshing the dependent stores. Without this, notes/canvases/
-    // todos from the now-disconnected repo keep showing up in their lists
-    // even though the repo is gone from settings.
     await StorageService.purgeRepoData(path);
+
+    const template = await TemplateRepoPreferenceService.get();
+    if (template?.repoPath === path) {
+      await TemplateRepoPreferenceService.clear();
+    }
+
+    const lastUsed = await LastUsedRepoService.get();
+    if (lastUsed === path) {
+      await LastUsedRepoService.clear();
+    }
+
+    await SyncEngineService.clear(path);
+
+    if ((await SyncEngineService.getMode(path)) === 'clone') {
+      GitFsService.removeRepo({ repoPath: path }).catch(() => undefined);
+    }
+
+    const { chatRepoOwner, chatRepoName } = useAIStore.getState();
+    if (chatRepoOwner && chatRepoName && `${chatRepoOwner}/${chatRepoName}` === path) {
+      await useAIStore.getState().setChatRepo(null, null, 'main', null);
+    }
+
+    await NoteSyncQueueService.purgeForRepo(path);
+
     set((state) => ({
       repositories: state.repositories.filter(
         (r) => !(r.path === path && (r.provider ?? 'github') === provider),


### PR DESCRIPTION
## Summary

Five UI/data-disconnect fixes:

1. **Templates page margins** — `TemplateManagerScreen` now uses an explicit `contentContainerStyle` (16px margins) and a card layout (`radii.sm`), instead of the NativeWind `contentContainerClassName` that rendered flush to the edges.
2. **Repo removal disconnect** — `removeRepository` now also clears the template-repo preference, last-used repo, clone-mode override, on-disk clone, AI chat repo binding, and pending note-sync queue/tombstones/delete-failures for the removed repo.
3. **Token/account/host removal disconnect** — removing an account (or host, or token via `clearToken`) now clears the AI chat repo binding when it points at the removed account (or the removed active account).
4. **Add-repo popup notch** — bottom-sheet modals now cap their `maxHeight` below the top safe-area inset so a tall sheet never reaches the notch.
5. **Unified header blur** — Notes and Todos lists now render one continuous `BlurView` for title + search + filter chips (via a new `ScreenHeader` `footer` prop) instead of two stacked blur bands with a visible seam.

## Verification
- `yarn ts:check` — pass
- `yarn jest` — 252 suites / 2216 tests pass
- `yarn eslint . --ext .ts,.tsx` — 0 errors