### PR TITLE
fix(sync): surface required GitHub token scopes in 403 messages and token-add UI

### DIFF
--- a/__tests__/empty-error-guard.test.ts
+++ b/__tests__/empty-error-guard.test.ts
@@ -92,4 +92,48 @@ describe('empty-error guard', () => {
 
     expect(() => rejected?.({ message: '', config: {} })).toThrow('Network error');
   });
+
+  test('http interceptor appends the sanitized GitHub reason to a status error', () => {
+    const [handler] = http.interceptors.response.handlers ?? [];
+    const rejected = handler?.rejected as ((error: unknown) => unknown) | undefined;
+    expect(rejected).toBeDefined();
+
+    const error = {
+      message: 'Request failed with status code 403',
+      config: {},
+      response: { status: 403, data: { message: 'Resource not accessible by integration' } },
+    };
+
+    expect(() => rejected?.(error)).toThrow('GitHub API error: 403 (Resource not accessible by integration)');
+  });
+
+  test('http interceptor scrubs bearer tokens from the appended reason', () => {
+    const [handler] = http.interceptors.response.handlers ?? [];
+    const rejected = handler?.rejected as ((error: unknown) => unknown) | undefined;
+    expect(rejected).toBeDefined();
+
+    const error = {
+      message: 'Request failed with status code 403',
+      config: {},
+      response: { status: 403, data: { message: 'Rate limited for Bearer super-secret-token' } },
+    };
+
+    let thrown: unknown;
+    try {
+      rejected?.(error);
+    } catch (caught) {
+      thrown = caught;
+    }
+    expect(String(thrown)).not.toContain('super-secret-token');
+    expect(String(thrown)).toContain('Bearer ***');
+  });
+
+  test('http interceptor keeps a plain status error when no reason is available', () => {
+    const [handler] = http.interceptors.response.handlers ?? [];
+    const rejected = handler?.rejected as ((error: unknown) => unknown) | undefined;
+    expect(rejected).toBeDefined();
+
+    expect(() => rejected?.({ message: 'Request failed with status code 422', config: {}, response: { status: 422, data: undefined } }))
+      .toThrow('GitHub API error: 422');
+  });
 });

--- a/__tests__/services/git/formatSyncError.test.ts
+++ b/__tests__/services/git/formatSyncError.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from '@jest/globals';
+import { formatSyncError } from '../../../src/services/git/formatSyncError';
+
+describe('formatSyncError', () => {
+  test('maps a 403 to a scopes message instead of mislabeling it a rate limit', () => {
+    const message = formatSyncError('GitHub API error: 403');
+    expect(message).toContain('token');
+    expect(message).toContain('Contents: Read and write');
+    expect(message).not.toContain('rate limit');
+  });
+
+  test('maps a 403 with a GitHub permission reason to the scopes message', () => {
+    const message = formatSyncError('GitHub API error: 403 (Resource not accessible by integration)');
+    expect(message).toContain('Contents: Read and write');
+    expect(message).not.toContain('rate limit');
+  });
+
+  test('keeps a genuine rate-limit 403 on the rate-limit message', () => {
+    const message = formatSyncError('GitHub API error: 403 (API rate limit exceeded for 1.2.3.4)');
+    expect(message).toBe('GitHub rate limit hit — try again in a few minutes.');
+  });
+
+  test('maps an explicit 429 to the rate-limit message', () => {
+    const message = formatSyncError('GitHub API error: 429');
+    expect(message).toBe('GitHub rate limit hit — try again in a few minutes.');
+  });
+
+  test.each([
+    ['push rejected', 'Someone else changed this on GitHub. Pull and try again.'],
+    ['GitHub API error: 401', 'Sign in to GitHub again.'],
+    ['GitHub API error: 409', 'This file changed on GitHub. Pull and try again.'],
+    ['GitHub API error: 422', 'GitHub rejected the change. Try again.'],
+    ['GitHub API error: 503', 'GitHub is having trouble — will retry.'],
+    ['Network Error', "No connection. Will retry when you're back online."],
+  ])('preserves the existing behavior for %s', (raw, expected) => {
+    expect(formatSyncError(raw)).toBe(expected);
+  });
+
+  test('strips jargon and returns the deliberate fallback for unknown errors', () => {
+    const message = formatSyncError('Error: something went wrong in (src/foo/bar.ts:12:34)');
+    expect(message).toBe('Sync to GitHub failed');
+  });
+
+  test('uses the delete fallback when the operation is a delete', () => {
+    expect(formatSyncError('weird unknown errz', 'delete')).toBe("Couldn't delete from GitHub");
+  });
+});

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -21,6 +21,7 @@
 | [Settings — Add Repo Fixes](./settings-add-repo-fixes.md) | invisible primary-button fix + repo list not loading after adding a token |
 | [Stage → Push UX](./stage-push-ux.md) | staged-upsert locks, spinner-free push buttons, GitHubActivity push progress |
 | [Token Removal Repo Cascade](./repo-removal-cascade.md) | removing a token also removes its synced repos, with a confirmation warning |
