### PR TITLE
fix(paywall): inline RevenueCat key statically + surface offering load errors

### DIFF
--- a/__tests__/stores/proStore.test.ts
+++ b/__tests__/stores/proStore.test.ts
@@ -373,10 +373,12 @@ describe('offerings', () => {
     expect(useProStore.getState().lifetimePackage?.identifier).toBe('lifetime');
   });
 
-  it('surfaces an error when offerings fail to load', async () => {
+  it('surfaces an error and resolves the loading state when offerings fail to load', async () => {
     packagesMock.mockRejectedValue(new Error('no offerings'));
     await useProStore.getState().loadOfferingsIfNeeded();
-    expect(useProStore.getState().error).toBe('no offerings');
+    const s = useProStore.getState();
+    expect(s.error).toBe('no offerings');
+    expect(s.offeringsReady).toBe(true);
   });
 
   it('stores the current offering once offerings load', async () => {

--- a/eas.json
+++ b/eas.json
@@ -39,6 +39,7 @@
     },
     "production": {
       "autoIncrement": true,
+      "environment": "production",
       "ios": {
         "resourceClass": "m-medium"
       },

--- a/src/screens/PaywallScreen.tsx
+++ b/src/screens/PaywallScreen.tsx
@@ -208,33 +208,33 @@ export default function PaywallScreen() {
           {t('paywall.subtitle')}
         </Text>
 
+        {error ? (
+          <View className="mt-6 rounded-xl border p-4 flex-row items-start gap-3" style={{ backgroundColor: colors.error + '14', borderColor: colors.error + '44' }} testID="paywall.error">
+            <Ionicons name="alert-circle" size={22} color={colors.error} />
+            <View className="flex-1">
+              <Text className="text-sm font-semibold" style={{ color: colors.error }}>
+                {t('paywall.purchaseError')}
+              </Text>
+              <Text className="text-[13px] mt-1 leading-[18px]" style={{ color: colors.textSecondary }}>
+                {error}
+              </Text>
+              <Button
+                testID="paywall.retry"
+                variant="secondary"
+                label={t('paywall.retry')}
+                onPress={() => void loadOfferingsIfNeeded()}
+                style={{ marginTop: 12 }}
+              />
+            </View>
+          </View>
+        ) : null}
+
         {!offeringsReady ? (
           <View className="mt-8 items-center" testID="paywall.loading">
             <ActivityIndicator color={colors.primary} size="large" />
           </View>
         ) : (
           <>
-            {error ? (
-              <View className="mt-6 rounded-xl border p-4 flex-row items-start gap-3" style={{ backgroundColor: colors.error + '14', borderColor: colors.error + '44' }} testID="paywall.error">
-                <Ionicons name="alert-circle" size={22} color={colors.error} />
-                <View className="flex-1">
-                  <Text className="text-sm font-semibold" style={{ color: colors.error }}>
-                    {t('paywall.purchaseError')}
-                  </Text>
-                  <Text className="text-[13px] mt-1 leading-[18px]" style={{ color: colors.textSecondary }}>
-                    {error}
-                  </Text>
-                  <Button
-                    testID="paywall.retry"
-                    variant="secondary"
-                    label={t('paywall.retry')}
-                    onPress={() => void loadOfferingsIfNeeded()}
-                    style={{ marginTop: 12 }}
-                  />
-                </View>
-              </View>
-            ) : null}
-
             {/* Payment options first for ease of access, features below. */}
             <View className="mt-6">
               <PaywallPlanGrid plans={plans} />

--- a/src/services/RevenueCatService.ts
+++ b/src/services/RevenueCatService.ts
@@ -7,9 +7,6 @@ import type {
   PurchasesPackage,
 } from 'react-native-purchases';
 
-const IOS_API_KEY_ENV = 'EXPO_PUBLIC_REVENUECAT_API_KEY_IOS';
-const ANDROID_API_KEY_ENV = 'EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID';
-
 export interface ConfigureResult {
   configured: boolean;
 }
@@ -33,7 +30,10 @@ function isPlaceholderKey(apiKey: string | undefined): boolean {
 let configured = false;
 
 export async function configureRevenueCat(): Promise<ConfigureResult> {
-  const apiKey = Platform.OS === 'ios' ? process.env[IOS_API_KEY_ENV] : process.env[ANDROID_API_KEY_ENV];
+  const apiKey =
+    Platform.OS === 'ios'
+      ? process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS
+      : process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID;
   if (isPlaceholderKey(apiKey)) {
     return { configured: false };
   }

--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -266,7 +266,10 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
         error: null,
       });
     } catch (error) {
-      set({ error: error instanceof Error ? error.message : 'Failed to load offerings' });
+      set({
+        offeringsReady: true,
+        error: error instanceof Error ? error.message : 'Failed to load offerings',
+      });
     }
   },
 


### PR DESCRIPTION
## Problem

App Store rejected build 52 (2.1(b) Performance: App Completeness) — the paywall showed an infinite spinner after tapping the upgrade button.

Two root causes:

1. **RevenueCat API key never reached production bundles.** `RevenueCatService.configureRevenueCat` read the key via `process.env[IOS_API_KEY_ENV]` (bracket notation). Expo/Metro only inlines `process.env.EXPO_PUBLIC_X` with static dot notation — bracket access is never inlined, so the key was absent from every EAS production build (verified in IPAs 52/53/54). Without the key, `Purchases.getOfferings()` throws → paywall spinner.

2. **`loadOfferingsIfNeeded` never resolved the loading state on failure.** The catch block set `error` but left `offeringsReady` false, and the error banner/Retry lived *inside* the `offeringsReady` branch — so any offerings failure rendered an infinite spinner with no visible error or retry.

## Changes

- `src/services/RevenueCatService.ts`: read `EXPO_PUBLIC_REVENUECAT_API_KEY_IOS` / `_ANDROID` via static dot notation so Metro inlines them into production bundles. Verified: build 55 IPA contains the `appl_` key.
- `eas.json`: production build profile now declares `"environment": "production"` so EAS env vars are injected into the build.
- `src/stores/proStore.ts`: `loadOfferingsIfNeeded` catch now sets `offeringsReady: true` — the paywall shows the error banner instead of spinning forever.
- `src/screens/PaywallScreen.tsx`: error banner + Retry now render regardless of `offeringsReady`.
- `__tests__/stores/proStore.test.ts`: strengthened regression test asserting `offeringsReady` resolves on failure.

## Verification

- `yarn ts:check` ✅
- `yarn jest`: 2718 passed ✅
- `yarn eslint`: 0 errors on changed files ✅
- Build 55 IPA confirmed to contain `appl_FkapXKWzoILnkihgbAeRCQDYqtZ` (key inlined, env var reference fully substituted)