### PR TITLE
fix(explore): remove black box outline around repo-detail branch row

### DIFF
--- a/docs/wiki/theme-styling.md
+++ b/docs/wiki/theme-styling.md
@@ -420,3 +420,13 @@ getting cut off at the bottom. The tag input row also carries 16px of
 horizontal padding so it aligns with the other NoteEditor form rows (title,
 folder, format). See `src/components/ui/Input.tsx` and
 `src/components/TagInput.tsx`.
+
+### Hairline border gotcha
+
+`borderWidth: StyleSheet.hairlineWidth` sets the width on **all four sides**.
+If only `borderTopColor` is set, the other three sides fall back to React
+Native's default black border — e.g. the Explore repo-detail branch row
+rendered with a black box outline around the branch name. Prefer the
+`border-t` NativeWind class (top border only) plus an explicit
+`borderTopColor`, and only use `borderWidth` when `borderColor` is also set.
+See `src/screens/ExploreScreen.tsx`.

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -285,7 +285,7 @@ export default function ExploreScreen() {
           </View>
 
           {selectedRepo.branch && (
-            <View className="flex-row items-center gap-1.5 mt-3 pt-3 border-t" style={{ borderTopColor: 'rgba(150,150,150,0.2)', borderWidth: StyleSheet.hairlineWidth }}>
+            <View className="flex-row items-center gap-1.5 mt-3 pt-3 border-t" style={{ borderTopColor: 'rgba(150,150,150,0.2)' }}>
               <Ionicons name="git-branch-outline" size={14} color={colors.textSecondary} />
               <Text className="text-xs" style={{ color: colors.textSecondary }}>
                 {selectedRepo.branch}


### PR DESCRIPTION
## Summary

The branch selector row in the Explore **repo detail** view rendered with a **black box outline** around it — looking unstyled/buggy.

**Root cause** (`ExploreScreen.tsx` line 288):
```jsx
<View className="... border-t" style={{ borderTopColor: 'rgba(150,150,150,0.2)', borderWidth: StyleSheet.hairlineWidth }}>
```
`borderWidth: StyleSheet.hairlineWidth` sets border width on **all four sides**, but only `borderTopColor` was specified — so the left/right/bottom borders fell back to React Native's default **black** border color. Pixel analysis of the screenshot confirmed black hairlines at the row's left/right/bottom edges (top was light gray as intended).

**Fix**: removed the stray `borderWidth` — the `border-t` class provides the intended light-gray top separator and the other sides stay borderless.

Also added a wiki note about the `hairlineWidth` + missing `borderColor` gotcha to `docs/wiki/theme-styling.md`.

## Verification
- `yarn ts:check` ✓
- `yarn eslint src/screens/ExploreScreen.tsx` ✓
- `yarn jest __tests__/screens/ExploreScreen.test.tsx` — 5/5 pass