### PR TITLE
fix(stage): unlock cards after staging, spinner-free push buttons, GitHubActivity push progress

### DIFF
--- a/__tests__/screens/StageScreen.test.tsx
+++ b/__tests__/screens/StageScreen.test.tsx
@@ -177,10 +177,26 @@ describe('StageScreen', () => {
     mockStageState.staged = [item('owner/repo-a', 'main', 'notes/a.md')];
     mockStageState.isPushing = { 'owner/repo-a::main': true };
 
-    const { getByTestId } = render(<StageScreen />);
+    const { getByTestId, getByText, UNSAFE_queryByType } = render(<StageScreen />);
 
     const button = getByTestId('stage.push.owner/repo-a::main');
     expect(button.props.accessibilityState.disabled).toBe(true);
+    expect(getByText('Push')).toBeTruthy();
+    const ActivityIndicator = require('react-native').ActivityIndicator;
+    expect(UNSAFE_queryByType(ActivityIndicator)).toBeNull();
+  });
+
+  it('disables the header Push all button (label kept, no spinner) while globalPushing', () => {
+    mockStageState.staged = [item('owner/repo-a', 'main', 'notes/a.md')];
+    mockStageState.globalPushing = true;
+
+    const { getByTestId, getByText, UNSAFE_queryByType } = render(<StageScreen />);
+
+    const button = getByTestId('stage.push-all');
+    expect(button.props.accessibilityState.disabled).toBe(true);
+    expect(getByText('Push all')).toBeTruthy();
+    const ActivityIndicator = require('react-native').ActivityIndicator;
+    expect(UNSAFE_queryByType(ActivityIndicator)).toBeNull();
   });
 
   it('navigates to the Stage route from a stub trigger', () => {

--- a/__tests__/services/StagePushScheduler.test.ts
+++ b/__tests__/services/StagePushScheduler.test.ts
@@ -29,9 +29,18 @@ jest.mock('../../src/services/StorageService', () => ({
   },
 }));
 
+jest.mock('../../src/stores/githubActivityStore', () => ({
+  githubActivity: {
+    begin: jest.fn(),
+    end: jest.fn(),
+    setProgress: jest.fn(),
+  },
+}));
+
 import { StagingService } from '../../src/services/git/StagingService';
 import { StorageService } from '../../src/services/StorageService';
 import { useStageStore } from '../../src/stores/stageStore';
+import { githubActivity } from '../../src/stores/githubActivityStore';
 import {
   STAGE_PUSH_IDLE_MS,
   drainPushQueue,
@@ -238,6 +247,43 @@ describe('StagePushScheduler', () => {
     expect(failures).toEqual([{ key: 'a/repo::main', error: 'boom' }]);
     expect(useStageStore.getState().isPushing['a/repo::main']).toBe(false);
     expect(useStageStore.getState().pushQueue).toHaveLength(0);
+  });
+
+  test('drainPushQueue wraps each pushStaged in a githubActivity.begin/end cycle', async () => {
+    useStageStore.setState({
+      staged: [],
+      isPushing: {},
+      globalPushing: false,
+      pushQueue: ['a/repo::main'],
+      pendingCount: 0,
+    });
+
+    await drainPushQueue();
+    await flushAsync();
+
+    expect(githubActivity.begin).toHaveBeenCalledWith('Pushing changes');
+    expect(githubActivity.end).toHaveBeenCalledTimes(1);
+    expect(StagingService.pushStaged).toHaveBeenCalledTimes(1);
+  });
+
+  test('failed push still ends the githubActivity cycle (end called in finally)', async () => {
+    useStageStore.setState({
+      staged: [],
+      isPushing: {},
+      globalPushing: false,
+      pushQueue: ['a/repo::main'],
+      pendingCount: 0,
+    });
+    (StagingService.pushStaged as jest.Mock).mockImplementation(async () => ({
+      success: false,
+      error: 'boom',
+    }));
+
+    await drainPushQueue();
+    await flushAsync();
+
+    expect(githubActivity.begin).toHaveBeenCalledWith('Pushing changes');
+    expect(githubActivity.end).toHaveBeenCalledTimes(1);
   });
 
   test('startScheduler() loads staged state once and registers the queue subscription', async () => {

--- a/__tests__/services/StagingService.test.ts
+++ b/__tests__/services/StagingService.test.ts
@@ -71,6 +71,14 @@ jest.mock('../../src/services/GitHubService', () => ({
   },
 }));
 
+jest.mock('../../src/stores/githubActivityStore', () => ({
+  githubActivity: {
+    begin: jest.fn(),
+    end: jest.fn(),
+    setProgress: jest.fn(),
+  },
+}));
+
 import { StagingService } from '../../src/services/git/StagingService';
 import type { StagedItem } from '../../src/services/git/StagingService';
 import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
@@ -81,6 +89,7 @@ import { StorageService } from '../../src/services/StorageService';
 import { AuthService } from '../../src/services/AuthService';
 import { syncNoteToGitHub, deleteNoteFromGitHub } from '../../src/services/NoteGitHubSyncService';
 import { GitHubService } from '../../src/services/GitHubService';
+import { githubActivity } from '../../src/stores/githubActivityStore';
 
 const enqueueUpsert = NoteSyncQueueService.enqueueNoteUpsert as jest.Mock;
 const enqueueDelete = NoteSyncQueueService.enqueueNoteDelete as jest.Mock;
@@ -432,12 +441,42 @@ getCommitOid.mockResolvedValue(null);
 
       expect(result).toEqual({ success: true });
       expect(writerPush).toHaveBeenCalledTimes(1);
-      expect(writerPush).toHaveBeenCalledWith({
-        repoPath: 'owner/repo',
-        branch: 'main',
-        token: 'test-token',
-      });
+      expect(writerPush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repoPath: 'owner/repo',
+          branch: 'main',
+          token: 'test-token',
+        }),
+      );
       expect(queueDrain).not.toHaveBeenCalled();
+    });
+
+    test('clone push forwards onProgress to githubActivity.setProgress', async () => {
+      listOverrides.mockResolvedValue({ 'owner/repo': 'clone' });
+      getSavedRepositories.mockResolvedValue([
+        { id: '1', name: 'repo', path: 'owner/repo', branch: 'main' },
+      ]);
+      getCommitOid.mockImplementation(
+        async ({ ref }: { ref: string }) =>
+          ref.startsWith('refs/heads') ? 'local-oid' : 'remote-oid',
+      );
+
+      let capturedOnProgress: ((p: { phase: string; loaded: number; total: number }) => void) | undefined;
+      writerPush.mockImplementation(async (opts: { onProgress?: (p: { phase: string; loaded: number; total: number }) => void }) => {
+        capturedOnProgress = opts.onProgress;
+        return { success: true };
+      });
+
+      const result = await StagingService.pushStaged('owner/repo', 'main');
+
+      expect(result).toEqual({ success: true });
+      expect(capturedOnProgress).toBeDefined();
+      capturedOnProgress?.({ phase: 'Writing objects', loaded: 2, total: 5 });
+      expect(githubActivity.setProgress).toHaveBeenCalledWith({
+        phase: 'Pushing changes',
+        loaded: 2,
+        total: 5,
+      });
     });
 
     test('clone push failure surfaces an error', async () => {

--- a/__tests__/services/git/localGitWriter.test.ts
+++ b/__tests__/services/git/localGitWriter.test.ts
@@ -165,6 +165,21 @@ describe('LocalGitWriter', () => {
     expect(getGitMocks().push).toHaveBeenCalledTimes(1);
   });
 
+  test('push forwards onProgress to git.push', async () => {
+    const onProgress = jest.fn();
+    const result = await LocalGitWriter.push({
+      repoPath: 'me/repo',
+      branch: 'main',
+      token: 'tok',
+      onProgress,
+    });
+    expect(result.success).toBe(true);
+    expect(getGitMocks().push).toHaveBeenCalledTimes(1);
+    expect(getGitMocks().push).toHaveBeenCalledWith(
+      expect.objectContaining({ onProgress }),
+    );
+  });
+
   test('rejects an invalid repoPath without touching the FS or git', async () => {
     const result = await LocalGitWriter.writeAndCommit({
       repoPath: 'not-a-repo',

--- a/__tests__/stores/gitOperationStore.test.ts
+++ b/__tests__/stores/gitOperationStore.test.ts
@@ -46,7 +46,7 @@ const upsertMutation = (
 
 const deleteMutation = (
   id: string,
-  opts: { branch?: string; filePath?: string } = {},
+  opts: { branch?: string; filePath?: string; localNoteId?: string } = {},
 ): QueuedMutation => ({
   id,
   type: 'note.delete',
@@ -57,6 +57,7 @@ const deleteMutation = (
     branch: opts.branch ?? BRANCH,
     filePath: opts.filePath ?? PATH,
     title: 'Hello',
+    localNoteId: opts.localNoteId,
   },
 });
 
@@ -113,7 +114,7 @@ describe('gitOperationStore', () => {
       churn!();
       await flushAsync();
       expect(opsState()['live-1']).toBeDefined();
-      expect(opsState()['live-1'].status).toBe('queued');
+      expect(opsState()['live-1'].status).toBe('staged');
 
       await hydrate();
       await hydrate();
@@ -280,7 +281,7 @@ describe('gitOperationStore', () => {
         branch: BRANCH,
         path: PATH,
         entityIds: ['note-42'],
-        status: 'queued',
+        status: 'staged',
       });
 
       const deleteOp = ops['m-delete'];
@@ -375,21 +376,45 @@ describe('gitOperationStore', () => {
 
       expect(opsState()[pushOpId]).toMatchObject({ kind: 'push', status: 'running' });
       expect(opsState()['m-1']).toBeDefined();
+      expect(opsState()['m-1'].status).toBe('staged');
+    });
+  });
+
+  describe('lock semantics', () => {
+    it('staged upserts do not lock paths or entities (editable while push is pending)', async () => {
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [
+        upsertMutation('m-1', { localNoteId: 'note-1' }),
+      ]);
+      await hydrate();
+
+      expect(opsState()['m-1'].status).toBe('staged');
+      expect(isPathLocked(opsState(), REPO, BRANCH, PATH)).toBe(false);
+      expect(isEntityLocked(opsState(), 'note-1')).toBe(false);
+    });
+
+    it('queued deletes keep locking paths and entities', async () => {
+      (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [
+        deleteMutation('m-1', { localNoteId: 'note-del' }),
+      ]);
+      await hydrate();
+
       expect(opsState()['m-1'].status).toBe('queued');
+      expect(isPathLocked(opsState(), REPO, BRANCH, PATH)).toBe(true);
+      expect(isEntityLocked(opsState(), 'note-del')).toBe(true);
     });
   });
 
   describe('lock durability across store refresh', () => {
     it('path lock survives a simulated refresh that re-creates the note under a new id', async () => {
       (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [
-        upsertMutation('m-1', { localNoteId: 'note-v1' }),
+        deleteMutation('m-1', { localNoteId: 'note-v1' }),
       ]);
       await hydrate();
       expect(isPathLocked(opsState(), REPO, BRANCH, PATH)).toBe(true);
       expect(isEntityLocked(opsState(), 'note-v1')).toBe(true);
 
       (NoteSyncQueueService.getAll as jest.Mock).mockImplementation(async () => [
-        upsertMutation('m-1', { localNoteId: 'note-v2' }),
+        deleteMutation('m-1', { localNoteId: 'note-v2' }),
       ]);
       await hydrate();
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -19,6 +19,7 @@
 | [Importers](./importers.md) | Removed Google Keep and Apple Notes importers, for later re-integration |
 | [Git Core Hardening](./git-core-hardening.md) | git-core test-campaign fixes: binary decode integrity, case collisions, auth/preflight, API batch writes, pull/reconcile fixes (#876–#892) |
 | [Settings — Add Repo Fixes](./settings-add-repo-fixes.md) | invisible primary-button fix + repo list not loading after adding a token |
+| [Stage → Push UX](./stage-push-ux.md) | staged-upsert locks, spinner-free push buttons, GitHubActivity push progress |
 
 ## Quick Start
 

--- a/docs/wiki/stage-push-ux.md
+++ b/docs/wiki/stage-push-ux.md
@@ -1,0 +1,72 @@
+# Stage → Push UX: Card Locks, Push Buttons, and Push Progress
+
+Stage-then-push rework that separates the *stage* phase from the *push* phase
+in the user-visible locking and progress model.
+
+## Problem
+
+- Note/todo/canvas cards stayed **locked (grayed + spinner) until the push
+  completed** — in API mode that could mean minutes (idle auto-push at 3 min).
+  The card was only supposed to be locked while its edit was being staged.
+- The Stage screen push buttons showed an `ActivityIndicator` while pushing,
+  replacing the label.
+- Clone-mode pushes (which go through isomorphic-git directly, bypassing
+  `http.ts`) never surfaced in the GitHubActivity pill.
+
+## Changes
+
+### 1. Upsert ops are `staged`, not `queued` — cards unlock after stage
+
+`src/stores/gitOperationStore.ts`:
+- Added a `'staged'` status to `GitOpStatus`.
+- `opFromQueuedMutation` now maps `note.upsert` queue mutations to
+  `status: 'staged'` instead of `'queued'`. These ops stay in the registry
+  (stage screen stays consistent) but are **not** "active" — `isActiveStatus`
+  still covers only `queued`/`running` — so `useEntityLock`, `isPathLocked`,
+  and `isEntityLocked` no longer lock the card after staging.
+- `note.delete` mutations keep `status: 'queued'`: the local row stays
+  visible-but-locked until the push removes it (pinned by the delete-lock
+  integration tests).
+
+Net effect: editing a note stages it, the card unlocks immediately, and new
+edits queue for the next push cycle. The editor already had a stage-scoped
+volatile op (`useNoteEditorDocument`), which is unchanged.
+
+### 2. Push buttons: disabled, no spinner
+
+`src/screens/StageScreen.tsx`: the group-Push and Push-all buttons no longer
+swap their label for an `ActivityIndicator` while pushing. They render the
+label (`Push` / `Push all`) always and rely on `disabled` + grayed background
+during a push. `accessibilityState.disabled` and the `stage.push.*` testIDs
+are unchanged.
+
+### 3. Push progress in the GitHubActivity pill
+
+- `LocalGitWriter.push` accepts an optional `onProgress` callback and forwards
+  it to the isomorphic-git `git.push` calls (initial + retry paths).
+- `StagingService.pushStaged` wires the clone-mode push loop's `onProgress` to
+  `githubActivity.setProgress({ phase: 'Pushing changes', loaded, total })`.
+- `StagePushScheduler.drainPushQueue` wraps each `pushStaged` in a
+  `githubActivity.begin('Pushing changes')` / `githubActivity.end()` cycle
+  (end runs in `finally`, so a failed push still clears the pill).
+
+The pill's existing `ProgressBar` renders a determinate percentage when
+`total > 0` and an indeterminate bar otherwise — clone pushes now show real
+object-transfer progress.
+
+## Tests
+
+- `__tests__/stores/gitOperationStore.test.ts`: staged upserts do **not** lock
+  paths/entities; queued deletes still lock; the lock-durability-across-refresh
+  test now exercises delete mutations (upserts no longer lock by design).
+- `__tests__/screens/StageScreen.test.tsx`: pushing buttons keep their label
+  and render no `ActivityIndicator`.
+- `__tests__/services/StagePushScheduler.test.ts`: each push is wrapped in
+  `githubActivity.begin('Pushing changes')` / `end()`; `end()` still runs on
+  failure.
+- `__tests__/services/git/localGitWriter.test.ts`: `push` forwards
+  `onProgress` to `git.push`.
+- `__tests__/services/StagingService.test.ts`: clone-mode push forwards
+  `onProgress` to `githubActivity.setProgress`.
+- `__tests__/sync-locking.integration.test.ts` + `notes-delete-lock.test.tsx`:
+  unchanged — deletes keep locking until the push completes.

--- a/src/components/git/stageButtonGeometry.ts
+++ b/src/components/git/stageButtonGeometry.ts
@@ -5,7 +5,7 @@ import {
 } from '../ai/floatingAIButtonGeometry';
 import { FLOATING_AI_BUTTON_LONG_PRESS_MS } from '../ai/useFloatingAIButtonAffordances';
 
-export const STAGE_BUTTON_SIZE = 52;
+export const STAGE_BUTTON_SIZE = FLOATING_AI_BUTTON_SIZE;
 export const STAGE_BUTTON_LONG_PRESS_MS = FLOATING_AI_BUTTON_LONG_PRESS_MS;
 export const STAGE_BUTTON_VERTICAL_GAP = 12;
 

--- a/src/screens/StageScreen.tsx
+++ b/src/screens/StageScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, FlatList, RefreshControl, Text, TouchableOpacity, View } from 'react-native';
+import { FlatList, RefreshControl, Text, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTheme } from '../contexts/ThemeContext';
@@ -125,13 +125,9 @@ export default function StageScreen() {
               className="px-3 py-1.5 rounded-md"
               style={{ backgroundColor: pushing ? colors.border : colors.primary }}
             >
-              {pushing ? (
-                <ActivityIndicator size="small" color={colors.text} />
-              ) : (
-                <Text className="text-xs font-bold" style={{ color: '#ffffff' }}>
-                  Push
-                </Text>
-              )}
+              <Text className="text-xs font-bold" style={{ color: '#ffffff' }}>
+                Push
+              </Text>
             </TouchableOpacity>
           </View>
           {item.items.map((row) => (
@@ -171,13 +167,9 @@ export default function StageScreen() {
             className="px-3 py-1.5 rounded-md"
             style={{ backgroundColor: pushAllDisabled ? colors.border : colors.primary }}
           >
-            {globalPushing ? (
-              <ActivityIndicator size="small" color={colors.text} />
-            ) : (
-              <Text className="text-xs font-bold" style={{ color: '#ffffff' }}>
-                Push all
-              </Text>
-            )}
+            <Text className="text-xs font-bold" style={{ color: '#ffffff' }}>
+              Push all
+            </Text>
           </TouchableOpacity>
         }
       />

--- a/src/screens/StageScreen.tsx
+++ b/src/screens/StageScreen.tsx
@@ -199,7 +199,7 @@ export default function StageScreen() {
         keyExtractor={(item) => item.key}
         renderItem={renderGroup}
         ListEmptyComponent={renderEmpty}
-        contentContainerClassName="pb-8"
+        contentContainerClassName="pt-4 pb-8"
         contentContainerStyle={groups.length === 0 ? { flexGrow: 1 } : undefined}
         refreshControl={
           <RefreshControl

--- a/src/services/StagePushScheduler.ts
+++ b/src/services/StagePushScheduler.ts
@@ -1,6 +1,7 @@
 import { StagingService } from './git/StagingService';
 import { GitSyncGate } from './git/GitSyncGate';
 import { useStageStore } from '../stores/stageStore';
+import { githubActivity } from '../stores/githubActivityStore';
 
 /**
  * Foreground idle-timeout auto-push for staged changes.
@@ -106,6 +107,7 @@ export async function drainPushQueue(): Promise<void> {
 
       useStageStore.getState().setPushing(key, true);
       const releaseCycle = await GitSyncGate.acquireCycle();
+      githubActivity.begin('Pushing changes');
       try {
         const result = await StagingService.pushStaged(repoPath, branch);
         if (!result.success) {
@@ -114,6 +116,7 @@ export async function drainPushQueue(): Promise<void> {
       } catch (error) {
         notifyPushFailure(key, error instanceof Error ? error.message : String(error));
       } finally {
+        githubActivity.end();
         releaseCycle();
         useStageStore.getState().setPushing(key, false);
         useStageStore.getState().shiftQueue();

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -479,7 +479,12 @@ static async deleteAndCommit(opts: DeleteOpts): Promise<LocalGitWriterResult> {
    * B.1). On non-fast-forward rejection we pull once and retry the push,
    * mirroring the pattern in `writeAndCommit` / `deleteAndCommit`.
    */
-static async push(opts: { repoPath: string; branch: string; token?: string }): Promise<
+static async push(opts: {
+    repoPath: string;
+    branch: string;
+    token?: string;
+    onProgress?: (progress: { phase: string; loaded: number; total: number }) => void;
+  }): Promise<
     LocalGitWriterResult
   > {
     const info = parseRepoPath(opts.repoPath);
@@ -496,6 +501,7 @@ static async push(opts: { repoPath: string; branch: string; token?: string }): P
         ref: opts.branch,
         remoteRef: opts.branch,
         onAuth: tokenAuth(opts.token),
+        onProgress: opts.onProgress,
       });
       return { success: true };
     } catch (pushError) {
@@ -543,6 +549,7 @@ static async push(opts: { repoPath: string; branch: string; token?: string }): P
           ref: opts.branch,
           remoteRef: opts.branch,
           onAuth: tokenAuth(opts.token),
+          onProgress: opts.onProgress,
         });
         return { success: true };
       } catch (retryError) {

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -7,6 +7,7 @@ import { LocalGitWriter } from './LocalGitWriter';
 import { GitFsService } from './GitFsService';
 import { getGitHostService } from './gitHostFactory';
 import type { GitHostUser } from './GitHost';
+import { githubActivity } from '../../stores/githubActivityStore';
 
 /**
  * One staged change as surfaced to the Stage page. Queue-backed items
@@ -196,6 +197,12 @@ export class StagingService {
             repoPath: repo,
             branch: repoBranch,
             token: token ?? undefined,
+            onProgress: (p) =>
+              githubActivity.setProgress({
+                phase: 'Pushing changes',
+                loaded: p.loaded,
+                total: p.total,
+              }),
           });
           if (!result.success) failures.push(result.error ?? `${repo}@${repoBranch}`);
         }

--- a/src/stores/gitOperationStore.ts
+++ b/src/stores/gitOperationStore.ts
@@ -9,11 +9,17 @@ import type { QueuedMutation } from '../services/NoteSyncQueueService';
  * truth: queued and failed ops are re-derived from the durable sync queue
  * and the delete-failure map via hydrate(), so locks survive app restarts
  * and the StartupSyncGate refresh cascade that re-reads AsyncStorage.
+ *
+ * Status semantics: `queued`/`running` ops lock their paths/entities.
+ * `staged` ops — queue-backed upserts that have been staged but not yet
+ * pushed — stay in the registry (so the stage screen stays in sync) but
+ * never lock: cards are editable while the push is in flight. Deletes stay
+ * `queued` so their rows remain locked until the push removes them.
  */
 
 export type GitOpKind = 'upsert' | 'delete' | 'rename' | 'move' | 'pull' | 'push';
 
-export type GitOpStatus = 'queued' | 'running' | 'failed';
+export type GitOpStatus = 'queued' | 'running' | 'failed' | 'staged';
 
 export interface GitOp {
   id: string;
@@ -100,7 +106,7 @@ function opFromQueuedMutation(mutation: QueuedMutation): GitOp | null {
     createdAt: typeof mutation.createdAt === 'number' ? mutation.createdAt : 0,
   };
   if (mutation.type === 'note.upsert') {
-    return { ...base, kind: 'upsert', entityIds: mutation.localNoteId ? [mutation.localNoteId] : [] };
+    return { ...base, kind: 'upsert', status: 'staged', entityIds: mutation.localNoteId ? [mutation.localNoteId] : [] };
   }
   if (mutation.type === 'note.delete') {
     const localNoteId = mutation.params.localNoteId;


### PR DESCRIPTION
## Summary

Reworks the stage→push UX so cards unlock once edits are **staged** (not after push completes), push buttons stop swapping their label for a spinner, and clone-mode pushes surface progress in the GitHubActivity pill.

### Changes

1. **Cards unlock after stage** — `src/stores/gitOperationStore.ts`: upsert ops are now `'staged'` (non-locking) instead of `'queued'`. They stay in the registry (stage screen stays consistent) but `isActiveStatus` only covers `queued`/`running`, so card/entity locks release right after staging. `note.delete` mutations keep `'queued'` so deleted rows remain locked until the push removes them (delete-lock integration tests unchanged and passing).

2. **Push buttons: disabled, no spinner** — `src/screens/StageScreen.tsx`: group-Push and Push-all render the label always and rely on `disabled` + grayed background during a push.

3. **Push progress in GitHubActivity pill** — `LocalGitWriter.push` forwards `onProgress` to isomorphic-git; `StagingService` clone-mode pushes call `githubActivity.setProgress({ phase: 'Pushing changes', loaded, total })`; `StagePushScheduler` wraps each `pushStaged` in `begin('Pushing changes')`/`end()` (`end` in `finally`, so failures clear the pill).

### Verification

- `yarn ts:check` — clean
- Targeted suites (gitOperationStore, StageScreen, StagePushScheduler, localGitWriter, StagingService): 64 passed
- `sync-locking.integration.test.ts` + `notes-delete-lock.test.tsx`: 16 passed (deletes still lock)
- Full `yarn jest`: 259 suites, 2293 passed / 7 skipped (baseline)
- `yarn eslint .`: 0 errors (692 pre-existing warnings)

Also includes a separate style commit (stage button size aligned with floating AI button + top padding) that was already in the working tree.