### PR TITLE
fix(theme, paywall, ai): toggle UX + Pro-gate Manage Templates + Daily Quote fallback (#922, #923, #929)

### DIFF
--- a/__tests__/components/settings/SettingsContent.pro-gate.test.tsx
+++ b/__tests__/components/settings/SettingsContent.pro-gate.test.tsx
@@ -234,6 +234,44 @@ describe('Settings Pro section', () => {
   });
 });
 
+describe('Settings Manage Templates — Pro gate', () => {
+  it('shows a locked Manage Templates row for a free user and routes to the paywall', () => {
+    const onOpenPaywall = jest.fn();
+    const onManageTemplates = jest.fn();
+    const alertSpy = autoConfirmUpgradeAlert();
+    const { getByTestId, queryByTestId, getAllByTestId } = renderContent({
+      isPro: false,
+      onOpenPaywall,
+      onManageTemplates,
+    });
+    expect(getByTestId('settings.row.manage-templates-locked')).toBeTruthy();
+    expect(queryByTestId('settings.button.manage-templates')).toBeNull();
+    expect(getAllByTestId('icon-lock-closed').length).toBeGreaterThan(0);
+    fireEvent.press(getByTestId('settings.row.manage-templates-locked'));
+    expect(onManageTemplates).not.toHaveBeenCalled();
+    expect(onOpenPaywall).toHaveBeenCalledTimes(1);
+    alertSpy.mockRestore();
+  });
+
+  it('keeps Manage Templates unlocked for a pro user and navigates on press', () => {
+    const onOpenPaywall = jest.fn();
+    const onManageTemplates = jest.fn();
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const { getByTestId, queryByTestId } = renderContent({
+      isPro: true,
+      onOpenPaywall,
+      onManageTemplates,
+    });
+    expect(getByTestId('settings.button.manage-templates')).toBeTruthy();
+    expect(queryByTestId('settings.row.manage-templates-locked')).toBeNull();
+    fireEvent.press(getByTestId('settings.button.manage-templates'));
+    expect(onManageTemplates).toHaveBeenCalledTimes(1);
+    expect(onOpenPaywall).not.toHaveBeenCalled();
+    expect(alertSpy).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
+  });
+});
+
 const oneAccountSummary = {
   accountId: 'a1',
   account: { id: 'a1', login: 'user' },

--- a/__tests__/components/settings/SettingsContent.theme-toggle.test.tsx
+++ b/__tests__/components/settings/SettingsContent.theme-toggle.test.tsx
@@ -1,0 +1,161 @@
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: { addEventListener: jest.fn(() => jest.fn()), fetch: jest.fn(async () => ({ isConnected: true })) },
+}));
+
+jest.mock('../../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    isDark: false,
+    colors: {
+      background: '#fff', surface: '#f4f4f4', primary: '#2563eb', accent: '#2563eb',
+      text: '#111', textSecondary: '#666', border: '#ddd', error: '#dc2626', elevated: '#fff',
+    },
+  }),
+  useTokens: () => ({
+    colors: {
+      background: '#fff', surface: '#f4f4f4', primary: '#2563eb', accent: '#2563eb',
+      text: '#111', textSecondary: '#666', border: '#ddd', error: '#dc2626', elevated: '#fff',
+    },
+    spacing: [0, 4, 8, 12, 16, 20, 24],
+    type: { sm: 12, md: 14, lg: 16, xl: 18, '2xl': 22 },
+  }),
+}));
+
+jest.mock('expo-haptics', () => ({
+  selectionAsync: jest.fn(() => Promise.resolve()),
+  impactAsync: jest.fn(() => Promise.resolve()),
+  notificationAsync: jest.fn(() => Promise.resolve()),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+  NotificationFeedbackType: { Success: 'success', Warning: 'warning', Error: 'error' },
+}));
+
+jest.mock('../../../src/components/ui', () => {
+  const React = require('react');
+  const { View, Text, TouchableOpacity, Switch } = require('react-native');
+  const Row = ({ children, onPress, testID, trailing }: any) =>
+    React.createElement(TouchableOpacity, { testID, onPress },
+      React.createElement(View, null, children, trailing));
+  return {
+    useScreenHeaderHeight: () => 60,
+    Group: ({ title, children }: any) =>
+      React.createElement(View, null,
+        React.createElement(Text, null, String(title)),
+        children),
+    GroupRow: Row,
+    Modal: ({ children }: any) => React.createElement(View, null, children),
+    Toggle: ({ value, onValueChange, testID, disabled }: any) =>
+      React.createElement(Switch, { value: Boolean(value), onValueChange, testID, disabled }),
+    HintIcon: () => React.createElement(View, null),
+  };
+});
+
+jest.mock('../../../src/components/ui/HintIcon', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return { HintIcon: () => React.createElement(View, null) };
+});
+
+jest.mock('../../../src/components/settings/ReminderSection', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return { ReminderSection: () => React.createElement(View, null) };
+});
+
+import React from 'react';
+import * as Haptics from 'expo-haptics';
+import { fireEvent, render } from '@testing-library/react-native';
+import { SettingsContent } from '../../../src/components/settings/SettingsContent';
+
+function renderContent(props: Record<string, unknown> = {}) {
+  const base = {
+    colors: {
+      background: '#fff', surface: '#f4f4f4', primary: '#2563eb', accent: '#2563eb',
+      text: '#111', textSecondary: '#666', border: '#ddd', error: '#dc2626',
+    },
+    headerHeight: 60,
+    tabBarHeight: 60,
+    theme: 'light',
+    uiStyle: 'flat',
+    accounts: [],
+    activeAccountId: null,
+    authState: { isAuthenticated: false },
+    accountSummaries: [],
+    repositories: [],
+    syncingRepo: null,
+    syncModes: {},
+    cloningRepo: null,
+    templatesRepoPref: null,
+    isSyncingExistingTemplates: false,
+    isAIEnabled: true,
+    selectedModelName: '',
+    actionMode: 'auto',
+    chatStorageLabel: '',
+    providers: [],
+    setTheme: jest.fn(),
+    setStyle: jest.fn(),
+    onOpenConnectToken: jest.fn(),
+    onOpenAddAccount: jest.fn(),
+    onSwitchAccount: jest.fn(),
+    onRemoveAccount: jest.fn(),
+    onRemoveToken: jest.fn(),
+    onDisconnectHost: jest.fn(),
+    onAddHost: jest.fn(),
+    onAddHostLocked: jest.fn(),
+    onOpenRepoPicker: jest.fn(),
+    onSyncRepo: jest.fn(),
+    onRemoveRepo: jest.fn(),
+    onEnableCloneMode: jest.fn(),
+    onDisableCloneMode: jest.fn(),
+    lfsPending: {},
+    lfsDownloadingRepo: null,
+    onDownloadLfsObjects: jest.fn(),
+    onOpenTemplatesRepoPicker: jest.fn(),
+    onSyncExistingTemplates: jest.fn(),
+    onClearTemplatesRepo: jest.fn(),
+    onOpenRenderStyleSettings: jest.fn(),
+    onClearData: jest.fn(),
+    onResetOnboarding: jest.fn(),
+    isPro: true,
+    proStatusLabel: 'pro.statusActive',
+    onOpenPaywall: jest.fn(),
+    ...props,
+  };
+  return render(React.createElement(SettingsContent as React.ComponentType<Record<string, unknown>>, base));
+}
+
+describe('Settings dark mode toggle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('toggling ON from system theme fires a selection haptic and calls setTheme("dark")', () => {
+    const setTheme = jest.fn();
+    const { getByTestId } = renderContent({ theme: 'system', setTheme });
+    fireEvent(getByTestId('settings.toggle.theme'), 'onValueChange', true);
+    expect(Haptics.selectionAsync).toHaveBeenCalledTimes(1);
+    expect(setTheme).toHaveBeenCalledTimes(1);
+    expect(setTheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('toggling OFF from dark theme fires a selection haptic and calls setTheme("light")', () => {
+    const setTheme = jest.fn();
+    const { getByTestId } = renderContent({ theme: 'dark', setTheme });
+    fireEvent(getByTestId('settings.toggle.theme'), 'onValueChange', false);
+    expect(Haptics.selectionAsync).toHaveBeenCalledTimes(1);
+    expect(setTheme).toHaveBeenCalledTimes(1);
+    expect(setTheme).toHaveBeenCalledWith('light');
+  });
+
+  it('shows Use System Theme as Active while in system theme', () => {
+    const { getByText } = renderContent({ theme: 'system' });
+    const row = getByText('Use System Theme');
+    expect(row).toBeTruthy();
+    expect(getByText('Active')).toBeTruthy();
+  });
+
+  it('shows Use System Theme as Inactive once an explicit theme is set', () => {
+    const { getByText } = renderContent({ theme: 'dark' });
+    expect(getByText('Use System Theme')).toBeTruthy();
+    expect(getByText('Inactive')).toBeTruthy();
+  });
+});

