### PR TITLE
fix #901: sync queue retains note.delete items with attempts 0 forever

### DIFF
--- a/__tests__/services/NoteSyncQueueService.test.ts
+++ b/__tests__/services/NoteSyncQueueService.test.ts
@@ -556,6 +556,26 @@ describe('NoteSyncQueueService', () => {
         expect((deleteNoteFromGitHub as jest.Mock).mock.calls[0][0].push).toBe(false);
         (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
       });
+
+      test('clears a leftover clone-mode delete from the queue after a successful flush (issue #901)', async () => {
+        (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
+        (LocalGitWriter.push as jest.Mock).mockResolvedValue({ success: true });
+        (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({ success: true });
+
+        await NoteSyncQueueService.enqueueNoteDelete({
+          repo: 'r', branch: 'main', filePath: 'stale.md', title: 'stale',
+        });
+
+        const result = await NoteSyncQueueService.drain();
+
+        expect(result.succeeded).toBe(1);
+        expect(result.remaining).toBe(0);
+        expect(result.failed).toBe(0);
+        // The item must not linger at attempts 0 in the durable queue.
+        const items = await NoteSyncQueueService.getAll();
+        expect(items).toHaveLength(0);
+        (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
+      });
     });
 
     describe('api-mode (no coalescing)', () => {

--- a/__tests__/services/StagingService.test.ts
+++ b/__tests__/services/StagingService.test.ts
@@ -448,7 +448,9 @@ getCommitOid.mockResolvedValue(null);
           token: 'test-token',
         }),
       );
-      expect(queueDrain).not.toHaveBeenCalled();
+      // drain() is now unconditional so stale API-mode queue items in a
+      // clone-mode repo (issue #900) never get stranded.
+      expect(queueDrain).toHaveBeenCalledTimes(1);
     });
 
     test('clone push forwards onProgress to githubActivity.setProgress', async () => {
@@ -493,6 +495,34 @@ getCommitOid.mockResolvedValue(null);
       const result = await StagingService.pushStaged('owner/repo', 'main');
 
       expect(result).toEqual({ success: false, error: 'push rejected' });
+      expect(writerPush).toHaveBeenCalledTimes(1);
+    });
+
+    test('clone-mode repo with leftover API-mode queue items still drains (issue #900)', async () => {
+      queueGetAll.mockResolvedValue([
+        queueItem('note.delete', {
+          repo: 'owner/repo',
+          branch: 'main',
+          filePath: 'notes/stale.md',
+          title: 'stale',
+        }),
+      ]);
+      listOverrides.mockResolvedValue({ 'owner/repo': 'clone' });
+      getSavedRepositories.mockResolvedValue([
+        { id: '1', name: 'repo', path: 'owner/repo', branch: 'main' },
+      ]);
+      getCommitOid.mockImplementation(
+        async ({ ref }: { ref: string }) =>
+          ref.startsWith('refs/heads') ? 'local-oid' : 'remote-oid',
+      );
+
+      const result = await StagingService.pushStaged('owner/repo', 'main');
+
+      expect(result).toEqual({ success: true });
+      // The stale API-mode delete would previously be stranded: listStaged
+      // tags queue items with the repo's current mode (clone), so the old
+      // hasApi gate skipped drain entirely and the item sat at attempts 0.
+      expect(queueDrain).toHaveBeenCalledTimes(1);
       expect(writerPush).toHaveBeenCalledTimes(1);
     });
 

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -173,21 +173,19 @@ export class StagingService {
       if (staged.length === 0) return { success: true };
 
       const cloneKeys = new Map<string, { repoPath: string; branch: string }>();
-      let hasApi = false;
       for (const item of staged) {
         if (item.mode === 'clone') {
           cloneKeys.set(`${item.repoPath}\n${item.branch}`, {
             repoPath: item.repoPath,
             branch: item.branch,
           });
-        } else {
-          hasApi = true;
         }
       }
 
-      if (hasApi) {
-        await NoteSyncQueueService.drain();
-      }
+      // Always drain: listStaged tags leftover API-mode mutations with the
+      // repo's current mode, so a hasApi gate would strand queue items in
+      // clone-mode repos forever. drain() handles clone groups internally.
+      await NoteSyncQueueService.drain();
 
       if (cloneKeys.size > 0) {
         const token = await AuthService.getToken();


### PR DESCRIPTION
## Fixes
Closes #901 (stacked on fix #900 → #904; retarget to main after #904 merges)

## Root cause
Same root cause as #900: `pushStaged` gated `NoteSyncQueueService.drain()` behind a `hasApi` flag, and `listStaged` tags queue mutations with the repo's **current** sync mode. Leftover API-mode `note.delete` items in a clone-mode repo (queued before a mode switch, or left by an interrupted session) were classified as clone items → `hasApi` false → drain never ran → items sat at `attempts: 0` with `nextRetryAt: null` forever, even after the file was deleted remotely.

## Fix
The clearing behavior is delivered by fix #900's unconditional drain (this branch inherits it). This PR locks the **queue-retention contract** with a regression test: a leftover clone-mode `note.delete` is cleared from the durable queue after a successful drain + coalesced push (succeeded 1, remaining 0, queue empty).

## Tests
New regression test in `__tests__/services/NoteSyncQueueService.test.ts`: 'clears a leftover clone-mode delete from the queue after a successful flush (issue #901)'.

## Gates
- `yarn ts:check` clean
- NoteSyncQueueService.test.ts 60/60 pass
- eslint 0 errors

## Evidence
Found during simulator QA (FINDING-3): `.omo/evidence/push-perf-progress-qa/todo-10-qa-record.md` — `@gitnotes:sync_queue_v1` held note.delete items with attempts 0 even after remote delete succeeded.