### PR TITLE
fix(git): git-core hardening — 17 bug fixes (#876–#892)

### DIFF
--- a/__tests__/GitHubService.batch-primitives.test.ts
+++ b/__tests__/GitHubService.batch-primitives.test.ts
@@ -1,0 +1,76 @@
+jest.mock('../src/services/http', () => ({
+  __esModule: true,
+  default: { request: jest.fn() },
+  setAuthToken: jest.fn(),
+  clearAuthToken: jest.fn(),
+}));
+
+jest.mock('../src/services/AuthService', () => ({
+  __esModule: true,
+  default: { setToken: jest.fn(), clearToken: jest.fn() },
+}));
+
+import { GitHubService } from '../src/services/GitHubService';
+import http from '../src/services/http';
+
+const mockHttpRequest = http.request as jest.Mock;
+
+const testUser = {
+  login: 'octocat',
+  id: 1,
+  avatar_url: '',
+  html_url: '',
+  name: 'Octocat',
+  email: 'octocat@example.com',
+};
+
+describe('GitHubService Git-Data batch primitives', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await GitHubService.setToken('token', testUser);
+  });
+
+  afterEach(async () => {
+    await GitHubService.clearToken();
+  });
+
+  test('createBlob posts base64 content to /git/blobs', async () => {
+    mockHttpRequest.mockResolvedValueOnce({ data: { sha: 'blob-sha' } });
+
+    await expect(GitHubService.createBlob('owner', 'repo', 'hello')).resolves.toEqual({ sha: 'blob-sha' });
+
+    expect(mockHttpRequest).toHaveBeenCalledWith({
+      url: 'https://api.github.com/repos/owner/repo/git/blobs',
+      method: 'POST',
+      data: { content: Buffer.from('hello', 'utf-8').toString('base64'), encoding: 'base64' },
+    });
+  });
+
+  test('createTree sends base_tree when baseTree is provided', async () => {
+    mockHttpRequest.mockResolvedValueOnce({ data: { sha: 'tree-sha' } });
+    const tree = [{ path: 'notes/a.md', mode: '100644', type: 'blob', sha: 'blob-sha' }];
+
+    await expect(
+      GitHubService.createTree('owner', 'repo', tree, { baseTree: 'base-tree-sha' }),
+    ).resolves.toEqual({ sha: 'tree-sha' });
+
+    expect(mockHttpRequest).toHaveBeenCalledWith({
+      url: 'https://api.github.com/repos/owner/repo/git/trees',
+      method: 'POST',
+      data: { tree, base_tree: 'base-tree-sha' },
+    });
+  });
+
+  test('createTree omits base_tree when no baseTree provided', async () => {
+    mockHttpRequest.mockResolvedValueOnce({ data: { sha: 'tree-sha' } });
+    const tree = [{ path: 'notes/a.md', mode: '100644', type: 'blob', sha: 'blob-sha' }];
+
+    await expect(GitHubService.createTree('owner', 'repo', tree)).resolves.toEqual({ sha: 'tree-sha' });
+
+    expect(mockHttpRequest).toHaveBeenCalledWith({
+      url: 'https://api.github.com/repos/owner/repo/git/trees',
+      method: 'POST',
+      data: { tree },
+    });
+  });
+});

--- a/__tests__/GitHubService.updateFile.test.ts
+++ b/__tests__/GitHubService.updateFile.test.ts
@@ -74,4 +74,58 @@ describe('GitHubService.updateFile', () => {
       GitHubService.updateFile('owner', 'repo', 'notes/already-updated.md', 'content', 'Update note'),
     ).resolves.toEqual({ content: { sha: '' }, commit: { sha: '' } });
   });
+
+  test('#881: updateFile throws a typed 409 conflict when upstream content diverges', async () => {
+    mockHttpRequest.mockResolvedValueOnce({ data: { sha: 'old-sha' } });
+    mockHttpRequest.mockRejectedValueOnce({
+      response: { status: 409, data: { message: 'Conflict' } },
+    });
+    mockHttpRequest.mockResolvedValueOnce({
+      data: { type: 'file', content: 'ZGlmZmVyZW50', sha: 'new-sha' },
+    });
+
+    await expect(
+      GitHubService.updateFile('owner', 'repo', 'notes/conflict.md', 'local content', 'Update note'),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+});
+
+describe('GitHubService.getFileContent', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await GitHubService.setToken('token', testUser);
+  });
+
+  afterEach(async () => {
+    await GitHubService.clearToken();
+  });
+
+  test('#883: resolves empty string for empty files (content === "")', async () => {
+    mockHttpRequest.mockResolvedValueOnce({ data: { type: 'file', content: '', sha: 's' } });
+
+    await expect(
+      GitHubService.getFileContent('owner', 'repo', 'notes/.gitkeep'),
+    ).resolves.toBe('');
+  });
+});
+
+describe('GitHubService.createFile', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await GitHubService.setToken('token', testUser);
+  });
+
+  afterEach(async () => {
+    await GitHubService.clearToken();
+  });
+
+  test('#884: rethrows HTTP errors with their status instead of resolving null', async () => {
+    mockHttpRequest.mockRejectedValueOnce({
+      response: { status: 401, data: { message: 'Bad credentials' } },
+    });
+
+    await expect(
+      GitHubService.createFile('owner', 'repo', 'notes/new.md', 'content', 'Create note'),
+    ).rejects.toMatchObject({ response: { status: 401 } });
+  });
 });

--- a/__tests__/canvas-race.test.ts
+++ b/__tests__/canvas-race.test.ts
@@ -80,11 +80,10 @@ jest.mock('../src/services/GitHubService', () => ({
   GitHubService: {
     isAuthenticated: jest.fn(() => true),
     getTreeRecursive: jest.fn(async () => []),
-    getTreeRecursiveOrThrow: jest.fn(async () => []),
-    getRepoContents: jest.fn(async (_owner: string, _repo: string, dirPath: string) => {
-      if (dirPath !== 'canvases') return [];
-      return [{ type: 'file', path: 'canvases/remote-canvas.json', download_url: 'https://example.com/remote-canvas.json' }];
-    }),
+    getTreeRecursiveOrThrow: jest.fn(async () => [
+      { path: 'canvases/remote-canvas.json', type: 'blob', sha: 'remote-1' },
+    ]),
+    getRepoContents: jest.fn(async () => []),
     getFileContent: jest.fn(async (_owner: string, _repo: string, path: string) => {
       if (path !== 'canvases/remote-canvas.json') return null;
       return JSON.stringify({

--- a/__tests__/gitPathParser.test.ts
+++ b/__tests__/gitPathParser.test.ts
@@ -1,0 +1,40 @@
+import { parseRepoPath } from '../src/utils/gitPathParser';
+
+describe('parseRepoPath', () => {
+  const cases: Array<{ input: string; expected: { owner: string; repo: string } | null }> = [
+    { input: 'facebook/react', expected: { owner: 'facebook', repo: 'react' } },
+    { input: 'github.com/facebook/react', expected: { owner: 'facebook', repo: 'react' } },
+    { input: 'https://github.com/facebook/react', expected: { owner: 'facebook', repo: 'react' } },
+    { input: 'http://github.com/facebook/react', expected: { owner: 'facebook', repo: 'react' } },
+    { input: 'facebook/react.git', expected: { owner: 'facebook', repo: 'react' } },
+    { input: 'vidwadeseram/test-notes.git/', expected: { owner: 'vidwadeseram', repo: 'test-notes' } },
+    { input: 'git@github.com:vidwadeseram/test-notes.git', expected: { owner: 'vidwadeseram', repo: 'test-notes' } },
+    { input: 'git@github.com:vidwadeseram/test-notes.git/', expected: { owner: 'vidwadeseram', repo: 'test-notes' } },
+    { input: 'git@github.com:vidwadeseram/test-notes', expected: { owner: 'vidwadeseram', repo: 'test-notes' } },
+    { input: 'ssh://git@github.com/vidwadeseram/test-notes.git', expected: { owner: 'vidwadeseram', repo: 'test-notes' } },
+    { input: '  https://github.com/a/b.git/  ', expected: { owner: 'a', repo: 'b' } },
+    { input: 'github.com/owner/repo/subdir', expected: { owner: 'owner', repo: 'repo' } },
+    { input: 'https://github.com/owner/repo/', expected: { owner: 'owner', repo: 'repo' } },
+    { input: 'owner/repo', expected: { owner: 'owner', repo: 'repo' } },
+  ];
+
+  it.each(cases)('parses "$input"', ({ input, expected }) => {
+    expect(parseRepoPath(input)).toEqual(expected);
+  });
+
+  const invalidCases = [
+    '',
+    '   ',
+    'nope',
+    'github.com',
+    'https://github.com',
+    '/owner/repo',
+    'git@github.com:onlyowner',
+    '@:bad/repo',
+    'foo:@bar/repo',
+  ];
+
+  it.each(invalidCases)('returns null for "%s"', (input) => {
+    expect(parseRepoPath(input)).toBeNull();
+  });
+});

--- a/__tests__/notes-pull-clone-mode.test.ts
+++ b/__tests__/notes-pull-clone-mode.test.ts
@@ -21,6 +21,10 @@ jest.mock('../src/services/StorageService', () => ({
     getSavedRepositories: jest.fn(async () => [
       { id: '1', name: 'gitnotes', path: 'me/gitnotes', branch: 'main' },
     ]),
+    getAllTodos: jest.fn(async () => []),
+    saveAllTodos: jest.fn(async () => undefined),
+    getAllCanvases: jest.fn(async () => []),
+    mutateCanvases: jest.fn(async () => undefined),
   },
 }));
 
@@ -90,7 +94,7 @@ describe('pullNotesFromRepo via clone mode', () => {
     });
     expect(GitFsService.fetch).not.toHaveBeenCalled();
 
-    (GitFsService.isCloned as jest.Mock).mockResolvedValueOnce(true);
+    (GitFsService.isCloned as jest.Mock).mockResolvedValue(true);
     (GitFsService.clone as jest.Mock).mockClear();
     (GitFsService.pullWithFastForward as jest.Mock).mockClear();
     await pullFromSingleRepo('me/gitnotes');
@@ -140,11 +144,11 @@ describe('pullNotesFromRepo via clone mode', () => {
   });
 
   test('api mode keeps using GitHubService (no clone-mode side effects)', async () => {
-    (SyncEngineService.getMode as jest.Mock).mockResolvedValueOnce('api');
-    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValueOnce([
+    (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
       { path: 'notes/foo.md', type: 'blob', sha: 'aa' },
     ]);
-    (GitHubService.getFileContent as jest.Mock).mockResolvedValueOnce('hello');
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue('hello');
 
     await pullFromSingleRepo('me/gitnotes');
     expect(GitFsService.clone).not.toHaveBeenCalled();

--- a/__tests__/repoAccessPreflight.test.ts
+++ b/__tests__/repoAccessPreflight.test.ts
@@ -32,14 +32,16 @@ describe('checkGitHubRepoAccess', () => {
     });
   });
 
-  it('returns write_unverified for read-only accepted permissions', async () => {
-    fetchSpy.mockResolvedValue(new Response('{}', {
-      status: 200,
-      headers: { 'x-accepted-github-permissions': 'contents:read' },
-    }));
+  it('probes when accepted permissions are read-only and reports no_access on a forbidden probe', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response('{}', {
+        status: 200,
+        headers: { 'x-accepted-github-permissions': 'contents:read' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'Forbidden' }), { status: 403 }));
 
     await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({
-      kind: 'write_unverified',
+      kind: 'no_access',
     });
   });
 
@@ -52,19 +54,72 @@ describe('checkGitHubRepoAccess', () => {
     });
   });
 
-  it('returns write_unverified when permissions.push is false', async () => {
-    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ permissions: { push: false } }), { status: 200 }));
+  it('probes when permissions.push is false', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(JSON.stringify({ permissions: { push: false } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'Forbidden' }), { status: 403 }));
 
     await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({
-      kind: 'write_unverified',
+      kind: 'no_access',
     });
   });
 
-  it('returns write_unverified when GitHub provides no permissions information', async () => {
-    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ private: true }), { status: 200 }));
+  it('probes when GitHub provides no permissions information and reports ok on a successful write probe', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(JSON.stringify({ private: true }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ content: { sha: 'abc123' } }), { status: 201 }))
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }));
 
-    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({
-      kind: 'write_unverified',
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toEqual({
+      kind: 'ok',
+      writeVerified: true,
+    });
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('/contents/.gitnotes-preflight-'),
+      expect.objectContaining({ method: 'PUT' }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('/contents/.gitnotes-preflight-'),
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('reports no_access when the write probe is forbidden', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(JSON.stringify({ private: true }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'Forbidden' }), { status: 403 }));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({ kind: 'no_access' });
+  });
+
+  it('reports transient when the write probe is rate-limited', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(JSON.stringify({ private: true }), { status: 200 }))
+      .mockResolvedValueOnce(new Response('{}', { status: 429 }));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({ kind: 'transient' });
+  });
+
+  it('reports transient when the write probe hits a network failure', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(JSON.stringify({ private: true }), { status: 200 }))
+      .mockRejectedValueOnce(new TypeError('Network request failed'));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toMatchObject({ kind: 'transient' });
+  });
+
+  it('still reports ok when probe cleanup fails', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(JSON.stringify({ private: true }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ content: { sha: 'abc123' } }), { status: 201 }))
+      .mockResolvedValueOnce(new Response('{}', { status: 500 }))
+      .mockResolvedValueOnce(new Response('{}', { status: 500 }));
+
+    await expect(checkGitHubRepoAccess('octo/notes', token)).resolves.toEqual({
+      kind: 'ok',
+      writeVerified: true,
     });
   });
 

--- a/__tests__/services/BatchGitOperations.test.ts
+++ b/__tests__/services/BatchGitOperations.test.ts
@@ -8,11 +8,17 @@ jest.mock('../../src/services/GitHubService', () => ({
     updateRef: jest.fn(),
     getFileSha: jest.fn(),
     deleteFile: jest.fn(),
+    createBlob: jest.fn(),
+    updateFile: jest.fn(),
   },
 }));
 
 import { GitHubService } from '../../src/services/GitHubService';