+| [Token Scope Error Messaging](./token-scope-error-messaging.md) | 403s surface needed token scopes in the sync message and token-add UI |
 
 ## Quick Start
 

--- a/docs/wiki/token-scope-error-messaging.md
+++ b/docs/wiki/token-scope-error-messaging.md
@@ -1,0 +1,71 @@
+# Token Scope Error Messaging
+
+Users hitting GitHub API 403s (rate limits, SAML, or — most relevant here — a
+fine-grained PAT that lacks the repository) now see the exact scopes their
+token needs, both in the sync error message and in the token-add UI.
+
+## Problem
+
+- `src/services/http.ts` collapsed every GitHub API error to
+  `GitHub API error: <status>`, throwing away the response body. A 403 from
+  "Resource not accessible by integration" (token missing the repo) is
+  indistinguishable from a rate-limit 403 at the message layer.
+- `formatSyncError` had a single combined matcher `['rate limit', '403']` that
+  labeled **every** 403 as "GitHub rate limit hit — try again in a few
+  minutes". For the common case (a fine-grained PAT whose repository selection
+  omits the target repo, or a classic token without `repo`) that message is
+  misleading — the fix is a token-scope change, not waiting a few minutes.
+- The token-add surfaces (`settings.tokenDescription` in `SettingsModals`,
+  `connectHost.help.github` in `ConnectHostModal`) said "fine-grained token
+  with write access" without naming the classic-token alternative or the
+  repository-selection requirement.
+
+## Changes
+
+### 1. `http.ts` keeps GitHub's sanitized reason
+
+`extractGitHubReason` pulls the human-readable reason from the error response
+body (GitHub returns `{ message, documentation_url }` JSON, or a raw string)
+and appends it: `GitHub API error: 403 (Resource not accessible by
+integration)`. Bearer tokens are scrubbed defensively and the reason is
+truncated at ~100 chars. Status-less errors still degrade to `Network error`.
+
+### 2. `formatSyncError` separates rate limits from scope 403s
+
+The 403 matcher is split into two ordered matchers:
+
+- **Rate-limit first** (`rate limit`, `rate-limit`, `ratelimit`, `too many
+  requests`, `429`) → "GitHub rate limit hit — try again in a few minutes."
+  This must precede the generic 403 matcher because GitHub signals rate limits
+  with a 403 status plus a rate-limit body.
+- **403 / permission** (`403`, `not accessible`, `resource not accessible`,
+  `permission denied`, `must have push access`, `integration`) → tells the user
+  the exact scopes: *"Your token can't access this repo — use a fine-grained
+  token with Contents: Read and write (and the repo selected) or a classic
+  token with the repo scope."*
+
+Now that `http.ts` surfaces the body, a rate-limit 403 ("API rate limit
+exceeded...") still matches the rate-limit matcher, while a permission 403
+("Resource not accessible by integration") correctly gets the scopes message.
+
+### 3. Token-add UI spells out the scopes
+
+`settings.tokenDescription` (Settings → Add GitHub Account token modal) and
+`connectHost.help.github` (Connect host modal) now state: a fine-grained token
+needs Contents: Read and write on each repository — with the repository
+selected in the token — or a classic token with the `repo` scope. Updated in
+all six locales (en, es, fr, de, ja, ko), keeping the key-parity test green.
+
+## Tests
+
+- `__tests__/services/git/formatSyncError.test.ts`: a plain 403 and a GitHub
+  permission-reason 403 map to the scopes message (never "rate limit"); a
+  rate-limit 403 or explicit 429 keeps the rate-limit message; existing
+  matchers (push rejected, 401, 409, 422, 5xx, network) and the fallbacks are
+  pinned.
+- `__tests__/empty-error-guard.test.ts`: the http interceptor appends the
+  GitHub reason, scrubs bearer tokens from it, keeps a plain status error when
+  no reason exists, and still degrades status-less empty messages to
+  `Network error`.
+- `__tests__/i18n-key-parity.test.ts` + `syncFailure.test.ts`: unchanged and
+  passing.

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -264,7 +264,7 @@
     "branch": "Branch: {{branch}}",
     "branchDefault": "main",
     "addGitHubAccount": "GitHub-Konto hinzufügen",
-    "tokenDescription": "Feingranulares persönliches Zugriffstoken mit Lese- und Schreibzugriff auf den Inhalt deiner Repositorys.",
+    "tokenDescription": "Dein Token benötigt Zugriff auf das Repository: ein feingranulares Token mit „Contents: Read and write“ für jedes Repository (wähle deine Repositorys) oder ein klassisches Token mit dem Bereich „repo“.",
     "openGithubTokenSettings": "GitHub-Token-Einstellungen öffnen",
     "hideToken": "Token ausblenden",
     "showToken": "Token anzeigen",
@@ -524,7 +524,7 @@
     "hide": "Hide",
     "connectHost": "Connect host",
     "help": {
-      "github": "Feingranulare Tokens benötigen „Contents: Read and write“ für jedes Repository. Klassische Tokens benötigen den Bereich „repo“."
+      "github": "Dein Token benötigt Zugriff auf das Repository: ein feingranulares Token mit „Contents: Read and write“ für jedes Repository (wähle deine Repositorys) oder ein klassisches Token mit dem Bereich „repo“."
     },
     "success": {
       "testTitle": "Success",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -353,7 +353,7 @@
     "branch": "Branch: {{branch}}",
     "branchDefault": "main",
     "addGitHubAccount": "Add GitHub Account",
-    "tokenDescription": "Fine-grained Personal Access Token with Contents: Read and write access to your repositories.",
+    "tokenDescription": "Your token needs access to the repository: a fine-grained token with Contents: Read and write on each repository (select your repos), or a classic token with the repo scope.",
     "openGithubTokenSettings": "Open GitHub token settings",
     "hideToken": "Hide token",
     "showToken": "Show token",
@@ -463,7 +463,7 @@
     "hide": "Hide",
     "connectHost": "Connect host",
     "help": {
-      "github": "Fine-grained tokens need Contents: Read and write for each repository. Classic tokens need the repo scope."
+      "github": "Your token needs access to the repository: a fine-grained token with Contents: Read and write on each repository (select your repos), or a classic token with the repo scope."
     },
     "success": {
       "testTitle": "Success",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -264,7 +264,7 @@
     "branch": "Rama: {{branch}}",
     "branchDefault": "main",
     "addGitHubAccount": "Añadir cuenta de GitHub",
-    "tokenDescription": "Token de acceso personal de grano fino con acceso de lectura y escritura al contenido de tus repositorios.",
+    "tokenDescription": "Tu token necesita acceso al repositorio: un token de grano fino con «Contents: Read and write» en cada repositorio (selecciona tus repositorios) o un token clásico con el ámbito repo.",
     "openGithubTokenSettings": "Abrir ajustes del token de GitHub",
     "hideToken": "Ocultar token",
     "showToken": "Mostrar token",
@@ -524,7 +524,7 @@
     "hide": "Hide",
     "connectHost": "Connect host",
     "help": {
-      "github": "Los tokens de grano fino necesitan «Contents: Read and write» para cada repositorio. Los tokens clásicos necesitan el ámbito repo."
+      "github": "Tu token necesita acceso al repositorio: un token de grano fino con «Contents: Read and write» en cada repositorio (selecciona tus repositorios) o un token clásico con el ámbito repo."
     },
     "success": {
       "testTitle": "Success",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -264,7 +264,7 @@
     "branch": "Branche : {{branch}}",
     "branchDefault": "main",
     "addGitHubAccount": "Ajouter un compte GitHub",
-    "tokenDescription": "Jeton d'accès personnel à granularité fine avec accès en lecture et écriture au contenu de vos dépôts.",
+    "tokenDescription": "Votre jeton doit avoir accès au dépôt : un jeton à granularité fine avec « Contents: Read and write » sur chaque dépôt (sélectionnez vos dépôts) ou un jeton classique avec la portée repo.",
     "openGithubTokenSettings": "Ouvrir les réglages du jeton GitHub",
     "hideToken": "Masquer le jeton",
     "showToken": "Afficher le jeton",
@@ -524,7 +524,7 @@
     "hide": "Hide",
     "connectHost": "Connect host",
     "help": {
-      "github": "Les jetons à granularité fine nécessitent l’autorisation « Contents: Read and write » pour chaque dépôt. Les jetons classiques nécessitent la portée repo."
+      "github": "Votre jeton doit avoir accès au dépôt : un jeton à granularité fine avec « Contents: Read and write » sur chaque dépôt (sélectionnez vos dépôts) ou un jeton classique avec la portée repo."
     },
     "success": {
       "testTitle": "Success",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -264,7 +264,7 @@
     "branch": "ブランチ: {{branch}}",
     "branchDefault": "main",
     "addGitHubAccount": "GitHubアカウントを追加",
-    "tokenDescription": "リポジトリのコンテンツへの読み取り・書き込みアクセス権を持つファイングレインド・パーソナルアクセストークン。",
+    "tokenDescription": "トークンにはリポジトリへのアクセス権が必要です: 各リポジトリの「Contents: Read and write」を持つファイングレインド・トークン(リポジトリを選択)または repo スコープのクラシックトークン。",
     "openGithubTokenSettings": "GitHubトークン設定を開く",
     "hideToken": "トークンを隠す",
     "showToken": "トークンを表示",
@@ -524,7 +524,7 @@
     "hide": "Hide",
     "connectHost": "Connect host",
     "help": {
-      "github": "きめ細かいトークンには、各リポジトリの「Contents: Read and write」権限が必要です。クラシックトークンには repo スコープが必要です。"
+      "github": "トークンにはリポジトリへのアクセス権が必要です: 各リポジトリの「Contents: Read and write」を持つファイングレインド・トークン(リポジトリを選択)または repo スコープのクラシックトークン。"
     },
     "success": {
       "testTitle": "Success",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -264,7 +264,7 @@
     "branch": "브랜치: {{branch}}",
     "branchDefault": "main",
     "addGitHubAccount": "GitHub 계정 추가",
-    "tokenDescription": "저장소 콘텐츠에 대한 읽기 및 쓰기 권한이 있는 세밀한 개인 액세스 토큰.",
+    "tokenDescription": "토큰에는 저장소에 대한 액세스 권한이 필요합니다: 각 저장소에 'Contents: Read and write' 권한이 있는 세분화된 토큰(저장소 선택) 또는 repo 스코프의 클래식 토큰.",
     "openGithubTokenSettings": "GitHub 토큰 설정 열기",
     "hideToken": "토큰 숨기기",
     "showToken": "토큰 표시",
@@ -524,7 +524,7 @@
     "hide": "Hide",
     "connectHost": "Connect host",
     "help": {
-      "github": "세분화된 토큰은 각 저장소에 'Contents: Read and write' 권한이 필요합니다. 클래식 토큰은 repo 스코프가 필요합니다."
+      "github": "토큰에는 저장소에 대한 액세스 권한이 필요합니다: 각 저장소에 'Contents: Read and write' 권한이 있는 세분화된 토큰(저장소 선택) 또는 repo 스코프의 클래식 토큰."
     },
     "success": {
       "testTitle": "Success",

--- a/src/services/git/formatSyncError.ts
+++ b/src/services/git/formatSyncError.ts
@@ -32,8 +32,16 @@ const MATCHERS: Matcher[] = [
     message: 'Sign in to GitHub again.',
   },
   {
-    needles: ['rate limit', '403'],
+    // Must precede the generic 403 matcher: GitHub signals API rate limits
+    // with a 403 status plus a rate-limit body (now surfaced by http.ts).
+    needles: ['rate limit', 'rate-limit', 'ratelimit', 'too many requests', '429'],
     message: 'GitHub rate limit hit — try again in a few minutes.',
+  },
+  {
+    // A non-rate-limit 403 means the token lacks access. Name the scopes so
+    // the user knows exactly what to grant.
+    needles: ['403', 'not accessible', 'resource not accessible', 'permission denied', 'must have push access', 'integration'],
+    message: "Your token can't access this repo — use a fine-grained token with Contents: Read and write (and the repo selected) or a classic token with the repo scope.",
   },
   {
     needles: ['409'],

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -63,6 +63,16 @@ function endIfTracked(config: TrackedConfig | undefined) {
   }
 }
 
+function extractGitHubReason(error: AxiosError): string | undefined {
+  // GitHub error bodies are { message, documentation_url } JSON, or a raw string.
+  const data = error.response?.data;
+  const message = typeof data === 'string' ? data : (data as { message?: unknown } | undefined)?.message;
+  if (typeof message !== 'string') return undefined;
+  const cleaned = message.replace(/Bearer\s+\S+/gi, 'Bearer ***').replace(/\s+/g, ' ').trim();
+  if (!cleaned) return undefined;
+  return cleaned.length > 100 ? `${cleaned.slice(0, 97)}...` : cleaned;
+}
+
 http.interceptors.response.use(
   (response) => {
     endIfTracked(response.config as TrackedConfig);
@@ -75,9 +85,12 @@ http.interceptors.response.use(
     // `||` (not `??`): a status-less error whose message is empty (e.g. a
     // dropped connection or an interceptor that lost the body) must surface
     // as a real "Network error", never an empty string that reaches the UI.
-    const safeMessage = status
-      ? `GitHub API error: ${status}`
-      : error.message?.replace(/Bearer\s+\S+/gi, 'Bearer ***') || 'Network error';
+    const reason = status ? extractGitHubReason(error) : undefined;
+    const safeMessage = reason
+      ? `GitHub API error: ${status} (${reason})`
+      : status
+        ? `GitHub API error: ${status}`
+        : error.message?.replace(/Bearer\s+\S+/gi, 'Bearer ***') || 'Network error';
 
     const normalized = new Error(safeMessage) as Error & { status?: number };
     normalized.status = status;


### PR DESCRIPTION
## Problem

- `src/services/http.ts` collapsed every GitHub API error to `GitHub API error: <status>`, discarding the response body — so a 403 from "Resource not accessible by integration" (fine-grained PAT missing the repo) was indistinguishable from a rate-limit 403.
- `formatSyncError` had one combined matcher `['rate limit', '403']` that labeled **every** 403 as "GitHub rate limit hit" — misleading for token-scope failures.
- The token-add surfaces didn't name the classic-token alternative or the repository-selection requirement.

## Changes

1. **`http.ts`** — `extractGitHubReason` preserves GitHub's sanitized body reason: `GitHub API error: 403 (Resource not accessible by integration)`. Bearer tokens scrubbed; ~100-char truncation.
2. **`formatSyncError.ts`** — split matchers: rate-limit needles first (403 + rate-limit body), then 403/permission needles → *"Your token can't access this repo — use a fine-grained token with Contents: Read and write (and the repo selected) or a classic token with the repo scope."*
3. **i18n (all 6 locales)** — `settings.tokenDescription` + `connectHost.help.github` spell out the scopes.

## Tests

- New `__tests__/services/git/formatSyncError.test.ts` (11 tests)
- `empty-error-guard.test.ts` extended (reason passthrough, bearer scrub, plain-status fallback)
- Full suite: 260 suites / 2308 tests passing; ts:check + eslint clean

## Docs

- `docs/wiki/token-scope-error-messaging.md` + index entry