### PR TITLE
feat(paywall): show locked features to free users instead of hiding them

### DIFF
--- a/__tests__/components/notes/NotesViewModePicker.graph-lock.test.tsx
+++ b/__tests__/components/notes/NotesViewModePicker.graph-lock.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * QA for the paywall graph-lock in NotesViewModePicker.
+ *
+ * When `mode === 'graph' && !isPro`, the graph option shows a lock-closed icon
+ * and pressing it calls `onLockedPress()` instead of `onChange('graph')`.
+ * Pro users keep the normal `onChange('graph')` flow with no lock icon, and
+ * non-graph modes always call `onChange(mode)` regardless of tier.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+jest.mock('../../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      primary: '#2563eb',
+      text: '#111',
+      textSecondary: '#666',
+      border: '#ddd',
+    },
+  }),
+}));
+
+// RN's Modal is already mocked by @react-native/jest-preset (renders children
+// when `visible !== false`), so rendering with `visible: true` mounts the sheet.
+
+import { NotesViewModePicker } from '../../../src/components/notes/NotesViewModePicker';
+
+const GRAPH_TEST_ID = 'notes-view-mode.button.change-graph';
+const LIST_TEST_ID = 'notes-view-mode.button.change-list';
+// The global @expo/vector-icons mock (jest.setup.ts) renders an icon as a View
+// with testID `icon-<name>`, so a lock icon surfaces as `icon-lock-closed`.
+const LOCK_ICON_TEST_ID = 'icon-lock-closed';
+
+function renderPicker(overrides: Partial<React.ComponentProps<typeof NotesViewModePicker>> = {}) {
+  const props = {
+    visible: true,
+    viewMode: 'list' as const,
+    onClose: jest.fn(),
+    onChange: jest.fn(),
+    isPro: false,
+    onLockedPress: jest.fn(),
+    ...overrides,
+  };
+  const utils = render(<NotesViewModePicker {...props} />);
+  return { ...utils, props };
+}
+
+describe('NotesViewModePicker graph lock', () => {
+  it('calls onLockedPress instead of onChange when a free user presses the graph option', () => {
+    const { getByTestId, props } = renderPicker();
+    fireEvent.press(getByTestId(GRAPH_TEST_ID));
+    expect(props.onLockedPress).toHaveBeenCalledTimes(1);
+    expect(props.onChange).not.toHaveBeenCalled();
+  });
+
+  it('shows a lock-closed icon on the graph option for a free user', () => {
+    const { queryByTestId } = renderPicker();
+    expect(queryByTestId(LOCK_ICON_TEST_ID)).not.toBeNull();
+  });
+
+  it('calls onChange("graph") for a pro user and never onLockedPress', () => {
+    const { getByTestId, props } = renderPicker({ isPro: true });
+    fireEvent.press(getByTestId(GRAPH_TEST_ID));
+    expect(props.onChange).toHaveBeenCalledTimes(1);
+    expect(props.onChange).toHaveBeenCalledWith('graph');
+    expect(props.onLockedPress).not.toHaveBeenCalled();
+  });
+
+  it('does not show a lock icon on the graph option for a pro user', () => {
+    const { queryByTestId } = renderPicker({ isPro: true });
+    expect(queryByTestId(LOCK_ICON_TEST_ID)).toBeNull();
+  });
+
+  it('calls onChange for non-graph modes for a free user (regression guard)', () => {
+    const { getByTestId, props } = renderPicker();
+    fireEvent.press(getByTestId(LIST_TEST_ID));
+    expect(props.onChange).toHaveBeenCalledTimes(1);
+    expect(props.onChange).toHaveBeenCalledWith('list');
+    expect(props.onLockedPress).not.toHaveBeenCalled();
+  });
+
+  it('calls onChange for non-graph modes for a pro user (regression guard)', () => {
+    const { getByTestId, props } = renderPicker({ isPro: true });
+    fireEvent.press(getByTestId(LIST_TEST_ID));
+    expect(props.onChange).toHaveBeenCalledTimes(1);
+    expect(props.onChange).toHaveBeenCalledWith('list');
+    expect(props.onLockedPress).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/settings/SettingsContent.pro-gate.test.tsx
+++ b/__tests__/components/settings/SettingsContent.pro-gate.test.tsx
@@ -54,8 +54,21 @@ jest.mock('../../../src/components/settings/ReminderSection', () => {
 });
 
 import React from 'react';
+import { Alert } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
+import { useTranslation } from 'react-i18next';
 import { SettingsContent } from '../../../src/components/settings/SettingsContent';
+import { promptProUpgrade } from '../../../src/utils/proAlerts';
+
+// Locked AI rows route through promptProUpgrade (src/utils/proAlerts.ts), which
+// shows an Alert and only calls onOpenPaywall from the upgrade button handler.
+// Auto-confirm that button so pressing a locked row can be asserted directly.
+function autoConfirmUpgradeAlert() {
+  return jest.spyOn(Alert, 'alert').mockImplementation((_title, _message, buttons) => {
+    const upgrade = (buttons ?? []).find((b: any) => b.style !== 'cancel');
+    upgrade?.onPress?.();
+  });
+}
 
 function renderContent(props: Record<string, unknown> = {}) {
   const base = {
@@ -91,6 +104,7 @@ function renderContent(props: Record<string, unknown> = {}) {
     onRemoveToken: jest.fn(),
     onDisconnectHost: jest.fn(),
     onAddHost: jest.fn(),
+    onAddHostLocked: jest.fn(),
     onOpenRepoPicker: jest.fn(),
     onSyncRepo: jest.fn(),
     onRemoveRepo: jest.fn(),
@@ -141,20 +155,61 @@ describe('Settings Pro section', () => {
     expect(queryByTestId('settings.row.ai-locked')).toBeNull();
   });
 
-  it('replaces the AI section with a locked row for a free user', () => {
-    const onOpenPaywall = jest.fn();
-    const { getByTestId, queryByTestId } = renderContent({ isPro: false, onOpenPaywall });
-    expect(getByTestId('settings.row.ai-locked')).toBeTruthy();
+  it('shows all AI feature rows locked for a free user (no collapsed row, no toggle)', () => {
+    const { getByTestId, queryByTestId } = renderContent({ isPro: false });
+    expect(queryByTestId('settings.row.ai-locked')).toBeNull();
     expect(queryByTestId('settings.toggle.ai')).toBeNull();
-    fireEvent.press(getByTestId('settings.row.ai-locked'));
-    expect(onOpenPaywall).toHaveBeenCalledTimes(1);
+    expect(getByTestId('settings.row.ai-locked-enable')).toBeTruthy();
+    expect(getByTestId('settings.row.ai-locked-daily-quote')).toBeTruthy();
+    expect(getByTestId('settings.row.ai-locked-personalization')).toBeTruthy();
+    expect(getByTestId('settings.row.ai-locked-github-tools')).toBeTruthy();
   });
 
-  it('hides the secondary AI rows (model selector, action mode, providers) for a free user', () => {
-    const { queryByTestId } = renderContent({ isPro: false, isAIEnabled: true });
+  it('routes to the paywall when a free user presses any locked AI feature row', () => {
+    const onOpenPaywall = jest.fn();
+    const alertSpy = autoConfirmUpgradeAlert();
+    const { getByTestId } = renderContent({ isPro: false, onOpenPaywall });
+    const lockedRows = [
+      'settings.row.ai-locked-enable',
+      'settings.row.ai-locked-daily-quote',
+      'settings.row.ai-locked-personalization',
+      'settings.row.ai-locked-github-tools',
+    ];
+    lockedRows.forEach((row, index) => {
+      fireEvent.press(getByTestId(row));
+      expect(onOpenPaywall).toHaveBeenCalledTimes(index + 1);
+    });
+    alertSpy.mockRestore();
+  });
+
+  it('shows the secondary AI config rows locked for a free user (no pro controls)', () => {
+    const { getByTestId, queryByTestId } = renderContent({ isPro: false });
+    expect(getByTestId('settings.row.ai-locked-model')).toBeTruthy();
+    expect(getByTestId('settings.row.ai-locked-action-mode')).toBeTruthy();
+    expect(getByTestId('settings.row.ai-locked-chat-storage')).toBeTruthy();
+    expect(getByTestId('settings.row.ai-locked-reset-memory')).toBeTruthy();
+    expect(getByTestId('settings.row.ai-locked-add-provider')).toBeTruthy();
     expect(queryByTestId('settings.button.model-selector')).toBeNull();
     expect(queryByTestId('settings.button.toggle-action-mode')).toBeNull();
     expect(queryByTestId('settings.button.add-provider')).toBeNull();
+  });
+
+  it('routes to the paywall when a free user presses any locked secondary AI row', () => {
+    const onOpenPaywall = jest.fn();
+    const alertSpy = autoConfirmUpgradeAlert();
+    const { getByTestId } = renderContent({ isPro: false, onOpenPaywall });
+    const lockedRows = [
+      'settings.row.ai-locked-model',
+      'settings.row.ai-locked-action-mode',
+      'settings.row.ai-locked-chat-storage',
+      'settings.row.ai-locked-reset-memory',
+      'settings.row.ai-locked-add-provider',
+    ];
+    lockedRows.forEach((row, index) => {
+      fireEvent.press(getByTestId(row));
+      expect(onOpenPaywall).toHaveBeenCalledTimes(index + 1);
+    });
+    alertSpy.mockRestore();
   });
 
   it('shows the secondary AI rows for a pro user', () => {
@@ -176,5 +231,142 @@ describe('Settings Pro section', () => {
     const { getByTestId } = renderContent({ isPro: true });
     expect(getByTestId('settings.toggle.neu')).toBeTruthy();
     expect(getByTestId('settings.row.updated-ui')).toBeTruthy();
+  });
+});
+
+const oneAccountSummary = {
+  accountId: 'a1',
+  account: { id: 'a1', login: 'user' },
+  hosts: [],
+  activeHostId: null,
+};
+
+describe('Settings Accounts group — second-account gate', () => {
+  it('locks the add connect-host row for a free user with one account and routes to the paywall', () => {
+    const onOpenPaywall = jest.fn();
+    const onAddHost = jest.fn();
+    const alertSpy = autoConfirmUpgradeAlert();
+    const { t } = useTranslation();
+    const { getByTestId, queryByTestId } = renderContent({
+      isPro: false,
+      onOpenPaywall,
+      onAddHost,
+      accountSummaries: [oneAccountSummary],
+      // Mirrors SettingsScreen.onAddHostLocked: the gated path routes
+      // through promptProUpgrade instead of the Connect Host modal.
+      onAddHostLocked: () => promptProUpgrade(t, onOpenPaywall),
+    });
+    expect(getByTestId('settings.row.connect-host-locked')).toBeTruthy();
+    expect(queryByTestId('settings.button.connect-host')).toBeNull();
+    fireEvent.press(getByTestId('settings.row.connect-host-locked'));
+    expect(onOpenPaywall).toHaveBeenCalledTimes(1);
+    expect(onAddHost).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
+  });
+
+  it('keeps the empty-state connect-host row ungated for a free user (first account is free)', () => {
+    const onOpenPaywall = jest.fn();
+    const onAddHost = jest.fn();
+    const { getByTestId, queryByTestId } = renderContent({
+      isPro: false,
+      onOpenPaywall,
+      onAddHost,
+      accountSummaries: [],
+    });
+    expect(getByTestId('settings.button.connect-host')).toBeTruthy();
+    expect(queryByTestId('settings.row.connect-host-locked')).toBeNull();
+    fireEvent.press(getByTestId('settings.button.connect-host'));
+    expect(onAddHost).toHaveBeenCalledTimes(1);
+    expect(onOpenPaywall).not.toHaveBeenCalled();
+  });
+
+  it('keeps the add connect-host row ungated for a pro user with one account', () => {
+    const onOpenPaywall = jest.fn();
+    const onAddHost = jest.fn();
+    const { getByTestId, queryByTestId } = renderContent({
+      isPro: true,
+      onOpenPaywall,
+      onAddHost,
+      accountSummaries: [oneAccountSummary],
+    });
+    expect(getByTestId('settings.button.connect-host')).toBeTruthy();
+    expect(queryByTestId('settings.row.connect-host-locked')).toBeNull();
+    fireEvent.press(getByTestId('settings.button.connect-host'));
+    expect(onAddHost).toHaveBeenCalledTimes(1);
+    expect(onOpenPaywall).not.toHaveBeenCalled();
+  });
+});
+
+const oneRepository = {
+  id: 'r1',
+  name: 'test-notes',
+  path: 'vidwadeseram/test-notes',
+  branch: 'main',
+};
+
+describe('Settings Repositories group — add-repo gate', () => {
+  it('locks the add-repo row for a free user with one repo and routes to the paywall', () => {
+    const onOpenPaywall = jest.fn();
+    const onOpenRepoPicker = jest.fn();
+    const alertSpy = autoConfirmUpgradeAlert();
+    const { getByTestId, queryByTestId } = renderContent({
+      isPro: false,
+      onOpenPaywall,
+      onOpenRepoPicker,
+      repositories: [oneRepository],
+    });
+    expect(getByTestId('settings.row.add-repo-locked')).toBeTruthy();
+    expect(queryByTestId('settings.button.repo-picker')).toBeNull();
+    fireEvent.press(getByTestId('settings.row.add-repo-locked'));
+    expect(onOpenPaywall).toHaveBeenCalledTimes(1);
+    expect(onOpenRepoPicker).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
+  });
+
+  it('keeps the empty-state add-repo row ungated for a free user (first repo is free)', () => {
+    const onOpenPaywall = jest.fn();
+    const onOpenRepoPicker = jest.fn();
+    const { getByTestId, queryByTestId } = renderContent({
+      isPro: false,
+      onOpenPaywall,
+      onOpenRepoPicker,
+      repositories: [],
+    });
+    expect(getByTestId('settings.button.repo-picker')).toBeTruthy();
+    expect(queryByTestId('settings.row.add-repo-locked')).toBeNull();
+    fireEvent.press(getByTestId('settings.button.repo-picker'));
+    expect(onOpenRepoPicker).toHaveBeenCalledTimes(1);
+    expect(onOpenPaywall).not.toHaveBeenCalled();
+  });
+
+  it('keeps the add-repo row ungated for a pro user with one repo', () => {
+    const onOpenPaywall = jest.fn();
+    const onOpenRepoPicker = jest.fn();
+    const { getByTestId, queryByTestId } = renderContent({
+      isPro: true,
+      onOpenPaywall,
+      onOpenRepoPicker,
+      repositories: [oneRepository],
+    });
+    expect(getByTestId('settings.button.repo-picker')).toBeTruthy();
+    expect(queryByTestId('settings.row.add-repo-locked')).toBeNull();
+    fireEvent.press(getByTestId('settings.button.repo-picker'));
+    expect(onOpenRepoPicker).toHaveBeenCalledTimes(1);
+    expect(onOpenPaywall).not.toHaveBeenCalled();
+  });
+
+  it('keeps per-repo sync and remove buttons active for a free user with one repo', () => {
+    const onSyncRepo = jest.fn();
+    const onRemoveRepo = jest.fn();
+    const { getByTestId } = renderContent({
+      isPro: false,
+      onSyncRepo,
+      onRemoveRepo,
+      repositories: [oneRepository],
+    });
+    fireEvent.press(getByTestId('settings.button.sync-repo'));
+    expect(onSyncRepo).toHaveBeenCalledWith(oneRepository);
+    fireEvent.press(getByTestId('settings.button.remove-repo'));
+    expect(onRemoveRepo).toHaveBeenCalledWith(oneRepository);
   });
 });

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -22,7 +22,7 @@
 | [Stage → Push UX](./stage-push-ux.md) | no row locks, vanish-immediate deletes, spinner-free grayed push buttons, determinate progress ring, body-text notifications, resume-on-foreground |
 | [Token Removal Repo Cascade](./repo-removal-cascade.md) | removing a token also removes its synced repos, with a confirmation warning |
 | [Token Scope Error Messaging](./token-scope-error-messaging.md) | 403s surface needed token scopes in the sync message and token-add UI |
-| [Pro Paywall & Monetization](./paywall-pro.md) | RevenueCat Pro paywall: 30-day trial / $2.99 mo / $40 lifetime, grandfathering, gating map, store setup checklist |
+| [Pro Paywall & Monetization](./paywall-pro.md) | RevenueCat Pro paywall: 30-day trial / $2.99 mo / $40 lifetime, grandfathering, show-locked feature UX, gating map, store setup checklist |
 
 ## Quick Start
 

--- a/docs/wiki/paywall-pro.md
+++ b/docs/wiki/paywall-pro.md
@@ -52,11 +52,19 @@ Caveat: the Android fallback flag is device-local — a grandfathered user who u
 | Canvases | `CanvasListScreen` create + open handlers; `CanvasEditorScreen` guard |
 | Custom templates | `TemplateManagerScreen` guard; `TemplateSelector` create-template CTA |
 | Render styles | `RenderStyleSettingsScreen` + `RenderStyleEditorScreen` guards |
-| Multiple GitHub accounts | `SettingsScreen` add-account handler (gated when ≥ 1 account exists) |
-| Settings AI section | `SettingsContent` — locked row for free users |
+| Settings AI section | `SettingsContent` — free users see ALL AI rows (feature + deep-config: Enable AI, Daily Quote, AI Personalization, GitHub Tools, model selector, action mode, chat storage, providers, reset AI memory) LOCKED — lock icon instead of toggle, tap → paywall; pro+AI users get functional rows |
+| Biometric lock | `SettingsContent` Security row — lock icon for free, tap → paywall |
+| Second GitHub account | `SettingsContent` "Connect host" add-row — lock icon when free user has 1 account, tap → paywall (first account free) |
+| Second repository | `SettingsContent` "Add Repository" row — lock icon when free user has 1 repo, tap → paywall (first repo free) |
+| Graph view | `NotesViewModePicker` / `NotesListScreen` — lock icon on graph option for free, tap → paywall |
+| AI button (FloatingAIButton) | `AppNavigator` renders for all users; `aiHubStore` routes free taps to Paywall |
 | All gates | `useProGate()` hook + `ProRequired` component (src/components/paywall/ProRequired.tsx) |
 
-**Free for everyone:** notes, todos, journals, single-account git sync, tags/folders/search/backlinks, themes, biometric lock, reminders.
+**Free for everyone:** notes, todos, journals, single-account git sync, tags/folders/search/backlinks, themes, reminders, one GitHub account, one repository. **Pro only:** biometric lock and the AI suite.
+
+### Show-locked pattern
+
+Pro features are no longer HIDDEN from free users — they are SHOWN with a `lock-closed` icon in place of the control (toggle, row action, picker option) and tapping the row opens the paywall (`promptProUpgrade` / `useProGate().openPaywall()` / `aiHubStore` → `Paywall`). Rows render identically for both tiers except the trailing control and `onPress`, which branch per-row on `isPro` (see `SettingsContent.tsx` rows `settings.row.ai-locked-*`, `settings.row.biometric-lock-locked`, `settings.row.connect-host-locked`, `settings.row.add-repo-locked`, and the graph option in `NotesViewModePicker.tsx`).
 
 ### Interstitial
 

--- a/src/components/notes/NotesViewModePicker.tsx
+++ b/src/components/notes/NotesViewModePicker.tsx
@@ -10,6 +10,8 @@ interface NotesViewModePickerProps {
   viewMode: ViewMode;
   onClose: () => void;
   onChange: (mode: ViewMode) => void;
+  isPro: boolean;
+  onLockedPress: () => void;
 }
 
 export function NotesViewModePicker({
@@ -17,6 +19,8 @@ export function NotesViewModePicker({
   viewMode,
   onClose,
   onChange,
+  isPro,
+  onLockedPress,
 }: NotesViewModePickerProps) {
   const { colors } = useTheme();
 
@@ -29,12 +33,13 @@ export function NotesViewModePicker({
           <View style={styles.options}>
             {(Object.keys(VIEW_MODE_LABELS) as ViewMode[]).map((mode) => {
               const isSelected = viewMode === mode;
+              const isLocked = mode === 'graph' && !isPro;
               return (
                 <TouchableOpacity
                   key={mode}
                   testID={`notes-view-mode.button.change-${mode}`}
                   style={[styles.option, isSelected && { backgroundColor: colors.primary + '15' }]}
-                  onPress={() => onChange(mode)}
+                  onPress={() => (isLocked ? onLockedPress() : onChange(mode))}
                   activeOpacity={0.7}
                 >
                   <Ionicons
@@ -47,7 +52,11 @@ export function NotesViewModePicker({
                   >
                     {VIEW_MODE_LABELS[mode]}
                   </Text>
-                  {isSelected ? <Ionicons name="checkmark" size={18} color={colors.primary} /> : null}
+                  {isLocked ? (
+                    <Ionicons name="lock-closed" size={16} color={colors.textSecondary} />
+                  ) : isSelected ? (
+                    <Ionicons name="checkmark" size={18} color={colors.primary} />
+                  ) : null}
                 </TouchableOpacity>
               );
             })}

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -9,6 +9,7 @@ import { Group, GroupRow, Modal, Toggle } from '../ui';
 import { HintIcon } from '../ui/HintIcon';
 import { aiMemoryIndex } from '../../services/ai/AIMemoryIndexService';
 import { HapticService } from '../../utils/haptics';
+import { promptProUpgrade } from '../../utils/proAlerts';
 import {
   SUPPORTED_LANGUAGES,
   getLanguagePreference,
@@ -97,6 +98,11 @@ onRemoveAccount: (id: string, login: string) => void;
   onDisconnectHost: (hostId: string) => void;
   /** Open Connect Host modal. Optional preset focuses the host picker. */
   onAddHost: (preset?: GitHostProvider) => void;
+  /**
+   * Gated add-host path for free users who already hold one account.
+   * The parent decides whether to open the paywall or the Connect Host modal.
+   */
+  onAddHostLocked: () => void;
   accountSummaries: AccountSummaryViewModel[];
   onOpenRepoPicker: () => void;
   onSyncRepo: (repo: GitRepository) => void;
@@ -181,6 +187,7 @@ export function SettingsContent(props: SettingsContentProps) {
     onRemoveToken,
     onDisconnectHost,
     onAddHost,
+    onAddHostLocked,
     onOpenRepoPicker,
     onSyncRepo,
     onRemoveRepo,
@@ -377,28 +384,34 @@ onSetSyncIntervalSeconds,
 
       <Group title={t('settings.security')}>
         <GroupRow
+          testID={isPro ? undefined : 'settings.row.biometric-lock-locked'}
+          onPress={isPro ? undefined : () => promptProUpgrade(t, onOpenPaywall)}
           trailing={
-            <View className="flex-row items-center gap-2">
-              <Toggle
-                testID="settings.toggle.biometric-lock"
-                value={isBiometricLockEnabled}
-                onValueChange={onToggleBiometricLock}
-                disabled={!isBiometricAvailable}
-              />
-              <HintIcon hintKey="hints.settings.biometricLock" testID="hint.biometric-lock" />
-            </View>
+            isPro ? (
+              <View className="flex-row items-center gap-2">
+                <Toggle
+                  testID="settings.toggle.biometric-lock"
+                  value={isBiometricLockEnabled}
+                  onValueChange={onToggleBiometricLock}
+                  disabled={!isBiometricAvailable}
+                />
+                <HintIcon hintKey="hints.settings.biometricLock" testID="hint.biometric-lock" />
+              </View>
+            ) : (
+              <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+            )
           }
         >
           <View className="flex-row items-center gap-2">
             <Ionicons
-            name={biometricKind === 'face' ? 'scan-outline' : 'finger-print-outline'}
+              name={biometricKind === 'face' ? 'scan-outline' : 'finger-print-outline'}
               size={20}
               color={colors.text}
             />
             <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.biometricLockLabel', { kind: biometricLabel })}</Text>
           </View>
         </GroupRow>
-        {isBiometricLockEnabled ? (
+        {isPro && isBiometricLockEnabled ? (
           <GroupRow
             testID="settings.button.timeout-picker"
             onPress={() => setShowTimeoutPicker(true)}
@@ -538,10 +551,16 @@ onSetSyncIntervalSeconds,
             })}
 
             <GroupRow
-              testID="settings.button.connect-host"
-              onPress={() => onAddHost()}
+              testID={isPro ? 'settings.button.connect-host' : 'settings.row.connect-host-locked'}
+              onPress={isPro ? () => onAddHost() : onAddHostLocked}
               leading={<Ionicons name="add-circle-outline" size={20} color={colors.primary} />}
-              trailing={<Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
+              trailing={
+                isPro ? (
+                  <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
+                ) : (
+                  <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+                )
+              }
             >
               <Text style={[styles.settingLabel, { color: colors.primary }]}>
                 {t('connectHost.connectHost')}
@@ -593,9 +612,14 @@ onSetSyncIntervalSeconds,
           ))
         )}
         <GroupRow
-          testID="settings.button.repo-picker"
-          onPress={onOpenRepoPicker}
+          testID={!isPro && repositories.length >= 1 ? 'settings.row.add-repo-locked' : 'settings.button.repo-picker'}
+          onPress={!isPro && repositories.length >= 1 ? () => promptProUpgrade(t, onOpenPaywall) : onOpenRepoPicker}
           leading={<Ionicons name="add" size={20} color={colors.primary} />}
+          trailing={
+            !isPro && repositories.length >= 1 ? (
+              <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+            ) : undefined
+          }
         >
           <Text style={[styles.settingLabel, { color: colors.primary, fontWeight: '600' }]}>{t('settings.addRepository')}</Text>
         </GroupRow>
@@ -793,26 +817,40 @@ onSetSyncIntervalSeconds,
         </GroupRow>
       </Group>
 
-      {isPro ? (
       <Group title={t('settings.artificialIntelligence')}>
-        <GroupRow trailing={<View className="flex-row items-center gap-2">
-          <Toggle testID="settings.toggle.ai" value={isAIEnabled} onValueChange={onToggleAI} />
-          <HintIcon hintKey="hints.settings.enableAI" testID="hint.enable-ai" />
-        </View>}>
+        <GroupRow
+          testID={isPro ? undefined : 'settings.row.ai-locked-enable'}
+          onPress={isPro ? undefined : () => promptProUpgrade(t, onOpenPaywall)}
+          trailing={
+            isPro ? (
+              <View className="flex-row items-center gap-2">
+                <Toggle testID="settings.toggle.ai" value={isAIEnabled} onValueChange={onToggleAI} />
+                <HintIcon hintKey="hints.settings.enableAI" testID="hint.enable-ai" />
+              </View>
+            ) : (
+              <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+            )
+          }
+        >
           <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.enableAI')}</Text>
         </GroupRow>
         <GroupRow
-          testID="settings.row.daily-quote"
+          testID={isPro ? 'settings.row.daily-quote' : 'settings.row.ai-locked-daily-quote'}
+          onPress={isPro ? undefined : () => promptProUpgrade(t, onOpenPaywall)}
           trailing={
-            <View className="flex-row items-center gap-2">
-              <Toggle
-                testID="settings.toggle.daily-quote"
-                value={isAIEnabled ? dailyQuoteEnabled : false}
-                onValueChange={onToggleDailyQuote}
-                disabled={!isAIEnabled}
-              />
-              <HintIcon hintKey="hints.settings.dailyQuote" testID="hint.daily-quote" />
-            </View>
+            isPro ? (
+              <View className="flex-row items-center gap-2">
+                <Toggle
+                  testID="settings.toggle.daily-quote"
+                  value={isAIEnabled ? dailyQuoteEnabled : false}
+                  onValueChange={onToggleDailyQuote}
+                  disabled={!isAIEnabled}
+                />
+                <HintIcon hintKey="hints.settings.dailyQuote" testID="hint.daily-quote" />
+              </View>
+            ) : (
+              <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+            )
           }
         >
           <View>
@@ -825,17 +863,22 @@ onSetSyncIntervalSeconds,
           </View>
         </GroupRow>
         <GroupRow
-          testID="settings.row.ai-personalization"
+          testID={isPro ? 'settings.row.ai-personalization' : 'settings.row.ai-locked-personalization'}
+          onPress={isPro ? undefined : () => promptProUpgrade(t, onOpenPaywall)}
           trailing={
-            <View className="flex-row items-center gap-2">
-              <Toggle
-                testID="settings.toggle.ai-personalization"
-                value={isAIEnabled ? aiPersonalizationEnabled : false}
-                onValueChange={onToggleAiPersonalization}
-                disabled={!isAIEnabled}
-              />
-              <HintIcon hintKey="hints.settings.aiPersonalization" testID="hint.ai-personalization" />
-            </View>
+            isPro ? (
+              <View className="flex-row items-center gap-2">
+                <Toggle
+                  testID="settings.toggle.ai-personalization"
+                  value={isAIEnabled ? aiPersonalizationEnabled : false}
+                  onValueChange={onToggleAiPersonalization}
+                  disabled={!isAIEnabled}
+                />
+                <HintIcon hintKey="hints.settings.aiPersonalization" testID="hint.ai-personalization" />
+              </View>
+            ) : (
+              <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+            )
           }
         >
           <View>
@@ -848,17 +891,22 @@ onSetSyncIntervalSeconds,
           </View>
         </GroupRow>
         <GroupRow
-          testID="settings.row.github-tools"
+          testID={isPro ? 'settings.row.github-tools' : 'settings.row.ai-locked-github-tools'}
+          onPress={isPro ? undefined : () => promptProUpgrade(t, onOpenPaywall)}
           trailing={
-            <View className="flex-row items-center gap-2">
-              <Toggle
-                testID="settings.toggle.github-tools"
-                value={isAIEnabled ? githubToolsEnabled : false}
-                onValueChange={onToggleGithubTools}
-                disabled={!isAIEnabled}
-              />
-              <HintIcon hintKey="hints.settings.githubTools" testID="hint.github-tools" />
-            </View>
+            isPro ? (
+              <View className="flex-row items-center gap-2">
+                <Toggle
+                  testID="settings.toggle.github-tools"
+                  value={isAIEnabled ? githubToolsEnabled : false}
+                  onValueChange={onToggleGithubTools}
+                  disabled={!isAIEnabled}
+                />
+                <HintIcon hintKey="hints.settings.githubTools" testID="hint.github-tools" />
+              </View>
+            ) : (
+              <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+            )
           }
         >
           <View>
@@ -871,61 +919,85 @@ onSetSyncIntervalSeconds,
           </View>
         </GroupRow>
       </Group>
-      ) : (
-      <Group title={t('settings.artificialIntelligence')}>
-        <GroupRow
-          testID="settings.row.ai-locked"
-          onPress={onOpenPaywall}
-          trailing={
-            <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
-          }
-        >
-          <Text style={[styles.settingLabel, { color: colors.text }]}>
-            {t('pro.gateTitle')}
-          </Text>
-        </GroupRow>
-      </Group>
-      )}
 
-      {isPro && isAIEnabled ? (
+      {!isPro || isAIEnabled ? (
         <>
-          <Group>
-            <GroupRow testID="settings.button.model-selector" onPress={onOpenModelSelector} trailing={<Text style={[styles.settingValue, { color: colors.textSecondary }]}>{selectedModelName}</Text>}>
-              <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.model')}</Text>
-            </GroupRow>
-            <GroupRow testID="settings.button.toggle-action-mode" onPress={onToggleActionMode} trailing={<View className="flex-row items-center gap-1">
-              <Text style={[styles.settingValue, { color: colors.textSecondary }]}>{actionMode === 'auto' ? t('settings.auto') : t('settings.confirm')}</Text>
-              <HintIcon hintKey={actionMode === 'auto' ? 'hints.settings.actionModeAuto' : 'hints.settings.actionModeConfirm'} testID="hint.action-mode" />
-            </View>}>
-              <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.actionMode')}</Text>
-            </GroupRow>
-            <GroupRow testID="settings.button.chat-repo-picker" onPress={onOpenChatRepoPicker} trailing={<View className="flex-row items-center gap-1">
-              <Text style={[styles.settingValue, { color: colors.textSecondary }]}>{chatStorageLabel}</Text>
-              <HintIcon hintKey="hints.settings.chatStorage" testID="hint.chat-storage" />
-            </View>}>
-              <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.chatStorage')}</Text>
-            </GroupRow>
-          </Group>
+        <Group>
+          <GroupRow
+            testID={isPro ? 'settings.button.model-selector' : 'settings.row.ai-locked-model'}
+            onPress={isPro ? onOpenModelSelector : () => promptProUpgrade(t, onOpenPaywall)}
+            trailing={
+              isPro ? (
+                <Text style={[styles.settingValue, { color: colors.textSecondary }]}>{selectedModelName}</Text>
+              ) : (
+                <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+              )
+            }
+          >
+            <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.model')}</Text>
+          </GroupRow>
+          <GroupRow
+            testID={isPro ? 'settings.button.toggle-action-mode' : 'settings.row.ai-locked-action-mode'}
+            onPress={isPro ? onToggleActionMode : () => promptProUpgrade(t, onOpenPaywall)}
+            trailing={
+              isPro ? (
+                <View className="flex-row items-center gap-1">
+                  <Text style={[styles.settingValue, { color: colors.textSecondary }]}>{actionMode === 'auto' ? t('settings.auto') : t('settings.confirm')}</Text>
+                  <HintIcon hintKey={actionMode === 'auto' ? 'hints.settings.actionModeAuto' : 'hints.settings.actionModeConfirm'} testID="hint.action-mode" />
+                </View>
+              ) : (
+                <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+              )
+            }
+          >
+            <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.actionMode')}</Text>
+          </GroupRow>
+          <GroupRow
+            testID={isPro ? 'settings.button.chat-repo-picker' : 'settings.row.ai-locked-chat-storage'}
+            onPress={isPro ? onOpenChatRepoPicker : () => promptProUpgrade(t, onOpenPaywall)}
+            trailing={
+              isPro ? (
+                <View className="flex-row items-center gap-1">
+                  <Text style={[styles.settingValue, { color: colors.textSecondary }]}>{chatStorageLabel}</Text>
+                  <HintIcon hintKey="hints.settings.chatStorage" testID="hint.chat-storage" />
+                </View>
+              ) : (
+                <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+              )
+            }
+          >
+            <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.chatStorage')}</Text>
+          </GroupRow>
+        </Group>
 
-          <Group>
-            <GroupRow testID="settings.button.reset-ai-memory" onPress={handleResetAIMemory}>
-              <Text style={[styles.settingLabel, { color: colors.error }]}>{t('settings.resetAIMemory')}</Text>
-            </GroupRow>
-          </Group>
+        <Group>
+          <GroupRow
+            testID={isPro ? 'settings.button.reset-ai-memory' : 'settings.row.ai-locked-reset-memory'}
+            onPress={isPro ? handleResetAIMemory : () => promptProUpgrade(t, onOpenPaywall)}
+            trailing={
+              isPro ? undefined : (
+                <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+              )
+            }
+          >
+            <Text style={[styles.settingLabel, { color: colors.error }]}>{t('settings.resetAIMemory')}</Text>
+          </GroupRow>
+        </Group>
 
-          <Group title={t('settings.providers')}>
-            {visibleProviders.map((provider) => {
-              const availability = providerAvailability[provider.id];
-              const isUnavailable = availability?.kind === 'unavailable';
-              const reasonText = isUnavailable
-                ? describeAvailability(t, availability.reason)
-                : null;
-              return (
-                <GroupRow
-                  key={provider.id}
-                  testID={`settings.button.provider`}
-                  onPress={() => onProviderPress(provider)}
-                  trailing={
+        <Group title={t('settings.providers')}>
+          {visibleProviders.map((provider) => {
+            const availability = providerAvailability[provider.id];
+            const isUnavailable = availability?.kind === 'unavailable';
+            const reasonText = isUnavailable
+              ? describeAvailability(t, availability.reason)
+              : null;
+            return (
+              <GroupRow
+                key={provider.id}
+                testID={isPro ? 'settings.button.provider' : 'settings.row.ai-locked-provider'}
+                onPress={isPro ? () => onProviderPress(provider) : () => promptProUpgrade(t, onOpenPaywall)}
+                trailing={
+                  isPro ? (
                     <Text style={[styles.settingValue, { color: colors.textSecondary }]}>
                       {isUnavailable
                         ? t('settings.unavailable')
@@ -933,26 +1005,39 @@ onSetSyncIntervalSeconds,
                           ? t('settings.enabled')
                           : t('settings.disabled')}
                     </Text>
-                  }
-                  style={isUnavailable ? { opacity: 0.5 } : undefined}
-                >
-                  <View>
-                    <Text style={[styles.settingLabel, { color: colors.text }]}>{provider.name}</Text>
-                    {reasonText ? (
-                      <Text style={[styles.settingValue, { color: colors.textSecondary, marginTop: 2 }]}>
-                        {reasonText}
-                      </Text>
-                    ) : null}
-                  </View>
-                </GroupRow>
-              );
-            })}
-            <GroupRow testID="settings.button.add-provider" onPress={onAddProvider} trailing={<HintIcon hintKey="hints.settings.providers" testID="hint.providers" />}>
-              <Text style={[styles.settingLabel, { color: colors.primary }]}>{t('settings.addProvider')}</Text>
-            </GroupRow>
-          </Group>
+                  ) : (
+                    <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+                  )
+                }
+                style={isPro && isUnavailable ? { opacity: 0.5 } : undefined}
+              >
+                <View>
+                  <Text style={[styles.settingLabel, { color: colors.text }]}>{provider.name}</Text>
+                  {reasonText ? (
+                    <Text style={[styles.settingValue, { color: colors.textSecondary, marginTop: 2 }]}>
+                      {reasonText}
+                    </Text>
+                  ) : null}
+                </View>
+              </GroupRow>
+            );
+          })}
+          <GroupRow
+            testID={isPro ? 'settings.button.add-provider' : 'settings.row.ai-locked-add-provider'}
+            onPress={isPro ? onAddProvider : () => promptProUpgrade(t, onOpenPaywall)}
+            trailing={
+              isPro ? (
+                <HintIcon hintKey="hints.settings.providers" testID="hint.providers" />
+              ) : (
+                <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+              )
+            }
+          >
+            <Text style={[styles.settingLabel, { color: colors.primary }]}>{t('settings.addProvider')}</Text>
+          </GroupRow>
+        </Group>
 
-          <ReminderSection colors={colors} />
+        {isPro && isAIEnabled ? <ReminderSection colors={colors} /> : null}
         </>
       ) : null}
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -33,7 +33,7 @@ import { RootStackParamList } from './types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAIStore } from '../stores/aiStore';
 import { useAIHubStore } from '../stores/aiHubStore';
-import { selectIsPro, useProStore } from '../stores/proStore';
+import { useProStore } from '../stores/proStore';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -78,7 +78,6 @@ export default function AppNavigator() {
   const [currentRouteName, setCurrentRouteName] = useState<string | undefined>(undefined);
   const interstitialEligible = useProStore((s) => s.interstitialEligible);
   const markInterstitialShown = useProStore((s) => s.markInterstitialShown);
-  const isPro = useProStore(selectIsPro);
 
   useEffect(() => {
     if (!interstitialEligible) return;
@@ -253,8 +252,9 @@ export default function AppNavigator() {
               />
             )}
           </Stack.Navigator>
-          {isPro ? <FloatingAIButton currentRouteName={currentRouteName} /> : null}
-          <FloatingStageButton currentRouteName={currentRouteName} />        </View>
+          <FloatingAIButton currentRouteName={currentRouteName} />
+          <FloatingStageButton currentRouteName={currentRouteName} />
+        </View>
       </NavigationContainer>
         <ChatRepoPickerModal
           visible={showChatRepoPicker}

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -515,7 +515,10 @@ export default function NotesListScreen() {
         onClose={() => setShowViewModePicker(false)}
         onChange={handleViewModeChange}
         isPro={isPro}
-        onLockedPress={() => openPaywall()}
+        onLockedPress={() => {
+          setShowViewModePicker(false);
+          openPaywall();
+        }}
       />
 
       <FlatList

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -26,6 +26,7 @@ import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { requireRepo } from '../utils/requireRepo';
 import { HapticService } from '../utils/haptics';
 import { useNetworkStatus } from '../hooks/useNetworkStatus';
+import { useProGate } from '../hooks/useProGate';
 import { GitHubActivityIndicator } from '../components/GitHubActivityIndicator';
 import { ViewMode, VIEW_MODE_ICONS } from '../utils/viewModes';
 import { formatJournalDate } from '../services/JournalService';
@@ -56,6 +57,7 @@ export default function NotesListScreen() {
   const tabBarHeight = useTabBarHeight();
   const { viewMode, setViewMode } = useViewMode();
   const { isConnected } = useNetworkStatus();
+  const { isPro, openPaywall } = useProGate();
   const { repositories } = useRepos();
   const { columnCount } = useResponsive('list');
   const {
@@ -409,6 +411,11 @@ export default function NotesListScreen() {
   const handleViewModeChange = useCallback(
     (mode: ViewMode) => {
       HapticService.selection();
+      if (mode === 'graph' && !isPro) {
+        openPaywall();
+        setShowViewModePicker(false);
+        return;
+      }
       if (mode === 'graph') {
         navigation.navigate('GraphView');
       } else {
@@ -416,7 +423,7 @@ export default function NotesListScreen() {
       }
       setShowViewModePicker(false);
     },
-    [navigation, setViewMode],
+    [navigation, setViewMode, isPro, openPaywall],
   );
 
   const scrollToSearchMatch = useCallback(
@@ -507,6 +514,8 @@ export default function NotesListScreen() {
         viewMode={viewMode}
         onClose={() => setShowViewModePicker(false)}
         onChange={handleViewModeChange}
+        isPro={isPro}
+        onLockedPress={() => openPaywall()}
       />
 
       <FlatList

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -848,6 +848,14 @@ export default function SettingsScreen() {
           setConnectHostPreset(preset);
           setShowConnectHostModal(true);
         }}
+        onAddHostLocked={() => {
+          if (accounts.length >= 1 && !isPro) {
+            promptProUpgrade(t, openPaywall);
+          } else {
+            setConnectHostPreset(undefined);
+            setShowConnectHostModal(true);
+          }
+        }}
         onOpenRepoPicker={() => void openRepoPicker()}
         onSyncRepo={(repo) => void handleSyncRepo(repo)}
         onRemoveRepo={handleRemoveRepo}


### PR DESCRIPTION
Free users now see paid features with lock icons instead of having them hidden. Tapping a locked feature (Settings AI section incl. model/action-mode/chat-storage/providers, biometric lock, second GitHub account, second repository, Graph view, FloatingAIButton) opens the GitNotēs Pro paywall. First account and first repo stay free; remove/disconnect/sync options remain available. Fixes the startup 'Text strings must be rendered within a <Text> component.' error by rendering FloatingAIButton unconditionally (aiHubStore already routes free taps to the paywall). Tests: full suite green (2480 passing), new NotesViewModePicker.graph-lock test added.