-import { batchDeleteFiles, buildTreeMinusPaths } from '../../src/services/git/BatchGitOperations';
+import {
+  batchDeleteFiles,
+  buildTreeMinusPaths,
+  batchUpsertFiles,
+} from '../../src/services/git/BatchGitOperations';
 
 const TREE_ENTRIES = [
   { path: 'notes', mode: '040000', type: 'tree', sha: 'tree-notes' },
@@ -248,6 +254,119 @@ describe('batchDeleteFiles', () => {
     expect(result.deleted).toEqual(['notes/a.md']);
     expect(result.failed).toEqual([{ path: 'notes/b.md', error: 'lookup blew up' }]);
     expect(GitHubService.deleteFile).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('batchUpsertFiles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    happyPathMocks();
+    (GitHubService.createBlob as jest.Mock).mockImplementation(
+      async (_o: string, _r: string, content: string) => ({ sha: `blob-${content}` }),
+    );
+    (GitHubService.updateFile as jest.Mock).mockResolvedValue({
+      content: { sha: 'fallback-sha' },
+      commit: { sha: 'fallback-commit' },
+    });
+  });
+
+  test('2 files -> parallel createBlob + ONE createTree(base_tree) + ONE commit + ONE updateRef', async () => {
+    const result = await batchUpsertFiles({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      files: [
+        { path: 'notes/a.md', content: 'AAA' },
+        { path: 'notes/b.md', content: 'BBB' },
+      ],
+      message: 'Update 2 notes',
+    });
+
+    expect(result).toEqual({ success: true, upserted: ['notes/a.md', 'notes/b.md'], failed: [] });
+    expect(GitHubService.getBranchHead).toHaveBeenCalledTimes(1);
+    expect(GitHubService.getCommit).toHaveBeenCalledTimes(1);
+    // No recursive tree read: base_tree derives parents/structure.
+    expect(GitHubService.getTreeRaw).not.toHaveBeenCalled();
+    expect(GitHubService.createBlob).toHaveBeenCalledTimes(2);
+    expect(GitHubService.createTree).toHaveBeenCalledTimes(1);
+    expect(GitHubService.createCommit).toHaveBeenCalledTimes(1);
+    expect(GitHubService.updateRef).toHaveBeenCalledTimes(1);
+    expect(GitHubService.updateFile).not.toHaveBeenCalled();
+
+    // Tree entries map each blob sha to its path in input order; base_tree set.
+    const [treeOwner, treeRepo, treeEntries, treeOpts] = (GitHubService.createTree as jest.Mock).mock.calls[0];
+    expect(treeOwner).toBe('owner');
+    expect(treeRepo).toBe('repo');
+    expect(treeEntries).toEqual([
+      { path: 'notes/a.md', mode: '100644', type: 'blob', sha: 'blob-AAA' },
+      { path: 'notes/b.md', mode: '100644', type: 'blob', sha: 'blob-BBB' },
+    ]);
+    expect(treeOpts).toEqual({ baseTree: 'tree-root' });
+
+    expect(GitHubService.createCommit).toHaveBeenCalledWith(
+      'owner',
+      'repo',
+      { message: 'Update 2 notes', tree: 'new-tree-1', parents: ['head-1'] },
+      undefined,
+    );
+    expect(GitHubService.updateRef).toHaveBeenCalledWith(
+      'owner',
+      'repo',
+      'heads/main',
+      'new-commit-1',
+      false,
+      undefined,
+    );
+  });
+
+  test('updateRef 409 on every attempt -> falls back to sequential updateFile', async () => {
+    (GitHubService.updateRef as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('Cannot force-update ref'), { status: 409 }),
+    );
+    (GitHubService.updateFile as jest.Mock).mockImplementation(async (_o: string, _r: string, path: string) => {
+      if (path === 'notes/b.md') {
+        throw Object.assign(new Error('Server exploded'), { status: 500 });
+      }
+      return { content: { sha: 'fallback-sha' }, commit: { sha: 'fallback-commit' } };
+    });
+
+    const result = await batchUpsertFiles({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      files: [
+        { path: 'notes/a.md', content: 'AAA' },
+        { path: 'notes/b.md', content: 'BBB' },
+      ],
+      message: 'Update 2 notes',
+    });
+
+    // Initial cycle + 2 branch-moved retries, then sequential fallback.
+    expect(GitHubService.getBranchHead).toHaveBeenCalledTimes(3);
+    expect(GitHubService.updateRef).toHaveBeenCalledTimes(3);
+    expect(GitHubService.createBlob).toHaveBeenCalledTimes(6);
+    expect(GitHubService.updateFile).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      success: false,
+      upserted: ['notes/a.md'],
+      failed: [{ path: 'notes/b.md', error: 'Server exploded' }],
+    });
+  });
+
+  test('1 file -> throws (case 4)', async () => {
+    await expect(
+      batchUpsertFiles({
+        owner: 'owner',
+        repo: 'repo',
+        branch: 'main',
+        files: [{ path: 'notes/a.md', content: 'AAA' }],
+        message: 'Update 1 note',
+      }),
+    ).rejects.toThrow(/at least 2 files/);
+
+    expect(GitHubService.getBranchHead).not.toHaveBeenCalled();
+    expect(GitHubService.createBlob).not.toHaveBeenCalled();
+    expect(GitHubService.updateFile).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/services/NoteGitHubSyncService.test.ts
+++ b/__tests__/services/NoteGitHubSyncService.test.ts
@@ -1,0 +1,183 @@
+jest.mock('../../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getFileShaOrNull: jest.fn(async () => null),
+    updateFile: jest.fn(async () => ({ content: { sha: 'newsha' }, commit: { sha: 'commitsha' } })),
+    uploadBinaryFile: jest.fn(async () => null),
+    getRepoPrivacy: jest.fn(async () => true),
+  },
+}));
+
+jest.mock('../../src/services/SyncEngineService', () => ({
+  SyncEngineService: {
+    getMode: jest.fn(async () => 'api'),
+  },
+}));
+
+jest.mock('../../src/services/AuthService', () => ({
+  AuthService: {
+    getToken: jest.fn(async () => 'test-token'),
+    getTokenById: jest.fn(async () => 'test-token'),
+  },
+}));
+
+jest.mock('../../src/services/git/LocalGitWriter', () => ({
+  LocalGitWriter: {
+    writeAndCommit: jest.fn(async () => ({ success: true })),
+    deleteAndCommit: jest.fn(async () => ({ success: true })),
+  },
+}));
+
+jest.mock('../../src/services/git/GitFsService', () => ({
+  GitFsService: {
+    isCloned: jest.fn(async () => false),
+    readFile: jest.fn(async () => null),
+  },
+}));
+
+jest.mock('../../src/services/git/resolveBranch', () => ({
+  resolveBranch: jest.fn(async (_repo: string, branch?: string) => branch ?? 'main'),
+}));
+
+jest.mock('../../src/services/git/gitHostFactory', () => ({
+  getGitHostService: jest.fn(() => ({
+    getAuthenticatedUser: jest.fn(async () => ({ login: 'testuser', email: 'test@test.com' })),
+  })),
+}));
+
+jest.mock('../../src/services/featureFlags', () => ({
+  FEATURE_USE_MULTI_HOST_WRITE: false,
+}));
+
+jest.mock('../../src/stores/githubActivityStore', () => ({
+  githubActivity: {
+    begin: jest.fn(),
+    end: jest.fn(),
+    reset: jest.fn(),
+    setProgress: jest.fn(),
+  },
+}));
+
+import { syncNoteToGitHub } from '../../src/services/NoteGitHubSyncService';
+import { GitHubService } from '../../src/services/GitHubService';
+import { SyncEngineService } from '../../src/services/SyncEngineService';
+import { LocalGitWriter } from '../../src/services/git/LocalGitWriter';
+import { GitFsService } from '../../src/services/git/GitFsService';
+
+describe('NoteGitHubSyncService.syncNoteToGitHub', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
+    (GitHubService.getFileShaOrNull as jest.Mock).mockResolvedValue(null);
+    (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
+    (GitFsService.isCloned as jest.Mock).mockResolvedValue(false);
+    (GitFsService.readFile as jest.Mock).mockResolvedValue(null);
+    (LocalGitWriter.writeAndCommit as jest.Mock).mockResolvedValue({ success: true });
+  });
+
+  describe('clone mode existence probe (#890)', () => {
+    beforeEach(() => {
+      (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
+      (GitFsService.isCloned as jest.Mock).mockResolvedValue(true);
+    });
+
+    test('treats NotFoundError as a missing file without warning and commits as Create', async () => {
+      const notFound = Object.assign(new Error('Could not find notes/foo.md'), {
+        code: 'NotFoundError',
+      });
+      (GitFsService.readFile as jest.Mock).mockRejectedValue(notFound);
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const result = await syncNoteToGitHub({
+        repo: 'owner/repo',
+        branch: 'main',
+        title: 'Foo',
+        content: '# Foo\n\nbody',
+        format: 'markdown',
+        tags: ['a'],
+        color: null,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.filePath).toBe('notes/foo.md');
+
+      const writeArg = (LocalGitWriter.writeAndCommit as jest.Mock).mock.calls[0][0];
+      expect(writeArg.message).toMatch(/^Create note:/);
+
+      const warned = warnSpy.mock.calls.some((args) =>
+        String(args[0]).includes('fileExists check failed'),
+      );
+      expect(warned).toBe(false);
+
+      warnSpy.mockRestore();
+    });
+
+    test('keeps warn + null fileExists on non-NotFound errors', async () => {
+      (GitFsService.readFile as jest.Mock).mockRejectedValue(new Error('network down'));
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const result = await syncNoteToGitHub({
+        repo: 'owner/repo',
+        branch: 'main',
+        title: 'Foo',
+        content: '# Foo',
+        format: 'markdown',
+      });
+
+      expect(result.success).toBe(true);
+      // Unknown probe failure -> fileExists null -> heuristic falls back to
+      // caller intent (no filePath / knownSha) -> still a Create verb.
+      const writeArg = (LocalGitWriter.writeAndCommit as jest.Mock).mock.calls[0][0];
+      expect(writeArg.message).toMatch(/^Create note:/);
+
+      const warned = warnSpy.mock.calls.some((args) =>
+        String(args[0]).includes('fileExists check failed'),
+      );
+      expect(warned).toBe(true);
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('api mode expectExists (#882)', () => {
+    test('passes expectExists:false when the probe authoritatively finds the file absent', async () => {
+      (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
+      (GitHubService.getFileShaOrNull as jest.Mock).mockResolvedValue(null);
+
+      const result = await syncNoteToGitHub({
+        repo: 'owner/repo',
+        branch: 'main',
+        filePath: '/scratch/new.md',
+        title: 'New note',
+        content: '# New note',
+        format: 'markdown',
+      });
+
+      expect(result.success).toBe(true);
+      expect(GitHubService.updateFile).toHaveBeenCalledTimes(1);
+      const opts = (GitHubService.updateFile as jest.Mock).mock.calls[0][6];
+      expect(opts.expectExists).toBe(false);
+    });
+
+    test('passes expectExists:true when the probe finds the file present', async () => {
+      (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
+      (GitHubService.getFileShaOrNull as jest.Mock).mockResolvedValue('sha123');
+
+      const result = await syncNoteToGitHub({
+        repo: 'owner/repo',
+        branch: 'main',
+        filePath: '/scratch/existing.md',
+        title: 'Existing note',
+        content: '# Existing note',
+        format: 'markdown',
+      });
+
+      expect(result.success).toBe(true);
+      expect(GitHubService.updateFile).toHaveBeenCalledTimes(1);
+      const opts = (GitHubService.updateFile as jest.Mock).mock.calls[0][6];
+      expect(opts.expectExists).toBe(true);
+    });
+  });
+});

--- a/__tests__/services/NoteSyncQueueService.test.ts
+++ b/__tests__/services/NoteSyncQueueService.test.ts
@@ -34,7 +34,7 @@ jest.mock('../../src/services/SyncEngineService', () => ({
 }));
 
 jest.mock('../../src/services/AuthService', () => ({
-  AuthService: { getToken: jest.fn(async () => 'tok') },
+  AuthService: { getToken: jest.fn(async () => 'tok'), getTokenById: jest.fn(async () => 'tok') },
 }));
 
 jest.mock('../../src/services/git/LocalGitWriter', () => ({
@@ -43,6 +43,7 @@ jest.mock('../../src/services/git/LocalGitWriter', () => ({
 
 jest.mock('../../src/services/git/BatchGitOperations', () => ({
   batchDeleteFiles: jest.fn(),
+  batchUpsertFiles: jest.fn(),
 }));
 
 jest.mock('../../src/services/git/resolveBranch', () => ({
@@ -54,7 +55,7 @@ import { NoteSyncQueueService, DroppedMutationEvent } from '../../src/services/N
 import { syncNoteToGitHub, deleteNoteFromGitHub } from '../../src/services/NoteGitHubSyncService';
 import { SyncEngineService } from '../../src/services/SyncEngineService';
 import { LocalGitWriter } from '../../src/services/git/LocalGitWriter';
-import { batchDeleteFiles } from '../../src/services/git/BatchGitOperations';
+import { batchDeleteFiles, batchUpsertFiles } from '../../src/services/git/BatchGitOperations';
 import { resolveBranch } from '../../src/services/git/resolveBranch';
 import {
   DELETE_FAILURES_STORAGE_KEY,
@@ -116,6 +117,24 @@ describe('NoteSyncQueueService', () => {
       const m = items[0];
       expect(m.type).toBe('note.upsert');
       if (m.type === 'note.upsert') expect(m.params.content).toBe('third');
+    });
+
+    test('dedupes a rename: same path with a different title drops the prior upsert (#880)', async () => {
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a.md', title: 'A', content: 'x', format: 'markdown',
+      });
+      await NoteSyncQueueService.enqueueNoteUpsert({
+        repo: 'r', branch: 'main', filePath: 'a.md', title: 'B', content: 'y', format: 'markdown',
+      });
+
+      const items = await NoteSyncQueueService.getAll();
+      expect(items).toHaveLength(1);
+      const m = items[0];
+      expect(m.type).toBe('note.upsert');
+      if (m.type === 'note.upsert') {
+        expect(m.params.title).toBe('B');
+        expect(m.params.content).toBe('y');
+      }
     });
 
     test('treats missing branch as "main" for dedupe', async () => {
@@ -1090,6 +1109,128 @@ describe('NoteSyncQueueService', () => {
       expect(batchDeleteFiles).toHaveBeenCalledTimes(1);
       expect(deleteNoteFromGitHub).toHaveBeenCalledTimes(3);
       expect(result).toEqual({ succeeded: 3, failed: 0, remaining: 0 });
+    });
+  });
+
+  describe('api-mode batch upsert drain', () => {
+    test('2 clean upserts -> ONE batchUpsertFiles; both removed from queue', async () => {
+      (batchUpsertFiles as jest.Mock).mockResolvedValue({
+        success: true,
+        upserted: ['a.md', 'b.md'],
+        failed: [],
+      });
+
+      await NoteSyncQueueService.enqueueNoteUpserts([
+        { repo: 'owner/repo', branch: 'main', filePath: 'a.md', title: 'A', content: 'aaa', format: 'markdown' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'b.md', title: 'B', content: 'bbb', format: 'markdown' },
+      ]);
+      const result = await NoteSyncQueueService.drain();
+
+      expect(batchUpsertFiles).toHaveBeenCalledTimes(1);
+      expect((batchUpsertFiles as jest.Mock).mock.calls[0][0]).toMatchObject({
+        owner: 'owner',
+        repo: 'repo',
+        branch: 'main',
+        files: [
+          { path: 'a.md', content: 'aaa' },
+          { path: 'b.md', content: 'bbb' },
+        ],
+        message: 'Update 2 notes',
+      });
+      // The batched group never hit the per-item API path.
+      expect(syncNoteToGitHub).not.toHaveBeenCalled();
+      expect(result).toEqual({ succeeded: 2, failed: 0, remaining: 0 });
+      expect(await NoteSyncQueueService.pendingCount()).toBe(0);
+    });
+
+    test('knownSha upsert is excluded from the batch and runs per-item', async () => {
+      (batchUpsertFiles as jest.Mock).mockResolvedValue({
+        success: true,
+        upserted: ['a.md', 'b.md'],
+        failed: [],
+      });
+      (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: true });
+
+      await NoteSyncQueueService.enqueueNoteUpserts([
+        { repo: 'owner/repo', branch: 'main', filePath: 'a.md', title: 'A', content: 'aaa', format: 'markdown' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'b.md', title: 'B', content: 'bbb', format: 'markdown' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'c.md', title: 'C', content: 'ccc', format: 'markdown', knownSha: 'sha-c' },
+      ]);
+      const result = await NoteSyncQueueService.drain();
+
+      expect(batchUpsertFiles).toHaveBeenCalledTimes(1);
+      expect((batchUpsertFiles as jest.Mock).mock.calls[0][0].files).toEqual([
+        { path: 'a.md', content: 'aaa' },
+        { path: 'b.md', content: 'bbb' },
+      ]);
+      // The knownSha item stayed on the per-item path.
+      expect(syncNoteToGitHub).toHaveBeenCalledTimes(1);
+      expect((syncNoteToGitHub as jest.Mock).mock.calls[0][0].filePath).toBe('c.md');
+      expect(result).toEqual({ succeeded: 3, failed: 0, remaining: 0 });
+    });
+
+    test('upsert whose content references a local image URI is NOT batched', async () => {
+      (batchUpsertFiles as jest.Mock).mockResolvedValue({
+        success: true,
+        upserted: ['a.md', 'b.md'],
+        failed: [],
+      });
+      (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: true });
+
+      await NoteSyncQueueService.enqueueNoteUpserts([
+        { repo: 'owner/repo', branch: 'main', filePath: 'a.md', title: 'A', content: 'aaa', format: 'markdown' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'b.md', title: 'B', content: 'bbb', format: 'markdown' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'c.md', title: 'C', content: '![img](file:///tmp/img.png)', format: 'markdown' },
+      ]);
+      const result = await NoteSyncQueueService.drain();
+
+      expect(batchUpsertFiles).toHaveBeenCalledTimes(1);
+      expect((batchUpsertFiles as jest.Mock).mock.calls[0][0].files).toEqual([
+        { path: 'a.md', content: 'aaa' },
+        { path: 'b.md', content: 'bbb' },
+      ]);
+      expect(syncNoteToGitHub).toHaveBeenCalledTimes(1);
+      expect((syncNoteToGitHub as jest.Mock).mock.calls[0][0].filePath).toBe('c.md');
+      expect(result).toEqual({ succeeded: 3, failed: 0, remaining: 0 });
+    });
+
+    test('batch that throws reverts the group to per-item syncNoteToGitHub', async () => {
+      (batchUpsertFiles as jest.Mock).mockRejectedValue(new Error('boom'));
+      (syncNoteToGitHub as jest.Mock).mockResolvedValue({ success: true });
+
+      await NoteSyncQueueService.enqueueNoteUpserts([
+        { repo: 'owner/repo', branch: 'main', filePath: 'a.md', title: 'A', content: 'aaa', format: 'markdown' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'b.md', title: 'B', content: 'bbb', format: 'markdown' },
+      ]);
+      const result = await NoteSyncQueueService.drain();
+
+      expect(batchUpsertFiles).toHaveBeenCalledTimes(1);
+      expect(syncNoteToGitHub).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ succeeded: 2, failed: 0, remaining: 0 });
+    });
+
+    test('durable per-path failure drops the mutation via the side channel', async () => {
+      (batchUpsertFiles as jest.Mock).mockResolvedValue({
+        success: false,
+        upserted: ['a.md'],
+        failed: [{ path: 'b.md', error: '401 Unauthorized' }],
+      });
+      const events: DroppedMutationEvent[] = [];
+      const unsub = NoteSyncQueueService.onDroppedMutation((e) => events.push(e));
+
+      await NoteSyncQueueService.enqueueNoteUpserts([
+        { repo: 'owner/repo', branch: 'main', filePath: 'a.md', title: 'A', content: 'aaa', format: 'markdown' },
+        { repo: 'owner/repo', branch: 'main', filePath: 'b.md', title: 'B', content: 'bbb', format: 'markdown' },
+      ]);
+      const result = await NoteSyncQueueService.drain();
+
+      expect(result).toEqual({ succeeded: 1, failed: 0, remaining: 0 });
+      expect(events).toHaveLength(1);
+      expect(events[0].reason).toBe('durable');
+      expect(events[0].status).toBe(401);
+      expect(events[0].mutation.params.filePath).toBe('b.md');
+      expect(syncNoteToGitHub).not.toHaveBeenCalled();
+      unsub();
     });
   });
 });

--- a/__tests__/services/RepoPullService.canvas-pull.test.ts
+++ b/__tests__/services/RepoPullService.canvas-pull.test.ts
@@ -1,0 +1,135 @@
+jest.mock('../../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getTreeRecursiveOrThrow: jest.fn(),
+    getFileContent: jest.fn(),
+    getRepoContents: jest.fn(async () => []),
+    updateFile: jest.fn(async () => ({ ok: true })),
+  },
+}));
+
+const mockLocalCanvases: any[] = [];
+
+jest.mock('../../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(),
+    getAllNotes: jest.fn(async () => []),
+    saveAllNotes: jest.fn(async () => undefined),
+    getAllTodos: jest.fn(async () => []),
+    saveAllTodos: jest.fn(async () => undefined),
+    getAllCanvases: jest.fn(async () => mockLocalCanvases),
+    mutateCanvases: jest.fn(async (mutator: any) => mutator(mockLocalCanvases)),
+  },
+}));
+
+jest.mock('../../src/services/GitService', () => ({
+  GitService: {
+    invalidateRepoFoldersCache: jest.fn(async () => undefined),
+  },
+}));
+
+import { pullFromSingleRepo } from '../../src/services/RepoPullService';
+import { GitHubService } from '../../src/services/GitHubService';
+import { StorageService } from '../../src/services/StorageService';
+
+const scene = {
+  version: 1,
+  width: 800,
+  height: 600,
+  background: '#FFFFFF',
+  elements: [],
+};
+
+const buildCanvas = (overrides: Record<string, unknown>) => ({
+  id: 'c-' + Math.random().toString(36).slice(2),
+  title: 'canvas',
+  scene,
+  tags: [],
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides,
+});
+
+describe('RepoPullService canvas pull + reconcile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocalCanvases.length = 0;
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([
+      { path: 'org/repo', branch: 'main' },
+    ]);
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue(null);
+  });
+
+  // Bug #885: fetchDirectoryFiles used a non-recursive listing, so a canvas
+  // nested under canvases/<subdir>/ was never pulled.
+  it('pulls canvases nested under subdirectories', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
+      { type: 'blob', path: 'canvases/nested/foo.json', sha: 'a' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock).mockImplementation(
+      async (_owner: string, _repo: string, path: string) =>
+        path === 'canvases/nested/foo.json' ? JSON.stringify(scene) : null,
+    );
+
+    await pullFromSingleRepo('org/repo');
+
+    const pulledCanvas = mockLocalCanvases.find(
+      (c: any) => c.filePath === 'canvases/nested/foo.json',
+    );
+    expect(pulledCanvas).toBeDefined();
+    expect(pulledCanvas.scene).toEqual(scene);
+    expect(pulledCanvas.lastPulledScene).toBe(JSON.stringify(scene));
+  });
+
+  // Bug #886: a canvas whose remote file was deleted, and which was NOT edited
+  // locally since the last pull, must be dropped.
+  it('drops a locally-unmodified canvas whose remote file was deleted', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    mockLocalCanvases.push(
+      buildCanvas({
+        id: 'gone',
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: 'canvases/gone.json',
+        lastPulledScene: JSON.stringify(scene),
+      }),
+    );
+
+    await pullFromSingleRepo('org/repo');
+
+    expect(mockLocalCanvases.find((c: any) => c.id === 'gone')).toBeUndefined();
+    expect(mockLocalCanvases).toHaveLength(0);
+  });
+
+  // Same remote deletion, but the local scene was edited since the last pull:
+  // the canvas carries unsaved local work and must be kept.
+  it('keeps a locally-edited canvas whose remote file was deleted', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    mockLocalCanvases.push(
+      buildCanvas({
+        id: 'edited',
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: 'canvases/edited.json',
+        scene: { ...scene, background: '#000000' },
+        lastPulledScene: JSON.stringify(scene),
+      }),
+    );
+
+    await pullFromSingleRepo('org/repo');
+
+    expect(mockLocalCanvases.find((c: any) => c.id === 'edited')).toBeDefined();
+  });
+
+  // Local-only canvases (no filePath) are never reconciled away.
+  it('keeps local-only canvases (no filePath) when the remote is empty', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    mockLocalCanvases.push(buildCanvas({ id: 'draft', repo: 'org/repo', branch: 'main' }));
+
+    await pullFromSingleRepo('org/repo');
+
+    expect(mockLocalCanvases.find((c: any) => c.id === 'draft')).toBeDefined();
+  });
+});

