### PR TITLE
fix(settings): cascade repo removal when a token is removed

### DIFF
--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -77,19 +77,24 @@ jest.mock('../../src/contexts/ThemeContext', () => ({
   }),
 }));
 
+const mockAccountSummaries: any[] = [];
+const mockDisconnectHost = jest.fn(async () => undefined);
+const mockRemoveAccount = jest.fn(async () => undefined);
+const mockClearToken = jest.fn(async () => undefined);
+
 jest.mock('../../src/contexts/AuthContext', () => {
   const fn = () => ({
     authState: { isAuthenticated: false, token: null },
     accounts: [],
     activeAccountId: null,
-    accountSummaries: [],
+    accountSummaries: mockAccountSummaries,
     setToken: jest.fn(async () => true),
-    clearToken: jest.fn(async () => undefined),
+    clearToken: mockClearToken,
     addAccount: jest.fn(async () => null),
-    removeAccount: jest.fn(async () => undefined),
+    removeAccount: mockRemoveAccount,
     switchAccount: jest.fn(async () => undefined),
     switchToHost: jest.fn(async () => true),
-    disconnectHost: jest.fn(async () => undefined),
+    disconnectHost: mockDisconnectHost,
     connectHost: jest.fn(async () => ({ ok: true })),
   });
   return {
@@ -249,6 +254,15 @@ jest.mock('../../src/stores/aiStore', () => ({
   useAIStore: (selector: any) => {
     if (selector) return selector(mockAIStore);
     return mockAIStore;
+  },
+}));
+
+const mockRemoveRepositoriesForHosts = jest.fn(async () => 0);
+jest.mock('../../src/stores/repoStore', () => ({
+  useRepoStore: {
+    getState: () => ({
+      removeRepositoriesForHosts: mockRemoveRepositoriesForHosts,
+    }),
   },
 }));
 
@@ -413,6 +427,11 @@ describe('SettingsScreen', () => {
     mockAddRepository.mockReset();
     alertSpy.mockClear();
     stableRepositories.length = 0;
+    mockAccountSummaries.length = 0;
+    mockDisconnectHost.mockReset();
+    mockRemoveAccount.mockReset();
+    mockClearToken.mockReset();
+    mockRemoveRepositoriesForHosts.mockReset();
     jest.useRealTimers();
     (GitHubService.isAuthenticated as jest.Mock).mockReset().mockReturnValue(false);
     (GitFsService.clone as jest.Mock).mockReset().mockResolvedValue(undefined);
@@ -611,5 +630,42 @@ describe('SettingsScreen', () => {
     expect(getByTestId('modal')).toBeTruthy();
     expect(getByText('Clone Failed')).toBeTruthy();
     expect(getByText(/Packfile trailer mismatch/)).toBeTruthy();
+  });
+
+  it('warns about cascaded repos and removes them when a host is disconnected', async () => {
+    mockAccountSummaries.push({
+      account: { id: 'acc-1', login: 'octocat', name: 'Octo Cat', avatarUrl: '' },
+      hosts: [
+        { id: 'host-1', provider: 'github', hostLogin: 'octocat', instanceBaseUrl: null },
+      ],
+      activeHostId: 'host-1',
+    });
+    stableRepositories.push({
+      id: 'github:1',
+      name: 'notes',
+      path: 'octo/notes',
+      provider: 'github',
+      hostId: 'host-1',
+    });
+
+    const { getByTestId } = render(<SettingsScreen />);
+    fireEvent.press(getByTestId('settings.button.disconnect-host.host-1'));
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    const lastCall = alertSpy.mock.calls[alertSpy.mock.calls.length - 1];
+    const body = lastCall?.[1] as string;
+    expect(body).toContain('This will also remove 1 synced repo(s) from this device.');
+
+    const buttons = lastCall?.[2] as AlertButton[] | undefined;
+    const disconnectButton = buttons?.find((b) => b.text === 'Disconnect');
+    await act(async () => {
+      await disconnectButton?.onPress?.();
+    });
+
+    expect(mockDisconnectHost).toHaveBeenCalledWith('host-1');
+    expect(mockRemoveRepositoriesForHosts).toHaveBeenCalledTimes(1);
+    const [removedHosts, counts] = mockRemoveRepositoriesForHosts.mock.calls[0];
+    expect(removedHosts).toEqual([{ id: 'host-1', provider: 'github' }]);
+    expect(counts.get('github')).toBe(1);
   });
 });

--- a/__tests__/services/git/repoRemovalCascade.test.ts
+++ b/__tests__/services/git/repoRemovalCascade.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { GitRepository } from '../../../src/services/GitService';
+import type { GitHostProvider } from '../../../src/services/git/GitHost';
+import {
+  buildProviderAccountCount,
+  reposAffectedByRemovedHosts,
+  type RemovedHostRef,
+} from '../../../src/services/git/repoRemovalCascade';
+
+function repo(overrides: Partial<GitRepository> & { path: string }): GitRepository {
+  return {
+    id: `id-${overrides.path}`,
+    name: overrides.path,
+    provider: 'github',
+    ...overrides,
+  };
+}
+
+describe('reposAffectedByRemovedHosts', () => {
+  it('matches repos stamped with a removed host id', () => {
+    const repositories = [
+      repo({ path: 'octo/notes', hostId: 'host-1' }),
+      repo({ path: 'octo/other', hostId: 'host-2' }),
+      repo({ path: 'mono/draw', hostId: 'host-3' }),
+    ];
+    const removedHosts: RemovedHostRef[] = [
+      { id: 'host-1', provider: 'github' },
+      { id: 'host-3', provider: 'gitlab' },
+    ];
+    const counts = new Map<GitHostProvider, number>([['github', 1], ['gitlab', 1]]);
+
+    const affected = reposAffectedByRemovedHosts(repositories, removedHosts, counts);
+
+    expect(affected.map((r) => r.path).sort()).toEqual(['mono/draw', 'octo/notes']);
+  });
+
+  it('matches legacy unstamped repos by provider when only one account uses that provider', () => {
+    const repositories = [
+      repo({ path: 'legacy/notes' }),
+      repo({ path: 'legacy/todos', provider: 'gitlab' }),
+    ];
+    const removedHosts: RemovedHostRef[] = [{ id: 'host-1', provider: 'github' }];
+    const counts = new Map<GitHostProvider, number>([['github', 1]]);
+
+    const affected = reposAffectedByRemovedHosts(repositories, removedHosts, counts);
+
+    expect(affected.map((r) => r.path)).toEqual(['legacy/notes']);
+  });
+
+  it('does NOT match legacy repos when multiple accounts use the same provider', () => {
+    const repositories = [
+      repo({ path: 'legacy/notes' }),
+      repo({ path: 'legacy/todos' }),
+    ];
+    const removedHosts: RemovedHostRef[] = [{ id: 'host-1', provider: 'github' }];
+    const counts = new Map<GitHostProvider, number>([['github', 2]]);
+
+    const affected = reposAffectedByRemovedHosts(repositories, removedHosts, counts);
+
+    expect(affected).toEqual([]);
+  });
+
+  it('defaults a legacy repo with undefined provider to github', () => {
+    const repositories: GitRepository[] = [
+      { id: 'id-1', name: 'legacy', path: 'legacy/notes' },
+    ];
+    const removedHosts: RemovedHostRef[] = [{ id: 'host-1', provider: 'github' }];
+    const counts = new Map<GitHostProvider, number>([['github', 1]]);
+
+    const affected = reposAffectedByRemovedHosts(repositories, removedHosts, counts);
+
+    expect(affected.map((r) => r.path)).toEqual(['legacy/notes']);
+  });
+
+  it('does not mutate the input array', () => {
+    const repositories = [
+      repo({ path: 'octo/notes', hostId: 'host-1' }),
+      repo({ path: 'octo/other', hostId: 'host-2' }),
+    ];
+    const removedHosts: RemovedHostRef[] = [{ id: 'host-1', provider: 'github' }];
+    const counts = new Map<GitHostProvider, number>([['github', 1]]);
+    const snapshot = [...repositories];
+
+    reposAffectedByRemovedHosts(repositories, removedHosts, counts);
+
+    expect(repositories).toEqual(snapshot);
+  });
+
+  it('returns an empty array when no hosts are removed', () => {
+    const repositories = [repo({ path: 'octo/notes', hostId: 'host-1' })];
+    const counts = new Map<GitHostProvider, number>([['github', 1]]);
+
+    const affected = reposAffectedByRemovedHosts(repositories, [], counts);
+
+    expect(affected).toEqual([]);
+  });
+});
+
+describe('buildProviderAccountCount', () => {
+  it('counts multiple hosts with the same provider on one account as a single account', () => {
+    const summaries = [
+      {
+        hosts: [
+          { provider: 'github' as const },
+          { provider: 'github' as const },
+          { provider: 'gitlab' as const },
+        ],
+      },
+    ];
+
+    const counts = buildProviderAccountCount(summaries);
+
+    expect(counts.get('github')).toBe(1);
+    expect(counts.get('gitlab')).toBe(1);
+  });
+
+  it('counts distinct providers across multiple accounts', () => {
+    const summaries = [
+      { hosts: [{ provider: 'github' as const }] },
+      { hosts: [{ provider: 'github' as const }, { provider: 'gitlab' as const }] },
+      { hosts: [{ provider: 'gitea' as const }] },
+    ];
+
+    const counts = buildProviderAccountCount(summaries);
+
+    expect(counts.get('github')).toBe(2);
+    expect(counts.get('gitlab')).toBe(1);
+    expect(counts.get('gitea')).toBe(1);
+    expect(counts.get('forgejo')).toBeUndefined();
+  });
+
+  it('returns an empty map for no summaries', () => {
+    const counts = buildProviderAccountCount([]);
+
+    expect(counts.size).toBe(0);
+  });
+});

--- a/__tests__/stores/repoStore.test.ts
+++ b/__tests__/stores/repoStore.test.ts
@@ -8,6 +8,8 @@ import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
 import { getActiveGitHost } from '../../src/services/git/activeHost';
 import { gitHubHostService } from '../../src/services/git/gitHostFactory';
 import { checkGitHubRepoAccess } from '../../src/services/git/repoAccessPreflight';
+import type { GitHostProvider } from '../../src/services/git/GitHost';
+import type { RemovedHostRef } from '../../src/services/git/repoRemovalCascade';
 import { useAIStore } from '../../src/stores/aiStore';
 import { useRepoStore } from '../../src/stores/repoStore';
 import { beforeEach, describe, expect, it } from '@jest/globals';
@@ -95,6 +97,7 @@ describe('repoStore addRepository preflight', () => {
       baseUrl: 'https://api.github.com',
       token: 'secret-token',
       host: gitHubHostService,
+      hostId: 'host-1',
     });
     jest.mocked(checkGitHubRepoAccess).mockResolvedValue({
       kind: 'write_unverified',
@@ -118,7 +121,7 @@ describe('repoStore addRepository preflight', () => {
       'octo/notes',
       { allowUnverifiedWrite: true },
     )).resolves.toEqual(repository);
-    expect(GitService.addRepository).toHaveBeenCalledWith('octo/notes', undefined, 'github');
+    expect(GitService.addRepository).toHaveBeenCalledWith('octo/notes', undefined, 'github', 'host-1');
   });
 });
 
@@ -185,5 +188,64 @@ describe('repoStore removeRepository', () => {
     await useRepoStore.getState().removeRepository(repoPath);
 
     expect(GitFsService.removeRepo).toHaveBeenCalledWith({ repoPath });
+  });
+});
+
+describe('repoStore removeRepositoriesForHosts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('removes only repos stamped with a removed host id and returns the count', async () => {
+    const stamped = {
+      id: 'github:1',
+      name: 'notes',
+      path: 'octo/notes',
+      branch: 'main',
+      provider: 'github' as const,
+      hostId: 'host-1',
+    };
+    const other = {
+      id: 'github:2',
+      name: 'other',
+      path: 'octo/other',
+      branch: 'main',
+      provider: 'github' as const,
+      hostId: 'host-2',
+    };
+    useRepoStore.setState({ repositories: [stamped, other] });
+
+    const removeSpy = jest
+      .spyOn(useRepoStore.getState(), 'removeRepository')
+      .mockResolvedValue(undefined);
+
+    const removedHosts: RemovedHostRef[] = [{ id: 'host-1', provider: 'github' }];
+    const counts = new Map<GitHostProvider, number>([['github', 1]]);
+
+    const removed = await useRepoStore.getState().removeRepositoriesForHosts(removedHosts, counts);
+
+    expect(removed).toBe(1);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledWith('octo/notes', 'github');
+  });
+
+  it('removes nothing when no repo matches the removed host', async () => {
+    useRepoStore.setState({
+      repositories: [
+        { id: 'github:2', name: 'other', path: 'octo/other', provider: 'github' as const, hostId: 'host-2' },
+      ],
+    });
+
+    const removeSpy = jest
+      .spyOn(useRepoStore.getState(), 'removeRepository')
+      .mockResolvedValue(undefined);
+
+    const removedHosts: RemovedHostRef[] = [{ id: 'host-1', provider: 'github' }];
+    const counts = new Map<GitHostProvider, number>([['github', 1]]);
+
+    const removed = await useRepoStore.getState().removeRepositoriesForHosts(removedHosts, counts);
+
+    expect(removed).toBe(0);
+    expect(removeSpy).not.toHaveBeenCalled();
   });
 });

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -20,6 +20,7 @@
 | [Git Core Hardening](./git-core-hardening.md) | git-core test-campaign fixes: binary decode integrity, case collisions, auth/preflight, API batch writes, pull/reconcile fixes (#876–#892) |
 | [Settings — Add Repo Fixes](./settings-add-repo-fixes.md) | invisible primary-button fix + repo list not loading after adding a token |
 | [Stage → Push UX](./stage-push-ux.md) | staged-upsert locks, spinner-free push buttons, GitHubActivity push progress |
+| [Token Removal Repo Cascade](./repo-removal-cascade.md) | removing a token also removes its synced repos, with a confirmation warning |
 
 ## Quick Start
 

--- a/docs/wiki/repo-removal-cascade.md
+++ b/docs/wiki/repo-removal-cascade.md
@@ -1,0 +1,68 @@
+# Token Removal Repo Cascade
+
+> When a token (host connection) is removed in Settings, the repositories that
+> were synced with it are removed from the device too.
+
+## Why
+
+Removing a token used to leave orphaned repositories in the local store. The
+repos stayed on the device but could no longer sync (the token that owned them
+was gone), producing confusing "failed to sync" states. Now removing a token
+cleans up its repos as part of the same confirmed action.
+
+## Behavior
+
+Three removal flows in `SettingsScreen` now cascade:
+
+| Flow | What gets removed |
+|------|-------------------|
+| Disconnect host (`handleDisconnectHost`) | Repos stamped with that host id |
+| Remove account (`handleRemoveAccount`) | Repos stamped with any host of the account |
+| Remove token — legacy (`handleRemoveToken`) | Repos stamped with the active host |
+
+Before removal, the confirmation Alert appends a warning line when affected
+repos exist:
+
+> This will also remove {{count}} synced repo(s) from this device.
+
+On confirm the repos are removed via the existing full cleanup path
+(`repoStore.removeRepository`), so template preferences, last-used repo, sync
+engine state, cloned files, chat repo binding, and the note/canvas/todo lists
+are all cleaned up exactly as if the user removed each repo manually.
+
+## How a repo is linked to a token
+
+`GitRepository` gained an optional `hostId` field (one host connection == one
+token). It is stamped at add time from the active host:
+
+- `GitService.addRepository(path, name, provider, hostId?)` stores it.
+- `repoStore.addRepository` resolves the active host once via
+  `getActiveGitHost()` (which now returns `hostId`) and passes it through.
+- `ActiveGitHost` interface extended with `hostId`.
+
+Legacy repos saved before this change have no `hostId`. They are still removed
+when the removed host's provider is used by **no other account** on the device
+(`providerAccountCount[provider] <= 1`). On multi-account installs where another
+account still uses the same provider, unstamped legacy repos are left in place —
+removing one GitHub token must not wipe another GitHub account's repos.
+
+## Code layout
+
+| File | Responsibility |
+|------|----------------|
+| `src/services/git/repoRemovalCascade.ts` | Pure helpers: `reposAffectedByRemovedHosts`, `buildProviderAccountCount`, `RemovedHostRef` |
+| `src/stores/repoStore.ts` | `removeRepositoriesForHosts` action (loops `removeRepository`) |
+| `src/screens/SettingsScreen.tsx` | Alert copy + cascade call in the three removal handlers |
+| `src/services/GitService.ts` / `src/services/git/activeHost.ts` | `hostId` stamping |
+
+## Tests
+
+- `__tests__/services/git/repoRemovalCascade.test.ts` — pure-helper unit tests
+  (stamped match, legacy single-account match, legacy multi-account no-match,
+  default provider, no mutation).
+- `__tests__/stores/repoStore.test.ts` — `removeRepositoriesForHosts` action
+  (delegates to `removeRepository`, returns count).
+- `__tests__/screens/SettingsScreen.test.tsx` — disconnect-host flow shows the
+  cascade warning and calls `removeRepositoriesForHosts`.
+- `__tests__/i18n-key-parity.test.ts` — `settings.cascadeRemoveWarning` present
+  in all 6 locales.

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -318,6 +318,7 @@
     "removeAccountBody": "Das Token für dieses Konto wird von diesem Gerät gelöscht. Mit dem Konto erstellte Notizen/Aufgaben bleiben lokal erhalten.",
     "removeTokenTitle": "GitHub-Token entfernen",
     "removeTokenBody": "Dadurch wird dein GitHub-Konto getrennt. Fortfahren?",
+    "cascadeRemoveWarning": "Dadurch wird/werden auch {{count}} synchronisierte(s) Repo(s) von diesem Gerät entfernt.",
     "resetOnboardingTitle": "Onboarding zurücksetzen",
     "resetOnboardingBody": "Der Onboarding-Bildschirm wird beim nächsten Start der App angezeigt.",
     "resetOnboardingSuccess": "Das Onboarding wird beim nächsten Start angezeigt.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -407,6 +407,7 @@
     "removeAccountBody": "The token for this account will be deleted from this device. Notes/todos created under it stay locally.",
     "removeTokenTitle": "Remove GitHub Token",
     "removeTokenBody": "This will disconnect your GitHub account. Continue?",
+    "cascadeRemoveWarning": "This will also remove {{count}} synced repo(s) from this device.",
     "resetOnboardingTitle": "Reset Onboarding",
     "resetOnboardingBody": "This will show the onboarding screen on next app launch.",
     "resetOnboardingSuccess": "Onboarding will show on next launch.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -318,6 +318,7 @@
     "removeAccountBody": "El token de esta cuenta se eliminará de este dispositivo. Las notas/tareas creadas con ella permanecen en local.",
     "removeTokenTitle": "Eliminar token de GitHub",
     "removeTokenBody": "Esto desconectará tu cuenta de GitHub. ¿Continuar?",
+    "cascadeRemoveWarning": "Esto también eliminará {{count}} repositorio(s) sincronizado(s) de este dispositivo.",
     "resetOnboardingTitle": "Restablecer introducción",
     "resetOnboardingBody": "La pantalla de introducción se mostrará en el próximo inicio de la aplicación.",
     "resetOnboardingSuccess": "La introducción se mostrará en el próximo inicio.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -318,6 +318,7 @@
     "removeAccountBody": "Le jeton de ce compte sera supprimé de cet appareil. Les notes/tâches créées avec ce compte restent en local.",
     "removeTokenTitle": "Supprimer le jeton GitHub",
     "removeTokenBody": "Cela déconnectera votre compte GitHub. Continuer ?",
+    "cascadeRemoveWarning": "Cela supprimera également {{count}} dépôt(s) synchronisé(s) de cet appareil.",
     "resetOnboardingTitle": "Réinitialiser l'intégration",
     "resetOnboardingBody": "L'écran d'intégration s'affichera au prochain lancement de l'application.",
     "resetOnboardingSuccess": "L'intégration s'affichera au prochain lancement.",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -318,6 +318,7 @@
     "removeAccountBody": "このアカウントのトークンはこのデバイスから削除されます。このアカウントで作成したノート/ToDoはローカルに残ります。",
     "removeTokenTitle": "GitHubトークンを削除",
     "removeTokenBody": "GitHubアカウントの接続が解除されます。続行しますか？",
+    "cascadeRemoveWarning": "同期された {{count}} 個のリポジトリもこの端末から削除されます。",
     "resetOnboardingTitle": "オンボーディングをリセット",
     "resetOnboardingBody": "次回アプリ起動時にオンボーディング画面が表示されます。",
     "resetOnboardingSuccess": "オンボーディングは次回起動時に表示されます。",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -318,6 +318,7 @@
     "removeAccountBody": "이 계정의 토큰이 이 기기에서 삭제됩니다. 이 계정으로 만든 노트/할 일은 로컬에 유지됩니다.",
     "removeTokenTitle": "GitHub 토큰 제거",
     "removeTokenBody": "GitHub 계정 연결이 해제됩니다. 계속하시겠습니까?",
+    "cascadeRemoveWarning": "동기화된 {{count}}개의 리포지토리도 이 기기에서 제거됩니다.",
     "resetOnboardingTitle": "온보딩 재설정",
     "resetOnboardingBody": "다음 앱 실행 시 온보딩 화면이 표시됩니다.",
     "resetOnboardingSuccess": "온보딩은 다음 실행 시 표시됩니다.",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -40,6 +40,8 @@ import { SettingsContent } from '../components/settings/SettingsContent';
 import { SettingsModals } from '../components/settings/SettingsModals';
 import { CloneProgressModal, type CloneProgress } from '../components/settings/CloneProgressModal';
 import type { GitRepository } from '../services/GitService';
+import { reposAffectedByRemovedHosts, buildProviderAccountCount, type RemovedHostRef } from '../services/git/repoRemovalCascade';
+import { useRepoStore } from '../stores/repoStore';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { RepoAccessPreflightError } from '../services/git/repoAccessPreflight';
@@ -618,7 +620,16 @@ export default function SettingsScreen() {
 
   const handleRemoveAccount = useCallback((id: string, login: string) => {
     HapticService.warning();
-    Alert.alert(t('settings.removeAccountTitle', { login }), t('settings.removeAccountBody'), [
+    const summary = accountSummaries.find((s) => s.account.id === id);
+    const removedHosts: RemovedHostRef[] = summary
+      ? summary.hosts.map((h) => ({ id: h.id, provider: h.provider }))
+      : [];
+    const providerAccountCount = buildProviderAccountCount(accountSummaries);
+    const affectedCount = reposAffectedByRemovedHosts(repositories, removedHosts, providerAccountCount).length;
+    const body = affectedCount > 0
+      ? `${t('settings.removeAccountBody')}\n\n${t('settings.cascadeRemoveWarning', { count: affectedCount })}`
+      : t('settings.removeAccountBody');
+    Alert.alert(t('settings.removeAccountTitle', { login }), body, [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('common.remove'),
@@ -626,6 +637,7 @@ export default function SettingsScreen() {
         onPress: async () => {
           try {
             await removeAccount(id);
+            await useRepoStore.getState().removeRepositoriesForHosts(removedHosts, providerAccountCount);
             HapticService.success();
           } catch (err) {
             HapticService.error();
@@ -637,11 +649,21 @@ export default function SettingsScreen() {
         },
       },
     ]);
-  }, [removeAccount, t]);
+  }, [accountSummaries, repositories, removeAccount, t]);
 
   const handleRemoveToken = useCallback(() => {
     HapticService.warning();
-    Alert.alert(t('settings.removeTokenTitle'), t('settings.removeTokenBody'), [
+    const summary = accountSummaries[0];
+    const host = summary
+      ? summary.hosts.find((h) => h.id === summary.activeHostId) ?? summary.hosts[0]
+      : undefined;
+    const removedHosts: RemovedHostRef[] = host ? [{ id: host.id, provider: host.provider }] : [];
+    const providerAccountCount = buildProviderAccountCount(accountSummaries);
+    const affectedCount = reposAffectedByRemovedHosts(repositories, removedHosts, providerAccountCount).length;
+    const body = affectedCount > 0
+      ? `${t('settings.removeTokenBody')}\n\n${t('settings.cascadeRemoveWarning', { count: affectedCount })}`
+      : t('settings.removeTokenBody');
+    Alert.alert(t('settings.removeTokenTitle'), body, [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('common.remove'),
@@ -649,6 +671,7 @@ export default function SettingsScreen() {
         onPress: async () => {
           try {
             await clearToken();
+            await useRepoStore.getState().removeRepositoriesForHosts(removedHosts, providerAccountCount);
             HapticService.success();
           } catch (err) {
             HapticService.error();
@@ -660,7 +683,7 @@ export default function SettingsScreen() {
         },
       },
     ]);
-  }, [clearToken, t]);
+  }, [accountSummaries, repositories, clearToken, t]);
 
   // Native-only "Connected hosts" UI: a single Alert lists each connected
   // host as a button; tapping one shows the disconnect confirmation Alert.
@@ -672,20 +695,29 @@ export default function SettingsScreen() {
     // Find the host across accounts so the label in the confirmation Alert
     // matches what the user just tapped on.
     let label = hostId;
+    let hostProvider: GitHostProvider = 'github';
     for (const summary of accountSummaries) {
       const host = summary.hosts.find((h) => h.id === hostId);
       if (host) {
         label = host.instanceBaseUrl
           ? `${GIT_HOST_LABELS[host.provider]} · ${host.instanceBaseUrl} (${host.hostLogin})`
           : `${GIT_HOST_LABELS[host.provider]} · ${host.hostLogin}`;
+        hostProvider = host.provider;
         break;
       }
     }
 
+    const removedHosts: RemovedHostRef[] = [{ id: hostId, provider: hostProvider }];
+    const providerAccountCount = buildProviderAccountCount(accountSummaries);
+    const affectedCount = reposAffectedByRemovedHosts(repositories, removedHosts, providerAccountCount).length;
+    const body = affectedCount > 0
+      ? `${t('accounts.disconnectBody', { label })}\n\n${t('settings.cascadeRemoveWarning', { count: affectedCount })}`
+      : t('accounts.disconnectBody', { label });
+
     HapticService.warning();
     Alert.alert(
       t('accounts.disconnectTitle'),
-      t('accounts.disconnectBody', { label }),
+      body,
       [
         { text: t('common.cancel'), style: 'cancel' as const },
         {
@@ -694,6 +726,7 @@ export default function SettingsScreen() {
           onPress: async () => {
             try {
               await disconnectHost(hostId);
+              await useRepoStore.getState().removeRepositoriesForHosts(removedHosts, providerAccountCount);
               HapticService.success();
             } catch (err) {
               HapticService.error();
@@ -706,7 +739,7 @@ export default function SettingsScreen() {
         },
       ],
     );
-  }, [accountSummaries, disconnectHost, t]);
+  }, [accountSummaries, repositories, disconnectHost, t]);
 
   const handleResetOnboarding = useCallback(() => {
     HapticService.warning();

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -14,6 +14,8 @@ export interface GitRepository {
   commit?: string;
   /** Which host this repository lives on. Defaults to 'github' for legacy entries. */
   provider?: GitHostProvider;
+  /** Host connection (token) this repo was added under. */
+  hostId?: string;
 }
 
 export interface GitBranch {
@@ -73,6 +75,7 @@ export class GitService {
     path: string,
     name?: string,
     provider: GitHostProvider = 'github',
+    hostId?: string,
   ): Promise<GitRepository> {
     try {
       const repoName = name || path.split('/').pop() || path;
@@ -95,6 +98,7 @@ export class GitService {
         path: path,
         branch,
         provider,
+        hostId,
       };
 
       await StorageService.addRepository(repo);

--- a/src/services/git/activeHost.ts
+++ b/src/services/git/activeHost.ts
@@ -19,6 +19,8 @@ export interface ActiveGitHost {
   baseUrl: string;
   token: string;
   host: GitHostFullService;
+  /** Host connection id this active host was resolved from. */
+  hostId: string;
 }
 
 /** Scratch cache so two callers in the same tick don't re-instantiate services. */
@@ -66,6 +68,7 @@ export async function getActiveGitHost(): Promise<ActiveGitHost | null> {
     baseUrl,
     token,
     host,
+    hostId: hostSummary.id,
   };
   cache = { key, value };
   return value;

--- a/src/services/git/repoRemovalCascade.ts
+++ b/src/services/git/repoRemovalCascade.ts
@@ -1,0 +1,65 @@
+import type { GitRepository } from '../GitService';
+import type { GitHostProvider } from './GitHost';
+
+/**
+ * Reference to a host connection (one token) that is being removed.
+ * `id` matches `HostConnection.id` / `ActiveGitHost.hostId`; `provider` is
+ * the host's provider so legacy (unstamped) repos can be matched by provider.
+ */
+export interface RemovedHostRef {
+  id: string;
+  provider: GitHostProvider;
+}
+
+/**
+ * Returns the subset of `repositories` that should be removed when the given
+ * hosts are removed. Pure: no mutation, returns a filtered array.
+ *
+ * A repo is affected when EITHER:
+ *  a) it was stamped with a `hostId` that is in the set of removed host ids; OR
+ *  b) it is a legacy (unstamped) repo whose `provider` (default 'github')
+ *     matches a removed host's provider AND that provider is used by no other
+ *     remaining account (`providerAccountCount.get(provider) ?? 0 <= 1`).
+ *     The `<= 1` guard keeps legacy repos in place on multi-account installs
+ *     where another account still uses the same provider.
+ */
+export function reposAffectedByRemovedHosts(
+  repositories: GitRepository[],
+  removedHosts: RemovedHostRef[],
+  providerAccountCount: ReadonlyMap<GitHostProvider, number>,
+): GitRepository[] {
+  const removedIds = new Set(removedHosts.map((h) => h.id));
+  const removedProviders = new Set(removedHosts.map((h) => h.provider));
+
+  return repositories.filter((repo) => {
+    if (repo.hostId) {
+      return removedIds.has(repo.hostId);
+    }
+    const provider = repo.provider ?? 'github';
+    if (!removedProviders.has(provider)) return false;
+    return (providerAccountCount.get(provider) ?? 0) <= 1;
+  });
+}
+
+/**
+ * Counts how many accounts have at least one host with each provider.
+ *
+ * Iterates the account summaries; per summary, collects its unique host
+ * providers into a Set, then increments the map once per unique provider.
+ * Multiple hosts on the same provider within one account count as one account.
+ */
+export function buildProviderAccountCount(
+  accountSummaries: Array<{ hosts: Array<{ provider: GitHostProvider }> }>,
+): Map<GitHostProvider, number> {
+  const counts = new Map<GitHostProvider, number>();
+  for (const summary of accountSummaries) {
+    const uniqueProviders = new Set<GitHostProvider>();
+    for (const host of summary.hosts) {
+      uniqueProviders.add(host.provider);
+    }
+    for (const provider of uniqueProviders) {
+      counts.set(provider, (counts.get(provider) ?? 0) + 1);
+    }
+  }
+  return counts;
+}

--- a/src/stores/repoStore.ts
+++ b/src/stores/repoStore.ts
@@ -16,6 +16,7 @@ import {
   checkGitHubRepoAccess,
   RepoAccessPreflightError,
 } from '../services/git/repoAccessPreflight';
+import { reposAffectedByRemovedHosts, type RemovedHostRef } from '../services/git/repoRemovalCascade';
 
 interface RepoState {
   repositories: GitRepository[];
@@ -35,6 +36,10 @@ interface RepoActions {
     options?: AddRepositoryOptions,
   ) => Promise<GitRepository>;
   removeRepository: (path: string, provider?: GitHostProvider) => Promise<void>;
+  removeRepositoriesForHosts: (
+    removedHosts: RemovedHostRef[],
+    providerAccountCount: ReadonlyMap<GitHostProvider, number>,
+  ) => Promise<number>;
   refreshRepos: () => Promise<void>;
 }
 
@@ -57,8 +62,8 @@ export const useRepoStore = create<RepoState & RepoActions>()((set, get) => ({
     const name = typeof nameOrOptions === 'string' ? nameOrOptions : undefined;
     const resolvedOptions = typeof nameOrOptions === 'object' ? nameOrOptions : options;
     const resolvedProvider = provider ?? 'github';
+    const activeHost = await getActiveGitHost();
     if (resolvedProvider === 'github') {
-      const activeHost = await getActiveGitHost();
       if (activeHost?.provider === 'github') {
         const access = await checkGitHubRepoAccess(path, activeHost.token);
         switch (access.kind) {
@@ -81,7 +86,7 @@ export const useRepoStore = create<RepoState & RepoActions>()((set, get) => ({
         }
       }
     }
-    const repo = await GitService.addRepository(path, name, resolvedProvider);
+    const repo = await GitService.addRepository(path, name, resolvedProvider, activeHost?.hostId);
     const updated = await StorageService.getSavedRepositories();
     set({ repositories: updated });
     return repo;
@@ -124,6 +129,14 @@ export const useRepoStore = create<RepoState & RepoActions>()((set, get) => ({
       useCanvasStore.getState().refreshCanvases(),
       useTodoStore.getState().refreshTodos(),
     ]);
+  },
+
+  removeRepositoriesForHosts: async (removedHosts, providerAccountCount) => {
+    const targets = reposAffectedByRemovedHosts(get().repositories, removedHosts, providerAccountCount);
+    for (const repo of targets) {
+      await get().removeRepository(repo.path, repo.provider);
+    }
+    return targets.length;
   },
 
   refreshRepos: async () => {


### PR DESCRIPTION
## Summary

When a user removes a token in Settings (Disconnect host, Remove account, or the legacy Remove token), the repositories synced with that token are now removed from the device too — with a confirmation alert that warns how many repos will be affected.

## Behavior

| Flow | Repos removed |
|---|---|
| Disconnect host | repos stamped with that host id |
| Remove account | repos stamped with any host of the account |
| Remove token (legacy) | repos stamped with the active host |

The Alert appends *"This will also remove {{count}} synced repo(s) from this device."* when affected repos exist. On confirm, repos go through the existing full `removeRepository` cleanup (template prefs, sync engine, cloned files, chat repo, note/canvas/todo purge).

## How it works

- `GitRepository` gains `hostId?`, stamped at add time (host connection == one token).
- `ActiveGitHost` returns `hostId`; `GitService.addRepository` accepts it; `repoStore.addRepository` passes the active host's id.
- Legacy unstamped repos are only removed when the removed host's provider has no other account (`providerAccountCount <= 1`) — safe for multi-account installs.
- Pure matching logic: `src/services/git/repoRemovalCascade.ts`.

## Tests

- `repoRemovalCascade.test.ts` — pure-helper unit tests
- `repoStore.test.ts` — `removeRepositoriesForHosts` action
- `SettingsScreen.test.tsx` — cascade alert + invocation
- i18n parity for `settings.cascadeRemoveWarning` in all 6 locales

## Verification

- `yarn ts:check` — clean
- `yarn jest` — 2305 passed, 0 failed
- `yarn eslint . --ext .ts,.tsx` — 0 errors (693 pre-existing warnings)

Wiki: `docs/wiki/repo-removal-cascade.md`