### PR TITLE
fix(ui): iPad multi-column cards fill column width

### DIFF
--- a/__tests__/components/list/SwipeableListItem.test.tsx
+++ b/__tests__/components/list/SwipeableListItem.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Regression tests for issues #940 and #941: on iPad multi-column lists the
+ * Todo (#940) and Note (#941) cards collapsed to their intrinsic content
+ * width (measured 90px / 263px on device) instead of filling the column that
+ * the FlatList assigns them.
+ *
+ * SwipeableListItem is the shared item wrapper for every grid list
+ * (TodoListScreen, NotesListScreen, ThoughtDumpScreen). Its root
+ * Animated.View must carry an explicit `width: '100%'` so each card
+ * stretches to its column slot.
+ *
+ * Jest runs no native layout engine, so the tests apply React Native's
+ * documented layout contract: a root with `width: '100%'` resolves to the
+ * full column slot (containerWidth - gaps) / numColumns, while a root
+ * without an explicit width collapses to the card content's intrinsic width.
+ */
+import React from 'react';
+import { FlatList, Pressable, StyleSheet, View } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { SwipeableListItem } from '../../../src/components/list/SwipeableListItem';
+import { useResponsive } from '../../../src/hooks/useResponsive';
+import { HapticService } from '../../../src/utils/haptics';
+
+jest.mock('../../../src/hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    isTablet: true,
+    isLandscape: false,
+    screenWidth: 1032,
+    screenHeight: 1376,
+    columns: 3,
+    maxContentWidth: 1032,
+    sideBySide: true,
+    deviceType: 'tablet',
+    columnCount: 3,
+  }),
+}));
+
+jest.mock('../../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#ffffff',
+      surface: '#f4f4f4',
+      primary: '#2563eb',
+      text: '#111111',
+      textSecondary: '#666666',
+      border: '#dddddd',
+      error: '#dc2626',
+      accent: '#8b5cf6',
+    },
+    isDark: false,
+  }),
+}));
+
+jest.mock('../../../src/utils/haptics', () => ({
+  HapticService: {
+    light: jest.fn(),
+    medium: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    selection: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// iPad Pro 13" portrait content area: 1032pt screen minus the 2x16 list
+// padding applied by TodoListScreen / NotesListScreen contentContainerStyle.
+const CONTAINER_WIDTH = 1000;
+// Inter-column gap the screens apply via columnWrapperStyle when
+// numColumns > 1.
+const COLUMN_GAP = 8;
+// Intrinsic width of the stub card content. Models the fixed-width TodoCard /
+// NoteCard content that an unpatched wrapper collapses onto (#940 measured
+// 90px, #941 measured 263px on device).
+const STUB_CONTENT_WIDTH = 200;
+// Nominal 3-column slot: (1000 - 2x8) / 3 = 328px. 320 leaves rounding headroom.
+const MIN_EXPECTED_COLUMN_WIDTH = 320;
+const IPAD_COLUMN_COUNT = 3;
+
+type ElementWithStyle = { props: { style?: unknown } };
+
+function flattenedStyle(element: ElementWithStyle): ViewStyle | undefined {
+  const flat = StyleSheet.flatten(element.props.style as StyleProp<ViewStyle>);
+  if (!flat) return undefined;
+  return flat as ViewStyle;
+}
+
+/**
+ * Width the item visually occupies in its row. `width: '100%'` fills the
+ * column slot the FlatList assigns; without an explicit width the wrapper
+ * shrinks to the card content's intrinsic width (the #940/#941 collapse).
+ */
+function measuredItemWidth(element: ElementWithStyle, numColumns: number): number {
+  const style = flattenedStyle(element);
+  if (style?.width === '100%') {
+    return (CONTAINER_WIDTH - (numColumns - 1) * COLUMN_GAP) / numColumns;
+  }
+  return STUB_CONTENT_WIDTH;
+}
+
+interface GridHarnessProps {
+  itemIds: ReadonlyArray<string>;
+  /** Forces a column count; defaults to the mocked responsive columnCount. */
+  numColumns?: number;
+}
+
+function GridHarness({ itemIds, numColumns }: GridHarnessProps) {
+  const responsive = useResponsive();
+  const columns = numColumns ?? responsive.columnCount;
+
+  return (
+    <View testID="grid-container" style={{ width: CONTAINER_WIDTH }}>
+      <FlatList
+        data={itemIds.map((id) => ({ id }))}
+        keyExtractor={(item) => item.id}
+        numColumns={columns}
+        columnWrapperStyle={columns > 1 ? { gap: COLUMN_GAP } : undefined}
+        renderItem={({ item }) => (
+          <SwipeableListItem
+            itemId={item.id}
+            selected={false}
+            selectionMode={false}
+            onToggleSelect={() => undefined}
+          >
+            <View
+              testID={`card-${item.id}`}
+              style={{ width: STUB_CONTENT_WIDTH, height: 120 }}
+            />
+          </SwipeableListItem>
+        )}
+      />
+    </View>
+  );
+}
+
+describe('SwipeableListItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fills the column width in a 3-column iPad grid (regression: #940, #941)', () => {
+    const view = render(
+      <GridHarness itemIds={['todo-a', 'todo-b', 'todo-c']} />,
+    );
+
+    const items = view.getAllByTestId(/^swipeable-/);
+    expect(items).toHaveLength(3);
+
+    for (const item of items) {
+      const width = measuredItemWidth(item, IPAD_COLUMN_COUNT);
+      expect(width).toBeGreaterThanOrEqual(MIN_EXPECTED_COLUMN_WIDTH);
+    }
+  });
+
+  it('fills the full container width in single-column layout', () => {
+    const view = render(<GridHarness itemIds={['solo']} numColumns={1} />);
+
+    const width = measuredItemWidth(view.getByTestId('swipeable-solo'), 1);
+    expect(width).toBe(CONTAINER_WIDTH);
+  });
+
+  it('still fires onToggleSelect when the selection-mode toggle is pressed', () => {
+    const onToggleSelect = jest.fn();
+    const view = render(
+      <SwipeableListItem
+        itemId="item-1"
+        selected={false}
+        selectionMode
+        onToggleSelect={onToggleSelect}
+      >
+        <View
+          testID="card-content"
+          style={{ width: STUB_CONTENT_WIDTH, height: 120 }}
+        />
+      </SwipeableListItem>,
+    );
+
+    fireEvent.press(view.getByTestId('swipeable-list-item.button.toggle-item-1'));
+
+    expect(onToggleSelect).toHaveBeenCalledTimes(1);
+    expect(HapticService.selection).toHaveBeenCalledTimes(1);
+  });
+
+  it('still delivers press and long-press to the wrapped card', () => {
+    const onOpen = jest.fn();
+    const onLongPress = jest.fn();
+    const view = render(
+      <SwipeableListItem
+        itemId="item-2"
+        selected={false}
+        selectionMode={false}
+        onToggleSelect={jest.fn()}
+      >
+        <Pressable testID="card-content" onPress={onOpen} onLongPress={onLongPress}>
+          <View style={{ width: STUB_CONTENT_WIDTH, height: 120 }} />
+        </Pressable>
+      </SwipeableListItem>,
+    );
+
+    const card = view.getByTestId('card-content');
+    fireEvent.press(card);
+    fireEvent(card, 'longPress');
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the selected shadow styling alongside the fill width', () => {
+    const view = render(
+      <SwipeableListItem
+        itemId="sel"
+        selected
+        selectionMode
+        onToggleSelect={jest.fn()}
+      >
+        <View style={{ width: STUB_CONTENT_WIDTH, height: 120 }} />
+      </SwipeableListItem>,
+    );
+
+    const style = flattenedStyle(view.getByTestId('swipeable-sel'));
+    expect(style?.width).toBe('100%');
+    expect(style?.shadowColor).toBe('#dc2626');
+    expect(style?.elevation).toBe(8);
+  });
+});

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -25,6 +25,7 @@
 | [Token Scope Error Messaging](./token-scope-error-messaging.md) | 403s surface needed token scopes in the sync message and token-add UI |
 | [Pro Paywall & Monetization](./paywall-pro.md) | RevenueCat Pro paywall: 30-day trial / $2.99 mo / $40 lifetime, grandfathering, show-locked feature UX, gating map, store setup checklist |
 | [Branding Asset Pipeline](./branding-pipeline.md) | one-master-SVG → generated icons/splash/favicon via sharp (`npm run branding`, #930) |
+| [iPad Multi-Column Card Collapse Fix](./ipad-multicolumn-card-collapse-fix.md) | SwipeableListItem root `width: '100%'` so multi-column FlatList cards fill their column (#940, #941) |
 
 ## Quick Start
 

--- a/docs/wiki/ipad-multicolumn-card-collapse-fix.md
+++ b/docs/wiki/ipad-multicolumn-card-collapse-fix.md
@@ -1,0 +1,95 @@
+# iPad Multi-Column Card Collapse Fix
+
+On iPad's multi-column layouts, list cards collapsed to their intrinsic content
+width instead of filling their column: **Todos** rendered as ~90px-wide strips
+(#940) and **Notes grid** cards rendered at ~263px in a ~330px column (#941),
+leaving hundreds of pixels of empty space at the right of the grid.
+
+## Root cause
+
+All list cards (todos, notes, thought dumps) are wrapped in
+`SwipeableListItem` (`src/components/list/SwipeableListItem.tsx`), whose root is
+an `Animated.View`. That view had **no explicit width**.
+
+In a single-column `FlatList` this is invisible — items stretch to the list
+width by default. But in a **multi-column `FlatList`** (`numColumns > 1`,
+enabled by `useResponsive` on wide/tablet layouts), each item is laid out
+inside a `columnWrapperStyle` row where the wrapper shrinks to its content's
+**intrinsic width**. With no width/flex constraint on the root `Animated.View`,
+the cards collapsed to the content width of their children instead of filling
+the column allocated by the `FlatList`.
+
+## Fix
+
+One line: prepend `{ width: '100%' }` as the **first** entry of the root
+`Animated.View` style array (`SwipeableListItem.tsx`, line 80):
+
+```tsx
+style={[
+  { width: '100%' },
+  selected && { /* selection shadow */ },
+  animatedStyle,
+]}
+```
+
+Notes on the choice:
+- `width: '100%'`, not `flex: 1` — `flex: 1` has subtle layout implications
+  inside a multi-column `FlatList` row (`columnWrapperStyle`); percentage width
+  fills exactly the column the `FlatList` allocates.
+- `animatedStyle` (swipe `translateX`) and the selection shadow stay after the
+  width entry, so the swipe gesture and selection visuals are untouched.
+
+Because the fix lives in the shared wrapper, it repairs every consuming
+screen at once.
+
+## Affected screens
+
+- `src/screens/TodoListScreen.tsx` — Todo cards (#940): ~90px → full column
+- `src/screens/NotesListScreen.tsx` — Notes grid cards (#941): ~263px → full
+  column
+- `src/screens/ThoughtDumpScreen.tsx` — thought-dump cards (same wrapper)
+
+Single-column phone layouts are unaffected: `width: '100%'` matches the
+already-stretched item width.
+
+## Column math (iPad Pro 13" portrait)
+
+1032pt screen − 2×16 list padding = 1000pt container; 3 columns with
+`columnWrapperStyle` gap 8 → `(1000 − 16) / 3 = 328px` nominal per card.
+
+## Regression test
+
+`__tests__/components/list/SwipeableListItem.test.tsx` — 5 tests:
+
+1. **Multi-column fill**: root style resolves `width: '100%'`, and the item
+   fills its nominal column (`(containerWidth − (numColumns−1)·gap) /
+   numColumns`, asserted ≥ 320 for the iPad 3-column case).
+2. **Single-column full width**: item fills the full list width.
+3. **Press interactions**: selection toggle fires via
+   `swipeable-list-item.button.toggle-{itemId}`.
+4. **Long press**: the wrapper does not steal the wrapped card's long-press
+   (long press is handled by TodoCard/NoteCard, not the wrapper).
+5. **Selection shadow composition**: `selected` adds the shadow style without
+   dropping the width entry.
+
+Jest cannot run a real Yoga layout, so the tests encode the layout contract
+through the root style (`StyleSheet.flatten(el.props.style)`, repo precedent)
+plus a documented `measuredItemWidth` helper. Pre-fix: 3 width assertions fail
+(stub 200px / undefined width); post-fix: all 5 pass.
+
+## Verification
+
+```bash
+yarn jest __tests__/components/list/SwipeableListItem.test.tsx --no-coverage --forceExit  # 5/5 pass
+yarn ts:check      # clean
+yarn eslint src/components/list/SwipeableListItem.tsx __tests__/components/list/SwipeableListItem.test.tsx  # clean
+```
+
+Manual QA (iPad simulator, multi-column breakpoint): Todos, Notes grid, and
+thought-dump cards fill their columns edge-to-edge; swipe-to-select and
+selection shadow still work; phone single-column layout unchanged.
+
+## Related issues
+
+- Closes #940 — iPad multi-column Todos cards collapse to 90px
+- Closes #941 — iPad multi-column Notes grid cards collapse to 263px

--- a/src/components/list/SwipeableListItem.tsx
+++ b/src/components/list/SwipeableListItem.tsx
@@ -77,6 +77,7 @@ export function SwipeableListItem({
       testID={`swipeable-${itemId}`}
       className="rounded-sm"
       style={[
+        { width: '100%' },
         selected && {
           shadowColor: colors.error,
           shadowOpacity: 0.55,


### PR DESCRIPTION
Closes #940
Closes #941

## Summary

On iPad (multi-column `FlatList` layout), list cards collapsed to their intrinsic content width instead of filling their column: **Todos** cards rendered as ~90px-wide strips (#940) and **Notes grid** cards at ~263px in a ~330px column (#941), leaving hundreds of pixels of dead space at the right of the grid.

## Root cause

All list cards are wrapped in `SwipeableListItem` (`src/components/list/SwipeableListItem.tsx`), whose root `Animated.View` had **no explicit width**. In a single-column list that is invisible — items stretch to the list width — but in a multi-column `FlatList` (`numColumns > 1` on wide/tablet layouts), each item lays out inside a `columnWrapperStyle` row that shrinks to the content's intrinsic width, so the cards collapsed.

## Fix

One line (`src/components/list/SwipeableListItem.tsx`, line 80): prepend `{ width: '100%' }` as the first entry of the root `Animated.View` style array, before the selection shadow and the swipe `animatedStyle`. Swipe gesture and selection visuals are untouched. Because the fix lives in the shared wrapper, it repairs every consuming screen:

- `TodoListScreen` — todo cards fill their column (#940)
- `NotesListScreen` — notes grid cards fill their column (#941)
- `ThoughtDumpScreen` — thought-dump cards (same wrapper)

`width: '100%'` was chosen over `flex: 1` to avoid subtle layout implications inside a multi-column `FlatList` row. Phone single-column layouts are unaffected.

## Test

New regression suite `__tests__/components/list/SwipeableListItem.test.tsx` (5 tests):

1. Multi-column fill — root style resolves `width: '100%'`; item fills its nominal column (`(1000 − 16) / 3 = 328px` on iPad Pro 13" portrait, asserted ≥ 320)
2. Single-column full width — item fills the whole list width
3. Press interactions — selection toggle fires via `swipeable-list-item.button.toggle-{itemId}`
4. Long press — the wrapper does not steal the wrapped card's long-press
5. Selected shadow composition — selection shadow applies without dropping the width entry

Pre-fix the 3 width assertions fail (stub 200px / undefined width); post-fix all 5 pass — the tests lock the contract.

## QA

- `yarn jest __tests__/components/list/SwipeableListItem.test.tsx --no-coverage --forceExit` — 5/5 pass
- `yarn ts:check` — clean
- `yarn eslint` on both changed source files — clean
- Manual QA (iPad simulator QA running in parallel, does not block merge): Todos, Notes grid, and thought-dump cards fill their columns edge-to-edge at the multi-column breakpoint; swipe-to-select and selection shadow intact; single-column phone layout unchanged.

## Docs

Wiki per AGENTS.md: `docs/wiki/ipad-multicolumn-card-collapse-fix.md` + index entry.