--- a/__tests__/services/StagingService.listStaged.test.ts
+++ b/__tests__/services/StagingService.listStaged.test.ts
@@ -1,0 +1,130 @@
+jest.mock('../../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    enqueueNoteUpsert: jest.fn(async () => undefined),
+    enqueueNoteDelete: jest.fn(async () => undefined),
+    getAll: jest.fn(async () => []),
+    drain: jest.fn(async () => ({ succeeded: 0, failed: 0, remaining: 0 })),
+  },
+}));
+
+jest.mock('../../src/services/git/LocalGitWriter', () => ({
+  LocalGitWriter: {
+    writeAndCommit: jest.fn(async () => ({ success: true })),
+    deleteAndCommit: jest.fn(async () => ({ success: true })),
+    push: jest.fn(async () => ({ success: true })),
+  },
+}));
+
+jest.mock('../../src/services/SyncEngineService', () => ({
+  SyncEngineService: {
+    getMode: jest.fn(async () => 'api'),
+    listOverrides: jest.fn(async () => ({})),
+  },
+}));
+
+jest.mock('../../src/services/git/GitFsService', () => ({
+  GitFsService: {
+    getCommitOid: jest.fn(async () => null),
+    findMergeBase: jest.fn(async () => null),
+  },
+}));
+
+jest.mock('../../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('../../src/services/AuthService', () => ({
+  AuthService: {
+    getToken: jest.fn(async () => 'test-token'),
+  },
+}));
+
+jest.mock('../../src/services/git/gitHostFactory', () => ({
+  getGitHostService: jest.fn(() => ({
+    getAuthenticatedUser: jest.fn(async () => ({
+      login: 'testuser',
+      name: 'Test User',
+      email: 'test@example.com',
+    })),
+  })),
+}));
+
+import { StagingService } from '../../src/services/git/StagingService';
+import type { StagedItem } from '../../src/services/git/StagingService';
+import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
+import { SyncEngineService } from '../../src/services/SyncEngineService';
+import { GitFsService } from '../../src/services/git/GitFsService';
+import { StorageService } from '../../src/services/StorageService';
+
+const queueGetAll = NoteSyncQueueService.getAll as jest.Mock;
+const listOverrides = SyncEngineService.listOverrides as jest.Mock;
+const getSavedRepositories = StorageService.getSavedRepositories as jest.Mock;
+const getCommitOid = GitFsService.getCommitOid as jest.Mock;
+const findMergeBase = GitFsService.findMergeBase as jest.Mock;
+
+const UNPUSHED_COMMITS_PLACEHOLDER = '(unpushed commits)';
+const repo = 'owner/repo';
+
+function unpushedRows(items: StagedItem[]): StagedItem[] {
+  return items.filter((i) => i.filePath === UNPUSHED_COMMITS_PLACEHOLDER && i.repoPath === repo);
+}
+
+describe('StagingService.listStaged — unpushed-commits merge-base gating (#879)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queueGetAll.mockResolvedValue([]);
+    listOverrides.mockResolvedValue({ [repo]: 'clone' });
+    getSavedRepositories.mockResolvedValue([
+      { id: '1', name: 'repo', path: repo, branch: 'main' },
+    ]);
+  });
+
+  test('strictly behind origin (local is the merge base) emits no (unpushed commits) row', async () => {
+    getCommitOid.mockImplementation(async ({ ref }: { ref: string }) =>
+      ref.startsWith('refs/heads') ? 'A' : 'B',
+    );
+    findMergeBase.mockResolvedValue('A');
+
+    const staged = await StagingService.listStaged();
+
+    expect(unpushedRows(staged)).toHaveLength(0);
+  });
+
+  test('ahead of origin emits the (unpushed commits) row', async () => {
+    getCommitOid.mockImplementation(async ({ ref }: { ref: string }) =>
+      ref.startsWith('refs/heads') ? 'C' : 'B',
+    );
+    findMergeBase.mockResolvedValue('A');
+
+    const staged = await StagingService.listStaged();
+
+    const rows = unpushedRows(staged);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      repoPath: repo,
+      branch: 'main',
+      kind: 'upsert',
+      mode: 'clone',
+      localCommitOid: 'C',
+    });
+  });
+
+  test('missing remote ref still lists the whole local branch as unpushed', async () => {
+    getCommitOid.mockImplementation(async ({ ref }: { ref: string }) =>
+      ref.startsWith('refs/heads') ? 'C' : null,
+    );
+    findMergeBase.mockResolvedValue(null);
+
+    const staged = await StagingService.listStaged();
+
+    const rows = unpushedRows(staged);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      repoPath: repo,
+      branch: 'main',
+      localCommitOid: 'C',
+    });
+  });
+});

