### PR TITLE
fix(sync): prevent data loss after push+restart; fix progress ring + foreground notifications

### DIFF
--- a/__tests__/components/useNoteEditorDocument.stage.test.tsx
+++ b/__tests__/components/useNoteEditorDocument.stage.test.tsx
@@ -123,7 +123,7 @@ describe('useNoteEditorDocument stage-push rework', () => {
     );
   });
 
-  it('stages a new root-level note with a real path and no fallback toast', async () => {
+  it('stages a new note under notes/ by default so the pull can re-import it after restart', async () => {
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
     (StagingService.stageUpsert as jest.Mock).mockResolvedValue({ success: true });
     const createNote = jest.fn(async () => ({ id: 'new-root-note' }));
@@ -148,12 +148,14 @@ describe('useNoteEditorDocument stage-push rework', () => {
     });
 
     expect(StagingService.stageUpsert).toHaveBeenCalledTimes(1);
+    // A brand-new note defaults into notes/ (matching deriveDefaultNotePath),
+    // NOT the repo root — a root-level file is invisible to the pull's
+    // notes/* import filter and appears "gone" after push + restart.
     expect(StagingService.stageUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({ filePath: 'my-note.md', repo: 'owner/repo', branch: 'main' }),
+      expect.objectContaining({ filePath: 'notes/my-note.md', repo: 'owner/repo', branch: 'main' }),
     );
-    // A root note now gets a real syncPath, so metadata is persisted and nothing re-enqueues.
     expect(updateNote).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'new-root-note', filePath: 'my-note.md' }),
+      expect.objectContaining({ id: 'new-root-note', filePath: 'notes/my-note.md' }),
     );
     expect(NoteSyncQueueService.enqueueNoteUpsert).not.toHaveBeenCalled();
     expect(alertSpy).not.toHaveBeenCalledWith(SAVED_LOCALLY_TITLE, SAVED_LOCALLY_BODY, [

--- a/__tests__/services/PushNotificationService.test.ts
+++ b/__tests__/services/PushNotificationService.test.ts
@@ -26,6 +26,15 @@ jest.mock('../../src/stores/stageStore', () => ({
   useStageStore: { subscribe: mockSubscribe },
 }));
 
+let mockAppState = 'background';
+jest.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return mockAppState;
+    },
+  },
+}));
+
 let pushService: typeof import('../../src/services/PushNotificationService');
 
 describe('PushNotificationService', () => {
@@ -33,6 +42,7 @@ describe('PushNotificationService', () => {
     jest.useFakeTimers();
     jest.setSystemTime(5000);
     jest.clearAllMocks();
+    mockAppState = 'background';
     jest.isolateModules(() => {
       pushService = require('../../src/services/PushNotificationService');
     });
@@ -137,6 +147,27 @@ describe('PushNotificationService', () => {
     expect(completionContent.title).toBe('Push complete');
     expect(completionContent.body).toBe('All staged changes pushed to GitHub');
     expect(completionContent.data).toEqual({ kind: 'push-complete' });
+  });
+
+  test('no notifications fire while the app is foregrounded (start/progress/completion)', () => {
+    mockAppState = 'active';
+    pushService.subscribeToPushProgress();
+    const listener = mockSubscribe.mock.calls[0][0] as ProgressListener;
+
+    listener(
+      { isPushing: { a: true }, pendingCount: 3, pushProgress: null },
+      { isPushing: {}, pendingCount: 3, pushProgress: null },
+    );
+    listener(
+      { isPushing: { a: true }, pendingCount: 3, pushProgress: 0.5 },
+      { isPushing: { a: true }, pendingCount: 3, pushProgress: 0.25 },
+    );
+    listener(
+      { isPushing: {}, pendingCount: 0, pushProgress: null },
+      { isPushing: { a: true }, pendingCount: 3, pushProgress: 1 },
+    );
+
+    expect(mockDismissAndReschedule).not.toHaveBeenCalled();
   });
 
   test('resolvePushFailureRoute maps plain failures to stage and conflicts to conflicts', () => {

--- a/__tests__/services/RepoPullService.data-loss-guard.test.ts
+++ b/__tests__/services/RepoPullService.data-loss-guard.test.ts
@@ -127,4 +127,34 @@ describe('RepoPullService reconcile data-loss guard', () => {
     const saved = (StorageService.saveAllNotes as jest.Mock).mock.calls[0][0] as unknown[];
     expect(saved.map((n) => (n as { id: string }).id)).not.toContain('local-1');
   });
+
+  it('keeps a pushed root-level note (repo root, not notes/ prefix) that exists on the remote (issue: notes gone after push+restart)', async () => {
+    // The note was pushed successfully and lives at the REPO ROOT
+    // (folder = None in the editor). It is in the remote tree, but NOT under
+    // notes/ — this is the exact state right after a successful push + restart.
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
+      { type: 'blob', path: 'qa-data-loss-test.md', sha: 'a' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock)
+      .mockResolvedValueOnce('# QA Data Loss Test');
+
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([
+      {
+        id: 'local-1',
+        title: 'QA Data Loss Test',
+        content: '# QA Data Loss Test',
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: 'qa-data-loss-test.md',
+        format: 'markdown',
+      },
+    ]);
+    // Push already succeeded → queue is empty → no pending-path protection.
+    (NoteSyncQueueService.getAll as jest.Mock).mockResolvedValue([]);
+
+    await pullFromSingleRepo('org/repo');
+
+    const saved = (StorageService.saveAllNotes as jest.Mock).mock.calls[0][0] as unknown[];
+    expect(saved.map((n) => (n as { id: string }).id)).toContain('local-1');
+  });
 });

--- a/__tests__/services/RepoPullService.data-loss-guard.test.ts
+++ b/__tests__/services/RepoPullService.data-loss-guard.test.ts
@@ -1,0 +1,130 @@
+jest.mock('../../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getTreeRecursiveOrThrow: jest.fn(),
+    getFileContent: jest.fn(),
+    getRepoContents: jest.fn(async () => []),
+    updateFile: jest.fn(async () => ({ ok: true })),
+  },
+}));
+
+jest.mock('../../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(),
+    getAllNotes: jest.fn(),
+    saveAllNotes: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/services/GitService', () => ({
+  GitService: {
+    invalidateRepoFoldersCache: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock('../../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    getAll: jest.fn(async () => []),
+    isTombstoned: jest.fn(async () => false),
+  },
+}));
+
+jest.mock('../../src/services/SyncEngineService', () => ({
+  SyncEngineService: {
+    getMode: jest.fn(async () => 'api'),
+  },
+}));
+
+jest.mock('../../src/services/git/GitFsService', () => ({
+  GitFsService: {
+    listTree: jest.fn(async () => []),
+    isCloned: jest.fn(async () => true),
+    pullWithFastForward: jest.fn(async () => ({ ok: true })),
+  },
+}));
+
+import { pullFromSingleRepo } from '../../src/services/RepoPullService';
+import { GitHubService } from '../../src/services/GitHubService';
+import { StorageService } from '../../src/services/StorageService';
+import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
+
+describe('RepoPullService reconcile data-loss guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([
+      { path: 'org/repo', branch: 'main' },
+    ]);
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('keeps a locally-staged note that has not reached the remote yet (issue: notes gone after push+restart)', async () => {
+    // Remote tree does NOT contain the note yet — the push has not landed.
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
+      { type: 'blob', path: 'notes/remote-only.md', sha: 'a' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock)
+      .mockResolvedValueOnce('# Remote only');
+
+    // The local note is staged: it has a filePath but its mutation is still
+    // pending in the sync queue (API mode). This is the state right after
+    // saving a note and before/while the push runs.
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([
+      {
+        id: 'local-1',
+        title: 'Local staged',
+        content: '# Local',
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: 'notes/local-staged.md',
+        format: 'markdown',
+      },
+    ]);
+    (NoteSyncQueueService.getAll as jest.Mock).mockResolvedValue([
+      {
+        id: 'm-1',
+        type: 'note.upsert',
+        attempts: 0,
+        params: {
+          repo: 'org/repo',
+          branch: 'main',
+          filePath: 'notes/local-staged.md',
+        },
+      },
+    ]);
+
+    await pullFromSingleRepo('org/repo');
+
+    // The staged note must survive the reconcile — it was not deleted on the
+    // remote, it simply has not been pushed yet.
+    const saved = (StorageService.saveAllNotes as jest.Mock).mock.calls[0][0] as unknown[];
+    expect(saved.map((n) => (n as { id: string }).id)).toContain('local-1');
+  });
+
+  it('drops a local note whose file was truly deleted on the remote (no pending mutation)', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
+      { type: 'blob', path: 'notes/remote-only.md', sha: 'a' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock)
+      .mockResolvedValueOnce('# Remote only');
+
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([
+      {
+        id: 'local-1',
+        title: 'Local staged',
+        content: '# Local',
+        repo: 'org/repo',
+        branch: 'main',
+        filePath: 'notes/deleted-remotely.md',
+        format: 'markdown',
+      },
+    ]);
+    // No pending mutation for that path — the remote genuinely no longer has it.
+    (NoteSyncQueueService.getAll as jest.Mock).mockResolvedValue([]);
+
+    await pullFromSingleRepo('org/repo');
+
+    const saved = (StorageService.saveAllNotes as jest.Mock).mock.calls[0][0] as unknown[];
+    expect(saved.map((n) => (n as { id: string }).id)).not.toContain('local-1');
+  });
+});

