### PR TITLE
feat(paywall): one payment plan per row, payment options on top

### DIFF
--- a/__tests__/components/paywall/PaywallPlanGrid.test.tsx
+++ b/__tests__/components/paywall/PaywallPlanGrid.test.tsx
@@ -61,7 +61,7 @@ beforeEach(() => {
 });
 
 describe('PaywallPlanGrid', () => {
-  it('renders a half-width pair (monthly + yearly) and a full-width lifetime hero at phone width', () => {
+  it('renders one plan per full-width row at phone width', () => {
     const { getByTestId } = render(
       <PaywallPlanGrid
         plans={[
@@ -71,14 +71,15 @@ describe('PaywallPlanGrid', () => {
         ]}
       />,
     );
-    // usable = 390 - 40 = 350; pairW = (350 - 12) / 2 = 169.
-    expect(getByTestId('paywall.plan.monthly').props.style.width).toBe(169);
-    expect(getByTestId('paywall.plan.yearly').props.style.width).toBe(169);
+    // usable = 390 - 40 = 350 — every tile spans the full row.
+    expect(getByTestId('paywall.plan.monthly').props.style.width).toBe(350);
+    expect(getByTestId('paywall.plan.yearly').props.style.width).toBe(350);
     expect(getByTestId('paywall.plan.lifetime').props.style.width).toBe(350);
+    expect(getByTestId('paywall.plan.monthly').props.style.flexDirection).toBe('row');
     expect(getByTestId('paywall.plan.lifetime').props.style.flexDirection).toBe('row');
   });
 
-  it('stretches a lone non-hero plan to the full row width', () => {
+  it('renders every offered plan as a full-width row regardless of count', () => {
     const { getByTestId } = render(
       <PaywallPlanGrid
         plans={[

--- a/docs/wiki/paywall-pro.md
+++ b/docs/wiki/paywall-pro.md
@@ -256,25 +256,28 @@ The three pricing cards (Monthly / Yearly / Lifetime) previously rendered as ful
 
 ### Layout algorithm
 
-- The `lifetime` plan is the **hero tile** and spans the full grid row (`width = usable = screenWidth − 40`, horizontal row layout with a centered CTA).
-- Monthly and Yearly (when offered) render as a **half-width pair** (`pairW = (usable − 12) / 2`, vertical column layout).
-- If only one non-hero plan is offered, it **stretches to the full row** (`width = usable`) so no row dangles a half-empty cell — same last-tile rule as the feature grid.
-- Grid container: `flexDirection: 'row'`, `flexWrap: 'wrap'`, `gap: SPACING[3]`; container testID `paywall.plans`.
+- **One payment method per row** — every plan renders as a full-width horizontal tile (`width = usable = screenWidth − 40`), so each plan reads as its own complete choice.
+- Tile layout: horizontal row — icon badge left, title + price line center (flex: 1), CTA button right.
+- Grid container: `gap: SPACING[3]`, no wrapping; container testID `paywall.plans`.
 
 ### Tile anatomy
 
 | Layer | Implementation detail |
 |-------|----------------------|
-| Outer View | `Surface` with `elevation="raised"` `radius="md"`, `backgroundColor: colors.surface`, fixed height (`SMALL 180` / `HERO 120`), `padding: 12` |
-| Icon badge | 38×38 (`HERO` 44), `borderRadius: RADII.sm`, `backgroundColor: colors.primary + '1F'`; Ionicon `calendar` (monthly) / `pricetag` (yearly) / `infinite` (lifetime) at size 20 (hero 22), color `colors.primary` |
-| Title Text | `fontWeight: '700'`, `fontSize: 15` (hero 17), `numberOfLines: 1`, color `colors.text` |
-| Price line | `fontSize: 13` (hero 14), `numberOfLines: 2`, color `colors.textSecondary`, `marginTop: 2`; carries the trial / plain / one-time price string (`paywall.monthly.trialCta` etc.) |
-| CTA | `Button` with the existing testIDs (`paywall.monthly.cta`, `paywall.yearly.cta`, `paywall.lifetime.cta`), `fullWidth` on small tiles, variant `primary` (monthly) / `secondary` (yearly + lifetime) |
+| Outer View | `Surface` with `elevation="raised"` `radius="md"`, `backgroundColor: colors.surface`, fixed height `96`, `padding: 12` |
+| Icon badge | 40×40, `borderRadius: RADII.sm`, `backgroundColor: colors.primary + '1F'`; Ionicon `calendar` (monthly) / `pricetag` (yearly) / `infinite` (lifetime) at size 20, color `colors.primary` |
+| Title Text | `fontWeight: '700'`, `fontSize: 15`, `numberOfLines: 1`, color `colors.text` |
+| Price line | `fontSize: 13`, `numberOfLines: 1`, color `colors.textSecondary`, `marginTop: 2`; carries the trial / plain / one-time price string (`paywall.monthly.trialCta` etc.) |
+| CTA | `Button` with the existing testIDs (`paywall.monthly.cta`, `paywall.yearly.cta`, `paywall.lifetime.cta`), variant `primary` (monthly) / `secondary` (yearly + lifetime), right-aligned in the row |
 | a11y | `accessibilityLabel="${title}. ${priceLine}"` |
+
+### Screen placement
+
+`PaywallScreen` renders the payment options **above** the feature grid (payment options first for ease of access, features below), both inside the `offeringsReady` branch.
 
 ### Data flow
 
-`PaywallScreen` builds a `PlanTileData[]` array (title, resolved price line, CTA label/testID/variant/disabled, `onPress`) from the proStore packages + intro-eligibility state and passes it to `<PaywallPlanGrid plans={plans} />`. Yearly is only pushed when `yearlyPackage` exists; lifetime only when `lifetimePackage` exists — so the grid (and the bento stretch rule) adapts to whatever packages the offering provides.
+`PaywallScreen` builds a `PlanTileData[]` array (title, resolved price line, CTA label/testID/variant/disabled, `onPress`) from the proStore packages + intro-eligibility state and passes it to `<PaywallPlanGrid plans={plans} />`. Yearly is only pushed when `yearlyPackage` exists; lifetime only when `lifetimePackage` exists — the grid simply renders whatever plans are offered, one per row.
 
 ### testIDs
 
@@ -284,10 +287,10 @@ The three pricing cards (Monthly / Yearly / Lifetime) previously rendered as ful
 
 ### Test pointers
 
-- `__tests__/components/paywall/PaywallPlanGrid.test.tsx` — covers pair + hero widths at phone width, lone-plan stretch, title/price/CTA rendering, press + disabled behavior, a11y labels, and icon badges.
+- `__tests__/components/paywall/PaywallPlanGrid.test.tsx` — covers one-plan-per-full-width-row layout, title/price/CTA rendering, press + disabled behavior, a11y labels, and icon badges.
 
 ## Testing notes
 - `react-native-purchases` is globally mocked in `jest.setup.ts`; `proStore` is globally mocked **defaulting to PRO** so existing tests stay green — gating tests flip state via `__setProState` (import from `src/stores/proStore`). `proStore.test.ts` uses `jest.requireActual` to test the real store.
 - New i18n keys must be added to all six locales (`en/es/fr/de/ja/ko`) or `__tests__/i18n-key-parity.test.ts` fails.
 - Real purchases require a development build (`eas build --profile development`); Expo Go cannot purchase.
-- `PaywallAnalytics` module tests (7 cases) verify deterministic event emission via `console.warn` spy; swapping to any other log level breaks assertions. `PaywallFeatureGrid` component tests (Bento grid tile layout, responsive column breakpoints) and `PaywallPlanGrid` component tests (pricing bento tiles: pair/hero widths, lone-plan stretch, CTA behavior) cover the bento visual spec for #921.
+- `PaywallAnalytics` module tests (7 cases) verify deterministic event emission via `console.warn` spy; swapping to any other log level breaks assertions. `PaywallFeatureGrid` component tests (Bento grid tile layout, responsive column breakpoints) and `PaywallPlanGrid` component tests (one payment method per full-width row, CTA behavior) cover the bento visual spec for #921.

--- a/src/components/paywall/PaywallPlanGrid.tsx
+++ b/src/components/paywall/PaywallPlanGrid.tsx
@@ -22,44 +22,26 @@ const CARD_PADDING = SPACING[3];
 // Screen horizontal margin consumed by the paywall scroll container (20/edge).
 const HORIZONTAL_MARGIN = 40;
 
-const SMALL = { height: 180, badge: 38, icon: 20, titleSize: 15, priceSize: 13 } as const;
-const HERO = { height: 120, badge: 44, icon: 22, titleSize: 17, priceSize: 14 } as const;
+const ROW = { height: 96, badge: 40, icon: 20, titleSize: 15, priceSize: 13 } as const;
 
 export default function PaywallPlanGrid({ plans }: { plans: PlanTileData[] }) {
   const { width } = useWindowDimensions();
 
+  // One payment method per row — every tile spans the full content width so
+  // each plan reads as its own complete choice.
   const usable = width - HORIZONTAL_MARGIN;
-  const pairW = (usable - GAP) / 2;
-
-  // The lifetime plan is the bento hero (full row); everything before it packs
-  // side-by-side. A lone remaining plan stretches to the full row so no row
-  // ever dangles a half-empty cell (same rule as the feature grid).
-  const hero = plans.find((p) => p.id === 'lifetime');
-  const small = plans.filter((p) => p.id !== 'lifetime');
-  const smallWidth = small.length === 1 ? usable : pairW;
 
   return (
     <View testID="paywall.plans" style={styles.grid}>
-      {small.map((plan) => (
-        <PlanTile key={plan.id} plan={plan} width={smallWidth} size="small" />
+      {plans.map((plan) => (
+        <PlanTile key={plan.id} plan={plan} width={usable} />
       ))}
-      {hero ? <PlanTile key={hero.id} plan={hero} width={usable} size="hero" /> : null}
     </View>
   );
 }
 
-function PlanTile({
-  plan,
-  width,
-  size,
-}: {
-  plan: PlanTileData;
-  width: number;
-  size: 'small' | 'hero';
-}) {
+function PlanTile({ plan, width }: { plan: PlanTileData; width: number }) {
   const { colors } = useTheme();
-  const m = size === 'hero' ? HERO : SMALL;
-  const isHero = size === 'hero';
 
   return (
     <Surface
@@ -69,33 +51,32 @@ function PlanTile({
       accessibilityLabel={`${plan.title}. ${plan.priceLine ?? ''}`}
       style={{
         width,
-        height: m.height,
+        height: ROW.height,
         padding: CARD_PADDING,
         backgroundColor: colors.surface,
-        flexDirection: isHero ? 'row' : 'column',
-        alignItems: isHero ? 'center' : 'flex-start',
-        gap: isHero ? SPACING[3] : undefined,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: SPACING[3],
       }}
     >
       <View
         style={{
-          width: m.badge,
-          height: m.badge,
+          width: ROW.badge,
+          height: ROW.badge,
           borderRadius: RADII.sm,
           backgroundColor: colors.primary + '1F',
           alignItems: 'center',
           justifyContent: 'center',
-          marginBottom: isHero ? 0 : SPACING[2],
         }}
       >
-        <Ionicons name={plan.icon} size={m.icon} color={colors.primary} />
+        <Ionicons name={plan.icon} size={ROW.icon} color={colors.primary} />
       </View>
       <View style={styles.textBlock}>
-        <Text numberOfLines={1} style={{ fontSize: m.titleSize, fontWeight: '700', color: colors.text }}>
+        <Text numberOfLines={1} style={{ fontSize: ROW.titleSize, fontWeight: '700', color: colors.text }}>
           {plan.title}
         </Text>
         {plan.priceLine ? (
-          <Text numberOfLines={2} style={{ fontSize: m.priceSize, color: colors.textSecondary, marginTop: 2 }}>
+          <Text numberOfLines={1} style={{ fontSize: ROW.priceSize, color: colors.textSecondary, marginTop: 2 }}>
             {plan.priceLine}
           </Text>
         ) : null}
@@ -103,7 +84,6 @@ function PlanTile({
       <Button
         testID={plan.ctaTestID}
         variant={plan.variant}
-        fullWidth={!isHero}
         disabled={plan.disabled}
         label={plan.ctaLabel}
         onPress={plan.onPress}
@@ -114,8 +94,6 @@ function PlanTile({
 
 const styles = StyleSheet.create({
   grid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
     gap: GAP,
   },
   textBlock: {

--- a/src/screens/PaywallScreen.tsx
+++ b/src/screens/PaywallScreen.tsx
@@ -208,10 +208,6 @@ export default function PaywallScreen() {
           {t('paywall.subtitle')}
         </Text>
 
-        <View className="mt-6">
-          <PaywallFeatureGrid />
-        </View>
-
         {!offeringsReady ? (
           <View className="mt-8 items-center" testID="paywall.loading">
             <ActivityIndicator color={colors.primary} size="large" />
@@ -239,8 +235,13 @@ export default function PaywallScreen() {
               </View>
             ) : null}
 
+            {/* Payment options first for ease of access, features below. */}
             <View className="mt-6">
               <PaywallPlanGrid plans={plans} />
+            </View>
+
+            <View className="mt-6">
+              <PaywallFeatureGrid />
             </View>
 
             <TouchableOpacity


### PR DESCRIPTION
## What

Follow-up to #955. The user liked the bento styling but wants **one payment method per row** and the **payment options above the feature grid**.

## Changes

- **`PaywallPlanGrid.tsx`** — each plan (Monthly / Yearly / Lifetime) is now its own **full-width horizontal tile**: icon badge left, title + price centered, CTA right. Removed the half-width pair + hero split; every offered plan spans the full row regardless of count.
- **`PaywallScreen.tsx`** — payment options moved **above** the feature grid (immediately under the subtitle) for ease of access. Both grids now live inside the `offeringsReady` branch.
- **Tests** — width assertions updated to full-width rows (all tiles = usable width at phone).
- **Wiki** — layout docs updated to the one-per-row algorithm.

## Preserved

- All CTA testIDs (`paywall.monthly/yearly/lifetime.cta`) and pricing strings unchanged
- Bento card anatomy: `Surface raised/md`, primary-tinted icon badges, 12pt gap
- Yearly/lifetime auto-hide when package not offered

## Verification

- `yarn ts:check` ✅
- Full jest suite: 296 suites / 2716 tests pass (same as baseline) ✅
- `yarn eslint` clean ✅