--- a/__tests__/services/StagingService.test.ts
+++ b/__tests__/services/StagingService.test.ts
@@ -25,6 +25,7 @@ jest.mock('../../src/services/SyncEngineService', () => ({
 jest.mock('../../src/services/git/GitFsService', () => ({
   GitFsService: {
     getCommitOid: jest.fn(async () => null),
+    findMergeBase: jest.fn(async () => null),
   },
 }));
 
@@ -94,6 +95,7 @@ const getMode = SyncEngineService.getMode as jest.Mock;
 const listOverrides = SyncEngineService.listOverrides as jest.Mock;
 
 const getCommitOid = GitFsService.getCommitOid as jest.Mock;
+const findMergeBase = GitFsService.findMergeBase as jest.Mock;
 const getSavedRepositories = StorageService.getSavedRepositories as jest.Mock;
 const getToken = AuthService.getToken as jest.Mock;
 
@@ -342,12 +344,30 @@ describe('StagingService', () => {
       });
     });
 
+    test('strictly-behind local branch (local === merge base) emits no phantom unpushed row (#879)', async () => {
+      listOverrides.mockResolvedValue({ 'owner/repo': 'clone' });
+      getSavedRepositories.mockResolvedValue([
+        { id: '1', name: 'repo', path: 'owner/repo', branch: 'main' },
+      ]);
+      // Local is the ancestor of origin: localOid === merge base, remote descendants.
+      getCommitOid.mockImplementation(
+        async ({ ref }: { ref: string }) =>
+          ref.startsWith('refs/heads') ? 'ancestor-oid' : 'descendant-oid',
+      );
+      findMergeBase.mockResolvedValue('ancestor-oid');
+
+      const staged = await StagingService.listStaged();
+
+      expect(staged).toHaveLength(0);
+    });
+
     test('fresh clone with no commits on either side is not staged', async () => {
       listOverrides.mockResolvedValue({ 'owner/repo': 'clone' });
       getSavedRepositories.mockResolvedValue([
         { id: '1', name: 'repo', path: 'owner/repo', branch: 'main' },
       ]);
-      getCommitOid.mockResolvedValue(null);
+getCommitOid.mockResolvedValue(null);
+    findMergeBase.mockResolvedValue(null);
 
       const staged = await StagingService.listStaged();
 

--- a/__tests__/services/actionExecutor.edit-note.test.ts
+++ b/__tests__/services/actionExecutor.edit-note.test.ts
@@ -1,0 +1,125 @@
+jest.mock('../../src/stores/noteStore', () => {
+  const state = {
+    notes: [] as Array<Record<string, unknown>>,
+    getNoteById: jest.fn((id: string) => state.notes.find((note) => note.id === id)),
+    updateNote: jest.fn(async () => ({
+      id: 'n1',
+      title: 'New Title',
+      content: 'New body',
+      filePath: 'notes/new-title.md',
+      format: 'markdown',
+      tags: ['a'],
+      createdAt: 100,
+      updatedAt: 200,
+    })),
+  };
+  return {
+    useNoteStore: { getState: () => state, __state: state },
+  };
+});
+
+jest.mock('../../src/stores/aiStore', () => {
+  const state = {
+    githubToolsEnabled: true,
+    chatRepoOwner: null as string | null,
+    chatRepoName: null as string | null,
+    chatRepoBranch: 'main',
+    selectedModel: undefined as Record<string, unknown> | undefined,
+    providers: [] as Array<Record<string, unknown>>,
+    getSelectedModel: () => state.selectedModel,
+  };
+  return {
+    useAIStore: { getState: () => state, __state: state },
+  };
+});
+
+jest.mock('../../src/stores/todoStore', () => ({
+  useTodoStore: { getState: () => ({ todos: [] }), __state: { todos: [] } },
+}));
+
+jest.mock('../../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    enqueueNoteUpsert: jest.fn(async () => undefined),
+    drain: jest.fn(),
+  },
+}));
+
+jest.mock('ai', () => ({
+  ...jest.requireActual('ai'),
+  generateText: jest.fn(async () => ({ text: 'graded' })),
+}));
+
+jest.mock('../../src/services/AIService', () => ({
+  initializeModel: jest.fn(async () => ({})),
+}));
+
+import { executeToolCall } from '../../src/services/ai/actionExecutor';
+import { useNoteStore } from '../../src/stores/noteStore';
+import { useAIStore } from '../../src/stores/aiStore';
+import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
+
+type StoreMock<T> = { getState: () => T; __state: T };
+
+const noteState = (useNoteStore as unknown as StoreMock<{
+  updateNote: jest.Mock;
+}>).__state;
+const aiState = (useAIStore as unknown as StoreMock<{
+  githubToolsEnabled: boolean;
+  chatRepoOwner: string | null;
+  chatRepoName: string | null;
+  chatRepoBranch: string;
+}>).__state;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  aiState.githubToolsEnabled = true;
+  aiState.chatRepoOwner = null;
+  aiState.chatRepoName = null;
+  aiState.chatRepoBranch = 'main';
+  noteState.updateNote.mockClear();
+  (NoteSyncQueueService.enqueueNoteUpsert as jest.Mock).mockClear();
+});
+
+describe('executeToolCall edit_note sync enqueue', () => {
+  test('enqueues a sync upsert carrying repo, filePath, title, content and localNoteId when a chat repo is set', async () => {
+    aiState.chatRepoOwner = 'owner';
+    aiState.chatRepoName = 'repo';
+    aiState.chatRepoBranch = 'dev';
+
+    const result = await executeToolCall(
+      'edit_note',
+      { noteId: 'n1', title: 'New Title', content: 'New body' },
+      'auto',
+    );
+
+    expect(result.success).toBe(true);
+    expect(NoteSyncQueueService.enqueueNoteUpsert).toHaveBeenCalledTimes(1);
+
+    const [params, localNoteId] = (NoteSyncQueueService.enqueueNoteUpsert as jest.Mock).mock
+      .calls[0];
+    expect(params).toEqual(
+      expect.objectContaining({
+        repo: 'owner/repo',
+        branch: 'dev',
+        filePath: 'notes/new-title.md',
+        title: 'New Title',
+        content: 'New body',
+        format: 'markdown',
+        tags: ['a'],
+      }),
+    );
+    expect(localNoteId).toBe('n1');
+  });
+
+  test('skips the sync queue when no chat repo is set but the edit still succeeds', async () => {
+    const result = await executeToolCall(
+      'edit_note',
+      { noteId: 'n1', title: 'New Title', content: 'New body' },
+      'auto',
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ noteId: 'n1', title: 'New Title' });
+    expect(NoteSyncQueueService.enqueueNoteUpsert).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/git/branchResolver.test.ts
+++ b/__tests__/services/git/branchResolver.test.ts
@@ -1,0 +1,74 @@
+import { fetchGitHubDefaultBranch } from '../../../src/services/git/branchResolver';
+import AuthService from '../../../src/services/AuthService';
+
+jest.mock('../../../src/services/AuthService', () => ({
+  __esModule: true,
+  default: { getToken: jest.fn() },
+}));
+
+jest.mock('../../../src/services/git/GitFsService', () => ({
+  GitFsService: { getCurrentBranch: jest.fn() },
+}));
+
+const getTokenMock = AuthService.getToken as jest.Mock;
+
+describe('fetchGitHubDefaultBranch', () => {
+  beforeEach(() => {
+    getTokenMock.mockReset();
+    (global.fetch as jest.Mock | undefined)?.mockReset?.();
+  });
+
+  it('sends an Authorization header when a token is available', async () => {
+    getTokenMock.mockResolvedValue('ghp_token');
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ default_branch: 'trunk' }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(await fetchGitHubDefaultBranch('foo/bar')).toBe('trunk');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/foo/bar',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer ghp_token',
+          Accept: 'application/vnd.github.v3+json',
+        },
+      }),
+    );
+  });
+
+  it('omits the Authorization header when no token is available', async () => {
+    getTokenMock.mockResolvedValue(null);
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ default_branch: 'main' }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(await fetchGitHubDefaultBranch('foo/bar')).toBe('main');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/foo/bar',
+      expect.objectContaining({
+        headers: { Accept: 'application/vnd.github.v3+json' },
+      }),
+    );
+  });
+
+  it('returns null on a non-OK response', async () => {
+    getTokenMock.mockResolvedValue('ghp_token');
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as unknown as typeof fetch;
+
+    expect(await fetchGitHubDefaultBranch('foo/bar')).toBeNull();
+  });
+
+  it('returns null when the token lookup fails', async () => {
+    getTokenMock.mockRejectedValue(new Error('storage unavailable'));
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ default_branch: 'main' }),
+    }) as unknown as typeof fetch;
+
+    expect(await fetchGitHubDefaultBranch('foo/bar')).toBeNull();
+  });
+});

--- a/__tests__/services/git/gitFs.test.ts
+++ b/__tests__/services/git/gitFs.test.ts
@@ -126,6 +126,24 @@ function getStore(): Map<string, Entry> {
   return (globalThis as any).__gitFsTestStore;
 }
 
+function fnv1a(bytes: Uint8Array): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < bytes.length; i++) {
+    hash ^= bytes[i];
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+async function captureError(p: Promise<unknown>): Promise<unknown> {
+  try {
+    await p;
+    return undefined;
+  } catch (e) {
+    return e;
+  }
+}
+
 beforeEach(() => {
   const s = getStore();
   s.clear();
@@ -257,5 +275,42 @@ describe('gitFs adapter', () => {
       encoding: 'utf8',
     });
     expect(back).toBe('idx');
+  });
+
+  test('large binary (>49KB) round-trips without truncation or corruption', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    const size = 200000;
+    const bytes = new Uint8Array(size);
+    for (let i = 0; i < size; i++) bytes[i] = (i * 31 + 7) & 0xff;
+
+    await fs.promises.writeFile('/big.bin', bytes);
+    const data = await fs.promises.readFile('/big.bin');
+
+    expect(data).toBeInstanceOf(Uint8Array);
+    const decoded = data as Uint8Array;
+    expect(decoded.length).toBe(size);
+    expect(fnv1a(decoded)).toBe(fnv1a(bytes));
+  });
+
+  test('case-collision guard: second casing throws EEXIST instead of clobbering', async () => {
+    const fs = makeGitFs('file:///doc/git/');
+    await fs.promises.writeFile('/notes/Foo.md', 'first');
+
+    const writeErr = await captureError(
+      fs.promises.writeFile('/notes/foo.md', 'second'),
+    );
+    expect(writeErr).toBeInstanceOf(FsError);
+    expect((writeErr as FsError).code).toBe('EEXIST');
+    expect((writeErr as FsError).message).toMatch(/case-collision/);
+
+    const readErr = await captureError(
+      fs.promises.readFile('/notes/foo.md', { encoding: 'utf8' }),
+    );
+    expect(readErr).toBeInstanceOf(FsError);
+    expect((readErr as FsError).code).toBe('EEXIST');
+
+    expect(await fs.promises.readFile('/notes/Foo.md', { encoding: 'utf8' })).toBe(
+      'first',
+    );
   });
 });

--- a/__tests__/services/git/gitFsService.test.ts
+++ b/__tests__/services/git/gitFsService.test.ts
@@ -116,15 +116,25 @@ describe('GitFsService', () => {
     expect(getGitMocks().clone).not.toHaveBeenCalled();
   });
 
