### PR TITLE
fix(paywall): bordered secondary CTAs, two-line price on plan tiles

### DIFF
--- a/__tests__/components/paywall/PaywallPlanGrid.test.tsx
+++ b/__tests__/components/paywall/PaywallPlanGrid.test.tsx
@@ -30,10 +30,16 @@ jest.mock('../../../src/components/ui', () => {
   const React = require('react');
   const { View, Text, TouchableOpacity } = require('react-native');
   const Surface = (props: Record<string, unknown>) => React.createElement(View, props);
-  const Button = (props: { label?: string; onPress?: () => void; testID?: string; disabled?: boolean }) =>
+  const Button = (props: {
+    label?: string;
+    onPress?: () => void;
+    testID?: string;
+    disabled?: boolean;
+    style?: Record<string, unknown>;
+  }) =>
     React.createElement(
       TouchableOpacity,
-      { testID: props.testID, disabled: props.disabled, onPress: props.onPress },
+      { testID: props.testID, disabled: props.disabled, onPress: props.onPress, style: props.style },
       React.createElement(Text, null, props.label),
     );
   return { Surface, Button };
@@ -161,5 +167,41 @@ describe('PaywallPlanGrid', () => {
     expect(getByTestId('icon-calendar')).toBeTruthy();
     expect(getByTestId('icon-pricetag')).toBeTruthy();
     expect(getByTestId('icon-infinite')).toBeTruthy();
+  });
+
+  it('adds a border to secondary CTA buttons but not the primary', () => {
+    const { getByTestId } = render(
+      <PaywallPlanGrid
+        plans={[
+          plan({ id: 'monthly', variant: 'primary', ctaTestID: 'paywall.monthly.cta' }),
+          plan({ id: 'yearly', variant: 'secondary', ctaTestID: 'paywall.yearly.cta' }),
+          plan({ id: 'lifetime', variant: 'secondary', ctaTestID: 'paywall.lifetime.cta' }),
+        ]}
+      />,
+    );
+    expect(getByTestId('paywall.monthly.cta').props.style).not.toHaveProperty('borderWidth');
+    expect(getByTestId('paywall.yearly.cta').props.style).toEqual(
+      expect.objectContaining({ borderWidth: 1, borderColor: '#ddd' }),
+    );
+    expect(getByTestId('paywall.lifetime.cta').props.style).toEqual(
+      expect.objectContaining({ borderWidth: 1, borderColor: '#ddd' }),
+    );
+  });
+
+  it('lets the price line wrap to two lines instead of truncating', () => {
+    const { getByText } = render(
+      <PaywallPlanGrid
+        plans={[
+          plan({
+            id: 'monthly',
+            priceLine: 'Try 30 days free, then $2.99/month',
+            ctaTestID: 'paywall.monthly.cta',
+          }),
+        ]}
+      />,
+    );
+    const price = getByText('Try 30 days free, then $2.99/month');
+    expect(price.props.numberOfLines).toBe(2);
+    expect(price.props.style.lineHeight).toBe(18);
   });
 });

--- a/docs/wiki/paywall-pro.md
+++ b/docs/wiki/paywall-pro.md
@@ -264,11 +264,11 @@ The three pricing cards (Monthly / Yearly / Lifetime) previously rendered as ful
 
 | Layer | Implementation detail |
 |-------|----------------------|
-| Outer View | `Surface` with `elevation="raised"` `radius="md"`, `backgroundColor: colors.surface`, fixed height `96`, `padding: 12` |
+| Outer View | `Surface` with `elevation="raised"` `radius="md"`, `backgroundColor: colors.surface`, fixed height `112`, `padding: 12` |
 | Icon badge | 40×40, `borderRadius: RADII.sm`, `backgroundColor: colors.primary + '1F'`; Ionicon `calendar` (monthly) / `pricetag` (yearly) / `infinite` (lifetime) at size 20, color `colors.primary` |
 | Title Text | `fontWeight: '700'`, `fontSize: 15`, `numberOfLines: 1`, color `colors.text` |