--- a/__tests__/services/DailyQuoteService.test.ts
+++ b/__tests__/services/DailyQuoteService.test.ts
@@ -1,0 +1,120 @@
+jest.mock('ai', () => ({
+  generateText: jest.fn(),
+}));
+
+jest.mock('../../src/services/AIService', () => ({
+  initializeModel: jest.fn(),
+}));
+
+jest.mock('../../src/stores/aiStore', () => {
+  let state: Record<string, unknown> = {
+    dailyQuoteEnabled: true,
+    aiPersonalizationEnabled: true,
+    selectedModelId: null,
+    getSelectedModel: jest.fn(() => undefined),
+  };
+  return {
+    useAIStore: Object.assign(jest.fn(), {
+      getState: () => state,
+      __setMockState: (next: Record<string, unknown>) => {
+        state = { ...state, ...next };
+      },
+      __reset: () => {
+        state = {
+          dailyQuoteEnabled: true,
+          aiPersonalizationEnabled: true,
+          selectedModelId: null,
+          getSelectedModel: jest.fn(() => undefined),
+        };
+      },
+    }),
+  };
+});
+
+import { dailyQuoteService } from '../../src/services/DailyQuoteService';
+import { useAIStore } from '../../src/stores/aiStore';
+import { __setProState } from '../../src/stores/proStore';
+
+type AIStoreMock = typeof useAIStore & {
+  __setMockState: (next: Record<string, unknown>) => void;
+  __reset: () => void;
+};
+
+const aiStoreMock = useAIStore as AIStoreMock;
+
+function setFree(): void {
+  __setProState({ status: 'free', entitlementActive: false, isGrandfathered: false });
+}
+
+function setPro(): void {
+  __setProState({ status: 'pro', entitlementActive: true, isGrandfathered: false });
+}
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  aiStoreMock.__reset();
+  setPro();
+  await dailyQuoteService.clearCache();
+});
+
+describe('DailyQuoteService Pro-aware fallback', () => {
+  it('non-Pro user with no model gets a neutral fallback (no Settings instruction)', async () => {
+    setFree();
+    const quote = await dailyQuoteService.getDailyQuote([], []);
+    expect(quote).not.toBeNull();
+    expect(quote!.description).not.toMatch(/Choose a model/);
+    expect(quote!.description).not.toMatch(/Settings/);
+    expect(quote!.description).toMatch(/GitNotēs Pro|collection/i);
+  });
+
+  it('Pro user with no model keeps the original "Choose a model" copy', async () => {
+    setPro();
+    const quote = await dailyQuoteService.getDailyQuote([], []);
+    expect(quote).not.toBeNull();
+    expect(quote!.description).toMatch(/Choose a model/);
+  });
+
+  it('non-Pro user with the Daily Quote disabled gets the neutral Pro message', async () => {
+    setFree();
+    aiStoreMock.__setMockState({ dailyQuoteEnabled: false });
+    const quote = await dailyQuoteService.getDailyQuote([], []);
+    expect(quote).not.toBeNull();
+    expect(quote!.description).not.toMatch(/Settings/);
+    expect(quote!.description).toMatch(/GitNotēs Pro/);
+  });
+
+  it('Pro user with the Daily Quote disabled keeps the original copy', async () => {
+    setPro();
+    aiStoreMock.__setMockState({ dailyQuoteEnabled: false });
+    const quote = await dailyQuoteService.getDailyQuote([], []);
+    expect(quote).not.toBeNull();
+    expect(quote!.description).toMatch(/Daily Quote feature is disabled/);
+  });
+
+  it('non-Pro user with personalization off gets the neutral Pro message', async () => {
+    setFree();
+    aiStoreMock.__setMockState({ aiPersonalizationEnabled: false });
+    const quote = await dailyQuoteService.getDailyQuote([], []);
+    expect(quote).not.toBeNull();
+    expect(quote!.description).not.toMatch(/data safety/);
+    expect(quote!.description).toMatch(/GitNotēs Pro/);
+  });
+
+  it('Pro user with personalization off keeps the original copy', async () => {
+    setPro();
+    aiStoreMock.__setMockState({ aiPersonalizationEnabled: false });
+    const quote = await dailyQuoteService.getDailyQuote([], []);
+    expect(quote).not.toBeNull();
+    expect(quote!.description).toMatch(/data safety/);
+  });
+
+  it('always returns a real quote payload with the fallback', async () => {
+    setFree();
+    const quote = await dailyQuoteService.getDailyQuote([], []);
+    expect(quote).not.toBeNull();
+    expect(typeof quote!.quoteId).toBe('string');
+    expect(typeof quote!.text).toBe('string');
+    expect(typeof quote!.author).toBe('string');
+    expect(Array.isArray(quote!.tags)).toBe(true);
+  });
+});

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -344,7 +344,10 @@ onSetSyncIntervalSeconds,
               <Toggle
                 testID="settings.toggle.theme"
                 value={theme === 'dark'}