-  test('fetch forwards branch + depth + token-derived auth', async () => {
-    await GitFsService.fetch({ repoPath: 'me/repo', branch: 'feature/x', token: 'tok', depth: 2 });
+  test('fetch forwards branch + token-derived auth and floors depth to >=3', async () => {
+    await GitFsService.fetch({ repoPath: 'me/repo', branch: 'feature/x', token: 'tok' });
     expect(getGitMocks().fetch).toHaveBeenCalledTimes(1);
     const args = getGitMocks().fetch.mock.calls[0][0];
     expect(args.dir).toBe('/me/repo');
     expect(args.ref).toBe('feature/x');
-    expect(args.depth).toBe(2);
+    expect(args.depth).toBeGreaterThanOrEqual(3);
     expect(args.tags).toBe(false);
     expect(args.onAuth()).toEqual({ username: 'x-access-token', password: 'tok' });
+  });
+
+  test('fetch honors an explicit larger depth', async () => {
+    await GitFsService.fetch({ repoPath: 'me/repo', branch: 'main', depth: 50 });
+    expect(getGitMocks().fetch.mock.calls[0][0].depth).toBe(50);
+  });
+
+  test('fetch floors an explicit shallow depth up to the minimum', async () => {
+    await GitFsService.fetch({ repoPath: 'me/repo', branch: 'main', depth: 1 });
+    expect(getGitMocks().fetch.mock.calls[0][0].depth).toBe(3);
   });
 
   test('listTree maps walk entries into the tree-entry shape (matches GitHubService)', async () => {
@@ -221,6 +231,23 @@ describe('GitFsService', () => {
     expect(result.ok).toBe(true);
     expect(getGitMocks().fetch).toHaveBeenCalled();
     expect(getGitMocks().fastForward).toHaveBeenCalled();
+  });
+
+  test('pullWithFastForward fetches with depth >=3 when no explicit depth given', async () => {
+    await GitFsService.pullWithFastForward({
+      repoPath: 'me/repo',
+      branch: 'main',
+    });
+    expect(getGitMocks().fetch.mock.calls[0][0].depth).toBeGreaterThanOrEqual(3);
+  });
+
+  test('pullWithFastForward passes through an explicit larger depth', async () => {
+    await GitFsService.pullWithFastForward({
+      repoPath: 'me/repo',
+      branch: 'main',
+      depth: 50,
+    });
+    expect(getGitMocks().fetch.mock.calls[0][0].depth).toBe(50);
   });
 
   test('pullWithFastForward returns diverged when fast-forward fails', async () => {

--- a/docs/wiki/git-core-hardening.md
+++ b/docs/wiki/git-core-hardening.md
@@ -1,0 +1,113 @@
+# Git Core Hardening
+
+Fixes from the git-core test campaign (issues #876–#892) — data-integrity, auth, sync, and pull-layer defects found by the live test harness.
+
+## Data integrity
+
+### #891 — base64 chunked decode dropped bytes over ~49KB (HIGH)
+
+`base64ToBytesAsync` (`src/services/git/gitFs.ts`) advanced the loop cursor twice: the for-loop header stepped by `CHUNK_CHARS` and the body also set `i = alignedEnd - 1`. With a non-4-aligned chunk size that left a ~65534-char undecoded gap between chunks, so binary blobs larger than ~49KB came back truncated/corrupt and the corrupt blob is what got pushed.
+
+Fix: `CHUNK_CHARS` is now 65532 (a multiple of 4, so every chunk boundary is base64-aligned) and the body no longer rewrites the cursor. The decode loop now tiles the input exactly.
+
+### #892 — case-collision paths clobbered on case-insensitive filesystems (MEDIUM)
+
+On APFS/NTFS, two distinct virtual paths that differ only by case (`notes/Foo.md` vs `notes/foo.md`, or repos `Foo/bar` vs `foo/Bar`) map to the same on-disk URI, so the second write silently clobbers the first. Git stores both blobs fine; the working tree was corrupt.
+
+Fix: `makeGitFs` keeps a per-root map of lowercased URI → first-seen canonical spelling. `readFile`/`writeFile` (plus `mkdir`/`readdir`/`stat`) throw `FsError('EEXIST', 'case-collision: …')` when a variant path is touched — the clobber is now loud and diagnosable instead of silent.
+
+## Auth & access
+
+### #876 — false-negative write preflight for fine-grained PATs (MEDIUM)
+
+`preflightGitHubRepoAccess` decided write capability from the `x-accepted-github-permissions` header or `permissions.push`. Fine-grained PATs only ever advertise `metadata=read` on `GET /repos` even when they can write, so a write-capable token was reported `write_unverified`.
+
+Fix: when the header/`permissions.push` check is inconclusive, the preflight performs a real probe — `PUT` a scratch file under `.gitnotes-preflight-<ts>.tmp` and best-effort `DELETE` it. Success ⇒ `ok: writeVerified`; 401/403/404 ⇒ `no_access`; 429/5xx ⇒ `transient`.
+
+### #877 — default-branch resolution 404'd on private repos (HIGH)
+
+`fetchGitHubDefaultBranch` sent no `Authorization` header, so private repos 404'd and fell through to the hardcoded `'main'` fallback — wrong for any private repo whose default branch isn't `main`.
+
+Fix: the GitHub fetch now sends `Authorization: Bearer <token>` (via `AuthService.getToken()`; verified no import cycle), keeping the null-on-error contract.
+
+### #878 — `parseRepoPath` failed trailing-slash `.git` and SSH scp formats (LOW)
+
+Two common GitHub clone-dropdown pastes mis-parsed: `owner/repo.git/` kept the `.git` (no `.git$` match at the `/`), and `git@github.com:owner/repo.git` folded the scp prefix into the owner. Both 404'd downstream.
+
+Fix: normalize by trimming trailing slashes first, strip optional `git@host:` scp prefixes (`git@host:owner/repo` and `ssh://git@host/owner/repo`), then the existing `.git`/URL-prefix cleanup — with segment validation and a variant-table test.
+
+## API-mode sync
+
+### #883 — `getFileContent` returned null for empty files (LOW)
+
+The truthy `data.content` gate treated an empty file (`content === ''`) as missing, giving false-negative existence checks.
+
+Fix: gate on `data.type === 'file' && typeof data.content === 'string'` (empty string is a valid file).
+
+### #884 — `createFile` swallowed 401s → infinite retry loop (MEDIUM)
+
+`createFile` caught all errors, logged and returned null; the queue classifier saw `'GitHub API returned no result'` with no status, classified it retryable-unknown, and retried forever with no terminal failure surfaced.
+
+Fix: `createFile` now rethrows HTTP errors with their status/message so the queue classifier gets a real 401 and drops the mutation durably. `createFolder`/`moveFile` wrap the call to preserve their null/false-on-failure contracts.
+
+### #881 — `updateFile` 409 divergence was silent (MEDIUM)
+
+A stale-sha PUT → 409 → upstream content differs → `updateFile` returned null, which collapsed to the generic `'GitHub API returned no result'` — the conflict never reached the user.
+
+Fix: the divergence branch now throws a typed `status: 409` error (`upstream-content-changed, pull to resolve`) so `syncNoteToGitHub` maps it to `conflict-detected` and the UI can suggest a pull.
+
+### #880 — sync queue dedup keyed by title instead of path (LOW)
+
+Two upserts for the same `(repo, branch, filePath)` with different titles (a rename) both survived in the queue and flushed as 2 writes.
+
+Fix: same-path upserts now collapse regardless of title — latest enqueue wins.
+
+### #888 — API-mode batch writes (HIGH perf)
+
+API mode drained N upserts as N serial GET(sha)+PUT round trips (~16× slower than clone mode's single push). The batch machinery for deletes already existed in `BatchGitOperations`; upserts now use it too.
+
+Fix: `batchUpsertFiles` builds ONE Git-Data commit per (repo, branch) group — parallel blob creation, `createTree` with `base_tree` (parents derived automatically), one commit, one ref update, retried on branch-moved, falling back to per-file writes on terminal failure. The queue wires it for ≥2 eligible upserts (eligible = no `knownSha` guard needed and no local-image URIs that require the per-item upload rewrite).
+
+### #882 — `syncNoteToGitHub` couldn't create a missing remote file with explicit filePath (MEDIUM)
+
+`updateFile` was called with `expectExists: !!filePath`, but the editor sets filePath for new AND updated notes — so a first-write with an explicit path aborted against the resurrection guard.
+
+Fix: the create-vs-update intent computed from the probe (`useUpdateVerb`) is now passed through as `expectExists`.
+
+### #890 — clone-mode existence probe warned on NotFoundError for derived paths (LOW)
+
+AI upserts that omit `filePath` derive the path at sync time; the clone probe (`GitFsService.readFile`) throws `NotFoundError` for a not-yet-pushed path, which logged a warning per upsert and degraded the commit verb to "Create note:".
+
+Fix: the probe catch treats NotFound-style errors (`code === 'NotFoundError'` or message match) as `fileExists = false` silently.
+
+## Clone-mode sync
+
+### #889 — AI `edit_note` never enqueued a sync (MEDIUM)
+
+The `edit_note` tool edited only locally — `updateNote` neither enqueued nor staged, so the edit never reached git in either mode (silent divergence).
+
+Fix: the auto branch now enqueues a `NoteUpsert` for the updated note when a chat-repo context is set, mirroring `grade_questioner_answers`.
+
+### #879 — phantom "(unpushed commits)" row when local is strictly behind (HIGH, false push state)
+
+`listStaged` emitted the synthetic unpushed row whenever `localOid !== remoteOid` — including when origin descended from local (nothing to push).
+
+Fix: the row is gated on `localOid !== mergeBase && localOid !== remoteOid`, mirroring `LocalGitWriter.hasUnpushedLocalCommits`.
+
+### #885 — nested todos/canvases never pulled (MEDIUM)
+
+`fetchDirectoryFiles` listed only direct children, so `todos/nested/foo.json` / `canvases/nested/bar.json` were never pulled in either mode.
+
+Fix: todos/canvases now route through the same mode-aware reader as notes — recursive tree in API mode, local clone in clone mode — filtered by the `dirPath/` prefix, fetched with bounded concurrency.
+
+### #886 — deleted remote canvases persisted locally (MEDIUM)
+
+The canvas reconcile was disabled because local canvases without remote backing could be unsaved edits. Result: deleting a canvas's remote file never removed it locally.
+
+Fix: canvases track `lastPulledScene` at pull time; reconcile drops a remote-origin canvas when its file is gone **and** its scene still matches the last pulled state. A locally-edited canvas (scene drift) or a local-only draft is kept.
+
+### #887 — depth-1 clone made merge-base detection unreachable (LOW)
+
+`findMergeBase` needs ≥2-3 commits of shared ancestry; the default `depth: 1` clone (and the equally shallow fetches) silently disabled divergence-conflict recording.
+
+Fix: `fetch` and `pullWithFastForward` never fetch shallower than 3 commits (`MIN_DIVERGENCE_HISTORY_DEPTH`), so after the first pull cycle merge-base-based conflict detection is reachable. The initial clone stays shallow by design.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -17,6 +17,7 @@
 | [AI Providers](./ai-providers.md) | Provider types, Anthropic defaults, adding providers |
 | [Filter Persistence](./filter-persistence.md) | Filter state architecture and AsyncStorage |
 | [Importers](./importers.md) | Removed Google Keep and Apple Notes importers, for later re-integration |
+| [Git Core Hardening](./git-core-hardening.md) | git-core test-campaign fixes: binary decode integrity, case collisions, auth/preflight, API batch writes, pull/reconcile fixes (#876–#892) |
 
 ## Quick Start
 

--- a/src/models/Canvas.ts
+++ b/src/models/Canvas.ts
@@ -125,6 +125,9 @@ export interface Canvas {
   createdAt: number;
   updatedAt: number;
   accountId?: string;
+  /** Stable serialization of `scene` as observed on the last pull, used to
+   * detect unsaved local edits during reconcile. */
+  lastPulledScene?: string;
 }
 
 export interface CanvasCreateInput {
@@ -136,6 +139,7 @@ export interface CanvasCreateInput {
   filePath?: string;
   tags?: string[];
   accountId?: string;
+  lastPulledScene?: string;
 }
 
 export interface CanvasUpdateInput {
@@ -148,6 +152,7 @@ export interface CanvasUpdateInput {
   filePath?: string;
   tags?: string[];
   accountId?: string;
+  lastPulledScene?: string;
 }
 
 function generateId(): string {
@@ -180,6 +185,7 @@ export function createCanvas(input: CanvasCreateInput): Canvas {
     createdAt: now,
     updatedAt: now,
     accountId: input.accountId,
+    lastPulledScene: input.lastPulledScene,
   };
 }
 
@@ -194,6 +200,7 @@ export function updateCanvas(existing: Canvas, input: Partial<CanvasCreateInput>
     filePath: input.filePath ?? existing.filePath,
     tags: input.tags ?? existing.tags,
     accountId: input.accountId ?? existing.accountId,
+    lastPulledScene: input.lastPulledScene ?? existing.lastPulledScene,
     updatedAt: Date.now(),
   };
 }

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -606,7 +606,11 @@ class GitHubServiceClass {
       let url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
       if (ref) url += `?ref=${encodeURIComponent(ref)}`;
       const data = await this.request(url, 'GET', undefined, opts);
-      if (data.type === 'file' && data.content) {
+      // Gate on the type + content *field presence*, not truthiness: an empty
+      // file legitimately has `content === ''` and must not read as "missing"
+      // (#883 — `.gitkeep` and other empty files were false-negatived by the
+      // old `data.content` truthiness check).
+      if (data.type === 'file' && typeof data.content === 'string') {
         const base64 = data.content.replace(/\n/g, '');
         return decodeBase64(base64);
       }
@@ -729,6 +733,12 @@ class GitHubServiceClass {
     return result.kind === 'found' ? result.sha : null;
   }
 
+  /**
+   * Create a remote file. HTTP errors are rethrown (rather than collapsed to
+   * null) so a 401/403/409 propagates to the queue classifier with its status
+   * intact — swallowing it here made bad-credential failures surface as an
+   * unknown retryable and loop forever (#884).
+   */
   async createFile(
     owner: string,
     repo: string,
@@ -738,19 +748,14 @@ class GitHubServiceClass {
     branch: string = 'main',
     opts?: TokenOpts,
   ): Promise<GitHubFileCommit | null> {
-    try {
-      const encodedPath = path.split('/').map(encodeURIComponent).join('/');
-      const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
-      const base64Content = await bytesToBase64Async(content);
-      return await this.request(url, 'PUT', {
-        message,
-        content: base64Content,
-        branch,
-      }, opts);
-    } catch (error) {
-      console.warn('[GitHubService] Failed to create file:', error);
-      return null;
-    }
+    const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+    const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
+    const base64Content = await bytesToBase64Async(content);
+    return await this.request(url, 'PUT', {
+      message,
+      content: base64Content,
+      branch,
+    }, opts);
   }
 
   async uploadBinaryFile(
@@ -885,7 +890,12 @@ class GitHubServiceClass {
     opts?: TokenOpts,
   ): Promise<GitHubFileCommit | null> {
     const keepPath = folderPath ? `${folderPath}/.gitkeep` : '.gitkeep';
-    return this.createFile(owner, repo, keepPath, '', `Create folder ${folderPath || '/'}`, branch, opts);
+    try {
+      return await this.createFile(owner, repo, keepPath, '', `Create folder ${folderPath || '/'}`, branch, opts);
+    } catch (error) {
+      console.warn('[GitHubService] Failed to create folder:', error);
+      return null;
+    }
   }
 
   async updateFile(
@@ -935,13 +945,14 @@ class GitHubServiceClass {
         const status = details.status;
         if (status === 409 && attempt < 2) {
           this.shaCache.delete(cacheKey);
+          let upstreamContent: string | null = null;
           try {
-            const upstreamContent = await this.getFileContent(owner, repo, path, branch);
-            if (upstreamContent !== null && upstreamContent !== content) {
-              console.warn(`[GitHubService] Aborting update: upstream content diverged for ${path}`);
-              return null;
-            }
+            upstreamContent = await this.getFileContent(owner, repo, path, branch);
           } catch {
+            // getFileContent swallows its own failures; treat as unresolved.
+          }
+          if (upstreamContent !== null && upstreamContent !== content) {
+            throw Object.assign(new Error('upstream-content-changed, pull to resolve'), { status: 409 });
           }
           continue;
         }
@@ -973,7 +984,13 @@ class GitHubServiceClass {
     branch: string = 'main',
     opts?: TokenOpts,
   ): Promise<boolean> {
-    const createResult = await this.createFile(owner, repo, newPath, content, message, branch, opts);
+    let createResult: GitHubFileCommit | null = null;
+    try {
+      createResult = await this.createFile(owner, repo, newPath, content, message, branch, opts);
+    } catch (error) {
+      console.warn('[GitHubService] moveFile create failed for', newPath, error);
+      return false;
+    }
     if (!createResult) return false;
     try {
       await this.deleteFile(owner, repo, oldPath, message, oldSha, branch, opts);
@@ -1052,18 +1069,37 @@ class GitHubServiceClass {
     }));
   }
 
+  async createBlob(
+    owner: string,
+    repo: string,
+    content: string,
+    opts?: TokenOpts,
+  ): Promise<{ sha: string }> {
+    const data = await this.request<{ sha?: string }>(
+      `https://api.github.com/repos/${owner}/${repo}/git/blobs`,
+      'POST',
+      { content: await bytesToBase64Async(content), encoding: 'base64' },
+      opts,
+    );
+    if (!data?.sha) {
+      throw new Error('GitHub create blob returned no sha');
+    }
+    return { sha: data.sha };
+  }
+
   async createTree(
     owner: string,
     repo: string,
     tree: GitHubTreeEntry[],
-    opts?: TokenOpts,
+    opts?: TokenOpts & { baseTree?: string },
   ): Promise<{ sha: string }> {
     // Explicit tree (no base_tree): omitting a path from base_tree does NOT
     // delete it, so batch deletes always send the FULL tree minus deletions.
+    const baseTree = opts?.baseTree;
     const data = await this.request<{ sha?: string }>(
       `https://api.github.com/repos/${owner}/${repo}/git/trees`,
       'POST',
-      { tree },
+      { tree, ...(baseTree ? { base_tree: baseTree } : {}) },
       opts,
     );
     if (!data?.sha) {

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -547,8 +547,14 @@ export async function syncNoteToGitHub(params: {
       }
     }
   } catch (error) {
-    console.warn('[NoteGitHubSync] fileExists check failed:', error);
-    fileExists = null;
+    const code = (error as Error & { code?: string }).code;
+    const message = error instanceof Error ? error.message : String(error);
+    if (code === 'NotFoundError' || /NotFoundError|Could not find|not foundobject/i.test(message)) {
+      fileExists = false;
+    } else {
+      console.warn('[NoteGitHubSync] fileExists check failed:', error);
+      fileExists = null;
+    }
   }
   const useUpdateVerb = fileExists ?? !!(knownSha || filePath);
   const message = useUpdateVerb ? `Update note: ${title}` : `Create note: ${title}`;
@@ -620,7 +626,7 @@ export async function syncNoteToGitHub(params: {
       finalContent,
       message,
       targetBranch,
-      { ...opts, expectExists: !!filePath },
+      { ...opts, expectExists: useUpdateVerb },
     );
 
     if (result) {

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -12,8 +12,8 @@ import { classifyGitHubSyncError, isRetryableFailure, syncStatusForError } from 
 import { resolveBranch } from './git/resolveBranch';
 import { clearDeleteFailure, clearDeleteFailuresForRepo, readDeleteFailures, recordDeleteFailure, DELETE_FAILURES_STORAGE_KEY } from './git/deleteFailures';
 import { GitSyncGate } from './git/GitSyncGate';
-import { batchDeleteFiles } from './git/BatchGitOperations';
-import type { BatchDeleteFilesResult } from './git/BatchGitOperations';
+import { batchDeleteFiles, batchUpsertFiles } from './git/BatchGitOperations';
+import type { BatchDeleteFilesResult, BatchUpsertFilesResult } from './git/BatchGitOperations';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { NoteColor, NoteFormat } from '../models/Note';
 
@@ -37,6 +37,7 @@ function backoffMsForAttempts(attempts: number): number {
 export interface NoteUpsertParams {
   repo: string;
   branch?: string;
+  accountId?: string;
   filePath?: string;
   title: string;
   content: string;
@@ -79,6 +80,34 @@ export type QueuedMutation =
       type: 'note.delete';
       params: NoteDeleteParams;
     });
+
+const LOCAL_IMAGE_URI_RE = /(file:\/\/|asset:\/\/|ph:\/\/|content:\/\/)/i;
+
+type BatchEligibleUpsert = QueuedMutation & {
+  type: 'note.upsert';
+  params: NoteUpsertParams & { filePath: string };
+};
+
+/**
+ * An upsert is batchable only when the per-item path would NOT have done
+ * something the batch can't replicate:
+ *  (a) `knownSha` is unset — the per-item path guards remote conflicts via
+ *      knownSha; batching skips that check, so those items stay per-item.
+ *  (b) the content references no local image URI — `syncNoteToGitHub`
+ *      rewrites file://, asset://, ph:// and content:// URIs to remote URLs
+ *      during upload; the batch writes content verbatim, so such items must
+ *      stay per-item (their images would 404 remotely).
+ * A missing filePath also disqualifies: the title-derived path is resolved
+ * on the per-item path, and without a concrete path the batch can't address
+ * the file.
+ */
+function isBatchEligibleUpsert(m: QueuedMutation): m is BatchEligibleUpsert {
+  if (m.type !== 'note.upsert') return false;
+  if (!m.params.filePath) return false;
+  if (m.params.knownSha) return false;
+  if (LOCAL_IMAGE_URI_RE.test(m.params.content)) return false;
+  return true;
+}
 
 /**
  * Side-channel notification for mutations the queue gave up on. Emitted
@@ -349,8 +378,9 @@ class NoteSyncQueueServiceClass {
   /**
    * Batch variant of `enqueueNoteUpsert`: ONE queue write for the whole
    * batch. Dedup mirrors the single-item rules — a new upsert drops
-   * same-path prior upserts with the same title (latest wins) and any
-   * pending same-path delete (the note was re-created, delete wasted).
+   * same-path prior upserts regardless of title (latest wins; a rename
+   * reuses the path under a new title and must not leave two writes) and
+   * any pending same-path delete (the note was re-created, delete wasted).
    */
   async enqueueNoteUpserts(
     items: NoteUpsertParams[],
@@ -370,14 +400,14 @@ class NoteSyncQueueServiceClass {
         m.params.repo === resolvedParams.repo &&
         (m.params.branch || 'main') === branch &&
         m.params.filePath === resolvedParams.filePath;
-      // note.delete entries are only dropped when filePath is set on both
-      // sides — undefined on either side means the blob match is unproven.
-      const keepExisting = (m: QueuedMutation): boolean => {
-        if (m.type === 'note.upsert') {
-          return !(sameRepoBranchPath(m) && m.params.title === resolvedParams.title);
-        }
-        return !(resolvedParams.filePath && sameRepoBranchPath(m));
-      };
+      // Drop any prior entry sharing the resolved (repo, branch, filePath):
+      // upserts regardless of title (a rename reuses the path under a new
+      // title, and the old title-only match left BOTH queued — two writes
+      // for one rename); deletes only when filePath is set on both sides
+      // (undefined on either side means the blob match is unproven). The
+      // filePath guard also keeps two un-pathed new notes from collapsing.
+      const keepExisting = (m: QueuedMutation): boolean =>
+        !(resolvedParams.filePath && sameRepoBranchPath(m));
       queue = queue.filter(keepExisting);
       for (let i = batchMutations.length - 1; i >= 0; i -= 1) {
         if (!keepExisting(batchMutations[i])) batchMutations.splice(i, 1);
@@ -619,6 +649,82 @@ class NoteSyncQueueServiceClass {
       }
     }
 
+    // API-mode single-commit bulk upserts: >=2 eligible upserts in one
+    // (repo, branch) group ship as ONE Git-Data commit (createBlob xN in
+    // parallel -> createTree with base_tree -> createCommit -> updateRef)
+    // instead of N serial GET(sha)+PUT(contents) round-trips. Only eligible
+    // items batch (see isBatchEligibleUpsert); ineligible upserts and any
+    // deletes flow through the per-item loop. A batch that throws reverts
+    // its group to per-item syncNoteToGitHub so items keep their full
+    // classification.
+    if (!isClone) {
+      const dueUpserts = items.filter(isBatchEligibleUpsert);
+      if (dueUpserts.length >= 2) {
+        const repoInfo = parseRepoPath(repoPath);
+        if (repoInfo) {
+          const subgroups = new Map<string, BatchEligibleUpsert[]>();
+          for (const item of dueUpserts) {
+            const key = item.params.accountId ?? '';
+            const arr = subgroups.get(key) ?? [];
+            arr.push(item);
+            subgroups.set(key, arr);
+          }
+          for (const [accountId, group] of subgroups) {
+            if (group.length < 2) continue;
+            let tokenOverride: string | undefined;
+            if (accountId) {
+              tokenOverride = (await AuthService.getTokenById(accountId)) ?? undefined;
+            }
+            let batchResult: BatchUpsertFilesResult | null = null;
+            try {
+              batchResult = await batchUpsertFiles({
+                owner: repoInfo.owner,
+                repo: repoInfo.repo,
+                branch,
+                files: group.map((item) => ({
+                  path: item.params.filePath,
+                  content: item.params.content,
+                })),
+                message: `Update ${group.length} notes`,
+                ...(tokenOverride ? { opts: { tokenOverride } } : {}),
+              });
+            } catch (batchError) {
+              console.warn('[NoteSyncQueue] batch upsert threw; group reverts to per-item processing:', batchError);
+            }
+            if (batchResult) {
+              const byPath = new Map(group.map((item) => [item.params.filePath, item]));
+              const upsertedPaths = new Set(batchResult.upserted);
+              for (const item of group) {
+                if (upsertedPaths.has(item.params.filePath)) {
+                  await this.applyPostSyncStorageUpdate(item, {
+                    success: true,
+                    filePath: item.params.filePath,
+                    finalContent: item.params.content,
+                  });
+                  succeeded += 1;
+                  droppedIds.add(item.id);
+                  this.emitMutationSucceeded({ mutation: item });
+                  handledByBatch.add(item.id);
+                }
+              }
+              for (const failure of batchResult.failed) {
+                const item = byPath.get(failure.path);
+                if (!item) continue;
+                handledByBatch.add(item.id);
+                await this.handleBatchUpsertFailure(item, failure.error, droppedIds, recordFailure);
+              }
+              for (const item of group) {
+                if (!handledByBatch.has(item.id)) {
+                  handledByBatch.add(item.id);
+                  await recordFailure(item, 'Batch upsert returned no outcome for path');
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     // Items whose local write/delete+commit succeeded but whose push is
     // deferred to the group flush. Recorded so we can apply the post-
     // success StorageService.updateNote (upserts only) and drop them
@@ -726,6 +832,23 @@ class NoteSyncQueueServiceClass {
       kind: failure.kind,
       at: Date.now(),
     });
+  }
+
+  private async handleBatchUpsertFailure(
+    item: QueuedMutation & { type: 'note.upsert' },
+    error: string,
+    droppedIds: Set<string>,
+    recordFailure: (item: QueuedMutation, error: string | undefined, status?: number) => Promise<void>,
+  ): Promise<void> {
+    const status = syncStatusForError(error);
+    const failure = classifyGitHubSyncError(new Error(error), status);
+    if (isRetryableFailure(failure)) {
+      await recordFailure(item, error, status);
+      return;
+    }
+    console.warn('[NoteSyncQueue] dropped durable batch-upsert failure:', failure.kind);
+    droppedIds.add(item.id);
+    this.emitDroppedMutation({ mutation: item, reason: 'durable', error, status });
   }
 
   private async applyPostSyncStorageUpdate(

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -176,44 +176,35 @@ const isMissingObject = /Could not find|not foundobject|NotFoundError|Packfile t
 async function fetchDirectoryFiles(
   owner: string,
   repo: string,
+  repoPath: string,
   dirPath: string,
   branch: string,
   provider?: GitHostProvider,
 ): Promise<{ path: string; content: string }[]> {
-  if (FEATURE_USE_MULTI_HOST_WRITE) {
-    const host = getGitHostService(provider);
-    const contents = await host.listContents(owner, repo, dirPath, branch);
-    const files = contents.filter((item) => item.type === 'file' && item.downloadUrl);
+  // Route through the mode-aware reader so clone mode reads todos/canvases
+  // from the local clone (no Contents-API calls) and the recursive tree
+  // pulls nested files under `dirPath/` (#885). The `dirPath + '/'` prefix
+  // guards against sibling-dir false matches (e.g. `todos/` vs `todos-archive/`).
+  const reader = await getRepoReader(repoPath, owner, repo, branch, provider);
+  const tree = await reader.listTree();
+  const files = tree.filter(
+    (item) => item.type === 'blob' && item.path.startsWith(dirPath + '/'),
+  );
 
-    const results: { path: string; content: string }[] = [];
-    for (const file of files) {
+  const fetched = await fetchInBatches(
+    files,
+    async (file) => {
       try {
-        const content = await host.getFileText(owner, repo, file.path, branch);
-        if (content) {
-          results.push({ path: file.path, content });
-        }
+        const content = await reader.readFile(file.path);
+        return content === null ? null : { path: file.path, content };
       } catch (error) {
         console.warn(`[RepoPullService] Failed to fetch ${file.path}:`, error);
+        return null;
       }
-    }
-    return results;
-  }
-
-  const contents = await GitHubService.getRepoContents(owner, repo, dirPath, branch);
-  const files = contents.filter((item) => item.type === 'file' && item.download_url);
-
-  const results: { path: string; content: string }[] = [];
-  for (const file of files) {
-    try {
-      const content = await GitHubService.getFileContent(owner, repo, file.path, branch);
-      if (content) {
-        results.push({ path: file.path, content });
-      }
-    } catch (error) {
-      console.warn(`[RepoPullService] Failed to fetch ${file.path}:`, error);
-    }
-  }
-  return results;
+    },
+    FILE_FETCH_CONCURRENCY,
+  );
+  return fetched.filter((f): f is { path: string; content: string } => f !== null);
 }
 
 const NOTE_EXTS = ['md', 'markdown', 'norg', 'org', 'txt'] as const;
@@ -488,7 +479,7 @@ async function pullCanvasesFromRepo(
   let directoryExists = false;
 
   try {
-    files = await fetchDirectoryFiles(owner, repo, 'canvases', branch, provider);
+    files = await fetchDirectoryFiles(owner, repo, repoPath, 'canvases', branch, provider);
     directoryExists = true;
   } catch {
     // Directory doesn't exist remotely (404) — treat as all canvases deleted.
@@ -517,12 +508,15 @@ async function pullCanvasesFromRepo(
             .replace(/\.json$/, '')
             .replace(/-/g, ' ');
 
+          const pulledScene = JSON.stringify(scene);
           const idx = allCanvases.findIndex((c) => c.filePath === file.path);
           if (idx !== -1) {
             const existing = allCanvases[idx];
-            if (JSON.stringify(existing.scene) !== JSON.stringify(scene)) {
-              allCanvases[idx] = updateCanvas(existing, { scene });
+            if (JSON.stringify(existing.scene) !== pulledScene) {
+              allCanvases[idx] = updateCanvas(existing, { scene, lastPulledScene: pulledScene });
               pulled++;
+            } else if (existing.lastPulledScene !== pulledScene) {
+              allCanvases[idx] = { ...existing, lastPulledScene: pulledScene };
             }
           } else {
             allCanvases.push(
@@ -532,6 +526,7 @@ async function pullCanvasesFromRepo(
                 repo: repoPath,
                 branch,
                 filePath: file.path,
+                lastPulledScene: pulledScene,
               }),
             );
             pulled++;
@@ -539,30 +534,33 @@ async function pullCanvasesFromRepo(
         }
 
         // Reconcile: drop local canvases whose backing file was deleted remotely.
-        // Safety mirrors the notes reconcile — scoped to (repoPath, branch),
-        // only touches canvases with a filePath (local-only drafts kept).
-        //
-        // TEMPORARILY DISABLED for release safety: local canvases without remote
-        // backing may be unsaved edits that would be incorrectly deleted.
-        // A proper dirty/tombstone tracking system is needed to safely reconcile.
-        // const before = allCanvases.length;
-        // const survivors = allCanvases.filter((c) => {
-        //   if (c.repo !== repoPath) return true;
-        //   if (c.branch !== branch) return true;
-        //   if (!c.filePath) return true;
-        //   return remotePaths.has(c.filePath);
-        // });
-        // allCanvases.length = 0;
-        // allCanvases.push(...survivors);
-        // void before;
-      } else {
-        // Directory gone — remove all canvases from this repo+branch that
-        // originated from a remote file. Local-only canvases stay.
+        // Safety mirrors the notes reconcile — scoped to (repoPath, branch), only
+        // touches canvases with a filePath (local-only drafts kept). A canvas whose
+        // backing file is missing is dropped only when its scene still matches
+        // `lastPulledScene`; a mismatch (or a missing marker) means the user edited
+        // locally since the last pull, so it is kept.
         const survivors = allCanvases.filter((c) => {
           if (c.repo !== repoPath) return true;
           if (c.branch !== branch) return true;
           if (!c.filePath) return true;
-          return false;
+          if (remotePaths.has(c.filePath)) return true;
+          const dirty =
+            c.lastPulledScene === undefined || c.lastPulledScene !== JSON.stringify(c.scene);
+          return dirty;
+        });
+        allCanvases.length = 0;
+        allCanvases.push(...survivors);
+      } else {
+        // Directory gone — remove all canvases from this repo+branch that
+        // originated from a remote file and were not locally modified since the
+        // last pull. Local-only drafts and dirty (unsaved-edit) canvases stay.
+        const survivors = allCanvases.filter((c) => {
+          if (c.repo !== repoPath) return true;
+          if (c.branch !== branch) return true;
+          if (!c.filePath) return true;
+          const dirty =
+            c.lastPulledScene === undefined || c.lastPulledScene !== JSON.stringify(c.scene);
+          return dirty;
         });
         allCanvases.length = 0;
         allCanvases.push(...survivors);
@@ -586,7 +584,7 @@ async function pullTodosFromRepo(
   let directoryExists = false;
 
   try {
-    files = await fetchDirectoryFiles(owner, repo, 'todos', branch, provider);
+    files = await fetchDirectoryFiles(owner, repo, repoPath, 'todos', branch, provider);
     directoryExists = true;
   } catch {
     directoryExists = false;

--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -769,6 +769,27 @@ export async function executeToolCall(
         if (!result) {
           return { success: false, requiresConfirmation: false, error: 'Note not found.' };
         }
+
+        if (repoPath) {
+          try {
+            await NoteSyncQueueService.enqueueNoteUpsert(
+              {
+                repo: repoPath,
+                branch,
+                filePath: result.filePath,
+                title: result.title,
+                content: result.content,
+                format: result.format ?? 'markdown',
+                tags: result.tags,
+                color: null,
+              },
+              result.id,
+            );
+          } catch (error) {
+            console.warn('[actionExecutor] edit_note sync enqueue failed:', error);
+          }
+        }
+
         return buildSuccessResult({ noteId: result.id, title: result.title });
       }
 

--- a/src/services/git/BatchGitOperations.ts
+++ b/src/services/git/BatchGitOperations.ts
@@ -21,6 +21,26 @@ export interface BatchDeleteFilesResult {
   failed: BatchDeleteFailedPath[];
 }
 
+export interface BatchUpsertFilesInput {
+  owner: string;
+  repo: string;
+  branch: string;
+  files: { path: string; content: string }[];
+  message: string;
+  opts?: TokenOpts;
+}
+
+export interface BatchUpsertFailedPath {
+  path: string;
+  error: string;
+}
+
+export interface BatchUpsertFilesResult {
+  success: boolean;
+  upserted: string[];
+  failed: BatchUpsertFailedPath[];
+}
+
 /** Initial cycle + up to 2 full retries when updateRef reports the branch moved. */
 const MAX_CYCLE_ATTEMPTS = 3;
 
@@ -175,6 +195,124 @@ export async function batchDeleteFiles(
     input.repo,
     input.branch,
     uniquePaths,
+    input.message,
+    input.opts,
+  );
+}
+
+async function runUpsertCycle(input: BatchUpsertFilesInput): Promise<CycleOutcome> {
+  const { owner, repo, branch, files, message, opts } = input;
+  try {
+    const head = await GitHubService.getBranchHead(owner, repo, branch, opts);
+    const commit = await GitHubService.getCommit(owner, repo, head.sha, opts);
+    // Small markdown blobs — parallel is safe and turns N uploads into one
+    // round-trip (issue #888).
+    const blobShas = await Promise.all(
+      files.map((file) => GitHubService.createBlob(owner, repo, file.content, opts)),
+    );
+    const entryList: GitHubTreeEntry[] = files.map((file, index) => ({
+      path: file.path,
+      mode: '100644',
+      type: 'blob',
+      sha: blobShas[index].sha,
+    }));
+    // With base_tree, GitHub derives the parent/structure automatically and
+    // merely overwrites these paths — omitted siblings are left untouched and
+    // there is no duplicate-coverage problem (unlike the delete flow).
+    const newTree = await GitHubService.createTree(owner, repo, entryList, {
+      baseTree: commit.treeSha,
+      ...opts,
+    });
+    const newCommit = await GitHubService.createCommit(owner, repo, {
+      message,
+      tree: newTree.sha,
+      parents: [head.sha],
+    }, opts);
+    try {
+      await GitHubService.updateRef(owner, repo, `heads/${branch}`, newCommit.sha, false, opts);
+    } catch (error) {
+      return { ok: false, fromUpdateRef: true, error };
+    }
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, fromUpdateRef: false, error };
+  }
+}
+
+async function upsertFilesSequentially(
+  owner: string,
+  repo: string,
+  branch: string,
+  files: { path: string; content: string }[],
+  message: string,
+  opts?: TokenOpts,
+): Promise<BatchUpsertFilesResult> {
+  const upserted: string[] = [];
+  const failed: BatchUpsertFailedPath[] = [];
+  for (const file of files) {
+    try {
+      const result = await GitHubService.updateFile(
+        owner,
+        repo,
+        file.path,
+        file.content,
+        message,
+        branch,
+        opts,
+      );
+      if (result) {
+        upserted.push(file.path);
+        continue;
+      }
+      failed.push({ path: file.path, error: 'GitHub API returned no result' });
+    } catch (error) {
+      const details = extractHttpErrorDetails(error);
+      const errorMessage = details.message ?? (error instanceof Error ? error.message : String(error));
+      failed.push({ path: file.path, error: errorMessage });
+    }
+  }
+  return { success: failed.length === 0, upserted, failed };
+}
+
+/**
+ * Upserts two or more remote files with ONE commit via the Git Data API:
+ * head → commit → blobs (parallel) → createTree(base_tree) →
+ * createCommit(parent=head) → updateRef.
+ *
+ * A 409/422 from updateRef means the branch moved mid-flight; the whole
+ * cycle is retried with a fresh head (up to 2 retries). Any terminal
+ * Git-Data failure degrades to sequential `updateFile` calls and merges the
+ * per-path outcomes — bulk must never be worse than per-file.
+ * Throws for fewer than 2 files (single files use the Contents API).
+ */
+export async function batchUpsertFiles(
+  input: BatchUpsertFilesInput,
+): Promise<BatchUpsertFilesResult> {
+  const { files } = input;
+  if (files.length < 2) {
+    throw new Error('batchUpsertFiles requires at least 2 files');
+  }
+
+  let terminalError: unknown = null;
+  for (let attempt = 0; attempt < MAX_CYCLE_ATTEMPTS; attempt += 1) {
+    const outcome = await runUpsertCycle(input);
+    if (outcome.ok) {
+      return { success: true, upserted: files.map((f) => f.path), failed: [] };
+    }
+    terminalError = outcome.error;
+    const retriable = outcome.fromUpdateRef && isBranchMovedError(outcome.error);
+    if (!retriable || attempt === MAX_CYCLE_ATTEMPTS - 1) break;
+  }
+
+  console.warn(
+    '[BatchGitOperations] batch upsert cycle failed, falling back to per-file upserts:',
+    terminalError,
+  );
+  return upsertFilesSequentially(
+    input.owner,
+    input.repo,
+    input.branch,
+    input.files,
     input.message,
     input.opts,
   );

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -8,6 +8,17 @@ import { LfsService } from './lfs';
 const CLONES_SUBDIR = 'GitNotes/';
 
 /**
+ * Minimum history depth we fetch so merge-base detection stays reachable.
+ * `findMergeBase` needs ~2-3 commits of shared ancestry to compute a common
+ * ancestor; a depth-1 shallow fetch cannot compute merge bases, which silently
+ * disables divergence-conflict recording (the conflict-store branch surfaced by
+ * `surfaceConflictsOnDiverged` in LocalGitWriter and RepoPullService's divergence
+ * detection). Fetching ≥3 commits is a small constant cost (a few objects) and
+ * makes the merge-base-based divergence detection in pull/push actually reachable.
+ */
+const MIN_DIVERGENCE_HISTORY_DEPTH = 3;
+
+/**
  * Tree entry shape that mirrors `GitHubService.getTreeRecursiveOrThrow` so
  * later phases can swap one for the other behind the SyncEngine flag without
  * the callers caring which transport produced the listing.
@@ -181,7 +192,7 @@ export class GitFsService {
         dir,
         ref: opts.branch,
         singleBranch: true,
-        depth: opts.depth ?? 1,
+        depth: Math.max(opts.depth ?? MIN_DIVERGENCE_HISTORY_DEPTH, MIN_DIVERGENCE_HISTORY_DEPTH),
         tags: false,
         onAuth: ensureToken(opts.token),
       });
@@ -221,7 +232,7 @@ export class GitFsService {
         dir,
         ref: opts.branch,
         singleBranch: true,
-        depth: opts.depth ?? 1,
+        depth: Math.max(opts.depth ?? MIN_DIVERGENCE_HISTORY_DEPTH, MIN_DIVERGENCE_HISTORY_DEPTH),
         tags: false,
         onAuth: ensureToken(opts.token),
       });

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -133,7 +133,19 @@ export class StagingService {
       });
       const hasLocal = localOid !== null;
       const hasRemote = remoteOid !== null;
-      if (!hasLocal || (hasRemote && localOid === remoteOid)) continue;
+      const mergeBase = hasRemote
+        ? await GitFsService.findMergeBase({
+            repoPath: repo,
+            ref1: `refs/heads/${repoBranch}`,
+            ref2: `refs/remotes/origin/${repoBranch}`,
+          })
+        : null;
+      if (
+        !hasLocal ||
+        (hasRemote && (localOid === remoteOid || (mergeBase !== null && localOid === mergeBase)))
+      ) {
+        continue;
+      }
 
       items.push({
         repoPath: repo,

--- a/src/services/git/branchResolver.ts
+++ b/src/services/git/branchResolver.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { parseRepoPath } from '../../utils/gitPathParser';
 import { GitFsService } from './GitFsService';
+import AuthService from '../AuthService';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 const GITLAB_API_BASE = 'https://gitlab.com/api/v4';
@@ -60,9 +61,14 @@ export async function fetchGitHubDefaultBranch(repoPath: string): Promise<string
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
+    const token = await AuthService.getToken();
+    const headers: Record<string, string> = { Accept: 'application/vnd.github.v3+json' };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
     const response = await fetch(
       `${GITHUB_API_BASE}/repos/${info.owner}/${info.repo}`,
-      { headers: { Accept: 'application/vnd.github.v3+json' }, signal: controller.signal },
+      { headers, signal: controller.signal },
     );
     if (!response.ok) {
       clearTimeout(timeoutId);

--- a/src/services/git/gitFs.ts
+++ b/src/services/git/gitFs.ts
@@ -15,7 +15,7 @@ class FsError extends Error {
 async function base64ToBytesAsync(b64: string): Promise<Uint8Array> {
   // Decode base64 in 4-char aligned chunks without calling atob on the full string.
   // atob materializes the entire decoded string synchronously, blocking the JS thread.
-  const CHUNK_CHARS = 65535; // Must be multiple of 4 for base64 boundary alignment
+  const CHUNK_CHARS = 65532; // Multiple of 4 so every chunk boundary is 4-char aligned
   const cleaned = b64.replace(/[^A-Za-z0-9+/=]/g, '');
   const totalChars = cleaned.length;
 
@@ -27,7 +27,6 @@ async function base64ToBytesAsync(b64: string): Promise<Uint8Array> {
   }
 
   // Chunked decoding with yields
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
   const resultParts: Uint8Array[] = [];
 
   for (let i = 0; i < totalChars; i += CHUNK_CHARS) {
@@ -44,8 +43,6 @@ async function base64ToBytesAsync(b64: string): Promise<Uint8Array> {
     if (alignedEnd < totalChars) {
       await new Promise<void>((r) => setTimeout(r, 0));
     }
-    // Move past any padding bytes at chunk boundary
-    i = alignedEnd - 1;
   }
 
   // Concatenate all parts
@@ -153,6 +150,28 @@ export function makeGitFs(root: string): PromiseFsClient {
   // single Set.has() check.
   const existingDirs = new Set<string>([root]);
 
+  // Case-insensitive filesystems (APFS/NTFS) collapse case-variant paths onto
+  // one file, so a second write would silently clobber the first. Remember the
+  // first-seen spelling per lowercased URI and throw EEXIST on any variant.
+  const caseMap = new Map<string, string>(); // lowercased URI -> canonical URI
+  function guardCase(filepath: string, uri: string): void {
+    if (uri === root) return; // the adapter root itself is case-exempt
+    const key = uri.toLowerCase();
+    const canonical = caseMap.get(key);
+    if (canonical === undefined) {
+      caseMap.set(key, uri);
+      return;
+    }
+    if (canonical !== uri) {
+      const incoming = filepath.replace(/^\/+/, '');
+      const existing = canonical.slice(root.length);
+      throw new FsError(
+        'EEXIST',
+        `case-collision: "${incoming}" collides with "${existing}" on this filesystem`,
+      );
+    }
+  }
+
   // Yield to the event loop every N writes. Cloning 10k+ objects still
   // accumulates JS-thread work even after the ancestor + base64 fixes;
   // without periodic yields, taps queued in the bridge would still see
@@ -176,6 +195,7 @@ export function makeGitFs(root: string): PromiseFsClient {
   const promises = {
     async readFile(filepath: string, opts?: ReadOpts | string): Promise<string | Uint8Array> {
       const uri = joinUri(root, filepath);
+      guardCase(filepath, uri);
       const info = await FileSystem.getInfoAsync(uri);
       if (!info.exists) {
         throw new FsError('ENOENT', `ENOENT: no such file '${filepath}'`);
@@ -199,6 +219,7 @@ export function makeGitFs(root: string): PromiseFsClient {
       opts?: ReadOpts | string,
     ): Promise<void> {
       const uri = joinUri(root, filepath);
+      guardCase(filepath, uri);
       await ensureParentDirs(uri, root, FileSystem, existingDirs);
       if (typeof data === 'string') {
         const encoding = typeof opts === 'string' ? opts : opts?.encoding;
@@ -240,6 +261,7 @@ export function makeGitFs(root: string): PromiseFsClient {
 
     async readdir(filepath: string): Promise<string[]> {
       const uri = joinUri(root, filepath);
+      guardCase(filepath, uri);
       const info = await FileSystem.getInfoAsync(uri);
       if (!info.exists) {
         throw new FsError('ENOENT', `ENOENT: no such directory '${filepath}'`);
@@ -294,6 +316,7 @@ export function makeGitFs(root: string): PromiseFsClient {
       isSymbolicLink: () => boolean;
     }> {
       const uri = joinUri(root, filepath);
+      guardCase(filepath, uri);
       const info = await FileSystem.getInfoAsync(uri);
       if (!info.exists) {
         throw new FsError('ENOENT', `ENOENT: no such path '${filepath}'`);

--- a/src/services/git/repoAccessPreflight.ts
+++ b/src/services/git/repoAccessPreflight.ts
@@ -118,11 +118,85 @@ export async function preflightGitHubRepoAccess(repoPath: string, token: string)
       if (writeVerified) {
         return { kind: 'ok', writeVerified: true };
       }
-      return failure('write_unverified', 'Write access not verified. Do you want to add anyway?');
+      return probeWriteAccess(url, token);
     }
     return classifyResponse(errorDetails);
   } catch {
     return failure('transient', 'GitHub repository access could not be verified right now.');
+  }
+}
+
+/**
+ * Fine-grained PATs only advertise `metadata:read` on `GET /repos` regardless
+ * of their real write capability, so the header/`permissions.push` fast path
+ * produces a false negative. Prove (or disprove) write access by creating a
+ * throwaway file, then best-effort delete it.
+ */
+async function probeWriteAccess(url: string, token: string): Promise<RepoAccessResult> {
+  const fileName = `.gitnotes-preflight-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`;
+  const probeUrl = `${url}/contents/${fileName}`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github.v3+json',
+  };
+
+  let putResponse: Response;
+  try {
+    putResponse = await fetch(probeUrl, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify({ message: 'GitNotes write preflight', content: 'cHJlZmxpZ2h0' }),
+    });
+  } catch {
+    return failure('transient', 'GitHub repository access could not be verified right now.');
+  }
+
+  if (putResponse.ok) {
+    let sha: string | undefined;
+    try {
+      const body = (await putResponse.json()) as { content?: { sha?: string }; sha?: string };
+      sha = body.content?.sha ?? body.sha;
+    } catch {
+      // Cleanup is best-effort; missing sha only means we skip the delete.
+    }
+    await cleanupProbeFile(probeUrl, token, sha);
+    return { kind: 'ok', writeVerified: true };
+  }
+
+  let responseBody: unknown;
+  try {
+    responseBody = await putResponse.json();
+  } catch {
+    responseBody = undefined;
+  }
+  const errorDetails = extractHttpErrorDetails({
+    response: {
+      data: responseBody,
+      status: putResponse.status,
+      headers: captureResponseHeaders(putResponse.headers),
+    },
+  });
+  return classifyResponse(errorDetails);
+}
+
+async function cleanupProbeFile(probeUrl: string, token: string, sha: string | undefined): Promise<void> {
+  if (!sha) return;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github.v3+json',
+  };
+  const body = JSON.stringify({ message: 'GitNotes preflight cleanup', sha });
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const response = await fetch(probeUrl, {
+        method: 'DELETE',
+        headers,
+        body,
+      });
+      if (response.ok) return;
+    } catch {
+      // Ignore; cleanup is best-effort and must not affect the write verdict.
+    }
   }
 }
 

--- a/src/utils/gitPathParser.ts
+++ b/src/utils/gitPathParser.ts
@@ -3,15 +3,47 @@
 //   github.com/facebook/react
 //   https://github.com/facebook/react
 //   facebook/react.git
+//   vidwadeseram/test-notes.git/            (trailing slash)
+//   git@github.com:vidwadeseram/test-notes.git  (scp syntax)
+//   ssh://git@github.com/vidwadeseram/test-notes.git
 export function parseRepoPath(repoPath: string): { owner: string; repo: string } | null {
-  const cleaned = repoPath
-    .replace(/^https?:\/\/github\.com\//, '')
-    .replace(/^github\.com\//, '')
-    .replace(/\.git$/, '')
-    .trim();
+  let cleaned = repoPath.trim();
+  if (!cleaned) return null;
+
+  // Drop trailing slashes so `.git/` still matches the `.git` strip below.
+  cleaned = cleaned.replace(/\/+$/, '');
+
+  // scp syntax: git@github.com:owner/repo.git -> owner/repo.git
+  cleaned = cleaned.replace(/^[^@\s]+@[^:\s]+:/, '');
+
+  // ssh URL: ssh://git@github.com/owner/repo.git -> owner/repo.git
+  cleaned = cleaned.replace(/^ssh:\/\//i, '');
+  cleaned = cleaned.replace(/^[^@\s]+@[^\/\s]+\/?/, '');
+
+  // Drop the trailing `.git`.
+  cleaned = cleaned.replace(/\.git$/, '');
+
+  // Drop leading GitHub web prefixes.
+  cleaned = cleaned.replace(/^https?:\/\/github\.com\//i, '');
+  cleaned = cleaned.replace(/^github\.com\//i, '');
+
   const parts = cleaned.split('/');
-  if (parts.length >= 2) {
-    return { owner: parts[0], repo: parts[1] };
-  }
-  return null;
+  if (parts.length < 2) return null;
+
+  const owner = parts[0];
+  const repo = parts[1];
+  if (!isOwnerSegment(owner) || !isRepoSegment(repo)) return null;
+
+  return { owner, repo };
+}
+
+function isOwnerSegment(value: string): boolean {
+  return value.length > 0
+    && !value.includes('@')
+    && !value.includes(':')
+    && !/^\.+$/.test(value);
+}
+
+function isRepoSegment(value: string): boolean {
+  return value.length > 0 && !/^\.+$/.test(value);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,19 +6,42 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["jest", "node"],
+    "types": [
+      "jest",
+      "node"
+    ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@components/*": ["./src/components/*"],
-      "@screens/*": ["./src/screens/*"],
-      "@navigation/*": ["./src/navigation/*"],
-      "@contexts/*": ["./src/contexts/*"],
-      "@services/*": ["./src/services/*"],
-      "@models/*": ["./src/models/*"],
-      "@utils/*": ["./src/utils/*"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@components/*": [
+        "./src/components/*"
+      ],
+      "@screens/*": [
+        "./src/screens/*"
+      ],
+      "@navigation/*": [
+        "./src/navigation/*"
+      ],
+      "@contexts/*": [
+        "./src/contexts/*"
+      ],
+      "@services/*": [
+        "./src/services/*"
+      ],
+      "@models/*": [
+        "./src/models/*"
+      ],
+      "@utils/*": [
+        "./src/utils/*"
+      ]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx"],
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "nativewind-env.d.ts"
+  ],
   "exclude": [
     "node_modules",
     "babel.config.js",


### PR DESCRIPTION
Closes #876, #877, #878, #879, #880, #881, #882, #883, #884, #885, #886, #887, #888, #889, #890, #891, #892

Fixes from the git-core test campaign. See [Git Core Hardening](https://github.com/gedwolmen/gitnotes/blob/fix/git-core-campaign/docs/wiki/git-core-hardening.md) for full details.

## Data integrity
- **#891** binary decode chunk-gap corruption over ~49KB (chunk cursor double-advance; 4-aligned chunk size)
- **#892** case-collision path clobber on APFS/NTFS — adapter now throws EEXIST instead of silently overwriting

## Auth & access
- **#876** write preflight false negative for fine-grained PATs — real PUT+DELETE probe fallback
- **#877** default-branch fetch now authenticated (private repos resolve correctly)
- **#878** `parseRepoPath` handles trailing-slash .git + SSH scp/ssh:// formats

## API-mode sync
- **#883** `getFileContent` returns `''` for empty files (no false negative)
- **#884** `createFile` rethrows 401s — no more infinite retry loop
- **#881** 409 divergence throws typed conflict — UI can suggest pull
- **#880** queue dedup by path (title-independent)
- **#888** Git-Data batch upserts — one commit per group, ~16x fewer round-trips
- **#882** explicit-filePath creates work (expectExists uses computed verb)
- **#890** clone probe NotFoundError treated as absent (no warning spam)

## Clone-mode sync
- **#889** AI `edit_note` now enqueues its update (reaches git)
- **#879** phantom "(unpushed commits)" row gated on merge-base
- **#885** nested todos/canvases pulled (recursive, mode-aware reader)
- **#886** canvas-delete reconcile enabled with lastPulledScene dirty-guard
- **#887** fetch/pull never shallower than 3 commits — divergence conflict detection reachable

## Verification
- `ts:check` ✅ · full jest: 259 suites / 2,282 tests passed, 0 failed ✅ · eslint 0 errors ✅
- 8 new test files + regression tests; wiki page added per AGENTS.md