### PR TITLE
fix #902: mixed API/clone repo state after interrupted sync session

### DIFF
--- a/__tests__/services/git/cloneMigration.test.ts
+++ b/__tests__/services/git/cloneMigration.test.ts
@@ -64,12 +64,19 @@ jest.mock('../../../src/services/NoteGitHubSyncService', () => ({
   applyNoteColorToContent: (content: string) => content,
 }));
 
+jest.mock('../../../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: { purgeForRepo: jest.fn(async () => undefined) },
+}));
+
 jest.mock('../../../src/services/TemplateMarkdownService', () => ({
   serializeTemplate: () => '---\n---\n',
   templateSlug: (s: string) => s,
 }));
 
 import { CloneMigrationService } from '../../../src/services/git/CloneMigrationService';
+import { NoteSyncQueueService } from '../../../src/services/NoteSyncQueueService';
+
+const purgeForRepo = NoteSyncQueueService.purgeForRepo as jest.Mock;
 
 function getLgwMocks() {
   return (globalThis as any).__lgwForMigrationTest as {
@@ -101,6 +108,9 @@ describe('CloneMigrationService.migrateRepo', () => {
       expect(call[0].push).toBe(false);
     }
     expect(getLgwMocks().push).not.toHaveBeenCalled();
+    // Leftover API-mode queue items for the migrated repo are purged so
+    // the Stage cannot show a mixed API/clone state (issue #902).
+    expect(purgeForRepo).toHaveBeenCalledWith('me/repo');
   });
 
   test('reports failures without pushing (the engine owns the flush)', async () => {

--- a/src/services/git/CloneMigrationService.ts
+++ b/src/services/git/CloneMigrationService.ts
@@ -1,6 +1,7 @@
 import { StorageService } from '../StorageService';
 import { GitHubService } from '../GitHubService';
 import { LocalGitWriter } from './LocalGitWriter';
+import { NoteSyncQueueService } from '../NoteSyncQueueService';
 import { TemplateRepoPreferenceService } from '../TemplateRepoPreferenceService';
 import { useTemplateStore } from '../../stores/templateStore';
 import { serializeTemplate, templateSlug } from '../TemplateMarkdownService';
@@ -167,6 +168,10 @@ export class CloneMigrationService {
           });
       }
     }
+
+    // Migration supersedes this repo's API-mode queue: drop leftovers so
+    // the Stage cannot show a mixed API/clone state (issue #902).
+    await NoteSyncQueueService.purgeForRepo(repoPath);
 
     if (report.failures.length > 0) report.success = report.failures.length === 0;
     return report;


### PR DESCRIPTION
## Fixes
Closes #902

## Root cause
When a repo is switched to clone mode, `CloneMigrationService.migrateRepo` re-writes every live local file into the clone but never reconciles the repo's leftover API-mode queue items (queued before the switch, or left by an interrupted session). `listStaged` tags those stale queue mutations with the repo's **current** mode, so the Stage rendered BOTH API DELETED badges AND clone unpushed-commit sections simultaneously — a mixed API/clone state.

## Fix
At the end of `migrateRepo` (the completion of the mode switch), call `NoteSyncQueueService.purgeForRepo(repoPath)` to drop the superseded API-mode queue items, tombstones, and delete failures for the migrated repo. Migration has already re-written all live content into the clone, so the queued mutations are redundant. The repo now presents a consistent clone-mode state.

## Tests
- Updated `__tests__/services/git/cloneMigration.test.ts`: mocks `NoteSyncQueueService.purgeForRepo` and asserts it is called with the migrated repo.

## Gates
- `yarn ts:check` clean
- cloneMigration.test.ts 3/3 pass
- eslint 0 errors

## Evidence
Found during simulator QA (FINDING-4): `.omo/evidence/push-perf-progress-qa/todo-10-qa-record.md` — `@gitnotes:sync_engine_modes` = clone while the API sync queue still held note.delete items; Stage showed both API DELETED badges and clone (unpushed commits) sections.