### PR TITLE
fix(settings): add-repo picker clone progress + first-connect repo load + delete false-failure

### DIFF
--- a/__tests__/AccountsContext.test.tsx
+++ b/__tests__/AccountsContext.test.tsx
@@ -94,6 +94,12 @@ let capturedMethods: {
   disconnectHost: (id: string) => Promise<void>;
   clearToken: () => Promise<void>;
   addAccount: (token: string) => Promise<unknown>;
+  connectHost: (input: {
+    provider: string;
+    token: string;
+    instanceBaseUrl?: string | null;
+    accountId?: string;
+  }) => Promise<unknown>;
   accountSummaries: Array<{ account: { id: string }; hosts: Array<{ id: string }> }>;
   activeAccountId: string | null;
 } | null = null;
@@ -105,6 +111,7 @@ function TestProbe() {
     disconnectHost: ctx.disconnectHost,
     clearToken: ctx.clearToken,
     addAccount: ctx.addAccount,
+    connectHost: ctx.connectHost,
     accountSummaries: ctx.accountSummaries,
     activeAccountId: ctx.activeAccountId,
   };
@@ -464,6 +471,67 @@ describe('AccountsContext — chat repo clearing on removal', () => {
       const added = await capturedMethods!.addAccount('bad-token');
 
       expect(added).toBeNull();
+      expect(GitHubService.setToken).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── connectHost (#953) ──────────────────────────────────────────────
+
+  describe('connectHost', () => {
+    it('hydrates the GitHubService singleton for github connects so repo listing works immediately', async () => {
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue(null);
+      (AuthService.getToken as jest.Mock).mockResolvedValue(null);
+      (AuthService.connectHost as jest.Mock).mockResolvedValue({
+        ok: true,
+        host: {
+          id: 'h1',
+          provider: 'github',
+          hostUserId: 42,
+          hostLogin: 'alice',
+          name: 'Alice',
+          email: 'alice@example.com',
+          avatarUrl: null,
+          instanceBaseUrl: null,
+        },
+        account: { id: 'acc-1' },
+      });
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      const result = await capturedMethods!.connectHost({
+        provider: 'github',
+        token: 'ghp_secret',
+      });
+
+      expect(result).toEqual({ ok: true, host: expect.objectContaining({ id: 'h1' }) });
+      expect(GitHubService.setToken).toHaveBeenCalledWith(
+        'ghp_secret',
+        expect.objectContaining({
+          id: 42,
+          login: 'alice',
+          name: 'Alice',
+          email: 'alice@example.com',
+        }),
+      );
+    });
+
+    it('does not hydrate GitHubService when connectHost fails', async () => {
+      (AuthService.listAccountSummaries as jest.Mock).mockResolvedValue([]);
+      (AuthService.getActiveSummary as jest.Mock).mockResolvedValue(null);
+      (AuthService.getToken as jest.Mock).mockResolvedValue(null);
+      (AuthService.connectHost as jest.Mock).mockResolvedValue(null);
+
+      const { getByTestId } = renderProvider();
+      await waitFor(() => expect(getByTestId('probe')).toBeTruthy());
+
+      const result = await capturedMethods!.connectHost({
+        provider: 'github',
+        token: 'ghp_secret',
+      });
+
+      expect(result).toEqual({ ok: false, error: 'Invalid token' });
       expect(GitHubService.setToken).not.toHaveBeenCalled();
     });
   });

--- a/__tests__/components/settings/SettingsModals.test.tsx
+++ b/__tests__/components/settings/SettingsModals.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import { ActivityIndicator, ScrollView, TouchableOpacity } from 'react-native';
 import { SettingsModals } from '../../../src/components/settings/SettingsModals';
 import type { GitRepository } from '../../../src/services/GitService';
@@ -16,6 +16,36 @@ jest.mock('react-i18next', () => ({
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+}));
+
+jest.mock('../../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f4f4f4',
+      primary: '#2563eb',
+      text: '#111',
+      textSecondary: '#666',
+      border: '#ddd',
+      error: '#dc2626',
+      elevated: '#fff',
+    },
+    isDark: false,
+  }),
+  useTokens: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f4f4f4',
+      primary: '#2563eb',
+      text: '#111',
+      textSecondary: '#666',
+      border: '#ddd',
+      error: '#dc2626',
+      elevated: '#fff',
+    },
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24 },
+    type: { xs: 12, sm: 14, md: 16, lg: 18 },
+  }),
 }));
 
 jest.mock('../../../src/components/SearchBar', () => {
@@ -72,6 +102,9 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof SettingsModals
     manualRepoInput: '',
     isAddingRepoPath: null,
     isLoadingGithubRepos: false,
+    cloneProgress: null,
+    onCancelClone: jest.fn(),
+    onRetryClone: jest.fn(),
     tokenInput: '',
     tokenVisible: false,
     tokenError: null,
@@ -206,5 +239,79 @@ describe('SettingsModals busy state', () => {
     );
     indicators = UNSAFE_queryAllByType(ActivityIndicator);
     expect(indicators.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('SettingsModals inline clone progress (#953)', () => {
+  it('renders clone progress inline inside the picker when cloneProgress is set', () => {
+    const { getByText, queryByText, UNSAFE_getByType } = render(
+      <SettingsModals
+        {...makeProps({
+          showRepoPickerModal: true,
+          authState: { isAuthenticated: true },
+          cloneProgress: {
+            repoName: 'me/notes',
+            phase: 'Receiving objects',
+            loaded: 50,
+            total: 100,
+          },
+        })}
+      />,
+    );
+    // Progress UI is inside the picker modal, not a separate stacked modal.
+    expect(getByText(/Cloning me\/notes/)).toBeTruthy();
+    expect(getByText(/Receiving objects/)).toBeTruthy();
+    expect(queryByText('Clone Failed')).toBeNull();
+    const scrollView = UNSAFE_getByType(ScrollView);
+    expect(scrollView).toBeTruthy();
+  });
+
+  it('renders error state with cancel and retry buttons when the clone fails', () => {
+    const { getByText, queryByText } = render(
+      <SettingsModals
+        {...makeProps({
+          showRepoPickerModal: true,
+          authState: { isAuthenticated: true },
+          cloneProgress: {
+            repoName: 'me/notes',
+            phase: 'failed',
+            loaded: 0,
+            total: null,
+            error: 'Packfile trailer mismatch',
+          },
+        })}
+      />,
+    );
+    expect(getByText('Clone Failed')).toBeTruthy();
+    expect(getByText(/Packfile trailer mismatch/)).toBeTruthy();
+    expect(queryByText('Cancel')).toBeTruthy();
+    expect(queryByText('Retry')).toBeTruthy();
+  });
+
+  it('wires cancel and retry callbacks from the inline progress content', () => {
+    const onCancel = jest.fn();
+    const onRetry = jest.fn();
+    const { getByText, getByTestId } = render(
+      <SettingsModals
+        {...makeProps({
+          showRepoPickerModal: true,
+          authState: { isAuthenticated: true },
+          cloneProgress: {
+            repoName: 'me/notes',
+            phase: 'failed',
+            loaded: 0,
+            total: null,
+            error: 'boom',
+          },
+          onCancelClone: onCancel,
+          onRetryClone: onRetry,
+        })}
+      />,
+    );
+    fireEvent.press(getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    fireEvent.press(getByText('Retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(getByTestId('modal')).toBeTruthy();
   });
 });

--- a/__tests__/screens/SettingsScreen.add-repo-import.test.tsx
+++ b/__tests__/screens/SettingsScreen.add-repo-import.test.tsx
@@ -393,7 +393,10 @@ jest.mock('../../src/components/settings/SettingsContent', () => {
 });
 
 // Test surface for the picker: exposes visibility + busy props as nodes so
-// timing assertions can observe them directly.
+// timing assertions can observe them directly. The clone progress now renders
+// INLINE inside the picker modal (iOS cannot stack a second native Modal on
+// top of the picker — "Attempt to present ... which is already presenting"),
+// so the mock mirrors that: progress nodes appear when cloneProgress is set.
 jest.mock('../../src/components/settings/SettingsModals', () => {
   const { Pressable, Text, TextInput, View } = require('react-native');
   return {
@@ -420,6 +423,20 @@ jest.mock('../../src/components/settings/SettingsModals', () => {
           }>
           <Text>Select github repo</Text>
         </Pressable>
+        {props.cloneProgress ? (
+          <View testID="test-progress-modal">
+            <Text testID="test-progress-phase">{props.cloneProgress.phase}</Text>
+            {props.cloneProgress.error ? (
+              <Text testID="test-progress-error">{props.cloneProgress.error}</Text>
+            ) : null}
+            <Pressable testID="test-progress-cancel" onPress={props.onCancelClone}>
+              <Text>Cancel</Text>
+            </Pressable>
+            <Pressable testID="test-progress-retry" onPress={props.onRetryClone}>
+              <Text>Retry</Text>
+            </Pressable>
+          </View>
+        ) : null}
       </View>
     ),
   };

--- a/__tests__/stores/noteStore.test.ts
+++ b/__tests__/stores/noteStore.test.ts
@@ -137,6 +137,28 @@ describe('useNoteStore', () => {
 
       expect(useNoteStore.getState().notes).toHaveLength(0);
     });
+
+    it('treats an already-removed row as success when the write-through side channel completed the delete (#932 QA)', async () => {
+      // API-mode write-through: stageDelete's drain already fired the queue
+      // side-channel, which removed the note from state + storage. The
+      // subsequent direct StorageService.deleteNote(id) returns false because
+      // the row is gone — deleteNote must report SUCCESS, not a failed delete.
+      const note = makeNote('1', { repo: 'me/repo', branch: 'main', filePath: 'notes/test.md' });
+      useNoteStore.setState({ notes: [note] });
+      // Simulate the write-through side channel removing the row during
+      // stageDelete (the drain completed the delete end-to-end).
+      (StagingService.stageDelete as jest.Mock).mockImplementation(async () => {
+        useNoteStore.setState({ notes: [] });
+        return { success: true };
+      });
+      (StorageService.deleteNote as jest.Mock).mockResolvedValue(false);
+
+      const result = await useNoteStore.getState().deleteNote('1');
+
+      expect(result).toBe(true);
+      expect(StagingService.stageDelete).toHaveBeenCalled();
+      expect(useGitOperationStore.getState().ops).toEqual({}); // op succeeded, not failed
+    });
   });
 
   describe('dropByFilePaths', () => {

--- a/docs/wiki/add-repo-picker-clone-progress.md
+++ b/docs/wiki/add-repo-picker-clone-progress.md
@@ -1,0 +1,88 @@
+# Add Repository Picker — Clone Progress & First-Connect Fixes (#953)
+
+Three bugs in the Add-Repository flow, all surfaced on a fresh simulator session
+during the #932 QA campaign and confirmed against Metro logs + accessibility
+tree:
+
+## 1. Repo click "just keeps loading" — clone progress modal never appeared
+
+When clicking a GitHub repo row in the Add-Repository picker, the row showed an
+endless spinner with **no progress and no cancel button** while the import ran
+(the default sync mode is now `clone`, so add-time import does a full clone).
+
+Root cause: `importRepoAfterAdd` set `cloneProgress`, which rendered
+`CloneProgressModal` — a **second native `Modal` on top of the already-open repo
+picker modal**. iOS Fabric rejects stacked native modals:
+
+```
+[UIKitCore] Attempt to present <RCTFabricModalHostViewController> ... which is already presenting
+```
+
+The presentation was silently dropped, so the user saw only the row spinner for
+the entire clone (which can take 1–10 minutes) with no way to cancel.
+
+Fix (`src/components/settings/CloneProgressModal.tsx`,
+`src/components/settings/SettingsModals.tsx`, `src/screens/SettingsScreen.tsx`):
+
+- Extracted the progress UI into a reusable `CloneProgressContent` component.
+- `SettingsModals` renders `CloneProgressContent` **inline inside the picker
+  bottom sheet** when `cloneProgress` is set (with Cancel / Retry wired to the
+  existing `handleCancelClone` / `handleRetryClone`).
+- The standalone `CloneProgressModal` (still used by the sync-engine clone
+  toggle, where no other modal is open) renders only when the repo picker is
+  closed (`!showRepoPickerModal`), so it never attempts the stacked presentation.
+- Guarded the inline render with `cloneProgress != null` (covers `undefined`
+  during hot reload, which previously crashed the new component).
+
+Result: clicking a repo now shows live progress + a Cancel button inside the
+picker, exactly matching the #938 contract (picker stays busy until import
+settles).
+
+## 2. Manual "Add" button spinner too close to the label
+
+The manual-add `Button` used `iconAlign="edge"`, which pins the trailing
+spinner to the button's right edge with no gap from the "Add" label on a narrow
+button.
+
+Fix (`src/components/settings/SettingsModals.tsx`): switched to
+`iconAlign="inline"` (the component default) so the spinner flows after the
+label with the standard 8px gap.
+
+## 3. First-time host connect: repo list empty until app restart
+
+Adding a token/account for the **first time** via the primary "Connect host"
+flow showed no repositories in the Add-Repository picker until the app was
+restarted.
+
+Root cause: `AccountsContext.connectHost` (used by `ConnectHostModal`, the
+first-run path) persisted the host and refreshed `authState` but **never
+hydrated the legacy `GitHubService` singleton**. `openRepoPicker` gates the
+fetch on `GitHubService.isAuthenticated()`, which stayed `false` until the app
+restarted (bootstrap `GitHubService.initialize()`). The earlier fix
+(documented in `settings-add-repo-fixes.md`) covered the `addAccount` path only.
+
+Fix (`src/contexts/AccountsContext.tsx`): after a successful `connectHost` for
+a GitHub host, best-effort `GitHubService.setToken(token, user)` — mirroring the
+existing `addAccount` / `setToken` / `switchToHost` hydration pattern.
+
+## QA findings fixed (#932)
+
+- **Delete-note false failure**: in API-mode write-through, the queue
+  side-channel (`onDeleteMutationSucceeded`) removes the note during
+  `stageDelete`'s drain, so the follow-up `StorageService.deleteNote(id)` returns
+  `false` for the already-removed row and the UI showed "Failed to delete note"
+  even though the delete fully succeeded locally and on GitHub.
+  Fix (`src/stores/noteStore.ts`): treat the already-removed state as success
+  (`deleteNote` returns true, op is succeeded).
+
+## Tests
+
+- `SettingsModals.test.tsx`: inline clone progress renders inside the picker,
+  error state with Cancel/Retry, callbacks wired.
+- `AccountsContext.test.tsx`: `connectHost` hydrates the GitHubService
+  singleton for github connects; no hydration on failure.
+- `SettingsScreen.add-repo-import.test.tsx`: mock surface updated to the
+  inline-progress contract (progress renders inside the picker, not a second
+  modal).
+- `noteStore.test.ts`: delete reports success when the write-through side
+  channel already removed the row.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -30,6 +30,7 @@
 | [Explore Repo Hub](./explore-repo-hub.md) | Hub page for selected repo with Browse Files / Pull Requests / Issues / branch selector; multi-provider data layer (#937) |
 | [Settings — Add Repo Fixes](./settings-add-repo-fixes.md) | Invisible primary-button fix + repo list not loading after adding a token + busy-state re-entry guard on Add-Repo picker (#936) |
 | [iPad Multi-Column Card Collapse Fix](./ipad-multicolumn-card-collapse-fix.md) | SwipeableListItem root `width: '100%'` so multi-column FlatList cards fill their column (#940, #941) |
+| [Add Repo Picker — Clone Progress & First-Connect Fixes](./add-repo-picker-clone-progress.md) | Inline clone progress in the repo picker (no stacked native modal), manual-Add spinner padding, connectHost hydrating GitHubService, delete-note false-failure fix (#953, QA #932) |
 
 ## Quick Start
 

--- a/src/components/settings/CloneProgressModal.tsx
+++ b/src/components/settings/CloneProgressModal.tsx
@@ -16,28 +16,37 @@ interface CloneProgressModalProps {
   onRetry?: () => void;
 }
 
-export function CloneProgressModal({ progress, onCancel, onRetry }: CloneProgressModalProps) {
+/**
+ * The clone/import progress UI, decoupled from the native Modal wrapper so it
+ * can be rendered inline inside the Add-Repository picker bottom sheet as well
+ * as standalone. The picker path MUST NOT stack a second native Modal on top of
+ * the open picker modal — iOS Fabric rejects the presentation
+ * ("Attempt to present ... which is already presenting"), which silently
+ * swallowed the progress UI and left users staring at an endless row spinner.
+ */
+export function CloneProgressContent({
+  progress,
+  onCancel,
+  onRetry,
+}: {
+  progress: CloneProgress;
+  onCancel: () => void;
+  onRetry?: () => void;
+}) {
   const { colors } = useTheme();
   const { spacing, type } = useTokens();
 
-  const visible = progress !== null;
-  const hasError = progress?.error !== undefined;
+  const hasError = progress.error !== undefined;
   const pct =
-    progress && progress.total && progress.total > 0
+    progress.total && progress.total > 0
       ? Math.min(1, progress.loaded / progress.total)
       : null;
   const pctLabel = pct !== null ? `${Math.round(pct * 100)}%` : '…';
 
   return (
-    <Modal
-      visible={visible}
-      onRequestClose={onCancel}
-      dismissOnBackdrop={false}
-      bottomSheet
-      contentStyle={{ padding: spacing[5], paddingBottom: spacing[6] + 18 }}
-    >
+    <>
       <Text style={{ color: colors.text, fontSize: type.lg, fontWeight: '600', marginBottom: spacing[1] }}>
-        {hasError ? 'Clone Failed' : `Cloning ${progress?.repoName ?? ''}`}
+        {hasError ? 'Clone Failed' : `Cloning ${progress.repoName}`}
       </Text>
 
       {hasError ? (
@@ -58,7 +67,7 @@ export function CloneProgressModal({ progress, onCancel, onRetry }: CloneProgres
       ) : (
         <>
           <Text style={{ color: colors.textSecondary, fontSize: type.sm, marginBottom: spacing[4] }}>
-            {progress?.phase ?? 'Preparing'} · {pctLabel}
+            {progress.phase} · {pctLabel}
           </Text>
 
           <View
@@ -86,6 +95,26 @@ export function CloneProgressModal({ progress, onCancel, onRetry }: CloneProgres
           </Text>
         </>
       )}
+    </>
+  );
+}
+
+export function CloneProgressModal({ progress, onCancel, onRetry }: CloneProgressModalProps) {
+  const { spacing } = useTokens();
+
+  const visible = progress !== null;
+
+  return (
+    <Modal
+      visible={visible}
+      onRequestClose={onCancel}
+      dismissOnBackdrop={false}
+      bottomSheet
+      contentStyle={{ padding: spacing[5], paddingBottom: spacing[6] + 18 }}
+    >
+      {progress ? (
+        <CloneProgressContent progress={progress} onCancel={onCancel} onRetry={onRetry} />
+      ) : null}
     </Modal>
   );
 }

--- a/src/components/settings/SettingsModals.tsx
+++ b/src/components/settings/SettingsModals.tsx
@@ -8,6 +8,7 @@ import { Modal, Input, Button } from '../ui';
 import type { GitRepository } from '../../services/GitService';
 import type { GitHubRepository } from '../../services/GitHubService';
 import type { TemplateRepoPreference } from '../../services/TemplateRepoPreferenceService';
+import { CloneProgressContent, type CloneProgress } from './CloneProgressModal';
 
 type ThemeColors = {
   background: string;
@@ -33,6 +34,9 @@ type SettingsModalsProps = {
   manualRepoInput: string;
   isAddingRepoPath: string | null;
   isLoadingGithubRepos: boolean;
+  cloneProgress: CloneProgress | null;
+  onCancelClone: () => void;
+  onRetryClone: () => void;
   tokenInput: string;
   tokenVisible: boolean;
   tokenError: string | null;
@@ -69,6 +73,9 @@ export function SettingsModals(props: SettingsModalsProps) {
     manualRepoInput,
     isAddingRepoPath,
     isLoadingGithubRepos,
+    cloneProgress,
+    onCancelClone,
+    onRetryClone,
     tokenInput,
     tokenVisible,
     tokenError,
@@ -129,9 +136,19 @@ export function SettingsModals(props: SettingsModalsProps) {
               style={{ paddingHorizontal: 16 }}
               textStyle={{ color: '#fff' }}
               trailingIcon={isAddingRepoPath !== null ? <ActivityIndicator size="small" color="#fff" /> : undefined}
-              iconAlign="edge"
+              iconAlign="inline"
             />
           </View>
+
+          {cloneProgress != null ? (
+            <View className="px-4 py-4 border-b" style={{ borderColor: colors.border }}>
+              <CloneProgressContent
+                progress={cloneProgress}
+                onCancel={onCancelClone}
+                onRetry={onRetryClone}
+              />
+            </View>
+          ) : null}
 
           {authState.isAuthenticated ? (
             <>

--- a/src/contexts/AccountsContext.tsx
+++ b/src/contexts/AccountsContext.tsx
@@ -168,6 +168,19 @@ export function AccountsProvider({ children }: { children: ReactNode }) {
       const result = await AuthService.connectHost(input);
       await refreshAccounts();
       if (!result) return { ok: false, error: 'Invalid token' };
+      // Keep the legacy GitHubService singleton in sync so repo listing /
+      // preflight checks (which gate on GitHubService.isAuthenticated) work
+      // immediately after connecting a host, not just after an app restart.
+      // Mirrors the addAccount/setToken/switchToHost hydration pattern.
+      if (result.host.provider === 'github') {
+        await GitHubService.setToken(input.token, {
+          id: result.host.hostUserId,
+          login: result.host.hostLogin,
+          name: result.host.name ?? result.host.hostLogin,
+          email: result.host.email ?? '',
+          avatar_url: result.host.avatarUrl ?? '',
+        } as unknown as GhSetTokenUser).catch(() => undefined);
+      }
       return { ok: true, host: result.host };
     },
     [refreshAccounts],

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -982,6 +982,9 @@ export default function SettingsScreen() {
         manualRepoInput={manualRepoInput}
         isAddingRepoPath={isAddingRepoPath}
         isLoadingGithubRepos={isLoadingGithubRepos}
+        cloneProgress={cloneProgress}
+        onCancelClone={handleCancelClone}
+        onRetryClone={handleRetryClone}
         tokenInput={tokenInput}
         tokenVisible={tokenVisible}
         tokenError={tokenError}
@@ -1009,7 +1012,13 @@ export default function SettingsScreen() {
         onSelected={() => setShowChatRepoPicker(false)}
         onGoToSettings={() => { setShowChatRepoPicker(false); void openRepoPicker(); }}
       />
-      <CloneProgressModal progress={cloneProgress} onCancel={handleCancelClone} onRetry={handleRetryClone} />
+      {/* When the repo picker is open, clone progress renders inline inside
+          the picker modal (iOS cannot stack a second native Modal on top of
+          the picker). The standalone modal only presents for flows with no
+          picker open (e.g. the sync-engine clone toggle). */}
+      {!showRepoPickerModal ? (
+        <CloneProgressModal progress={cloneProgress} onCancel={handleCancelClone} onRetry={handleRetryClone} />
+      ) : null}
       <ConnectHostModal
         visible={showConnectHostModal}
         onClose={() => { setShowConnectHostModal(false); setConnectHostPreset(undefined); }}

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -167,10 +167,16 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
           if (success) {
             set((state) => ({ notes: state.notes.filter((n) => n.id !== id) }));
             gitOperationRegistry.succeed(opId);
+          } else if (!get().notes.some((n) => n.id === id)) {
+            // The write-through drain already completed the delete and its
+            // side-channel removed the row (note gone from state + storage).
+            // `StorageService.deleteNote` returns false for the already-removed
+            // id — treat that as success, not as a failed delete.
+            gitOperationRegistry.succeed(opId);
           } else {
             gitOperationRegistry.fail(opId, 'Failed to delete note locally');
           }
-          return success;
+          return success || !get().notes.some((n) => n.id === id);
         }
         // Repo-backed note with no derivable path: nothing to enqueue, so
         // fall through to the instant local delete below.


### PR DESCRIPTION
## Summary

Fixes three bugs in the **Add-Repository** flow reported in this session, plus one bug found during the **#932 QA campaign**:

### 1. Repo click "just keeps loading" — clone progress never appeared
Clicking a repo in the Add-Repository picker showed an endless row spinner with **no progress and no cancel** while the add-time import ran (clone mode is now the default). Root cause: `importRepoAfterAdd` rendered `CloneProgressModal` — a **second native `Modal` on top of the already-open picker modal** — which iOS Fabric rejects (`Attempt to present ... which is already presenting`, confirmed in Metro logs). The progress UI was silently dropped.

**Fix:** extracted `CloneProgressContent` and render it **inline inside the picker bottom sheet** (progress bar + Cancel/Retry wired to the existing handlers). The standalone modal now only presents when no picker is open. Verified on simulator: clicking a repo shows live progress + Cancel.

### 2. Manual "Add" button spinner too close to the label
`iconAlign="edge"` pinned the spinner to the button edge with no gap. Switched to `iconAlign="inline"` (standard 8px gap).

### 3. First-time connect: repo list empty until app restart
`AccountsContext.connectHost` (the primary first-run "Connect host" flow) never hydrated the legacy `GitHubService` singleton, so `openRepoPicker`'s `GitHubService.isAuthenticated()` gate stayed false until restart. Mirrors the existing `addAccount`/`setToken`/`switchToHost` hydration.

### 4. QA #932 finding: false "Failed to delete note" after a successful delete
In API-mode write-through, the queue side-channel removes the row during `stageDelete`'s drain, so the follow-up `StorageService.deleteNote(id)` returned `false` for the already-removed id → spurious failure alert despite the delete fully succeeding locally and on GitHub. `deleteNote` now treats that state as success.

## QA (issue #932) — API mode, test-notes repo
- ✅ Create note → staged → pushed → verified on GitHub (`qa-932-api-create.md`)
- ✅ Edit note → pushed → remote content matches
- ✅ Delete note → removed locally + remote (after fix #4; pre-fix showed false error)
- ✅ Todo create → `todos/qa-932-todo.json` on remote
- ✅ Todo toggle → `completed: true` persisted remotely
- ⚠️ Clone-mode end-to-end blocked by this environment's github.com git-protocol hang from the simulator (proven environment-specific: identical isomorphic-git code clones from Node in <1s); clone-mode paths covered by the existing 295 passing test suites.

## Verification
- `yarn ts:check` ✅
- `yarn jest` — 295 suites / 2709 tests pass ✅
- `yarn eslint . --ext .ts,.tsx` — 0 errors ✅

Wiki: `docs/wiki/add-repo-picker-clone-progress.md`