--- a/docs/wiki/stage-push-ux.md
+++ b/docs/wiki/stage-push-ux.md
@@ -107,9 +107,10 @@ value, range 0..1):
 
 - When `pushProgress` is a number, `ringProgress` follows it directly, giving
   the user real progress feedback.
-- When `pushProgress` is `null` (API-mode drain where total item count is
-  unknown), the ring clamps at 0.9. This avoids an infinite indeterminate
-  animation while still signaling activity.
+- When `pushProgress` is `null` (total unknown, e.g. clone push before
+  transport progress lands), the ring holds a small `0.15` arc — it reads
+  "working", not "almost done". (Previously clamped at 0.9, which made a push
+  look ~90% complete from the start.)
 - When no push is in flight, the ring resets to 0.
 
 The progress fraction comes from `StagePushScheduler.drainPushQueue`, which
@@ -142,6 +143,29 @@ the scheduled notification and dismisses any presented one, then re-schedules
 under the same `PUSH_NOTIFICATION_ID` with a `TIME_INTERVAL` trigger of
 `seconds: 1`. This works around expo-notifications having no in-place update
 API.
+
+All push progress notifications are **suppressed while the app is in the
+foreground** (`AppState.currentState === 'active'`) — the in-app ring and the
+githubActivity banner already communicate progress, so a banner would be
+redundant noise. Notifications fire only when the push runs while the app is
+backgrounded.
+
+### 9. Data safety: note paths and the pull reconcile
+
+A note's backing file path is its identity across devices. Two rules keep a
+pushed note from appearing "gone" after a restart:
+
+- **New notes default into `notes/`.** The editor writes a brand-new note
+  (no folder) to `notes/<slug>.<ext>` — matching `deriveDefaultNotePath` in
+  `noteStore` — so the pull's `notes/*` import filter can re-import it after a
+  push + restart. Writing to the repo root would leave the file on GitHub but
+  invisible to the app.
+- **The reconcile never drops a file that exists on the remote.** The pull
+  builds its "still exists" set from **all** tree blobs (not just `notes/*`),
+  so a note at the repo root or in a custom folder is not mistaken for a
+  remote deletion. Staged-but-unpushed paths are also protected (pending sync
+  queue mutations in API mode; the local branch tree in clone mode), so a
+  restart mid-push cannot drop local work.
 
 ### 8. Resume on foreground
 
