### PR TITLE
fix: flat default UI for fresh installs + bottom-sheet keyboard avoidance

### DIFF
--- a/__tests__/themeContextHydration.test.tsx
+++ b/__tests__/themeContextHydration.test.tsx
@@ -59,4 +59,16 @@ describe('ThemeProvider initial paint', () => {
 
     expect(getByTestId('probe').props.children).toMatch(/theme=system/);
   });
+
+  it('defaults to the flat style on a fresh install because Fancy UI is pro-gated', async () => {
+    await bootstrapStorage();
+
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(getByTestId('probe').props.children).toMatch(/style=flat/);
+  });
 });

--- a/docs/wiki/paywall-pro.md
+++ b/docs/wiki/paywall-pro.md
@@ -57,6 +57,7 @@ Caveat: the Android fallback flag is device-local — a grandfathered user who u
 | Second GitHub account | `SettingsContent` "Connect host" add-row — lock icon when free user has 1 account, tap → paywall (first account free) |
 | Second repository | `SettingsContent` "Add Repository" row — lock icon when free user has 1 repo, tap → paywall (first repo free) |
 | Graph view | `NotesViewModePicker` / `NotesListScreen` — lock icon on graph option for free, tap → paywall |
+| Fancy UI style | `SettingsContent` `settings.row.updated-ui` — lock icon instead of toggle for free, tap → paywall; fresh installs default to `flat` |
 | AI button (FloatingAIButton) | `FloatingAIButton` returns `null` when `useProGate().isPro` is false (hidden for free users); `aiHubStore` still routes any free tap to Paywall as a backstop |
 | All gates | `useProGate()` hook + `ProRequired` component (src/components/paywall/ProRequired.tsx) |
 

--- a/docs/wiki/theme-styling.md
+++ b/docs/wiki/theme-styling.md
@@ -6,6 +6,13 @@
 
 GitNotēs uses **NativeWind v5** (Tailwind CSS for React Native) with custom theme tokens. Supports **light/dark/system** modes.
 
