### PR TITLE
fix(paywall): use actual RevenueCat entitlement identifier

### DIFF
--- a/__tests__/stores/proStore.test.ts
+++ b/__tests__/stores/proStore.test.ts
@@ -32,7 +32,7 @@ jest.mock('../../src/services/RevenueCatService', () => ({
   })),
   purchasePackage: jest.fn(async () => ({
     kind: 'purchased',
-    customerInfo: { entitlements: { active: { pro: { isActive: true, periodType: 'NORMAL' } } } },
+    customerInfo: { entitlements: { active: { 'GitNotēs Pro': { isActive: true, periodType: 'NORMAL' } } } },
   })),
   restorePurchases: jest.fn(async () => ({
     kind: 'purchased',
@@ -89,7 +89,7 @@ const restoreTapSpy = trackRestoreTap as jest.Mock;
 const restoreOutcomeSpy = trackRestoreOutcome as jest.Mock;
 
 const proCustomer = (periodType = 'NORMAL') => ({
-  entitlements: { active: { pro: { isActive: true, periodType, expiresDate: null } } },
+  entitlements: { active: { 'GitNotēs Pro': { isActive: true, periodType, expiresDate: null } } },
 });
 const freeCustomer = { entitlements: { active: {} } };
 
@@ -191,7 +191,7 @@ describe('trial + interstitial state machine', () => {
     customerInfoMock.mockResolvedValue({
       entitlements: {
         active: {
-          pro: { isActive: true, periodType: 'TRIAL', expiresDate: new Date(NOW + 86400000).toISOString() },
+          'GitNotēs Pro': { isActive: true, periodType: 'TRIAL', expiresDate: new Date(NOW + 86400000).toISOString() },
         },
       },
     });

--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -17,6 +17,8 @@ const TRIAL_EXPIRED_AT_KEY = '@gitnotes:trial_expired_at';
 const INTERSTITIAL_SHOWN_KEY = '@gitnotes:interstitial_offer_shown';
 const INTERSTITIAL_DELAY = 3 * 24 * 60 * 60 * 1000;
 
+export const PRO_ENTITLEMENT_ID = 'GitNotēs Pro';
+
 export type ProStatus = 'loading' | 'pro' | 'free';
 
 export type RestoreOutcome = 'restored' | 'nothing' | 'error';
@@ -70,7 +72,7 @@ function deriveTrialInfo(customerInfo: CustomerInfoLike | null): {
   trialEndsAt: number | null;
   entitlementExpiresAt: number | null;
 } {
-  const entitlement = customerInfo?.entitlements?.active?.pro;
+  const entitlement = customerInfo?.entitlements?.active?.[PRO_ENTITLEMENT_ID];
   const entitlementActive = Boolean(entitlement?.isActive);
   const trialActive = entitlementActive && entitlement?.periodType === 'TRIAL';
   const expiresMs = entitlement?.expiresDate ? Date.parse(entitlement.expiresDate) : NaN;
@@ -233,7 +235,9 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
       }
       // 'purchased' alone does not distinguish found vs not-found: derive it
       // from the returned customerInfo entitlements.
-      const proActive = Boolean(result.customerInfo?.entitlements?.active?.pro?.isActive);
+      const proActive = Boolean(
+        result.customerInfo?.entitlements?.active?.[PRO_ENTITLEMENT_ID]?.isActive,
+      );
       if (!proActive) {
         set({ isRestoring: false });
         PaywallAnalytics.trackRestoreOutcome('nothing');


### PR DESCRIPTION
## Problem

Purchases complete (StoreKit success popup) but Pro stays locked. The RevenueCat entitlement was created with identifier `GitNotēs Pro` (not `pro`), so `customerInfo.entitlements.active.pro` never matched and the app never flipped to `pro` status.

## Changes

- `src/stores/proStore.ts`: add `PRO_ENTITLEMENT_ID = 'GitNotēs Pro'` and use it in `deriveTrialInfo` + restore path.
- `__tests__/stores/proStore.test.ts`: fixtures use the `GitNotēs Pro` key.

## Verification

- `yarn ts:check` ✅
- `yarn jest`: 2718 passed ✅
- `yarn eslint`: 0 errors on changed files ✅