### PR TITLE
feat(paywall): pro plans bento grid matching feature section

### DIFF
--- a/__tests__/components/paywall/PaywallPlanGrid.test.tsx
+++ b/__tests__/components/paywall/PaywallPlanGrid.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+// Jest's default RN window is ~750x1334 (tablet branch). Mutate this object
+// per test — the useWindowDimensions mock below reads it lazily at call time.
+const mockWindowDimensions = { width: 390, height: 844, scale: 1, fontScale: 1 };
+
+jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
+  __esModule: true,
+  default: () => mockWindowDimensions,
+}));
+
+jest.mock('../../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    isDark: false,
+    colors: {
+      background: '#fff',
+      surface: '#f4f4f4',
+      primary: '#2563eb',
+      accent: '#2563eb',
+      text: '#111',
+      textSecondary: '#666',
+      border: '#ddd',
+      error: '#dc2626',
+    },
+  }),
+}));
+
+jest.mock('../../../src/components/ui', () => {
+  const React = require('react');
+  const { View, Text, TouchableOpacity } = require('react-native');
+  const Surface = (props: Record<string, unknown>) => React.createElement(View, props);
+  const Button = (props: { label?: string; onPress?: () => void; testID?: string; disabled?: boolean }) =>
+    React.createElement(
+      TouchableOpacity,
+      { testID: props.testID, disabled: props.disabled, onPress: props.onPress },
+      React.createElement(Text, null, props.label),
+    );
+  return { Surface, Button };
+});
+
+import PaywallPlanGrid, { PlanTileData } from '../../../src/components/paywall/PaywallPlanGrid';
+
+function plan(overrides: Partial<PlanTileData> & { id: PlanTileData['id'] }): PlanTileData {
+  return {
+    title: 'Title',
+    priceLine: '$9.99',
+    ctaLabel: 'Subscribe',
+    ctaTestID: `paywall.${overrides.id}.cta`,
+    variant: 'secondary',
+    disabled: false,
+    onPress: jest.fn(),
+    icon: 'calendar',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockWindowDimensions.width = 390;
+  mockWindowDimensions.height = 844;
+});
+
+describe('PaywallPlanGrid', () => {
+  it('renders a half-width pair (monthly + yearly) and a full-width lifetime hero at phone width', () => {
+    const { getByTestId } = render(
+      <PaywallPlanGrid
+        plans={[
+          plan({ id: 'monthly', title: 'Monthly' }),
+          plan({ id: 'yearly', title: 'Yearly' }),
+          plan({ id: 'lifetime', title: 'Lifetime' }),
+        ]}
+      />,
+    );
+    // usable = 390 - 40 = 350; pairW = (350 - 12) / 2 = 169.
+    expect(getByTestId('paywall.plan.monthly').props.style.width).toBe(169);
+    expect(getByTestId('paywall.plan.yearly').props.style.width).toBe(169);
+    expect(getByTestId('paywall.plan.lifetime').props.style.width).toBe(350);
+    expect(getByTestId('paywall.plan.lifetime').props.style.flexDirection).toBe('row');
+  });
+
+  it('stretches a lone non-hero plan to the full row width', () => {
+    const { getByTestId } = render(
+      <PaywallPlanGrid
+        plans={[
+          plan({ id: 'monthly', title: 'Monthly' }),
+          plan({ id: 'lifetime', title: 'Lifetime' }),
+        ]}
+      />,
+    );
+    expect(getByTestId('paywall.plan.monthly').props.style.width).toBe(350);
+    expect(getByTestId('paywall.plan.lifetime').props.style.width).toBe(350);
+  });
+
+  it('renders title, price line, and CTA per plan', () => {
+    const { getByText, getByTestId } = render(
+      <PaywallPlanGrid
+        plans={[
+          plan({ id: 'monthly', title: 'Monthly', priceLine: '$2.99/month', ctaTestID: 'paywall.monthly.cta' }),
+          plan({ id: 'lifetime', title: 'Lifetime', priceLine: '$40.00 one-time', ctaTestID: 'paywall.lifetime.cta' }),
+        ]}
+      />,
+    );
+    expect(getByText('Monthly')).toBeTruthy();
+    expect(getByText('$2.99/month')).toBeTruthy();
+    expect(getByText('Lifetime')).toBeTruthy();
+    expect(getByText('$40.00 one-time')).toBeTruthy();
+    expect(getByTestId('paywall.monthly.cta')).toBeTruthy();
+    expect(getByTestId('paywall.lifetime.cta')).toBeTruthy();
+  });
+
+  it('fires onPress when a CTA is pressed', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <PaywallPlanGrid
+        plans={[
+          plan({ id: 'monthly', title: 'Monthly', ctaTestID: 'paywall.monthly.cta', onPress }),
+        ]}
+      />,
+    );
+    fireEvent.press(getByTestId('paywall.monthly.cta'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onPress for a disabled CTA', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <PaywallPlanGrid
+        plans={[
+          plan({ id: 'monthly', title: 'Monthly', ctaTestID: 'paywall.monthly.cta', disabled: true, onPress }),
+        ]}
+      />,
+    );
+    fireEvent.press(getByTestId('paywall.monthly.cta'));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('labels each tile with "title. price" for screen readers', () => {
+    const { getByTestId } = render(
+      <PaywallPlanGrid
+        plans={[
+          plan({ id: 'monthly', title: 'Monthly', priceLine: '$2.99/month' }),
+          plan({ id: 'lifetime', title: 'Lifetime', priceLine: '$40.00 one-time' }),
+        ]}
+      />,
+    );
+    expect(getByTestId('paywall.plan.monthly').props.accessibilityLabel).toBe('Monthly. $2.99/month');
+    expect(getByTestId('paywall.plan.lifetime').props.accessibilityLabel).toBe('Lifetime. $40.00 one-time');
+  });
+
+  it('renders the per-plan icon badge in every tile', () => {
+    const { getByTestId } = render(
+      <PaywallPlanGrid
+        plans={[
+          plan({ id: 'monthly', icon: 'calendar' }),
+          plan({ id: 'yearly', icon: 'pricetag' }),
+          plan({ id: 'lifetime', icon: 'infinite' }),
+        ]}
+      />,
+    );
+    expect(getByTestId('icon-calendar')).toBeTruthy();
+    expect(getByTestId('icon-pricetag')).toBeTruthy();
+    expect(getByTestId('icon-infinite')).toBeTruthy();
+  });
+});

--- a/docs/wiki/paywall-pro.md
+++ b/docs/wiki/paywall-pro.md
@@ -137,7 +137,7 @@ The Pro upgrade page uses a bento-grid tile layout rather than full-width cards:
 - **Grid spec:** responsive two-column grid on screens ≥ 640pt width, single column below. Configurable via breakpoint constant `BENTO_BREAKPOINT_640PT`.
 - **Hero card:** the primary subscription card spans the full grid width on tablet breakpoints, centered visually with elevated shadow and accent-colored CTA.
 - **Tile structure:** each feature row renders as its own grid cell with rounded corners, padding gap 12pt, subtle background tint matching theme palette.
-- **i18n:** all tile labels live in translation keys under `paywall.bento.*` namespace (English, Spanish, French, German, Japanese, Korean). Grid column count itself is not translated — device width drives the layout.
+- **i18n:** all tile labels live in translation keys under `paywall.features.*` / `paywall.featureDescriptions.*` (English, Spanish, French, German, Japanese, Korean). Grid column count itself is not translated — device width drives the layout.
 
 ---
 
@@ -181,7 +181,7 @@ Replaced the old flat checkmark feature list on the PaywallScreen with a non-int
 
 ### Component path + purpose
 
-- Component: `src/components/paywall/ProFeatureBento.tsx` (default export)
+- Component: `src/components/paywall/PaywallFeatureGrid.tsx` (default export)
 - Rendered inside `src/screens/PaywallScreen.tsx`, which replaces the previous inline flat checklist at the top of the screen body
 - Non-interactive showcase cards (plain Views; no onPress, not clickable)
 
@@ -247,11 +247,47 @@ These keys must exist in every locale (`en.json`, `es.json`, `fr.json`, `de.json
 
 ### Test pointers
 
-- New unit test: `__tests__/components/paywall/ProFeatureBento.test.tsx` — covers 7 cases: render + text content + accessible labels + tablet layout + icon token correctness + unknown-key-resolve guard
+- New unit test: `__tests__/components/paywall/PaywallFeatureGrid.test.tsx` — covers render + text content + accessible labels + tablet layout + icon token correctness
 - Extended test: `__tests__/screens/PaywallScreen.test.tsx` adds an assertion that each bento card description renders alongside its per-card testID
+
+## Plan pricing bento grid
+
+The three pricing cards (Monthly / Yearly / Lifetime) previously rendered as full-width flat `Surface` rows. They are now a bento tile grid (`src/components/paywall/PaywallPlanGrid.tsx`) sharing the same card anatomy as the feature grid — `Surface elevation="raised" radius="md"`, icon badge (`colors.primary + '1F'` on `RADII.sm`), gap 12 (`SPACING[3]`), padding 12.
+
+### Layout algorithm
+
+- The `lifetime` plan is the **hero tile** and spans the full grid row (`width = usable = screenWidth − 40`, horizontal row layout with a centered CTA).
+- Monthly and Yearly (when offered) render as a **half-width pair** (`pairW = (usable − 12) / 2`, vertical column layout).
+- If only one non-hero plan is offered, it **stretches to the full row** (`width = usable`) so no row dangles a half-empty cell — same last-tile rule as the feature grid.
+- Grid container: `flexDirection: 'row'`, `flexWrap: 'wrap'`, `gap: SPACING[3]`; container testID `paywall.plans`.
+
+### Tile anatomy
+
+| Layer | Implementation detail |
+|-------|----------------------|
+| Outer View | `Surface` with `elevation="raised"` `radius="md"`, `backgroundColor: colors.surface`, fixed height (`SMALL 180` / `HERO 120`), `padding: 12` |
+| Icon badge | 38×38 (`HERO` 44), `borderRadius: RADII.sm`, `backgroundColor: colors.primary + '1F'`; Ionicon `calendar` (monthly) / `pricetag` (yearly) / `infinite` (lifetime) at size 20 (hero 22), color `colors.primary` |
+| Title Text | `fontWeight: '700'`, `fontSize: 15` (hero 17), `numberOfLines: 1`, color `colors.text` |
+| Price line | `fontSize: 13` (hero 14), `numberOfLines: 2`, color `colors.textSecondary`, `marginTop: 2`; carries the trial / plain / one-time price string (`paywall.monthly.trialCta` etc.) |
+| CTA | `Button` with the existing testIDs (`paywall.monthly.cta`, `paywall.yearly.cta`, `paywall.lifetime.cta`), `fullWidth` on small tiles, variant `primary` (monthly) / `secondary` (yearly + lifetime) |
+| a11y | `accessibilityLabel="${title}. ${priceLine}"` |
+
+### Data flow
+
+`PaywallScreen` builds a `PlanTileData[]` array (title, resolved price line, CTA label/testID/variant/disabled, `onPress`) from the proStore packages + intro-eligibility state and passes it to `<PaywallPlanGrid plans={plans} />`. Yearly is only pushed when `yearlyPackage` exists; lifetime only when `lifetimePackage` exists — so the grid (and the bento stretch rule) adapts to whatever packages the offering provides.
+
+### testIDs
+
+- Container: `paywall.plans`
+- Per-tile: `paywall.plan.<id>` (`monthly` / `yearly` / `lifetime`)
+- CTAs keep the pre-existing `paywall.<id>.cta` testIDs so Maestro flows and `PaywallScreen.test.tsx` keep working unchanged.
+
+### Test pointers
+
+- `__tests__/components/paywall/PaywallPlanGrid.test.tsx` — covers pair + hero widths at phone width, lone-plan stretch, title/price/CTA rendering, press + disabled behavior, a11y labels, and icon badges.
 
 ## Testing notes
 - `react-native-purchases` is globally mocked in `jest.setup.ts`; `proStore` is globally mocked **defaulting to PRO** so existing tests stay green — gating tests flip state via `__setProState` (import from `src/stores/proStore`). `proStore.test.ts` uses `jest.requireActual` to test the real store.
 - New i18n keys must be added to all six locales (`en/es/fr/de/ja/ko`) or `__tests__/i18n-key-parity.test.ts` fails.
 - Real purchases require a development build (`eas build --profile development`); Expo Go cannot purchase.
-- `PaywallAnalytics` module tests (7 cases) verify deterministic event emission via `console.warn` spy; swapping to any other log level breaks assertions. `PaywallFeatureGrid` component tests (Bento grid tile layout, responsive column breakpoints) cover the bento visual spec for #921.
+- `PaywallAnalytics` module tests (7 cases) verify deterministic event emission via `console.warn` spy; swapping to any other log level breaks assertions. `PaywallFeatureGrid` component tests (Bento grid tile layout, responsive column breakpoints) and `PaywallPlanGrid` component tests (pricing bento tiles: pair/hero widths, lone-plan stretch, CTA behavior) cover the bento visual spec for #921.

--- a/src/components/paywall/PaywallPlanGrid.tsx
+++ b/src/components/paywall/PaywallPlanGrid.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { StyleSheet, Text, View, useWindowDimensions } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Button, Surface } from '../ui';
+import { useTheme } from '../../contexts/ThemeContext';
+import { RADII, SPACING } from '../../theme/tokens';
+
+export interface PlanTileData {
+  id: 'monthly' | 'yearly' | 'lifetime';
+  title: string;
+  priceLine: string | null;
+  ctaLabel: string;
+  ctaTestID: string;
+  variant: 'primary' | 'secondary';
+  disabled: boolean;
+  onPress: () => void;
+  icon: keyof typeof Ionicons.glyphMap;
+}
+
+const GAP = SPACING[3];
+const CARD_PADDING = SPACING[3];
+// Screen horizontal margin consumed by the paywall scroll container (20/edge).
+const HORIZONTAL_MARGIN = 40;
+
+const SMALL = { height: 180, badge: 38, icon: 20, titleSize: 15, priceSize: 13 } as const;
+const HERO = { height: 120, badge: 44, icon: 22, titleSize: 17, priceSize: 14 } as const;
+
+export default function PaywallPlanGrid({ plans }: { plans: PlanTileData[] }) {
+  const { width } = useWindowDimensions();
+
+  const usable = width - HORIZONTAL_MARGIN;
+  const pairW = (usable - GAP) / 2;
+
+  // The lifetime plan is the bento hero (full row); everything before it packs
+  // side-by-side. A lone remaining plan stretches to the full row so no row
+  // ever dangles a half-empty cell (same rule as the feature grid).
+  const hero = plans.find((p) => p.id === 'lifetime');
+  const small = plans.filter((p) => p.id !== 'lifetime');
+  const smallWidth = small.length === 1 ? usable : pairW;
+
+  return (
+    <View testID="paywall.plans" style={styles.grid}>
+      {small.map((plan) => (
+        <PlanTile key={plan.id} plan={plan} width={smallWidth} size="small" />
+      ))}
+      {hero ? <PlanTile key={hero.id} plan={hero} width={usable} size="hero" /> : null}
+    </View>
+  );
+}
+
+function PlanTile({
+  plan,
+  width,
+  size,
+}: {
+  plan: PlanTileData;
+  width: number;
+  size: 'small' | 'hero';
+}) {
+  const { colors } = useTheme();
+  const m = size === 'hero' ? HERO : SMALL;
+  const isHero = size === 'hero';
+
+  return (
+    <Surface
+      testID={`paywall.plan.${plan.id}`}
+      elevation="raised"
+      radius="md"
+      accessibilityLabel={`${plan.title}. ${plan.priceLine ?? ''}`}
+      style={{
+        width,
+        height: m.height,
+        padding: CARD_PADDING,
+        backgroundColor: colors.surface,
+        flexDirection: isHero ? 'row' : 'column',
+        alignItems: isHero ? 'center' : 'flex-start',
+        gap: isHero ? SPACING[3] : undefined,
+      }}
+    >
+      <View
+        style={{
+          width: m.badge,
+          height: m.badge,
+          borderRadius: RADII.sm,
+          backgroundColor: colors.primary + '1F',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: isHero ? 0 : SPACING[2],
+        }}
+      >
+        <Ionicons name={plan.icon} size={m.icon} color={colors.primary} />
+      </View>
+      <View style={styles.textBlock}>
+        <Text numberOfLines={1} style={{ fontSize: m.titleSize, fontWeight: '700', color: colors.text }}>
+          {plan.title}
+        </Text>
+        {plan.priceLine ? (
+          <Text numberOfLines={2} style={{ fontSize: m.priceSize, color: colors.textSecondary, marginTop: 2 }}>
+            {plan.priceLine}
+          </Text>
+        ) : null}
+      </View>
+      <Button
+        testID={plan.ctaTestID}
+        variant={plan.variant}
+        fullWidth={!isHero}
+        disabled={plan.disabled}
+        label={plan.ctaLabel}
+        onPress={plan.onPress}
+      />
+    </Surface>
+  );
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: GAP,
+  },
+  textBlock: {
+    flex: 1,
+  },
+});

--- a/src/screens/PaywallScreen.tsx
+++ b/src/screens/PaywallScreen.tsx
@@ -15,6 +15,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { ScreenHeader, useScreenHeaderHeight, Button, Surface } from '../components/ui';
 import PaywallFeatureGrid from '../components/paywall/PaywallFeatureGrid';
+import PaywallPlanGrid, { PlanTileData } from '../components/paywall/PaywallPlanGrid';
 import { useTheme } from '../contexts/ThemeContext';
 import { useProStore } from '../stores/proStore';
 import { getIntroEligibilities, trackPaywallImpression } from '../services/RevenueCatService';
@@ -136,6 +137,54 @@ export default function PaywallScreen() {
     // 'error' surfaces through the existing error banner path.
   }, [restore, navigation]);
 
+  const plans: PlanTileData[] = [
+    {
+      id: 'monthly',
+      title: t('paywall.monthly.title'),
+      priceLine: monthlyPrice
+        ? monthlyTrialEligible
+          ? t('paywall.monthly.trialCta', { price: monthlyPrice })
+          : t('paywall.monthly.price', { price: monthlyPrice })
+        : null,
+      ctaLabel: monthlyTrialEligible ? t('paywall.action.trial') : t('paywall.action.subscribe'),
+      ctaTestID: 'paywall.monthly.cta',
+      variant: 'primary',
+      disabled: busy || !monthlyPrice,
+      onPress: handleMonthly,
+      icon: 'calendar',
+    },
+  ];
+  if (yearlyPackage) {
+    plans.push({
+      id: 'yearly',
+      title: t('paywall.yearly.title'),
+      priceLine: yearlyPrice
+        ? yearlyTrialEligible
+          ? t('paywall.yearly.trialCta', { price: yearlyPrice })
+          : t('paywall.yearly.cta', { price: yearlyPrice })
+        : null,
+      ctaLabel: t('paywall.action.subscribe'),
+      ctaTestID: 'paywall.yearly.cta',
+      variant: 'secondary',
+      disabled: busy || !yearlyPrice,
+      onPress: handleYearly,
+      icon: 'pricetag',
+    });
+  }
+  if (lifetimePackage) {
+    plans.push({
+      id: 'lifetime',
+      title: t('paywall.lifetime.title'),
+      priceLine: lifetimePrice ? t('paywall.lifetime.cta', { price: lifetimePrice }) : null,
+      ctaLabel: t('paywall.action.buy'),
+      ctaTestID: 'paywall.lifetime.cta',
+      variant: 'secondary',
+      disabled: busy || !lifetimePrice,
+      onPress: handleLifetime,
+      icon: 'infinite',
+    });
+  }
+
   return (
     <SafeAreaView edges={['top']} className="flex-1" style={{ backgroundColor: colors.background }}>
       <ScreenHeader
@@ -190,79 +239,9 @@ export default function PaywallScreen() {
               </View>
             ) : null}
 
-            <Surface elevation="raised" radius="md" className="mt-6 p-5">
-              <View className="flex-row items-center justify-between">
-                <Text className="text-lg font-bold" style={{ color: colors.text }}>
-                  {t('paywall.monthly.title')}
-                </Text>
-                {monthlyPrice ? (
-                  <Text className="text-base font-semibold" style={{ color: colors.textSecondary }}>
-                    {monthlyTrialEligible
-                      ? t('paywall.monthly.trialCta', { price: monthlyPrice })
-                      : t('paywall.monthly.price', { price: monthlyPrice })}
-                  </Text>
-                ) : null}
-              </View>
-              <Button
-                testID="paywall.monthly.cta"
-                variant="primary"
-                fullWidth
-                disabled={busy || !monthlyPrice}
-                label={monthlyTrialEligible ? t('paywall.action.trial') : t('paywall.action.subscribe')}
-                onPress={handleMonthly}
-                style={{ marginTop: 14 }}
-              />
-            </Surface>
-
-            {yearlyPackage ? (
-            <Surface elevation="raised" radius="md" className="mt-4 p-5">
-              <View className="flex-row items-center justify-between">
-                <Text className="text-lg font-bold" style={{ color: colors.text }}>
-                  {t('paywall.yearly.title')}
-                </Text>
-                {yearlyPrice ? (
-                  <Text className="text-base font-semibold" style={{ color: colors.textSecondary }}>
-                    {yearlyTrialEligible
-                      ? t('paywall.yearly.trialCta', { price: yearlyPrice })
-                      : t('paywall.yearly.cta', { price: yearlyPrice })}
-                  </Text>
-                ) : null}
-              </View>
-              <Button
-                testID="paywall.yearly.cta"
-                variant="secondary"
-                fullWidth
-                disabled={busy || !yearlyPrice}
-                label={t('paywall.action.subscribe')}
-                onPress={handleYearly}
-                style={{ marginTop: 14, borderWidth: 1, borderColor: colors.border }}
-              />
-            </Surface>
-            ) : null}
-
-            {lifetimePackage ? (
-            <Surface elevation="raised" radius="md" className="mt-4 p-5">
-              <View className="flex-row items-center justify-between">
-                <Text className="text-lg font-bold" style={{ color: colors.text }}>
-                  {t('paywall.lifetime.title')}
-                </Text>
-                {lifetimePrice ? (
-                  <Text className="text-base font-semibold" style={{ color: colors.textSecondary }}>
-                    {t('paywall.lifetime.cta', { price: lifetimePrice })}
-                  </Text>
-                ) : null}
-              </View>
-              <Button
-                testID="paywall.lifetime.cta"
-                variant="secondary"
-                fullWidth
-                disabled={busy || !lifetimePrice}
-                label={t('paywall.action.buy')}
-                onPress={handleLifetime}
-                style={{ marginTop: 14, borderWidth: 1, borderColor: colors.border }}
-              />
-            </Surface>
-            ) : null}
+            <View className="mt-6">
+              <PaywallPlanGrid plans={plans} />
+            </View>
 
             <TouchableOpacity
               testID="paywall.restore"


### PR DESCRIPTION
## What

Redesigns the Pro Plans pricing section on `PaywallScreen` from three flat full-width plan cards into a **bento tile grid** (`PaywallPlanGrid`), matching the visual language of the existing bento Feature section (`PaywallFeatureGrid`).

## Changes

- **New** `src/components/paywall/PaywallPlanGrid.tsx` — bento grid of plan tiles reusing the feature grid's card anatomy:
  - `Surface elevation="raised" radius="md"` tiles, 12pt gap, primary-tinted icon badges
  - `lifetime` = full-width hero tile (row layout, centered CTA)
  - Monthly + Yearly = half-width pair; a lone plan stretches to the full row (no dangling cell)
- **Refactor** `src/screens/PaywallScreen.tsx` — replaces the three inline plan `Surface` blocks with `<PaywallPlanGrid plans={plans} />`, driven by a typed `PlanTileData[]` built from proStore packages + intro-eligibility
- **Test** `__tests__/components/paywall/PaywallPlanGrid.test.tsx` — pair/hero widths, lone-plan stretch, CTA press/disabled, a11y labels, icon badges
- **Docs** `docs/wiki/paywall-pro.md` — documents the plan pricing bento grid + fixes the stale `ProFeatureBento.tsx` reference (actual file is `PaywallFeatureGrid.tsx`)

## Behavior preserved

- All CTA testIDs (`paywall.monthly.cta`, `paywall.yearly.cta`, `paywall.lifetime.cta`) unchanged — Maestro flows and existing tests keep working
- Pricing strings, trial eligibility, purchase/restore flows unchanged
- Yearly/lifetime tiles auto-hide when the package isn't offered (grid adapts via stretch rule)

## Verification

- `yarn ts:check` ✅
- Full jest suite: 296 suites / 2716 tests pass ✅
- `yarn eslint` on changed files: clean ✅