-| Price line | `fontSize: 13`, `numberOfLines: 1`, color `colors.textSecondary`, `marginTop: 2`; carries the trial / plain / one-time price string (`paywall.monthly.trialCta` etc.) |
-| CTA | `Button` with the existing testIDs (`paywall.monthly.cta`, `paywall.yearly.cta`, `paywall.lifetime.cta`), variant `primary` (monthly) / `secondary` (yearly + lifetime), right-aligned in the row |
+| Price line | `fontSize: 13`, `numberOfLines: 2`, `lineHeight: 18`, color `colors.textSecondary`, `marginTop: 2`; carries the trial / plain / one-time price string (`paywall.monthly.trialCta` etc.) and wraps instead of truncating |
+| CTA | `Button` with the existing testIDs (`paywall.monthly.cta`, `paywall.yearly.cta`, `paywall.lifetime.cta`), variant `primary` (monthly, filled bg) / `secondary` (yearly + lifetime, `borderWidth: 1` + `borderColor: colors.border` outline), right-aligned in the row |
 | a11y | `accessibilityLabel="${title}. ${priceLine}"` |
 
 ### Screen placement
@@ -287,7 +287,7 @@ The three pricing cards (Monthly / Yearly / Lifetime) previously rendered as ful
 
 ### Test pointers
 
-- `__tests__/components/paywall/PaywallPlanGrid.test.tsx` — covers one-plan-per-full-width-row layout, title/price/CTA rendering, press + disabled behavior, a11y labels, and icon badges.
+- `__tests__/components/paywall/PaywallPlanGrid.test.tsx` — covers one-plan-per-full-width-row layout, title/price/CTA rendering, secondary-CTA border vs primary, two-line price wrapping, press + disabled behavior, a11y labels, and icon badges.
 
 ## Testing notes
 - `react-native-purchases` is globally mocked in `jest.setup.ts`; `proStore` is globally mocked **defaulting to PRO** so existing tests stay green — gating tests flip state via `__setProState` (import from `src/stores/proStore`). `proStore.test.ts` uses `jest.requireActual` to test the real store.

--- a/src/components/paywall/PaywallPlanGrid.tsx
+++ b/src/components/paywall/PaywallPlanGrid.tsx
@@ -22,7 +22,7 @@ const CARD_PADDING = SPACING[3];
 // Screen horizontal margin consumed by the paywall scroll container (20/edge).
 const HORIZONTAL_MARGIN = 40;
 
-const ROW = { height: 96, badge: 40, icon: 20, titleSize: 15, priceSize: 13 } as const;
+const ROW = { height: 112, badge: 40, icon: 20, titleSize: 15, priceSize: 13 } as const;
 
 export default function PaywallPlanGrid({ plans }: { plans: PlanTileData[] }) {
   const { width } = useWindowDimensions();
@@ -76,7 +76,7 @@ function PlanTile({ plan, width }: { plan: PlanTileData; width: number }) {
           {plan.title}
         </Text>
         {plan.priceLine ? (
-          <Text numberOfLines={1} style={{ fontSize: ROW.priceSize, color: colors.textSecondary, marginTop: 2 }}>
+          <Text numberOfLines={2} style={{ fontSize: ROW.priceSize, color: colors.textSecondary, marginTop: 2, lineHeight: 18 }}>
             {plan.priceLine}
           </Text>
         ) : null}
@@ -87,6 +87,7 @@ function PlanTile({ plan, width }: { plan: PlanTileData; width: number }) {
         disabled={plan.disabled}
         label={plan.ctaLabel}
         onPress={plan.onPress}
+        style={plan.variant === 'secondary' ? { borderWidth: 1, borderColor: colors.border } : undefined}
       />
     </Surface>
   );


### PR DESCRIPTION
## What

Fixes two polish issues on the plan pricing tiles (follow-up to #956):

1. **Secondary CTAs now have borders** — the yearly + lifetime buttons previously rendered as borderless secondary buttons, looking flat next to the filled primary monthly CTA. They now get `borderWidth: 1` + `borderColor: colors.border` (matching the outline the original flat plan cards had).
2. **Price line no longer truncates** — the price/description line was `numberOfLines={1}` so long strings like "Try 30 days free, then $2.99/month" got cut off. It now wraps to 2 lines (`lineHeight: 18`) and the tile height grows 96 → 112.

## Changes

- `src/components/paywall/PaywallPlanGrid.tsx` — border on secondary-variant CTA buttons, `numberOfLines={2}` + `lineHeight: 18` on the price line, `ROW.height` 112
- `__tests__/components/paywall/PaywallPlanGrid.test.tsx` — Button mock forwards `style`; new tests for secondary-vs-primary border and two-line price wrapping
- `docs/wiki/paywall-pro.md` — tile anatomy + test-pointer docs updated

## Preserved

- All CTA testIDs, pricing strings, and the one-plan-per-row layout unchanged

## Verification

- `yarn ts:check` ✅
- Paywall tests: 42 pass ✅
- `yarn eslint` clean ✅