### PR TITLE
fix(paywall): hide AI float button for free users

### DIFF
--- a/__tests__/FloatingAIButton.global-gesture.test.tsx
+++ b/__tests__/FloatingAIButton.global-gesture.test.tsx
@@ -11,6 +11,15 @@ jest.mock('../src/stores/aiStore', () => ({
   useAIStore: () => ({ isEnabled: true }),
 }));
 
+jest.mock('../src/hooks/useProGate', () => ({
+  useProGate: () => ({
+    isPro: true,
+    status: 'pro',
+    loading: false,
+    openPaywall: jest.fn(),
+  }),
+}));
+
 jest.mock('../src/contexts/ThemeContext', () => {
   const { NEUMORPHIC_LIGHT, RADII } = require('../src/theme/tokens');
 

--- a/__tests__/FloatingAIButton.hub.test.tsx
+++ b/__tests__/FloatingAIButton.hub.test.tsx
@@ -9,6 +9,7 @@ const mockCreateThread = jest.fn(() => ({ id: 'thread-from-fab' }));
 const mockRunOnJSCallbacks: Array<() => void> = [];
 const mockDashIntervals: unknown[] = [];
 const mockTimingCalls: Array<[unknown, unknown]> = [];
+let mockIsPro = true;
 let mockAIState = {
   isEnabled: true,
   chatRepoOwner: 'owner',
@@ -54,6 +55,15 @@ jest.mock('../src/stores/aiStore', () => ({
     jest.fn(() => ({ isEnabled: mockAIState.isEnabled })),
     { getState: () => mockAIState },
   ),
+}));
+
+jest.mock('../src/hooks/useProGate', () => ({
+  useProGate: () => ({
+    isPro: mockIsPro,
+    status: mockIsPro ? 'pro' : 'free',
+    loading: false,
+    openPaywall: jest.fn(),
+  }),
 }));
 
 jest.mock('../src/stores/chatStore', () => ({
@@ -210,6 +220,7 @@ describe('FloatingAIButton liquid hub', () => {
     mockPanCallbacks.finalize = undefined;
     await AsyncStorage.clear();
     useAIHubStore.setState({ pickerVisible: false });
+    mockIsPro = true;
     mockAIState = {
       isEnabled: true,
       chatRepoOwner: 'owner',

--- a/__tests__/FloatingAIButton.test.tsx
+++ b/__tests__/FloatingAIButton.test.tsx
@@ -16,6 +16,7 @@ let mockPanUpdate: ((event: MockPanUpdateEvent) => void) | undefined;
 let mockPanEnd: ((successful: boolean) => void) | undefined;
 let mockPanFinalize: ((successful: boolean) => void) | undefined;
 let mockAIEnabled = true;
+let mockIsPro = true;
 let mockTabBarHeight = 0;
 let mockWindowDimensions = { width: 320, height: 480, scale: 2, fontScale: 1 };
 let mockSafeAreaInsets = { top: 24, right: 0, bottom: 20, left: 0 };
@@ -83,6 +84,15 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('../src/stores/aiStore', () => ({
   useAIStore: () => ({ isEnabled: mockAIEnabled }),
+}));
+
+jest.mock('../src/hooks/useProGate', () => ({
+  useProGate: () => ({
+    isPro: mockIsPro,
+    status: mockIsPro ? 'pro' : 'free',
+    loading: false,
+    openPaywall: jest.fn(),
+  }),
 }));
 
 jest.mock('../src/contexts/ThemeContext', () => {
@@ -205,6 +215,7 @@ describe('FloatingAIButton', () => {
     mockPanEnd = undefined;
     mockPanFinalize = undefined;
     mockAIEnabled = true;
+    mockIsPro = true;
     mockTabBarHeight = 0;
     mockWindowDimensions = { width: 320, height: 480, scale: 2, fontScale: 1 };
     mockSafeAreaInsets = { top: 24, right: 0, bottom: 20, left: 0 };
@@ -236,6 +247,25 @@ describe('FloatingAIButton', () => {
       });
     },
   );
+
+  it('stays hidden when the user is on the free plan', async () => {
+    mockIsPro = false;
+
+    const { queryByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+
+    await waitFor(() => {
+      expect(queryByTestId('floating-ai.button.navigate-chat')).toBeNull();
+      expect(queryByTestId('floating-ai.button.liquid')).toBeNull();
+    });
+  });
+
+  it('renders when the user is on a paid plan', async () => {
+    const { getByTestId } = render(<FloatingAIButton currentRouteName="Home" />);
+
+    await waitFor(() => {
+      expect(getByTestId('floating-ai.button.navigate-chat')).toBeTruthy();
+    });
+  });
 
   it('normalizes stale left and invalid vertical persisted coordinates', async () => {
     await AsyncStorage.setItem('ai-button-position', JSON.stringify({ x: -180, y: -90 }));

--- a/docs/wiki/paywall-pro.md
+++ b/docs/wiki/paywall-pro.md
@@ -57,14 +57,14 @@ Caveat: the Android fallback flag is device-local — a grandfathered user who u
 | Second GitHub account | `SettingsContent` "Connect host" add-row — lock icon when free user has 1 account, tap → paywall (first account free) |
 | Second repository | `SettingsContent` "Add Repository" row — lock icon when free user has 1 repo, tap → paywall (first repo free) |
 | Graph view | `NotesViewModePicker` / `NotesListScreen` — lock icon on graph option for free, tap → paywall |
-| AI button (FloatingAIButton) | `AppNavigator` renders for all users; `aiHubStore` routes free taps to Paywall |
+| AI button (FloatingAIButton) | `FloatingAIButton` returns `null` when `useProGate().isPro` is false (hidden for free users); `aiHubStore` still routes any free tap to Paywall as a backstop |
 | All gates | `useProGate()` hook + `ProRequired` component (src/components/paywall/ProRequired.tsx) |
 
 **Free for everyone:** notes, todos, journals, single-account git sync, tags/folders/search/backlinks, themes, reminders, one GitHub account, one repository. **Pro only:** biometric lock and the AI suite.
 
 ### Show-locked pattern
 
-Pro features are no longer HIDDEN from free users — they are SHOWN with a `lock-closed` icon in place of the control (toggle, row action, picker option) and tapping the row opens the paywall (`promptProUpgrade` / `useProGate().openPaywall()` / `aiHubStore` → `Paywall`). Rows render identically for both tiers except the trailing control and `onPress`, which branch per-row on `isPro` (see `SettingsContent.tsx` rows `settings.row.ai-locked-*`, `settings.row.biometric-lock-locked`, `settings.row.connect-host-locked`, `settings.row.add-repo-locked`, and the graph option in `NotesViewModePicker.tsx`).
+Pro features are no longer HIDDEN from free users — they are SHOWN with a `lock-closed` icon in place of the control (toggle, row action, picker option) and tapping the row opens the paywall (`promptProUpgrade` / `useProGate().openPaywall()` / `aiHubStore` → `Paywall`). Rows render identically for both tiers except the trailing control and `onPress`, which branch per-row on `isPro` (see `SettingsContent.tsx` rows `settings.row.ai-locked-*`, `settings.row.biometric-lock-locked`, `settings.row.connect-host-locked`, `settings.row.add-repo-locked`, and the graph option in `NotesViewModePicker.tsx`). **Exception:** the floating AI button is a draggable overlay with no lockable row control, so it is hidden entirely for free users (`FloatingAIButton` guards on `useProGate().isPro`).
 
 ### Interstitial
 

--- a/src/components/ai/FloatingAIButton.tsx
+++ b/src/components/ai/FloatingAIButton.tsx
@@ -11,6 +11,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useAIStore } from '../../stores/aiStore';
 import { useAIHubStore } from '../../stores/aiHubStore';
+import { useProGate } from '../../hooks/useProGate';
 import { useTheme } from '../../contexts/ThemeContext';
 import { HapticService } from '../../utils/haptics';
 import { Surface } from '../ui/Surface';
@@ -40,6 +41,7 @@ interface FloatingAIButtonProps {
 
 export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
   const { isEnabled } = useAIStore();
+  const { isPro } = useProGate();
   const { colors } = useTheme();
   const [reduceMotionEnabled, setReduceMotionEnabled] = useState(true);
   const [reduceMotionResolved, setReduceMotionResolved] = useState(false);
@@ -212,7 +214,12 @@ export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
     };
   });
 
-  if (!isEnabled || currentRouteName === 'ChatThreadList' || currentRouteName === 'ChatScreen') {
+  if (
+    !isEnabled
+    || !isPro
+    || currentRouteName === 'ChatThreadList'
+    || currentRouteName === 'ChatScreen'
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## What

The floating AI button (`FloatingAIButton`) was rendered for all users and only sent free users to the Paywall **after** they tapped it. Since the button is a draggable overlay (no lockable row control like other gated features), it is now hidden entirely for free users.

## Changes

- `src/components/ai/FloatingAIButton.tsx`: gate on `useProGate().isPro` — the button returns `null` for free users (same early-return as the existing `isEnabled` / chat-route guards)
- Tests: added `useProGate` mocks to the 3 FloatingAIButton test files; new cases assert the button is hidden on the free plan and rendered on a paid plan
- `docs/wiki/paywall-pro.md`: updated the gating map + show-locked pattern exception note

## Backstop

`aiHubStore` navigation guards (which route free taps to `Paywall`) are untouched and remain as a defense-in-depth layer.

## Verification

- `yarn ts:check` ✅
- `yarn jest` — 2482 passed, 0 failures ✅
- ESLint on changed files ✅ (0 errors; 1 pre-existing warning in untouched mock)