@@ -188,7 +212,8 @@ remain in the sync queue.
   rewritten for the vanish contract — deletes remove rows immediately, failures
   surface via the Stage screen, and no row ever renders a lock spinner.
 - `__tests__/components/FloatingStageButton.test.tsx`: progress ring follows
-  `storePushProgress`, clamps at 0.9 when null, resets when idle.
+  `storePushProgress`, holds a small 0.15 arc when total is unknown, resets
+  when idle.
 - `__tests__/services/StagePushScheduler.test.ts`: `drainPushQueue` forwards
   progress fraction to `stageStore.setPushProgress`; resets `pushProgress` to
   null when the queue empties.

--- a/src/components/editor/useNoteEditorDocument.ts
+++ b/src/components/editor/useNoteEditorDocument.ts
@@ -359,8 +359,15 @@ export function useNoteEditorDocument({
       }
 
       if (repo && savedNoteId) {
+        // Default a brand-new note into `notes/` (matching
+        // deriveDefaultNotePath) so the pull reconcile can re-import it after
+        // a push + restart. Writing to the repo root (the old fallback) left
+        // the file on GitHub but invisible to the notes/ import filter — the
+        // note appeared "gone" after restart (data-loss report).
+        const defaultSlug = `${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}`;
         const syncPath =
-          existingFilePath ?? (folderPath ? `${folderPath}/${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}` : `${slugifyLocal(title.trim())}${getExtensionForFormat(noteFormat)}`);
+          existingFilePath ??
+          (folderPath ? `${folderPath}/${defaultSlug}` : `notes/${defaultSlug}`);
         const upsertOpId = syncPath
           ? gitOperationRegistry.begin({
               kind: 'upsert',

--- a/src/components/git/FloatingStageButton.tsx
+++ b/src/components/git/FloatingStageButton.tsx
@@ -66,7 +66,9 @@ export function FloatingStageButton({ currentRouteName }: FloatingStageButtonPro
     } else if (storePushProgress !== null) {
       ringProgress.value = storePushProgress;
     } else {
-      ringProgress.value = 0.9;
+      // Total unknown (e.g. clone push before transport progress lands):
+      // show a small arc so the ring reads "working", not "almost done".
+      ringProgress.value = 0.15;
     }
   }, [anyPushing, storePushProgress, ringProgress]);
 

--- a/src/services/PushNotificationService.ts
+++ b/src/services/PushNotificationService.ts
@@ -1,8 +1,14 @@
+import { AppState } from 'react-native';
 import { setOnPushFailure } from './StagePushScheduler';
 import { useStageStore } from '../stores/stageStore';
 import { NotificationService } from './NotificationService';
 
 const PROGRESS_THROTTLE_MS = 1000;
+
+/** Foregrounded app shows progress in-UI (ring + activity banner) — no banner needed. */
+function appIsForegrounded(): boolean {
+  return AppState.currentState === 'active';
+}
 
 let lastProgressSentAt = 0;
 let unsubscribeProgress: (() => void) | null = null;
@@ -46,6 +52,7 @@ export function subscribeToPushProgress(): void {
   unsubscribeProgress = useStageStore.subscribe((state, prevState) => {
     const wasPushing = Object.values(prevState.isPushing).some(Boolean);
     const isPushing = Object.values(state.isPushing).some(Boolean);
+    if (appIsForegrounded()) return;
 
     if (isPushing && !wasPushing) {
       pushTotal = state.pendingCount;

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -370,10 +370,15 @@ async function pullNotesFromRepo(
 
     // Build a set of remote file paths we successfully observed. The set is
     // the basis for reconciling local notes against the remote tree below.
-    // We populate it from `noteBlobs` (the full list of relevant remote
-    // entries) — not `fetched` — so a transient per-file fetch failure does
-    // not cause us to drop a still-existing local note.
-    const remoteFilePaths = new Set<string>(noteBlobs.map((b) => b.path));
+    // We populate it from ALL tree blob paths — NOT just the notes/*-filtered
+    // `noteBlobs` — because a note's backing file can live at the repo root or
+    // in any custom folder (the editor writes filePath wherever the user
+    // chooses). Restricting the set to notes/* made root-level notes look
+    // "deleted on the remote" after a successful push, so the reconcile
+    // dropped them from the local index — data loss after push + restart.
+    const remoteFilePaths = new Set<string>(
+      tree.filter((item) => item.type === 'blob').map((b) => b.path),
+    );
 
     // Protect locally-staged-but-unpushed notes from the remote reconcile.
     // With stage-then-push, `updateNote({ filePath })` runs at SAVE time, so

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -209,6 +209,38 @@ async function fetchDirectoryFiles(
 
 const NOTE_EXTS = ['md', 'markdown', 'norg', 'org', 'txt'] as const;
 
+/**
+ * Paths that exist locally (staged but not yet pushed) and must be immune to
+ * the remote reconcile. API mode: pending sync-queue mutations. Clone mode:
+ * the local branch tree, which includes unpushed local commits — otherwise a
+ * pull that races an in-flight push would see the remote without the note and
+ * drop the local copy (data loss after restart).
+ */
+async function collectPendingPaths(
+  repoPath: string,
+  branch: string,
+  mode: 'api' | 'clone',
+  prefix: string,
+): Promise<string[]> {
+  if (mode === 'clone') {
+    try {
+      const tree = await GitFsService.listTree({ repoPath, ref: branch });
+      return tree.filter((e) => e.type === 'blob' && e.path.startsWith(prefix)).map((e) => e.path);
+    } catch {
+      return [];
+    }
+  }
+  try {
+    const queue = await NoteSyncQueueService.getAll();
+    return queue
+      .filter((m) => m.params.repo === repoPath && (m.params.branch ?? 'main') === branch)
+      .map((m) => m.params.filePath ?? '')
+      .filter((p) => p.startsWith(prefix));
+  } catch {
+    return [];
+  }
+}
+
 function noteFormatFromExt(ext: string): 'markdown' | 'neorg' | 'org' {
   if (ext === 'norg') return 'neorg';
   if (ext === 'org') return 'org';
@@ -342,6 +374,16 @@ async function pullNotesFromRepo(
     // entries) — not `fetched` — so a transient per-file fetch failure does
     // not cause us to drop a still-existing local note.
     const remoteFilePaths = new Set<string>(noteBlobs.map((b) => b.path));
+
+    // Protect locally-staged-but-unpushed notes from the remote reconcile.
+    // With stage-then-push, `updateNote({ filePath })` runs at SAVE time, so
+    // a note can carry a filePath before its push has reached GitHub (queue
+    // pending in API mode, unpushed local commit in clone mode). Dropping it
+    // here would DELETE a note the user just wrote — data loss after a
+    // restart mid-push. Only drop a note when we are sure the remote no
+    // longer has it AND nothing local is waiting to push it.
+    const protectedPaths = await collectPendingPaths(repoPath, branch, reader.mode, 'notes/');
+    for (const p of protectedPaths) remoteFilePaths.add(p);
 
     let allNotes = await StorageService.getAllNotes();
     let pulled = 0;
@@ -648,12 +690,21 @@ async function pullTodosFromRepo(
     }
 
     // Reconcile: drop local todos whose backing file was deleted remotely.
-    // Same safety scoping as notes and canvases reconcile.
+    // Same safety scoping as notes and canvases reconcile — but never drop
+    // a todo that is staged-but-unpushed (pending queue / unpushed local
+    // commit), otherwise a restart mid-push loses it (data loss, mirrors the
+    // notes protection).
+    const todoPending = new Set<string>();
+    const todoMode = await SyncEngineService.getMode(repoPath);
+    for (const p of await collectPendingPaths(repoPath, branch, todoMode, 'todos/')) {
+      todoPending.add(p);
+    }
     const before = allTodos.length;
     const reconciled = allTodos.filter((t) => {
       if (t.repo !== repoPath) return true;
       if (t.branch !== branch) return true;
       if (!t.filePath) return true;
+      if (todoPending.has(t.filePath)) return true;
       if (!directoryExists) return false;
       return remotePaths.has(t.filePath);
     });


### PR DESCRIPTION
## Fixes
Closes the user-reported data-loss bug: **notes disappear after pushing and restarting the app**.
Also fixes: progress ring showing ~90% at push start, and push notifications firing while the app is in the foreground.

## Root causes (all verified on simulator + regression tests)

### 1. DATA LOSS — notes gone after push + restart (critical)
Two interacting bugs:
- The editor (`useNoteEditorDocument`) saved a brand-new note (no folder) to the repo **root** (`my-note.md`), but the pull's import filter only reads `notes/*`. The note reached GitHub but the app couldn't re-import it — after restart it appeared gone, and a fresh install lost it entirely.
- The pull reconcile (`RepoPullService.pullNotesFromRepo`) built `remoteFilePaths` from `notes/*` blobs only. A note whose backing file lived at the repo root (or any custom folder) was treated as *deleted on the remote* and dropped from the local index — even though it was safely on GitHub.

### 2. Progress ring at ~90%
`FloatingStageButton` clamped unknown-total progress to `0.9` — a push with an unknown total looked 90% done from the start, then jumped to 100%.

### 3. Foreground notifications
`PushNotificationService.subscribeToPushProgress` fired start/progress/completion banners regardless of app foreground state.

## Fixes
1. **Editor**: default new-note path into `notes/` (matching `deriveDefaultNotePath` in noteStore) instead of the repo root.
2. **Reconcile**: build `remoteFilePaths` from ALL tree blobs (not just `notes/*`), plus protect staged-but-unpushed paths (pending sync-queue mutations in API mode; local branch tree in clone mode) so a restart mid-push cannot drop a local note/todo.
3. **Ring**: unknown-total now shows a small `0.15` arc ("working"), not `0.9`.
4. **Notifications**: suppressed while `AppState.currentState === 'active'` (in-app ring + activity banner already communicate progress).

## Verification (simulator, real token)
- **test-notes repo cleared** → created note → pushed → **restarted app → note survived**
- Second note created + pushed → both on GitHub under `notes/`
- Button shows `busy` during push; no notification banner while foregrounded

## Gates
- `yarn ts:check` clean
- `yarn test --ci` (CI-exact parallel): **2355 pass / 0 fail**
- `yarn eslint` on changed files: 0 errors (7 pre-existing warnings)

## Not fixed this round
- **#909** — intermittent native SIGSEGV on iOS simulator (rapid relaunch / secure-field typing). Separate native-module lifecycle investigation.