-                onValueChange={(value) => setTheme(value ? 'dark' : 'light')}
+                onValueChange={(value) => {
+                  HapticService.selection();
+                  setTheme(value ? 'dark' : 'light');
+                }}
               />
               <HintIcon hintKey="hints.settings.darkMode" testID="hint.dark-mode" />
             </View>

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -729,10 +729,16 @@ onSetSyncIntervalSeconds,
           </>
         ) : null}
         <GroupRow
-          testID="settings.button.manage-templates"
-          onPress={onManageTemplates}
+          testID={isPro ? 'settings.button.manage-templates' : 'settings.row.manage-templates-locked'}
+          onPress={isPro ? onManageTemplates : () => promptProUpgrade(t, onOpenPaywall)}
           leading={<Ionicons name="document-text-outline" size={20} color={colors.text} />}
-          trailing={<Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />}
+          trailing={
+            isPro ? (
+              <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
+            ) : (
+              <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+            )
+          }
         >
           <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.manageTemplates')}</Text>
         </GroupRow>

--- a/src/services/DailyQuoteService.ts
+++ b/src/services/DailyQuoteService.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { generateText } from 'ai';
 import type { Note } from '../models/Note';
 import { useAIStore } from '../stores/aiStore';
+import { useProStore, selectIsPro } from '../stores/proStore';
 import { initializeModel } from './AIService';
 import quotesJson from '../data/philosopher_quotes.json';
 
