### PR TITLE
fix(settings): invisible primary button + empty repo list after adding token

### DIFF
--- a/__tests__/AccountsContext.test.tsx
+++ b/__tests__/AccountsContext.test.tsx
@@ -53,6 +53,7 @@ jest.mock('../src/services/AuthService', () => ({
       token: null,
     })),
     validateAllAccounts: jest.fn(async () => ({ removed: [] })),
+    connectHost: jest.fn(async () => null),
   },
 }));
 
@@ -92,6 +93,7 @@ let capturedMethods: {
   removeAccount: (id: string) => Promise<void>;
   disconnectHost: (id: string) => Promise<void>;
   clearToken: () => Promise<void>;
+  addAccount: (token: string) => Promise<unknown>;
   accountSummaries: Array<{ account: { id: string }; hosts: Array<{ id: string }> }>;
   activeAccountId: string | null;
 } | null = null;
@@ -102,6 +104,7 @@ function TestProbe() {
     removeAccount: ctx.removeAccount,
     disconnectHost: ctx.disconnectHost,
     clearToken: ctx.clearToken,
+    addAccount: ctx.addAccount,
     accountSummaries: ctx.accountSummaries,
     activeAccountId: ctx.activeAccountId,
   };
@@ -118,6 +121,7 @@ describe('AccountsContext — chat repo clearing on removal', () => {
     aiStoreState.chatRepoName = null;
     aiStoreState.chatRepoBranch = 'main';
     mockSetChatRepo.mockClear();
+    (GitHubService.setToken as jest.Mock).mockClear();
   });
 
   function renderProvider() {
@@ -409,6 +413,58 @@ describe('AccountsContext — chat repo clearing on removal', () => {
       });
 
       expect(mockSetChatRepo).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── addAccount ─────────────────────────────────────────────────────
+
+  describe('addAccount', () => {
+    it('syncs the GitHubService singleton token so repo listing works immediately', async () => {
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue(null);
+      (AuthService.getToken as jest.Mock).mockResolvedValue(null);
+      (AuthService.connectHost as jest.Mock).mockResolvedValue({
+        ok: true,
+        host: {
+          id: 'h1',
+          hostUserId: 42,
+          hostLogin: 'alice',
+          name: 'Alice',
+          email: 'alice@example.com',
+        },
+        account: { id: 'acc-1' },
+      });
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      const added = await capturedMethods!.addAccount('ghp_secret');
+
+      expect(added).toEqual({ id: 'acc-1' });
+      expect(GitHubService.setToken).toHaveBeenCalledWith(
+        'ghp_secret',
+        expect.objectContaining({
+          id: 42,
+          login: 'alice',
+          name: 'Alice',
+          email: 'alice@example.com',
+        }),
+      );
+    });
+
+    it('does not touch GitHubService when connectHost fails', async () => {
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue(null);
+      (AuthService.getToken as jest.Mock).mockResolvedValue(null);
+      (AuthService.connectHost as jest.Mock).mockResolvedValue(null);
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      const added = await capturedMethods!.addAccount('bad-token');
+
+      expect(added).toBeNull();
+      expect(GitHubService.setToken).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/__snapshots__/theme-parity.test.tsx.snap
+++ b/__tests__/__snapshots__/theme-parity.test.tsx.snap
@@ -67,6 +67,9 @@ exports[`NativeWind theme parity matches the pre-migration key-kit snapshots in 
               {
                 "minHeight": 44,
               },
+              {
+                "backgroundColor": "#8B9BE8",
+              },
               undefined,
             ],
           ]
@@ -108,7 +111,7 @@ exports[`NativeWind theme parity matches the pre-migration key-kit snapshots in 
               style={
                 [
                   {
-                    "color": "#F2F2F7",
+                    "color": "#fff",
                     "fontSize": 16,
                     "fontWeight": "600",
                   },
@@ -317,6 +320,9 @@ exports[`NativeWind theme parity matches the pre-migration key-kit snapshots in 
               {
                 "minHeight": 44,
               },
+              {
+                "backgroundColor": "#7B8CDE",
+              },
               undefined,
             ],
           ]
@@ -358,7 +364,7 @@ exports[`NativeWind theme parity matches the pre-migration key-kit snapshots in 
               style={
                 [
                   {
-                    "color": "#1C1C1E",
+                    "color": "#fff",
                     "fontSize": 16,
                     "fontWeight": "600",
                   },

--- a/__tests__/ui/Button.test.tsx
+++ b/__tests__/ui/Button.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { Button } from '../../src/components/ui/Button';
 import { TestThemeProvider } from './testThemeProvider';
+import { NEUMORPHIC_LIGHT } from '../../src/theme/tokens';
 
 describe('Button', () => {
   it('renders the label and fires onPress', () => {
@@ -24,6 +25,42 @@ describe('Button', () => {
       );
       expect(getByText(variant)).toBeTruthy();
     }
+  });
+
+  it('primary variant fills the primary background and uses white text (not white-on-white)', () => {
+    const { getByText, UNSAFE_getByType } = render(
+      <TestThemeProvider>
+        <Button label="Save" variant="primary" />
+      </TestThemeProvider>,
+    );
+
+    const label = getByText('Save');
+    // Label text must be white (readable against the filled primary background).
+    expect(label.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ color: '#fff' })]),
+    );
+
+    // A primary button must carry the theme primary background on its surface.
+    const surfaces = UNSAFE_getByType(require('../../src/components/ui/Surface').Surface);
+    const flattened = require('react-native').StyleSheet.flatten(surfaces.props.style);
+    expect(flattened.backgroundColor).toBe(NEUMORPHIC_LIGHT.primary);
+  });
+
+  it('secondary variant keeps theme text color on the surface background', () => {
+    const { getByText, UNSAFE_getByType } = render(
+      <TestThemeProvider>
+        <Button label="Edit" variant="secondary" />
+      </TestThemeProvider>,
+    );
+
+    const label = getByText('Edit');
+    expect(label.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ color: NEUMORPHIC_LIGHT.text })]),
+    );
+
+    const surfaces = UNSAFE_getByType(require('../../src/components/ui/Surface').Surface);
+    const flattened = require('react-native').StyleSheet.flatten(surfaces.props.style);
+    expect(flattened.backgroundColor).toBeUndefined();
   });
 
   it('applies disabled state without firing onPress', () => {

--- a/__tests__/ui/__snapshots__/Button.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Button.test.tsx.snap
@@ -66,6 +66,9 @@ exports[`Button snapshots primary in light + dark: primary-dark 1`] = `
             {
               "minHeight": 44,
             },
+            {
+              "backgroundColor": "#8B9BE8",
+            },
             undefined,
           ],
         ]
@@ -107,7 +110,7 @@ exports[`Button snapshots primary in light + dark: primary-dark 1`] = `
             style={
               [
                 {
-                  "color": "#F2F2F7",
+                  "color": "#fff",
                   "fontSize": 16,
                   "fontWeight": "600",
                 },
@@ -190,6 +193,9 @@ exports[`Button snapshots primary in light + dark: primary-light 1`] = `
             {
               "minHeight": 44,
             },
+            {
+              "backgroundColor": "#7B8CDE",
+            },
             undefined,
           ],
         ]
@@ -231,7 +237,7 @@ exports[`Button snapshots primary in light + dark: primary-light 1`] = `
             style={
               [
                 {
-                  "color": "#1C1C1E",
+                  "color": "#fff",
                   "fontSize": 16,
                   "fontWeight": "600",
                 },

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -18,6 +18,7 @@
 | [Filter Persistence](./filter-persistence.md) | Filter state architecture and AsyncStorage |
 | [Importers](./importers.md) | Removed Google Keep and Apple Notes importers, for later re-integration |
 | [Git Core Hardening](./git-core-hardening.md) | git-core test-campaign fixes: binary decode integrity, case collisions, auth/preflight, API batch writes, pull/reconcile fixes (#876–#892) |
+| [Settings — Add Repo Fixes](./settings-add-repo-fixes.md) | invisible primary-button fix + repo list not loading after adding a token |
 
 ## Quick Start
 

--- a/docs/wiki/settings-add-repo-fixes.md
+++ b/docs/wiki/settings-add-repo-fixes.md
@@ -1,0 +1,52 @@
+# Settings — Add Repository Fixes
+
+Two UI bugs in the Add-Repository / GitHub-connection flow, both surfaced on a
+fresh simulator session and confirmed via screenshot + accessibility-tree analysis.
+
+## Invisible "Add" button (white-on-white)
+
+The "Add" manual-repo button (and every other `variant="primary"` button that
+overrode its text to white, e.g. Save-token, Onboarding) rendered as a **blank
+white rectangle** — the label was white text on a white surface.
+
+Root cause: the shared-kit refactor (`refactor(ui): rebuild shared kit on RN
+Reusables`, `d5d83a3`) rewrote `Button` to render **all** non-ghost variants on
+a raised `Surface` (a white card in light mode) with the theme text color.
+`variant="primary"` was only used for font-weight, so the primary background
+was never applied. Callers that set `textStyle={{color:'#fff'}}` therefore got
+white-on-white.
+
+Fix (`src/components/ui/Button.tsx`):
+- `variant="primary"` now fills `colors.primary` as the surface background.
+- primary text is white (`#fff`); secondary keeps the theme text color.
+
+Primary buttons now look and read as filled primary actions in light + dark.
+
+## "No repositories found" after adding a token
+
+Adding a GitHub token via the **Add GitHub Account** flow then opening Add
+Repository showed `No repositories found` — no loading, no error — even though
+the account was registered.
+
+Root cause: `AccountsContext.addAccount` (the "add" modal path) called
+`AuthService.connectHost` + `refreshAccounts` but never synced the legacy
+`GitHubService` singleton token. `SettingsScreen.openRepoPicker` gates the repo
+fetch on `GitHubService.isAuthenticated()`, which stayed `false`, so the fetch
+was skipped on every open — the list only populated after an app restart
+(bootstrap hydration). Note the "change token" path already synced via
+`setToken`; `addAccount` did not.
+
+Fix (`src/contexts/AccountsContext.tsx`): after a successful connect,
+`addAccount` now calls `GitHubService.setToken(token, user)` (best-effort,
+matching the existing `setToken`/`switchToHost` pattern) so the repo list and
+write preflight work immediately after adding an account.
+
+## Tests
+
+- `__tests__/ui/Button.test.tsx`: primary variant renders the primary
+  background with white text; secondary keeps theme text on the surface;
+  snapshots regenerated.
+- `__tests__/AccountsContext.test.tsx`: `addAccount` syncs the
+  GitHubService token, and does not when connectHost fails.
+- `__tests__/theme-parity.test.tsx` snapshot regenerated for the corrected
+  primary button.

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -59,7 +59,7 @@ export function Button(props: ButtonProps) {
     transform: [{ scale: scale.value }],
   }));
 
-  const textColor = colors.text;
+  const textColor = variant === 'primary' ? '#fff' : colors.text;
   const isGhost = variant === 'ghost';
 
   const labelNode = label !== undefined && (
@@ -139,6 +139,10 @@ export function Button(props: ButtonProps) {
             {
               minHeight: 44,
             },
+            // variant="primary" carries a filled primary background; the
+            // raised Surface alone renders a white card, which made primary
+            // labels overridden to white invisible (white-on-white).
+            variant === 'primary' && { backgroundColor: colors.primary },
             style,
           ]}
         >

--- a/src/contexts/AccountsContext.tsx
+++ b/src/contexts/AccountsContext.tsx
@@ -285,6 +285,18 @@ export function AccountsProvider({ children }: { children: ReactNode }) {
     async (token: string): Promise<StoredAccount | null> => {
       const result = await AuthService.connectHost({ provider: 'github', token });
       await refreshAccounts();
+      if (result) {
+        // Keep the legacy GitHubService singleton in sync so repo listing /
+        // preflight checks (which gate on GitHubService.isAuthenticated) work
+        // immediately after adding an account, not just after an app restart.
+        await GitHubService.setToken(token, {
+          id: result.host.hostUserId,
+          login: result.host.hostLogin,
+          name: result.host.name ?? result.host.hostLogin,
+          email: result.host.email ?? '',
+          avatar_url: result.host.avatarUrl ?? '',
+        } as unknown as GhSetTokenUser).catch(() => undefined);
+      }
       return result?.account ?? null;
     },
     [refreshAccounts],


### PR DESCRIPTION
## Two Add-Repository UI bugs (from screenshot on Desktop)

### 1. "Add" button was invisible (white-on-white)
Every `variant=\"primary\"` button that overrode its label to white (Add, Save-token, Onboarding, etc.) rendered as a blank white rectangle. Root cause: the shared-kit refactor (`d5d83a3`) renders all non-ghost variants on a raised *white* `Surface` with the theme text color — `variant=\"primary\"` only affected font-weight, never the background.

**Fix** is in `src/components/ui/Button.tsx`: primary now fills `colors.primary` with white text (secondary keeps the theme text on the surface). Verified in light + dark via regenerated snapshots.

### 2. "No repositories found" after adding a token
The **Add GitHub Account** flow registered the account but the repo picker stayed empty (no loading, no error) until an app restart. Root cause: `AccountsContext.addAccount` never synced the legacy `GitHubService` singleton token (`GitHubService.isAuthenticated()` stayed false), so the repo fetch was skipped — only the "change token" path synced.

**Fix** in `src/contexts/AccountsContext.tsx`: `addAccount` now calls `GitHubService.setToken` after a successful connect (mirroring `setToken`/`switchToHost`), so the repo list and write preflight work immediately.

## Verification
- `ts:check` ✅ · full jest: **2,286 passed / 0 failed** (2 skipped) ✅ · eslint 0 errors ✅
- New tests: Button variant styling (primary bg + white text / secondary theme text) + AccountsContext addAccount syncs token (and doesn't when connect fails); snapshots updated.
- Wiki page added per AGENTS.md: docs/wiki/settings-add-repo-fixes.md