### PR TITLE
fix #901: sync queue retains note.delete items with attempts 0 forever

### DIFF
--- a/__tests__/services/NoteSyncQueueService.test.ts
+++ b/__tests__/services/NoteSyncQueueService.test.ts
@@ -556,6 +556,26 @@ describe('NoteSyncQueueService', () => {
         expect((deleteNoteFromGitHub as jest.Mock).mock.calls[0][0].push).toBe(false);
         (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
       });
+
+      test('clears a leftover clone-mode delete from the queue after a successful flush (issue #901)', async () => {
+        (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
+        (LocalGitWriter.push as jest.Mock).mockResolvedValue({ success: true });
+        (deleteNoteFromGitHub as jest.Mock).mockResolvedValue({ success: true });
+
+        await NoteSyncQueueService.enqueueNoteDelete({
+          repo: 'r', branch: 'main', filePath: 'stale.md', title: 'stale',
+        });
+
+        const result = await NoteSyncQueueService.drain();
+
+        expect(result.succeeded).toBe(1);
+        expect(result.remaining).toBe(0);
+        expect(result.failed).toBe(0);
+        // The item must not linger at attempts 0 in the durable queue.
+        const items = await NoteSyncQueueService.getAll();
+        expect(items).toHaveLength(0);
+        (SyncEngineService.getMode as jest.Mock).mockResolvedValue('api');
+      });
     });
 
     describe('api-mode (no coalescing)', () => {


### PR DESCRIPTION
## Fixes
Closes #901 (supersedes closed PR #905; the base branch it stacked on was deleted after fix #900 merged)

## Root cause
Same root cause as #900: `pushStaged` gated `NoteSyncQueueService.drain()` behind a `hasApi` flag, and `listStaged` tags queue mutations with the repo's **current** sync mode. Leftover API-mode `note.delete` items in a clone-mode repo were classified as clone items → `hasApi` false → drain never ran → items sat at `attempts: 0` with `nextRetryAt: null` forever, even after the file was deleted remotely.

## Fix
The clearing behavior is delivered by fix #900's unconditional drain (already merged to main via #904). This PR locks the **queue-retention contract** with a regression test: a leftover clone-mode `note.delete` is cleared from the durable queue after a successful drain + coalesced push (succeeded 1, remaining 0, queue empty).

## Tests
Regression test in `__tests__/services/NoteSyncQueueService.test.ts`: 'clears a leftover clone-mode delete from the queue after a successful flush (issue #901)'.

## Gates
- `yarn ts:check` clean
- NoteSyncQueueService.test.ts 64/64 pass
- eslint 0 errors

## Evidence
Found during simulator QA (FINDING-3): `.omo/evidence/push-perf-progress-qa/todo-10-qa-record.md` — `@gitnotes:sync_queue_v1` held note.delete items with attempts 0 even after remote delete succeeded.