@@ -42,6 +43,20 @@ const FALLBACK_DESCRIPTIONS: Record<FallbackReason, string> = {
     'AI personalization is off for data safety. Showing a random quote from the collection.',
 };
 
+const PRO_BLOCKED_REASONS: FallbackReason[] = ['disabled', 'no_model', 'personalization_off'];
+
+function resolveDescription(reason: FallbackReason): string {
+  try {
+    const isPro = selectIsPro(useProStore.getState());
+    if (!isPro && PRO_BLOCKED_REASONS.includes(reason)) {
+      return 'AI personalization requires GitNotēs Pro. Showing a quote from the collection.';
+    }
+  } catch {
+    // proStore may throw on bare useProStore.getState() in some test setups
+  }
+  return FALLBACK_DESCRIPTIONS[reason];
+}
+
 function makeFallbackQuote(reason: FallbackReason): DailyQuote {
   const random = quotes[Math.floor(Math.random() * quotes.length)];
   return {
@@ -49,7 +64,7 @@ function makeFallbackQuote(reason: FallbackReason): DailyQuote {
     text: random.text,
     author: random.author,
     tags: random.tags,
-    description: FALLBACK_DESCRIPTIONS[reason],
+    description: resolveDescription(reason),
     generatedAt: Date.now(),
   };
 }


### PR DESCRIPTION
## Summary
Fix three issues related to theme UX, Pro-gating, and AI fallback messaging.

## Changes

- **#922** Theme toggle fires `HapticService.selection()` haptic and overrides "Use System Theme" immediately
- **#923** "Manage Templates" row shows lock icon for non-Pro users, tapping routes to paywall via `promptProUpgrade`
- **#929** Daily Quote fallback copy is now Pro-aware — free users see neutral message instead of Settings→AI instruction

## Test plan
- [ ] Toggle dark/light mode from "system" → theme switches immediately, Use System Theme row flips to Inactive, haptic fires
- [ ] Non-Pro user taps Manage Templates → Pro upgrade alert appears, lock icon visible in trailing slot
- [ ] Pro user taps Manage Templates → opens template manager, chevron visible
- [ ] Non-Pro user on fresh install → Daily Quote shows neutral "AI personalization requires GitNotēs Pro" description instead of Settings→AI instruction
- [ ] Pro user without model selected → still sees original "Choose a model in Settings → AI" message
- [ ] `yarn ts:check` passes
- [ ] `yarn jest` passes
- [ ] `yarn eslint . --ext .ts,.tsx` passes

Closes #922
Closes #923
Closes #929