+## UI styles
+
+Two visual styles, persisted under `@gitnotes:style` (`ThemeContext.readBootStyle`):
+
+- **`flat`** (classic look) — default for fresh installs. Fancy UI (neumorphic) is a pro-gated feature, so free users get the flat style unless they upgrade.
+- **`neumorphic`** ("Fancy UI") — soft-UI shadows. Pro-only: the toggle in Settings is locked for free users and routes to the paywall (`settings.row.updated-ui`).
+
 ## Architecture
 
 ```
@@ -409,6 +416,20 @@ The shared `Button` component centers its label optically even when a
 (`alignSelf: 'stretch'`) so `justify-center` centers against the actual
 button width. See `src/components/ui/Button.tsx` and
 `__tests__/ui/Button.test.tsx`.
+
+### Bottom-sheet modals must lift above the keyboard
+
+`src/components/ui/Modal.tsx` (`bottomSheet` variant) wraps the sheet slot in a
+`KeyboardAvoidingView` (`behavior="padding"` on iOS) so the whole sheet rises
+above the soft keyboard. This is the single place that handles keyboard
+avoidance for bottom sheets — the sheet is anchored to the screen bottom, so a
+`KeyboardAvoidingView` placed *inside* a sheet can only compress its own
+scroll area and can never lift the sheet itself; the token/URL inputs in
+`ConnectHostModal` and the Settings token modal were hidden by the keyboard
+before the slot was made keyboard-aware. Do NOT re-add per-modal
+`KeyboardAvoidingView`s around sheet content — the sheet slot already handles
+it, and nesting them causes a transient double-pad. Callers should keep
+`keyboardShouldPersistTaps="handled"` on their `ScrollView`s.
 
 ### Single-line Input descender clipping
 

--- a/src/components/ConnectHostModal.tsx
+++ b/src/components/ConnectHostModal.tsx
@@ -4,8 +4,6 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
-  KeyboardAvoidingView,
-  Platform,
   ScrollView,
   ActivityIndicator,
   StyleSheet,
@@ -192,136 +190,94 @@ export function ConnectHostModal({
       bottomSheet
       contentStyle={{ padding: 16, paddingBottom: 34, backgroundColor: colors.background }}
     >
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 24 : 0}
-      >
-        <ScrollView keyboardShouldPersistTaps="handled">
+      <ScrollView keyboardShouldPersistTaps="handled">
+        <Text
+          style={{
+            fontSize: 18,
+            fontWeight: '600',
+            color: colors.text,
+            marginBottom: spacing[2],
+          }}
+        >
+          {t('connectHost.title')}
+        </Text>
+        {accountLoginHint ? (
           <Text
             style={{
-              fontSize: 18,
-              fontWeight: '600',
-              color: colors.text,
-              marginBottom: spacing[2],
+              color: colors.textSecondary,
+              fontSize: 13,
+              marginBottom: spacing[3],
             }}
           >
-            {t('connectHost.title')}
+            {t('connectHost.attachingTo', { login: accountLoginHint })}
           </Text>
-          {accountLoginHint ? (
+        ) : null}
+
+        <Text
+          style={{
+            color: colors.textSecondary,
+            fontSize: 13,
+            marginBottom: spacing[2],
+          }}
+        >
+          {t('connectHost.providerLabel')}
+        </Text>
+        <View style={[styles.row, { marginBottom: spacing[3] }]}>
+          {ALL_PROVIDERS.map((entry) => {
+            const isSelected = provider === entry.provider;
+            return (
+              <TouchableOpacity
+                key={entry.provider}
+                onPress={() => handleSelectProvider(entry.provider)}
+                testID={`connect-host-provider-${entry.provider}`}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing[3],
+                  borderRadius: 12,
+                  alignItems: 'center',
+                  borderWidth: 1,
+                  borderColor: isSelected ? colors.primary : colors.border,
+                  backgroundColor: isSelected ? colors.primary + '12' : colors.surface,
+                }}
+              >
+                <Text
+                  style={{
+                    color: isSelected ? colors.primary : colors.text,
+                    fontSize: 13,
+                    fontWeight: '600',
+                  }}
+                >
+                  {GIT_HOST_LABELS[entry.provider]}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        {supportsSelfHost ? (
+          <>
             <Text
               style={{
                 color: colors.textSecondary,
                 fontSize: 13,
-                marginBottom: spacing[3],
+                marginBottom: spacing[2],
               }}
             >
-              {t('connectHost.attachingTo', { login: accountLoginHint })}
+              {t('connectHost.instanceUrlLabel')}
             </Text>
-          ) : null}
-
-          <Text
-            style={{
-              color: colors.textSecondary,
-              fontSize: 13,
-              marginBottom: spacing[2],
-            }}
-          >
-            {t('connectHost.providerLabel')}
-          </Text>
-          <View style={[styles.row, { marginBottom: spacing[3] }]}>
-            {ALL_PROVIDERS.map((entry) => {
-              const isSelected = provider === entry.provider;
-              return (
-                <TouchableOpacity
-                  key={entry.provider}
-                  onPress={() => handleSelectProvider(entry.provider)}
-                  testID={`connect-host-provider-${entry.provider}`}
-                  style={{
-                    flex: 1,
-                    paddingVertical: spacing[3],
-                    borderRadius: 12,
-                    alignItems: 'center',
-                    borderWidth: 1,
-                    borderColor: isSelected ? colors.primary : colors.border,
-                    backgroundColor: isSelected ? colors.primary + '12' : colors.surface,
-                  }}
-                >
-                  <Text
-                    style={{
-                      color: isSelected ? colors.primary : colors.text,
-                      fontSize: 13,
-                      fontWeight: '600',
-                    }}
-                  >
-                    {GIT_HOST_LABELS[entry.provider]}
-                  </Text>
-                </TouchableOpacity>
-              );
-            })}
-          </View>
-
-          {supportsSelfHost ? (
-            <>
-              <Text
-                style={{
-                  color: colors.textSecondary,
-                  fontSize: 13,
-                  marginBottom: spacing[2],
-                }}
-              >
-                {t('connectHost.instanceUrlLabel')}
-              </Text>
-              <TextInput
-                value={instanceBaseUrl}
-                onChangeText={(v) => {
-                  setInstanceBaseUrl(v);
-                  setVerifiedLogin(null);
-                }}
-                placeholder={GIT_HOST_API_BASES[provider]}
-                placeholderTextColor={colors.textSecondary}
-                autoCapitalize="none"
-                autoCorrect={false}
-                keyboardType="url"
-                testID="connect-host-instance-url-input"
-                style={{
-                  borderWidth: 1,
-                  borderColor: colors.border,
-                  borderRadius: 12,
-                  paddingHorizontal: spacing[3],
-                  paddingVertical: spacing[3],
-                  color: colors.text,
-                  backgroundColor: colors.surface,
-                  fontSize: 14,
-                  marginBottom: spacing[3],
-                }}
-              />
-            </>
-          ) : null}
-
-          <Text
-            style={{
-              color: colors.textSecondary,
-              fontSize: 13,
-              marginBottom: spacing[2],
-            }}
-          >
-            {t('connectHost.tokenLabel')}
-          </Text>
-          <View style={[styles.tokenRow, { marginBottom: spacing[3] }]}>
             <TextInput
-              value={token}
+              value={instanceBaseUrl}
               onChangeText={(v) => {
-                setToken(v);
+                setInstanceBaseUrl(v);
                 setVerifiedLogin(null);
               }}
-              placeholder={t('connectHost.tokenPlaceholder')}
+              placeholder={GIT_HOST_API_BASES[provider]}
               placeholderTextColor={colors.textSecondary}
               autoCapitalize="none"
               autoCorrect={false}
-              secureTextEntry={!tokenVisible}
-              testID="connect-host-token-input"
+              keyboardType="url"
+              testID="connect-host-instance-url-input"
               style={{
-                flex: 1,
                 borderWidth: 1,
                 borderColor: colors.border,
                 borderRadius: 12,
@@ -330,112 +286,149 @@ export function ConnectHostModal({
                 color: colors.text,
                 backgroundColor: colors.surface,
                 fontSize: 14,
+                marginBottom: spacing[3],
               }}
             />
-            <TouchableOpacity
-              onPress={() => setTokenVisible((v) => !v)}
-              testID="connect-host-token-toggle"
-              style={{
-                paddingHorizontal: spacing[3],
-                paddingVertical: spacing[3],
-                marginLeft: spacing[2],
-                borderRadius: 12,
-                borderWidth: 1,
-                borderColor: colors.border,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <Text style={{ color: colors.text, fontSize: 13, fontWeight: '600' }}>
-                {tokenVisible ? t('connectHost.hide') : t('connectHost.show')}
-              </Text>
-            </TouchableOpacity>
-          </View>
+          </>
+        ) : null}
 
-          {provider === 'github' ? (
-            <Text
-              style={{
-                color: colors.textSecondary,
-                fontSize: 12,
-                marginBottom: spacing[2],
-              }}
-            >
-              {t('connectHost.help.github')}
+        <Text
+          style={{
+            color: colors.textSecondary,
+            fontSize: 13,
+            marginBottom: spacing[2],
+          }}
+        >
+          {t('connectHost.tokenLabel')}
+        </Text>
+        <View style={[styles.tokenRow, { marginBottom: spacing[3] }]}>
+          <TextInput
+            value={token}
+            onChangeText={(v) => {
+              setToken(v);
+              setVerifiedLogin(null);
+            }}
+            placeholder={t('connectHost.tokenPlaceholder')}
+            placeholderTextColor={colors.textSecondary}
+            autoCapitalize="none"
+            autoCorrect={false}
+            secureTextEntry={!tokenVisible}
+            testID="connect-host-token-input"
+            style={{
+              flex: 1,
+              borderWidth: 1,
+              borderColor: colors.border,
+              borderRadius: 12,
+              paddingHorizontal: spacing[3],
+              paddingVertical: spacing[3],
+              color: colors.text,
+              backgroundColor: colors.surface,
+              fontSize: 14,
+            }}
+          />
+          <TouchableOpacity
+            onPress={() => setTokenVisible((v) => !v)}
+            testID="connect-host-token-toggle"
+            style={{
+              paddingHorizontal: spacing[3],
+              paddingVertical: spacing[3],
+              marginLeft: spacing[2],
+              borderRadius: 12,
+              borderWidth: 1,
+              borderColor: colors.border,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Text style={{ color: colors.text, fontSize: 13, fontWeight: '600' }}>
+              {tokenVisible ? t('connectHost.hide') : t('connectHost.show')}
             </Text>
-          ) : null}
+          </TouchableOpacity>
+        </View>
 
-          <View style={[styles.row, { marginTop: spacing[2] }]}>
-            <TouchableOpacity
-              onPress={onClose}
-              style={{
-                flex: 1,
-                paddingVertical: spacing[3],
-                borderRadius: 12,
-                alignItems: 'center',
-                borderWidth: 1,
-                borderColor: colors.border,
-              }}
-            >
+        {provider === 'github' ? (
+          <Text
+            style={{
+              color: colors.textSecondary,
+              fontSize: 12,
+              marginBottom: spacing[2],
+            }}
+          >
+            {t('connectHost.help.github')}
+          </Text>
+        ) : null}
+
+        <View style={[styles.row, { marginTop: spacing[2] }]}>
+          <TouchableOpacity
+            onPress={onClose}
+            style={{
+              flex: 1,
+              paddingVertical: spacing[3],
+              borderRadius: 12,
+              alignItems: 'center',
+              borderWidth: 1,
+              borderColor: colors.border,
+            }}
+          >
+            <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600' }}>
+              {t('common.cancel')}
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleTest}
+            disabled={isTesting || !token.trim()}
+            testID="connect-host-test"
+            style={{
+              flex: 1,
+              paddingVertical: spacing[3],
+              borderRadius: 12,
+              alignItems: 'center',
+              borderWidth: 1,
+              borderColor: colors.border,
+              opacity: isTesting || !token.trim() ? 0.6 : 1,
+            }}
+          >
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[2] }}>
               <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600' }}>
-                {t('common.cancel')}
+                {t('connectHost.test')}
               </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={handleTest}
-              disabled={isTesting || !token.trim()}
-              testID="connect-host-test"
-              style={{
-                flex: 1,
-                paddingVertical: spacing[3],
-                borderRadius: 12,
-                alignItems: 'center',
-                borderWidth: 1,
-                borderColor: colors.border,
-                opacity: isTesting || !token.trim() ? 0.6 : 1,
-              }}
-            >
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[2] }}>
-                <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600' }}>
-                  {t('connectHost.test')}
-                </Text>
-                {isTesting ? <ActivityIndicator size="small" color={colors.text} /> : null}
-              </View>
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={handleSave}
-              disabled={isTesting || !token.trim()}
-              testID="connect-host-save"
-              style={{
-                flex: 1,
-                paddingVertical: spacing[3],
-                borderRadius: 12,
-                alignItems: 'center',
-                backgroundColor:
-                  isTesting || !token.trim() ? colors.surface : colors.primary,
-                borderWidth: 1,
-                borderColor:
-                  isTesting || !token.trim() ? colors.border : colors.primary,
-                opacity: isTesting || !token.trim() ? 0.6 : 1,
-              }}
-            >
-              {isTesting ? (
-                <ActivityIndicator color={colors.text} />
-              ) : (
-                <Text
-                  style={{
-                    color:
-                      isTesting || !token.trim() ? colors.textSecondary : '#fff',
-                    fontSize: 14,
-                    fontWeight: '600',
-                  }}
-                >
-                  {t('connectHost.save')}
-                </Text>
-              )}
-            </TouchableOpacity>
-          </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
+              {isTesting ? <ActivityIndicator size="small" color={colors.text} /> : null}
+            </View>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleSave}
+            disabled={isTesting || !token.trim()}
+            testID="connect-host-save"
+            style={{
+              flex: 1,
+              paddingVertical: spacing[3],
+              borderRadius: 12,
+              alignItems: 'center',
+              backgroundColor:
+                isTesting || !token.trim() ? colors.surface : colors.primary,
+              borderWidth: 1,
+              borderColor:
+                isTesting || !token.trim() ? colors.border : colors.primary,
+              opacity: isTesting || !token.trim() ? 0.6 : 1,
+            }}
+          >
+            {isTesting ? (
+              <ActivityIndicator color={colors.text} />
+            ) : (
+              <Text
+                style={{
+                  color:
+                    isTesting || !token.trim() ? colors.textSecondary : '#fff',
+                  fontSize: 14,
+                  fontWeight: '600',
+                }}
+              >
+                {t('connectHost.save')}
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
     </Modal>
   );
 }

--- a/src/components/settings/SettingsModals.tsx
+++ b/src/components/settings/SettingsModals.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ActivityIndicator, KeyboardAvoidingView, Linking, Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Linking, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -221,78 +221,76 @@ export function SettingsModals(props: SettingsModalsProps) {
             <Ionicons name="close" size={24} color={colors.textSecondary} />
           </TouchableOpacity>
         </View>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-          <ScrollView className="px-4 py-4" keyboardShouldPersistTaps="handled" contentContainerStyle={{ paddingBottom: 16 }}>
-            <Text className="text-sm mb-3 leading-5" style={{ color: colors.textSecondary }}>{t('settings.tokenDescription')}</Text>
-            <TouchableOpacity className="flex-row items-center gap-1 mb-4" onPress={() => Linking.openURL('https://github.com/settings/personal-access-tokens/new?description=GitNotes')}>
-              <Ionicons name="open-outline" size={14} color={colors.primary} />
-              <Text style={{ color: colors.primary, fontSize: 14, fontWeight: '500' }}>{t('settings.openGithubTokenSettings')}</Text>
-            </TouchableOpacity>
-            <View
-              className="flex-row items-center rounded-lg px-3 mb-2 h-[50px]"
-              style={{ borderWidth: 1, borderColor: tokenError ? '#FF3B30' : colors.border, backgroundColor: colors.background }}
-            >
-              <Input
-                testID="settings-modals.input.token"
-                containerStyle={{ flex: 1, borderWidth: 0 }}
-                placeholder={t('settings.tokenPlaceholder')}
-                placeholderTextColor={colors.textSecondary}
-                value={tokenInput}
-                onChangeText={onSetTokenInput}
-                secureTextEntry={!tokenVisible}
-                autoCapitalize="none"
-                autoCorrect={false}
-                showSoftInputOnFocus={false}
-              />
-              <TouchableOpacity
-                testID="settings-modals.button.toggle-token-visible"
-                onPress={onToggleTokenVisible}
-                className="px-1.5 py-1.5 ml-1"
-                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                accessibilityLabel={tokenVisible ? t('settings.hideToken') : t('settings.showToken')}
-              >
-                <Ionicons name={tokenVisible ? 'eye-off-outline' : 'eye-outline'} size={20} color={colors.textSecondary} />
-              </TouchableOpacity>
-            </View>
-            <View className="flex-row gap-2 mb-2">
-              <TouchableOpacity
-                testID="settings-modals.button.paste-token"
-                className="flex-row items-center justify-center py-2.5 px-3 rounded-lg border flex-1 gap-1.5"
-                style={{ borderColor: colors.border }}
-                onPress={onPasteToken}
-                accessibilityLabel={t('settings.pasteToken')}
-              >
-                <Ionicons name="clipboard-outline" size={16} color={colors.primary} />
-                <Text style={{ color: colors.primary, fontSize: 14, fontWeight: '600' }}>{t('common.paste')}</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                testID="settings-modals.button.copy-token"
-                className="flex-row items-center justify-center py-2.5 px-3 rounded-lg border flex-1 gap-1.5"
-                style={[{ borderColor: colors.border }, { opacity: tokenInput.trim() ? 1 : 0.4 }]}
-                onPress={onCopyToken}
-                disabled={!tokenInput.trim()}
-                accessibilityLabel={t('settings.copyToken')}
-              >
-                <Ionicons name="copy-outline" size={16} color={colors.primary} />
-                <Text style={{ color: colors.primary, fontSize: 14, fontWeight: '600' }}>{t('common.copy')}</Text>
-              </TouchableOpacity>
-            </View>
-            {tokenError ? <Text style={{ color: '#FF3B30', fontSize: 13, marginBottom: 10 }}>{tokenError}</Text> : null}
-            <Button
-              testID="settings-modals.button.save-token"
-              label={tokenModalMode === 'add' ? t('settings.addAccount') : t('settings.saveToken')}
-              onPress={onSaveToken}
-              disabled={isVerifying}
-              variant="primary"
-              fullWidth
-              style={{ marginTop: 8, minHeight: 48 }}
-              textStyle={{ color: '#fff', fontWeight: '600' }}
-              trailingIcon={isVerifying ? <ActivityIndicator color="#fff" /> : undefined}
-              iconAlign="edge"
+        <ScrollView className="px-4 py-4" keyboardShouldPersistTaps="handled" contentContainerStyle={{ paddingBottom: 16 }}>
+          <Text className="text-sm mb-3 leading-5" style={{ color: colors.textSecondary }}>{t('settings.tokenDescription')}</Text>
+          <TouchableOpacity className="flex-row items-center gap-1 mb-4" onPress={() => Linking.openURL('https://github.com/settings/personal-access-tokens/new?description=GitNotes')}>
+            <Ionicons name="open-outline" size={14} color={colors.primary} />
+            <Text style={{ color: colors.primary, fontSize: 14, fontWeight: '500' }}>{t('settings.openGithubTokenSettings')}</Text>
+          </TouchableOpacity>
+          <View
+            className="flex-row items-center rounded-lg px-3 mb-2 h-[50px]"
+            style={{ borderWidth: 1, borderColor: tokenError ? '#FF3B30' : colors.border, backgroundColor: colors.background }}
+          >
+            <Input
+              testID="settings-modals.input.token"
+              containerStyle={{ flex: 1, borderWidth: 0 }}
+              placeholder={t('settings.tokenPlaceholder')}
+              placeholderTextColor={colors.textSecondary}
+              value={tokenInput}
+              onChangeText={onSetTokenInput}
+              secureTextEntry={!tokenVisible}
+              autoCapitalize="none"
+              autoCorrect={false}
+              showSoftInputOnFocus={false}
             />
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </Modal>
+            <TouchableOpacity
+              testID="settings-modals.button.toggle-token-visible"
+              onPress={onToggleTokenVisible}
+              className="px-1.5 py-1.5 ml-1"
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityLabel={tokenVisible ? t('settings.hideToken') : t('settings.showToken')}
+            >
+              <Ionicons name={tokenVisible ? 'eye-off-outline' : 'eye-outline'} size={20} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+          <View className="flex-row gap-2 mb-2">
+            <TouchableOpacity
+              testID="settings-modals.button.paste-token"
+              className="flex-row items-center justify-center py-2.5 px-3 rounded-lg border flex-1 gap-1.5"
+              style={{ borderColor: colors.border }}
+              onPress={onPasteToken}
+              accessibilityLabel={t('settings.pasteToken')}
+            >
+              <Ionicons name="clipboard-outline" size={16} color={colors.primary} />
+              <Text style={{ color: colors.primary, fontSize: 14, fontWeight: '600' }}>{t('common.paste')}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              testID="settings-modals.button.copy-token"
+              className="flex-row items-center justify-center py-2.5 px-3 rounded-lg border flex-1 gap-1.5"
+              style={[{ borderColor: colors.border }, { opacity: tokenInput.trim() ? 1 : 0.4 }]}
+              onPress={onCopyToken}
+              disabled={!tokenInput.trim()}
+              accessibilityLabel={t('settings.copyToken')}
+            >
+              <Ionicons name="copy-outline" size={16} color={colors.primary} />
+              <Text style={{ color: colors.primary, fontSize: 14, fontWeight: '600' }}>{t('common.copy')}</Text>
+            </TouchableOpacity>
+          </View>
+          {tokenError ? <Text style={{ color: '#FF3B30', fontSize: 13, marginBottom: 10 }}>{tokenError}</Text> : null}
+          <Button
+            testID="settings-modals.button.save-token"
+            label={tokenModalMode === 'add' ? t('settings.addAccount') : t('settings.saveToken')}
+            onPress={onSaveToken}
+            disabled={isVerifying}
+            variant="primary"
+            fullWidth
+            style={{ marginTop: 8, minHeight: 48 }}
+            textStyle={{ color: '#fff', fontWeight: '600' }}
+            trailingIcon={isVerifying ? <ActivityIndicator color="#fff" /> : undefined}
+            iconAlign="edge"
+          />
+        </ScrollView>
+        </Modal>
     </>
   );
 }

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,5 +1,15 @@
 import React, { ReactNode } from 'react';
-import { Modal as RNModal, Pressable, StyleSheet, useWindowDimensions, View, ViewStyle, StyleProp } from 'react-native';
+import {
+  KeyboardAvoidingView,
+  Modal as RNModal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+  ViewStyle,
+  StyleProp,
+} from 'react-native';
 import { BlurView } from 'expo-blur';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Surface } from './Surface';
@@ -111,14 +121,37 @@ export function Modal(props: ModalProps) {
                 }
           }
         >
-          <Surface
-            elevation="floating"
-            radius="lg"
-            onStartShouldSetResponder={() => true}
-            style={[surfaceStyle, contentStyle]}
-          >
-            {children}
-          </Surface>
+          {bottomSheet ? (
+            <KeyboardAvoidingView
+              behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                justifyContent: 'flex-end',
+              }}
+            >
+              <Surface
+                elevation="floating"
+                radius="lg"
+                onStartShouldSetResponder={() => true}
+                style={[surfaceStyle, contentStyle]}
+              >
+                {children}
+              </Surface>
+            </KeyboardAvoidingView>
+          ) : (
+            <Surface
+              elevation="floating"
+              radius="lg"
+              onStartShouldSetResponder={() => true}
+              style={[surfaceStyle, contentStyle]}
+            >
+              {children}
+            </Surface>
+          )}
         </View>
       </Pressable>
     </RNModal>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -48,7 +48,8 @@ function readBootTheme(): ThemeMode {
 function readBootStyle(): ThemeStyle {
   const v = getBootValue('@gitnotes:style');
   if (v === 'neumorphic' || v === 'flat') return v;
-  return 'neumorphic';
+  // Fancy UI (neumorphic) is pro-gated — default fresh installs to flat.
+  return 'flat';
 }
 
 export function ThemeProvider({ children }: ThemeProviderProps) {


### PR DESCRIPTION
## Summary

Two bug fixes:

### 1. Fresh installs no longer default to a pro-gated UI style
`ThemeContext.readBootStyle()` fell back to `neumorphic` ("Fancy UI") when no style was persisted — but Fancy UI is a **pro** feature and the toggle is locked for free users. Fresh installs now default to `flat`.

- `src/contexts/ThemeContext.tsx` — fallback default → `flat`
- `__tests__/themeContextHydration.test.tsx` — regression test asserting fresh-install default is `style=flat`
- Existing users keep their persisted preference.

### 2. Token inputs hidden by the keyboard in bottom-sheet modals
Bottom sheets are anchored to the screen bottom, so per-modal `KeyboardAvoidingView`s inside them could only compress their own scroll area — the sheet never lifted above the keyboard, hiding the token/URL inputs (Connect Host, Save Token, Add Repo).

- `src/components/ui/Modal.tsx` — bottomSheet slot now wrapped in a `KeyboardAvoidingView` (`behavior="padding"` on iOS) so the whole sheet rides above the keyboard
- `ConnectHostModal.tsx` / `SettingsModals.tsx` — removed the now-redundant inner `KeyboardAvoidingView`s (semantic diff is 7 lines; the rest is a 2-space dedent)

## Verification

- Full suite: 275 suites / 2483 tests pass, 13 snapshots pass
- `ts:check` clean, ESLint 0 errors
- Wiki updated per AGENTS.md (`theme-styling.md`, `paywall-pro.md`)