### PR TITLE
feat(thought-dump): repo/branch picker, distinct errors, empty-state fixes

### DIFF
--- a/__tests__/ThoughtDumpRepoPickerModal.test.tsx
+++ b/__tests__/ThoughtDumpRepoPickerModal.test.tsx
@@ -1,0 +1,237 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+
+const stableColors = {
+  background: '#fff',
+  surface: '#f4f4f4',
+  primary: '#2563eb',
+  text: '#111',
+  textSecondary: '#666',
+  border: '#ddd',
+  error: '#dc2626',
+  accent: '#8b5cf6',
+};
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({ colors: stableColors, isDark: false }),
+  useTokens: () => ({
+    colors: stableColors,
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 },
+    type: { xs: 12, sm: 14, md: 16, lg: 18, xl: 22 },
+    radii: { sm: 12, md: 18, lg: 24, pill: 999 },
+    style: 'flat',
+  }),
+}));
+
+let mockRepositories: Array<{ name: string; path: string }> = [
+  { name: 'owner/repo-a', path: 'owner/repo-a' },
+  { name: 'owner/repo-b', path: 'owner/repo-b' },
+];
+
+const mockAddRepository = jest.fn(async () => ({ id: 'new', name: 'new', path: 'new' }));
+
+jest.mock('../src/stores/repoStore', () => ({
+  useRepoStore: (selector: any) => {
+    const state = {
+      repositories: mockRepositories,
+      addRepository: mockAddRepository,
+    };
+    return selector(state);
+  },
+}));
+
+jest.mock('../src/components/SearchBar', () => {
+  const { View } = require('react-native');
+  return () => <View />;
+});
+
+jest.mock('../src/utils/haptics', () => ({
+  HapticService: {
+    selection: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../src/components/ui', () => {
+  const { View, Text, Pressable } = require('react-native');
+  return {
+    Modal: ({ visible, children }: any) => (visible ? <View>{children}</View> : null),
+    Button: ({ children, onPress, disabled, testID }: any) => (
+      <Pressable testID={testID} onPress={disabled ? undefined : onPress} disabled={disabled}>
+        <Text>{children}</Text>
+      </Pressable>
+    ),
+    Surface: ({ children }: any) => <View>{children}</View>,
+  };
+});
+
+jest.mock('../src/services/GitService', () => ({
+  GitService: {
+    getBranches: jest.fn(async () => [
+      { name: 'main', isCurrent: true },
+      { name: 'develop', isCurrent: false },
+    ]),
+  },
+}));
+
+const mockSetPreference = jest.fn(async () => undefined);
+const mockGetPreference = jest.fn(async () => null);
+
+jest.mock('../src/services/ThoughtDumpRepoPreferenceService', () => ({
+  ThoughtDumpRepoPreferenceService: {
+    set: (...args: unknown[]) => mockSetPreference(...args),
+    get: (...args: unknown[]) => mockGetPreference(...args),
+    clear: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock('../src/services/LastUsedRepoService', () => ({
+  LastUsedRepoService: {
+    get: jest.fn(async () => null),
+    set: jest.fn(async () => undefined),
+    clear: jest.fn(async () => undefined),
+  },
+}));
+
+import { ThoughtDumpRepoPickerModal } from '../src/components/thoughts/ThoughtDumpRepoPickerModal';
+
+describe('ThoughtDumpRepoPickerModal', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockRepositories = [
+      { name: 'owner/repo-a', path: 'owner/repo-a' },
+      { name: 'owner/repo-b', path: 'owner/repo-b' },
+    ];
+    mockSetPreference.mockReset();
+    mockSetPreference.mockResolvedValue(undefined);
+    mockGetPreference.mockReset();
+    mockGetPreference.mockResolvedValue(null);
+    mockAddRepository.mockClear();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('renders added repositories', () => {
+    const { getAllByTestId, getByText } = render(
+      <ThoughtDumpRepoPickerModal visible onClose={() => {}} onSelected={() => {}} />,
+    );
+
+    expect(getAllByTestId('thought-dump-repo-picker.button.select-repo')).toHaveLength(2);
+    expect(getByText('owner/repo-a')).toBeTruthy();
+    expect(getByText('owner/repo-b')).toBeTruthy();
+  });
+
+  test('tapping a repo loads branches and shows the branch row', async () => {
+    const { getAllByTestId, getByTestId, getByText } = render(
+      <ThoughtDumpRepoPickerModal visible onClose={() => {}} onSelected={() => {}} />,
+    );
+
+    fireEvent.press(getAllByTestId('thought-dump-repo-picker.button.select-repo')[0]);
+
+    await waitFor(() => {
+      expect(getByTestId('thought-dump-repo-picker.button.select-branch')).toBeTruthy();
+    });
+
+    // Defaults to the current branch ('main') from the mocked getBranches.
+    expect(getByText('main')).toBeTruthy();
+  });
+
+  test('selecting a branch and confirming calls set + onSelected with (repoPath, branch)', async () => {
+    const onSelected = jest.fn();
+    const { getAllByTestId, getByTestId } = render(
+      <ThoughtDumpRepoPickerModal visible onClose={() => {}} onSelected={onSelected} />,
+    );
+
+    fireEvent.press(getAllByTestId('thought-dump-repo-picker.button.select-repo')[0]);
+
+    await waitFor(() => {
+      expect(getByTestId('thought-dump-repo-picker.button.select-branch')).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('thought-dump-repo-picker.button.select-branch'));
+
+    const developBranch = await waitFor(() => getByTestId('thought-dump-repo-picker.button.branch-develop'));
+    fireEvent.press(developBranch);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('thought-dump-repo-picker.button.confirm'));
+    });
+
+    await waitFor(() => {
+      expect(mockSetPreference).toHaveBeenCalledWith('owner/repo-a', 'develop');
+      expect(onSelected).toHaveBeenCalledWith('owner/repo-a', 'develop');
+    });
+  });
+
+  test('a rejected set shows the error row and Retry works', async () => {
+    mockSetPreference
+      .mockRejectedValueOnce(new Error('Network Error'))
+      .mockResolvedValueOnce(undefined);
+    const onSelected = jest.fn();
+
+    const { getAllByTestId, getByTestId, queryByTestId } = render(
+      <ThoughtDumpRepoPickerModal visible onClose={() => {}} onSelected={onSelected} />,
+    );
+
+    fireEvent.press(getAllByTestId('thought-dump-repo-picker.button.select-repo')[0]);
+
+    await waitFor(() => {
+      expect(getByTestId('thought-dump-repo-picker.button.select-branch')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('thought-dump-repo-picker.button.confirm'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('thought-dump-repo-picker.text.error')).toBeTruthy();
+    });
+
+    expect(queryByTestId('thought-dump-repo-picker.button.confirm')).toBeTruthy();
+    expect(onSelected).not.toHaveBeenCalled();
+
+    const errorText = getByTestId('thought-dump-repo-picker.text.error');
+    expect(errorText.props.children).toMatch(/Network Error|couldn't|failed/i);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('thought-dump-repo-picker.button.confirm'));
+    });
+
+    await waitFor(() => {
+      expect(onSelected).toHaveBeenCalledTimes(1);
+    });
+    expect(queryByTestId('thought-dump-repo-picker.text.error')).toBeNull();
+  });
+
+  test('not-authenticated + no repos shows the connect-account state', () => {
+    mockRepositories = [];
+    const onGoToSettings = jest.fn();
+
+    const { getByText, getByTestId } = render(
+      <ThoughtDumpRepoPickerModal
+        visible
+        onClose={() => {}}
+        onSelected={() => {}}
+        onGoToSettings={onGoToSettings}
+      />,
+    );
+
+    expect(getByText('Connect your GitHub account in Settings to choose a repository.')).toBeTruthy();
+    const goSettings = getByTestId('thought-dump-repo-picker.button.go-settings');
+    fireEvent.press(goSettings);
+    expect(onGoToSettings).toHaveBeenCalled();
+  });
+});

--- a/__tests__/ThoughtDumpScreen.test.tsx
+++ b/__tests__/ThoughtDumpScreen.test.tsx
@@ -5,6 +5,9 @@ import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import ThoughtDumpScreen from '../src/screens/ThoughtDumpScreen';
 import { ThoughtDumpService } from '../src/services/ThoughtDumpService';
 import { StorageService } from '../src/services/StorageService';
+import { ThoughtDumpRepoPreferenceService } from '../src/services/ThoughtDumpRepoPreferenceService';
+import { LastUsedRepoService } from '../src/services/LastUsedRepoService';
+import { GitHubService } from '../src/services/GitHubService';
 import type { ThoughtDump } from '../src/models/ThoughtDump';
 
 jest.mock('../src/services/ThoughtDumpService', () => ({
@@ -20,6 +23,51 @@ jest.mock('../src/services/StorageService', () => ({
     getSavedRepositories: jest.fn(),
   },
 }));
+
+jest.mock('../src/services/ThoughtDumpRepoPreferenceService', () => ({
+  ThoughtDumpRepoPreferenceService: {
+    get: jest.fn(),
+    set: jest.fn(),
+    clear: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/LastUsedRepoService', () => ({
+  LastUsedRepoService: {
+    get: jest.fn(),
+    set: jest.fn(),
+    clear: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(),
+  },
+}));
+
+jest.mock('../src/components/thoughts/ThoughtDumpRepoPickerModal', () => {
+  const React = require('react');
+  const { View, Text, TouchableOpacity } = require('react-native');
+  const ThoughtDumpRepoPickerModal = ({ visible, onClose, onSelected, onGoToSettings }: any) =>
+    visible ? (
+      <View testID="thought-dump-repo-picker-modal">
+        <TouchableOpacity
+          testID="repo-picker-modal.on-selected"
+          onPress={() => onSelected('owner/repo', 'main')}
+        >
+          <Text>select</Text>
+        </TouchableOpacity>
+        <TouchableOpacity testID="repo-picker-modal.on-close" onPress={onClose}>
+          <Text>close</Text>
+        </TouchableOpacity>
+        <TouchableOpacity testID="repo-picker-modal.on-go-to-settings" onPress={onGoToSettings}>
+          <Text>settings</Text>
+        </TouchableOpacity>
+      </View>
+    ) : null;
+  return { ThoughtDumpRepoPickerModal };
+});
 
 jest.mock('../src/services/ai/thoughtDumpIndexing', () => ({
   indexDump: jest.fn(),
@@ -38,7 +86,7 @@ jest.mock('react-native-safe-area-context', () => ({
 jest.mock('@react-navigation/native', () => {
   const React = require('react');
   return {
-    useNavigation: () => ({ goBack: jest.fn(), canGoBack: () => true }),
+    useNavigation: () => ({ goBack: jest.fn(), canGoBack: () => true, navigate: jest.fn() }),
     useRoute: () => ({ params: {} }),
     useFocusEffect: (cb: () => unknown) => React.useEffect(cb),
   };
@@ -136,9 +184,10 @@ jest.mock('../src/components/ui', () => {
     />
   );
 
-  const EmptyState = ({ title }: any) => (
+  const EmptyState = ({ title, subtitle }: any) => (
     <View testID="empty-state">
       <Text>{title}</Text>
+      {subtitle ? <Text>{subtitle}</Text> : null}
     </View>
   );
 
@@ -163,6 +212,9 @@ const mockCreate = ThoughtDumpService.create as jest.MockedFunction<typeof Thoug
 const mockList = ThoughtDumpService.list as jest.MockedFunction<typeof ThoughtDumpService.list>;
 const mockDelete = ThoughtDumpService.delete as jest.MockedFunction<typeof ThoughtDumpService.delete>;
 const mockGetSavedRepositories = StorageService.getSavedRepositories as jest.MockedFunction<typeof StorageService.getSavedRepositories>;
+const mockGetPreference = ThoughtDumpRepoPreferenceService.get as jest.MockedFunction<typeof ThoughtDumpRepoPreferenceService.get>;
+const mockGetLastUsed = LastUsedRepoService.get as jest.MockedFunction<typeof LastUsedRepoService.get>;
+const mockIsAuthenticated = GitHubService.isAuthenticated as jest.MockedFunction<typeof GitHubService.isAuthenticated>;
 
 const makeDump = (overrides?: Partial<ThoughtDump>): ThoughtDump => ({
   id: 'dump-1',
@@ -176,13 +228,17 @@ describe('ThoughtDumpScreen', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
-    
+    jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
     mockList.mockImplementation(async () => []);
-    mockCreate.mockImplementation(async () => null);
+    mockCreate.mockImplementation(async () => ({ ok: false, reason: 'no-repos' }));
     mockDelete.mockImplementation(async () => true);
     mockGetSavedRepositories.mockImplementation(async () => [
       { path: 'owner/repo', branch: 'main' },
     ]);
+    mockGetPreference.mockResolvedValue(null);
+    mockGetLastUsed.mockResolvedValue(null);
+    mockIsAuthenticated.mockReturnValue(true);
   });
 
   it('renders empty state when no dumps', async () => {
@@ -192,9 +248,92 @@ describe('ThoughtDumpScreen', () => {
     });
   });
 
+  it('renders repo picker row and tapping it opens the modal', async () => {
+    const { getByTestId, queryByTestId } = render(<ThoughtDumpScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('thought-dump-repo-picker')).toBeTruthy();
+    });
+
+    expect(queryByTestId('thought-dump-repo-picker-modal')).toBeNull();
+
+    fireEvent.press(getByTestId('thought-dump-repo-picker'));
+
+    await waitFor(() => {
+      expect(getByTestId('thought-dump-repo-picker-modal')).toBeTruthy();
+    });
+  });
+
+  it('save with no repo configured opens the picker instead of calling create', async () => {
+    mockGetSavedRepositories.mockResolvedValue([]);
+
+    const { getByTestId, getByText } = render(<ThoughtDumpScreen />);
+
+    await waitFor(() => {
+      expect(getByText('thoughtDump.chooseRepo')).toBeTruthy();
+    });
+
+    fireEvent.changeText(getByTestId('thought-dump-input'), 'My thought');
+    fireEvent.press(getByTestId('thought-dump-save'));
+
+    await waitFor(() => {
+      expect(getByTestId('thought-dump-repo-picker-modal')).toBeTruthy();
+    });
+
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['no-repos', 'thoughtDump.errorNoRepo'],
+    ['not-authenticated', 'thoughtDump.errorNotAuthenticated'],
+    ['invalid-repo', 'thoughtDump.errorInvalidRepo'],
+    ['write-failed', 'thoughtDump.errorWriteFailed'],
+  ] as const)('shows %s alert on create failure', async (reason, messageKey) => {
+    mockCreate.mockResolvedValue({ ok: false, reason });
+
+    const { getByTestId } = render(<ThoughtDumpScreen />);
+
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalled();
+    });
+
+    fireEvent.changeText(getByTestId('thought-dump-input'), 'My thought');
+    fireEvent.press(getByTestId('thought-dump-save'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('common.error', messageKey);
+    });
+  });
+
+  it('renders not-authenticated empty state with go-to-settings action', async () => {
+    mockIsAuthenticated.mockReturnValue(false);
+
+    const { getByText, getByTestId } = render(<ThoughtDumpScreen />);
+
+    await waitFor(() => {
+      expect(getByText('thoughtDump.noAuthTitle')).toBeTruthy();
+      expect(getByText('thoughtDump.noAuthBody')).toBeTruthy();
+    });
+
+    expect(getByTestId('thought-dump-empty-action')).toBeTruthy();
+  });
+
+  it('renders no-repo empty state with go-to-settings action', async () => {
+    mockGetSavedRepositories.mockResolvedValue([]);
+
+    const { getByText, getByTestId } = render(<ThoughtDumpScreen />);
+
+    await waitFor(() => {
+      expect(getByText('thoughtDump.noRepoConfiguredTitle')).toBeTruthy();
+      expect(getByText('thoughtDump.noRepoConfiguredBody')).toBeTruthy();
+    });
+
+    expect(getByTestId('thought-dump-empty-action')).toBeTruthy();
+  });
+
   it('typing text + pressing save calls ThoughtDumpService.create with trimmed text', async () => {
     const newDump = makeDump({ text: 'My thought' });
-    mockCreate.mockResolvedValue(newDump);
+    mockCreate.mockResolvedValue({ ok: true, dump: newDump });
 
     const { getByTestId } = render(<ThoughtDumpScreen />);
 
@@ -209,13 +348,16 @@ describe('ThoughtDumpScreen', () => {
     fireEvent.press(saveButton);
 
     await waitFor(() => {
-      expect(mockCreate).toHaveBeenCalledWith('My thought');
+      expect(mockCreate).toHaveBeenCalledWith('My thought', {
+        repoPath: 'owner/repo',
+        branch: 'main',
+      });
     });
   }, 15000);
 
   it('after successful create, input clears and dump appears in list', async () => {
     const newDump = makeDump({ id: 'new-dump', text: 'My thought' });
-    mockCreate.mockResolvedValue(newDump);
+    mockCreate.mockResolvedValue({ ok: true, dump: newDump });
 
     const { getByTestId, queryByTestId, getByText } = render(<ThoughtDumpScreen />);
 
@@ -356,6 +498,88 @@ describe('ThoughtDumpScreen', () => {
 
     await waitFor(() => {
       expect(getByTestId('voice-input-modal.button.close-unavailable')).toBeTruthy();
+    });
+  });
+
+  describe('repo picker row and error/empty states', () => {
+    it('renders the repo picker row and tapping it opens the modal', async () => {
+      const { getByTestId, queryByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => {
+        expect(getByTestId('thought-dump-repo-picker')).toBeTruthy();
+      });
+      expect(queryByTestId('thought-dump-repo-picker-modal')).toBeNull();
+
+      fireEvent.press(getByTestId('thought-dump-repo-picker'));
+
+      await waitFor(() => {
+        expect(getByTestId('thought-dump-repo-picker-modal')).toBeTruthy();
+      });
+    });
+
+    it('save with no repo configured opens the picker instead of calling create', async () => {
+      mockGetSavedRepositories.mockResolvedValue([]);
+
+      const { getByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => {
+        expect(getByTestId('thought-dump-input')).toBeTruthy();
+      });
+
+      fireEvent.changeText(getByTestId('thought-dump-input'), 'some thought');
+      fireEvent.press(getByTestId('thought-dump-save'));
+
+      await waitFor(() => {
+        expect(getByTestId('thought-dump-repo-picker-modal')).toBeTruthy();
+      });
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['not-authenticated', 'thoughtDump.errorNotAuthenticated'],
+      ['no-repos', 'thoughtDump.errorNoRepo'],
+      ['invalid-repo', 'thoughtDump.errorInvalidRepo'],
+      ['write-failed', 'thoughtDump.errorWriteFailed'],
+    ] as const)('shows distinct alert for "%s" failure', async (reason, messageKey) => {
+      mockCreate.mockResolvedValue({ ok: false, reason });
+
+      const { getByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => {
+        expect(getByTestId('thought-dump-input')).toBeTruthy();
+      });
+
+      fireEvent.changeText(getByTestId('thought-dump-input'), 'some thought');
+      fireEvent.press(getByTestId('thought-dump-save'));
+
+      await waitFor(() => {
+        expect(Alert.alert).toHaveBeenCalledWith('common.error', messageKey);
+      });
+    });
+
+    it('shows not-authenticated empty state with go-to-settings action', async () => {
+      mockIsAuthenticated.mockReturnValue(false);
+      mockGetSavedRepositories.mockResolvedValue([]);
+
+      const { getByText, getByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => {
+        expect(getByText('thoughtDump.noAuthTitle')).toBeTruthy();
+        expect(getByText('thoughtDump.noAuthBody')).toBeTruthy();
+        expect(getByTestId('thought-dump-empty-action')).toBeTruthy();
+      });
+    });
+
+    it('shows no-repo empty state with go-to-settings action', async () => {
+      mockGetSavedRepositories.mockResolvedValue([]);
+
+      const { getByText, getByTestId } = render(<ThoughtDumpScreen />);
+
+      await waitFor(() => {
+        expect(getByText('thoughtDump.noRepoConfiguredTitle')).toBeTruthy();
+        expect(getByText('thoughtDump.noRepoConfiguredBody')).toBeTruthy();
+        expect(getByTestId('thought-dump-empty-action')).toBeTruthy();
+      });
     });
   });
 

--- a/__tests__/e2e-thought-dump-loop.test.tsx
+++ b/__tests__/e2e-thought-dump-loop.test.tsx
@@ -121,15 +121,71 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 jest.mock('../src/services/ThoughtDumpService', () => ({
   ThoughtDumpService: {
     create: jest.fn(async (text: string) => ({
-      id: 'test-dump-id',
-      text,
-      createdAt: new Date().toISOString(),
-      filePath: `thoughts/20240101-000000-test-d.md`,
+      ok: true,
+      dump: {
+        id: 'test-dump-id',
+        text,
+        createdAt: new Date().toISOString(),
+        filePath: `thoughts/20240101-000000-test-d.md`,
+      },
     })),
     list: jest.fn(async () => []),
     delete: jest.fn(async () => true),
   },
 }));
+
+jest.mock('../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(async () => [
+      { id: 'repo-1', name: 'repo', path: 'owner/repo', branch: 'main' },
+    ]),
+  },
+}));
+
+jest.mock('../src/services/ThoughtDumpRepoPreferenceService', () => ({
+  ThoughtDumpRepoPreferenceService: {
+    get: jest.fn(async () => null),
+    set: jest.fn(),
+    clear: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/LastUsedRepoService', () => ({
+  LastUsedRepoService: {
+    get: jest.fn(async () => null),
+    set: jest.fn(),
+    clear: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+  },
+}));
+
+jest.mock('../src/components/thoughts/ThoughtDumpRepoPickerModal', () => {
+  const React = require('react');
+  const { View, TouchableOpacity, Text } = require('react-native');
+  const ThoughtDumpRepoPickerModal = ({ visible, onClose, onSelected, onGoToSettings }: any) =>
+    visible ? (
+      <View testID="thought-dump-repo-picker-modal">
+        <TouchableOpacity
+          testID="repo-picker-modal.on-selected"
+          onPress={() => onSelected('owner/repo', 'main')}
+        >
+          <Text>select</Text>
+        </TouchableOpacity>
+        <TouchableOpacity testID="repo-picker-modal.on-close" onPress={onClose}>
+          <Text>close</Text>
+        </TouchableOpacity>
+        <TouchableOpacity testID="repo-picker-modal.on-go-to-settings" onPress={onGoToSettings}>
+          <Text>settings</Text>
+        </TouchableOpacity>
+      </View>
+    ) : null;
+  return { ThoughtDumpRepoPickerModal };
+});
 
 jest.mock('../src/services/ai/AIMemoryIndexService', () => {
   const entries = new Map<string, string>();
@@ -297,10 +353,13 @@ beforeEach(async () => {
   // by a timed-out test so they cannot leak into the next test.
   (ThoughtDumpService.create as jest.Mock).mockReset();
   (ThoughtDumpService.create as jest.Mock).mockImplementation(async (text: string) => ({
-    id: 'test-dump-id',
-    text,
-    createdAt: new Date().toISOString(),
-    filePath: `thoughts/20240101-000000-test-d.md`,
+    ok: true,
+    dump: {
+      id: 'test-dump-id',
+      text,
+      createdAt: new Date().toISOString(),
+      filePath: `thoughts/20240101-000000-test-d.md`,
+    },
   }));
   (ThoughtDumpService.list as jest.Mock).mockResolvedValue([]);
   (ThoughtDumpService.delete as jest.Mock).mockResolvedValue(true);
@@ -351,10 +410,13 @@ describe('e2e: FAB -> thought dump -> memory -> reset', () => {
 
   it('save entry on ThoughtDumpScreen calls indexDump', async () => {
     (ThoughtDumpService.create as jest.Mock).mockResolvedValueOnce({
-      id: 'e2e-dump-1',
-      text: 'My e2e test thought',
-      createdAt: '2024-01-01T00:00:00.000Z',
-      filePath: 'thoughts/20240101-000000-e2e-dum.md',
+      ok: true,
+      dump: {
+        id: 'e2e-dump-1',
+        text: 'My e2e test thought',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        filePath: 'thoughts/20240101-000000-e2e-dum.md',
+      },
     });
 
     const React = require('react');
@@ -369,6 +431,10 @@ describe('e2e: FAB -> thought dump -> memory -> reset', () => {
 
     const input = await waitFor(() => getByTestId('thought-dump-input'));
 
+    await waitFor(() => {
+      expect(ThoughtDumpService.list).toHaveBeenCalled();
+    });
+
     await act(async () => {
       fireEvent.changeText(input, 'My e2e test thought');
     });
@@ -379,7 +445,10 @@ describe('e2e: FAB -> thought dump -> memory -> reset', () => {
     });
 
     await waitFor(() => {
-      expect(ThoughtDumpService.create).toHaveBeenCalledWith('My e2e test thought');
+      expect(ThoughtDumpService.create).toHaveBeenCalledWith('My e2e test thought', {
+        repoPath: 'owner/repo',
+        branch: 'main',
+      });
     });
 
     await waitFor(() => {
@@ -453,16 +522,22 @@ describe('e2e: FAB -> thought dump -> memory -> reset', () => {
     expect(hub.goThoughtDump).toHaveBeenCalledWith(mockNavigation);
 
     (ThoughtDumpService.create as jest.Mock).mockResolvedValueOnce({
-      id: 'full-loop-dump',
-      text: 'full loop thought',
-      createdAt: new Date().toISOString(),
-      filePath: 'thoughts/20240101-000000-full-loo.md',
+      ok: true,
+      dump: {
+        id: 'full-loop-dump',
+        text: 'full loop thought',
+        createdAt: new Date().toISOString(),
+        filePath: 'thoughts/20240101-000000-full-loo.md',
+      },
     });
 
     const ThoughtDumpScreen = require('../src/screens/ThoughtDumpScreen').default;
     const screen = render(React.createElement(ThoughtDumpScreen, {}));
 
     const input = await waitFor(() => screen.getByTestId('thought-dump-input'));
+    await waitFor(() => {
+      expect(ThoughtDumpService.list).toHaveBeenCalled();
+    });
     await act(async () => {
       fireEvent.changeText(input, 'full loop thought');
     });
@@ -473,7 +548,10 @@ describe('e2e: FAB -> thought dump -> memory -> reset', () => {
     });
 
     await waitFor(() => {
-      expect(ThoughtDumpService.create).toHaveBeenCalledWith('full loop thought');
+      expect(ThoughtDumpService.create).toHaveBeenCalledWith('full loop thought', {
+        repoPath: 'owner/repo',
+        branch: 'main',
+      });
     });
 
     await waitFor(() => {

--- a/__tests__/services/ThoughtDumpRepoPreferenceService.test.ts
+++ b/__tests__/services/ThoughtDumpRepoPreferenceService.test.ts
@@ -1,0 +1,99 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  let store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (key: string) => (key in store ? store[key] : null)),
+      setItem: jest.fn(async (key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: jest.fn(async (key: string) => {
+        delete store[key];
+      }),
+      clear: jest.fn(async () => {
+        store = {};
+      }),
+      __reset: () => {
+        store = {};
+      },
+      __dump: () => ({ ...store }),
+      __setRaw: (key: string, value: string) => {
+        store[key] = value;
+      },
+    },
+  };
+});
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ThoughtDumpRepoPreferenceService } from '../../src/services/ThoughtDumpRepoPreferenceService';
+
+const KEY = '@gitnotes:thought_dump_repo';
+
+const store = AsyncStorage as unknown as {
+  __reset: () => void;
+  __dump: () => Record<string, string>;
+  __setRaw: (key: string, value: string) => void;
+};
+
+beforeEach(() => {
+  store.__reset();
+});
+
+describe('ThoughtDumpRepoPreferenceService', () => {
+  describe('get', () => {
+    it('returns null when no preference is stored', async () => {
+      expect(await ThoughtDumpRepoPreferenceService.get()).toBeNull();
+    });
+
+    it('returns the target after a set round-trip', async () => {
+      await ThoughtDumpRepoPreferenceService.set('org/repo', 'main');
+      expect(await ThoughtDumpRepoPreferenceService.get()).toEqual({
+        repoPath: 'org/repo',
+        branch: 'main',
+      });
+    });
+
+    it('round-trips a repo without a branch', async () => {
+      await ThoughtDumpRepoPreferenceService.set('org/repo');
+      expect(await ThoughtDumpRepoPreferenceService.get()).toEqual({
+        repoPath: 'org/repo',
+      });
+    });
+
+    it('returns null for corrupt JSON', async () => {
+      store.__setRaw(KEY, '{not valid json');
+      expect(await ThoughtDumpRepoPreferenceService.get()).toBeNull();
+    });
+
+    it('returns null when the stored value has no repoPath', async () => {
+      store.__setRaw(KEY, JSON.stringify({ branch: 'main' }));
+      expect(await ThoughtDumpRepoPreferenceService.get()).toBeNull();
+    });
+
+    it('returns null when repoPath is an empty string', async () => {
+      store.__setRaw(KEY, JSON.stringify({ repoPath: '', branch: 'main' }));
+      expect(await ThoughtDumpRepoPreferenceService.get()).toBeNull();
+    });
+  });
+
+  describe('set', () => {
+    it('stores JSON with repoPath and branch', async () => {
+      await ThoughtDumpRepoPreferenceService.set('org/repo', 'feature');
+      expect(store.__dump()[KEY]).toBe(JSON.stringify({ repoPath: 'org/repo', branch: 'feature' }));
+    });
+
+    it('stores JSON without branch when omitted', async () => {
+      await ThoughtDumpRepoPreferenceService.set('org/repo');
+      expect(store.__dump()[KEY]).toBe(JSON.stringify({ repoPath: 'org/repo' }));
+    });
+  });
+
+  describe('clear', () => {
+    it('removes the stored preference', async () => {
+      await ThoughtDumpRepoPreferenceService.set('org/repo', 'main');
+      await ThoughtDumpRepoPreferenceService.clear();
+      expect(store.__dump()[KEY]).toBeUndefined();
+      expect(await ThoughtDumpRepoPreferenceService.get()).toBeNull();
+    });
+  });
+});

--- a/__tests__/services/ThoughtDumpService.test.ts
+++ b/__tests__/services/ThoughtDumpService.test.ts
@@ -61,6 +61,7 @@ jest.mock('../../src/services/featureFlags', () => ({
 
 import { ThoughtDumpService } from '../../src/services/ThoughtDumpService';
 import { GitHubService } from '../../src/services/GitHubService';
+import { StorageService } from '../../src/services/StorageService';
 import { SyncEngineService } from '../../src/services/SyncEngineService';
 import { StagingService } from '../../src/services/git/StagingService';
 import { parseThoughtDump, serializeThoughtDump, createThoughtDump } from '../../src/models/ThoughtDump';
@@ -75,23 +76,25 @@ beforeEach(() => {
 
 describe('ThoughtDumpService.create', () => {
   it('stages the upsert for the new dump', async () => {
-    const dump = await ThoughtDumpService.create('my random thought', {
+    const result = await ThoughtDumpService.create('my random thought', {
       repoPath: 'org/repo',
       branch: 'main',
     });
 
-    expect(dump).not.toBeNull();
-    expect(dump!.text).toBe('my random thought');
-    expect(dump!.filePath).toMatch(/^thoughts\/\d{8}-\d{6}-[a-z0-9]+\.md$/);
-    expect(dump!.id).toBeTruthy();
-    expect(dump!.createdAt).toBeTruthy();
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    const dump = result.dump;
+    expect(dump.text).toBe('my random thought');
+    expect(dump.filePath).toMatch(/^thoughts\/\d{8}-\d{6}-[a-z0-9]+\.md$/);
+    expect(dump.id).toBeTruthy();
+    expect(dump.createdAt).toBeTruthy();
 
     expect(StagingService.stageUpsert).toHaveBeenCalledTimes(1);
     expect(StagingService.stageUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         repo: 'org/repo',
         branch: 'main',
-        filePath: dump!.filePath,
+        filePath: dump.filePath,
         title: 'Thought dump',
       }),
     );
@@ -101,10 +104,25 @@ describe('ThoughtDumpService.create', () => {
     expect(GitHubService.updateFile).not.toHaveBeenCalled();
   });
 
-  it('returns null when not authenticated', async () => {
+  it('returns not-authenticated when unauthenticated', async () => {
     (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(false);
-    const dump = await ThoughtDumpService.create('test', { repoPath: 'org/repo' });
-    expect(dump).toBeNull();
+    const result = await ThoughtDumpService.create('test', { repoPath: 'org/repo' });
+    expect(result).toEqual({ ok: false, reason: 'not-authenticated' });
+  });
+
+  it('returns no-repos when there are no saved repositories', async () => {
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([]);
+    const result = await ThoughtDumpService.create('test');
+    expect(result).toEqual({ ok: false, reason: 'no-repos' });
+  });
+
+  it('returns write-failed with the error when staging fails', async () => {
+    (StagingService.stageUpsert as jest.Mock).mockResolvedValue({
+      success: false,
+      error: 'boom',
+    });
+    const result = await ThoughtDumpService.create('test', { repoPath: 'org/repo', branch: 'main' });
+    expect(result).toEqual({ ok: false, reason: 'write-failed', error: 'boom' });
   });
 });
 

--- a/__tests__/staging-rewire.test.ts
+++ b/__tests__/staging-rewire.test.ts
@@ -558,17 +558,18 @@ describe('staging rewire — ThoughtDumpService', () => {
   });
 
   it('create stages the upsert, no GitHubService/LocalGitWriter write', async () => {
-    const dump = await ThoughtDumpService.create('hello dump', {
+    const result = await ThoughtDumpService.create('hello dump', {
       repoPath: 'owner/repo',
       branch: 'main',
     });
 
-    expect(dump).not.toBeNull();
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
     expect(stageUpsertMock).toHaveBeenCalledWith(
       expect.objectContaining({
         repo: 'owner/repo',
         branch: 'main',
-        filePath: dump!.filePath,
+        filePath: result.dump.filePath,
         title: 'Thought dump',
       }),
     );

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -31,6 +31,7 @@
 | [Settings — Add Repo Fixes](./settings-add-repo-fixes.md) | Invisible primary-button fix + repo list not loading after adding a token + busy-state re-entry guard on Add-Repo picker (#936) |
 | [iPad Multi-Column Card Collapse Fix](./ipad-multicolumn-card-collapse-fix.md) | SwipeableListItem root `width: '100%'` so multi-column FlatList cards fill their column (#940, #941) |
 | [Add Repo Picker — Clone Progress & First-Connect Fixes](./add-repo-picker-clone-progress.md) | Inline clone progress in the repo picker (no stacked native modal), manual-Add spinner padding, connectHost hydrating GitHubService, delete-note false-failure fix (#953, QA #932) |
+| [Thought Dump Repo Picker](./thought-dump-repo-picker.md) | "Save to \<repo\> · \<branch\>" picker row + repo/branch modal, `ThoughtDumpRepoPreferenceService` persistence, distinct save errors, and empty-state disambiguation |
 
 ## Quick Start
 

--- a/docs/wiki/thought-dump-repo-picker.md
+++ b/docs/wiki/thought-dump-repo-picker.md
@@ -1,0 +1,55 @@
+# Thought Dump — Repo Picker
+
+> The Thought Dump screen now lets the user choose which repository (and branch) a thought dump is saved to, instead of always writing to the first saved repo behind a generic error alert.
+
+## Background
+
+Previously a thought dump was saved unconditionally to the first saved repository. If that write failed — the user had no GitHub account, no repos, or a repo that had since been removed — the screen showed a single generic error alert (`thoughtDump.error`, "Something went wrong. Please try again.") with no guidance on what was actually wrong or how to fix it. The user had no control over the destination and no way to recover.
+
+This feature adds a repo+branch picker to the Thought Dump screen and splits the save-time failure modes into distinct, actionable errors.
+
+## The picker row
+
+Above the composer, the Thought Dump screen renders a "Save to `<repo>` · `<branch>`" picker row (`thoughtDump.repo`). Tapping it opens a repo+branch picker modal (titled `thoughtDump.repoPickerTitle`), which lists the user's saved repositories and their branches and explains the behavior (`thoughtDump.repoPickerDescription`: thought dumps are saved as Markdown in the `thoughts/` folder of the selected repository).
+
+## Preference persistence
+
+The selected repo is persisted through `ThoughtDumpRepoPreferenceService`, stored under the `@gitnotes:thought_dump_repo` AsyncStorage key. Resolution order on load:
+
+1. The stored preference (if the repo still exists).
+2. The last-used repository.
+3. The first saved repository.
+
+The fallback chain means an existing user keeps working without re-picking, while a repo that has been deleted since the last pick degrades gracefully to the next candidate.
+
+## Distinct save-time errors
+
+Instead of one generic alert, save failures now surface one of four targeted messages:
+
+| Key | Condition |
+|-----|-----------|
+| `errorNotAuthenticated` | No GitHub account / not signed in |
+| `errorNoRepo` | No repository selected |
+| `errorInvalidRepo` | The selected repository is no longer available |
+| `errorWriteFailed` | The write itself failed (network, permissions, etc.) |
+
+## Empty-state disambiguation
+
+The empty state now distinguishes three separate conditions instead of a single "no thought dumps" message:
+
+- **Connect account** (`noAuthTitle` / `noAuthBody`) — the user has no GitHub account connected.
+- **No repository set up** (`noRepoConfiguredTitle` / `noRepoConfiguredBody`) — an account is connected but no repository is saved.
+- **No thought dumps yet** (`thoughtDump.empty`) — everything is configured but the folder is empty.
+
+Each of the first two states offers a "Go to Settings" action (`goToSettings`) so the user can resolve the missing setup in place.
+
+## i18n
+
+Thirteen new `thoughtDump.*` keys added to all six locales (en/es/fr/de/ja/ko): `repo`, `chooseRepo`, `repoPickerTitle`, `repoPickerDescription`, `noRepoConfiguredTitle`, `noRepoConfiguredBody`, `noAuthTitle`, `noAuthBody`, `errorNotAuthenticated`, `errorNoRepo`, `errorWriteFailed`, `errorInvalidRepo`, `goToSettings`. All six locales verified by the existing `__tests__/i18n-key-parity.test.ts` gate.
+
+## Files
+
+- `src/screens/ThoughtDumpScreen.tsx` — picker row, repo+branch picker modal, empty-state branching, distinct error alerts
+- `src/services/ThoughtDumpService.ts` — writes to the selected repo/branch, typed save failures
+- `src/services/ThoughtDumpRepoPreferenceService.ts` — `@gitnotes:thought_dump_repo` persistence with last-used/first-repo fallback
+- `src/i18n/{en,es,fr,de,ja,ko}.json` — 13 new keys each

--- a/src/components/thoughts/ThoughtDumpRepoPickerModal.tsx
+++ b/src/components/thoughts/ThoughtDumpRepoPickerModal.tsx
@@ -1,0 +1,523 @@
+import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  FlatList,
+  ActivityIndicator,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { useTokens } from '../../contexts/ThemeContext';
+import { useRepoStore } from '../../stores/repoStore';
+import { GitService, GitBranch } from '../../services/GitService';
+import { GitHubService, GitHubRepository } from '../../services/GitHubService';
+import { LastUsedRepoService } from '../../services/LastUsedRepoService';
+import { ThoughtDumpRepoPreferenceService } from '../../services/ThoughtDumpRepoPreferenceService';
+import SearchBar from '../SearchBar';
+import { HapticService } from '../../utils/haptics';
+import { Modal, Button, Surface } from '../ui';
+
+interface ThoughtDumpRepoPickerModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSelected: (repoPath: string, branch: string) => void;
+  onGoToSettings?: () => void;
+}
+
+/**
+ * A repo row shown in the picker list. May be an already-added local repo, or
+ * a GitHub repo the user hasn't added yet. Tapping an unadded one auto-adds
+ * it and proceeds to branch selection.
+ */
+type DisplayRepo = {
+  readonly path: string;
+  readonly name: string;
+  readonly isAdded: boolean;
+};
+
+export const ThoughtDumpRepoPickerModal: React.FC<ThoughtDumpRepoPickerModalProps> = ({
+  visible,
+  onClose,
+  onSelected,
+  onGoToSettings,
+}) => {
+  const { colors, spacing } = useTokens();
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation();
+  const repositories = useRepoStore((state) => state.repositories);
+  const addRepository = useRepoStore((state) => state.addRepository);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedRepoPath, setSelectedRepoPath] = useState<string | null>(null);
+  const [branch, setBranch] = useState('main');
+  const [branches, setBranches] = useState<GitBranch[]>([]);
+  const [loadingBranches, setLoadingBranches] = useState(false);
+  const [showBranchPicker, setShowBranchPicker] = useState(false);
+  const [isInitializing, setIsInitializing] = useState(false);
+  const [initError, setInitError] = useState<string | null>(null);
+
+  // Fetch GitHub repos when the modal opens — covers fresh-account users who
+  // added a token but never manually added any repo in Settings.
+  const [githubRepos, setGithubRepos] = useState<GitHubRepository[]>([]);
+  const [isLoadingGithubRepos, setIsLoadingGithubRepos] = useState(false);
+  const [isAddingRepoPath, setIsAddingRepoPath] = useState<string | null>(null);
+  const [githubFetchError, setGithubFetchError] = useState<string | null>(null);
+
+  const isAuthenticated = GitHubService.isAuthenticated();
+  // Ref so each modal-open triggers exactly one fetch, even if auth state
+  // happens to change between renders while the modal is visible.
+  const didFetchGithubRef = useRef(false);
+
+  const fetchGithubRepos = useCallback(async () => {
+    if (!GitHubService.isAuthenticated()) return;
+    setIsLoadingGithubRepos(true);
+    setGithubFetchError(null);
+    try {
+      const repos = await GitHubService.getRepositories();
+      setGithubRepos(repos);
+    } catch (error) {
+      console.warn('[ThoughtDumpRepoPickerModal] Failed to fetch GitHub repos:', error);
+      setGithubRepos([]);
+      setGithubFetchError('Could not load GitHub repos. Check network or token.');
+    } finally {
+      setIsLoadingGithubRepos(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!visible) {
+      didFetchGithubRef.current = false;
+      return;
+    }
+    if (didFetchGithubRef.current) return;
+    didFetchGithubRef.current = true;
+    void fetchGithubRepos();
+  }, [visible, fetchGithubRepos]);
+
+  // Build the merged display list: added (local) repos first, then GitHub
+  // repos that haven't been added yet. Duplicates are excluded by path.
+  const displayRepos = useMemo<DisplayRepo[]>(() => {
+    const addedPaths = new Set(repositories.map((r) => r.path));
+    const added: DisplayRepo[] = repositories.map((r) => ({
+      path: r.path.includes('/') ? r.path : r.name,
+      name: r.name,
+      isAdded: true,
+    }));
+    const available: DisplayRepo[] = githubRepos
+      .filter((gr) => !addedPaths.has(gr.full_name))
+      .map((gr) => ({
+        path: gr.full_name,
+        name: gr.name,
+        isAdded: false,
+      }));
+    return [...added, ...available];
+  }, [repositories, githubRepos]);
+
+  const filteredRepos = useMemo(() => {
+    if (!searchQuery.trim()) return displayRepos;
+    const query = searchQuery.toLowerCase();
+    return displayRepos.filter(
+      (repo) =>
+        repo.name.toLowerCase().includes(query) ||
+        repo.path.toLowerCase().includes(query),
+    );
+  }, [displayRepos, searchQuery]);
+
+  // Auto-select repo when modal opens: single added repo → select it,
+  // multiple → last used. Only runs once per modal open.
+  const didAutoSelectRef = useRef(false);
+  useEffect(() => {
+    if (!visible) {
+      didAutoSelectRef.current = false;
+      return;
+    }
+    if (didAutoSelectRef.current) return;
+    if (repositories.length === 0) return;
+    didAutoSelectRef.current = true;
+
+    if (repositories.length === 1) {
+      void handleSelectRepo(repositories[0].path);
+      return;
+    }
+
+    void LastUsedRepoService.get().then((lastPath) => {
+      if (!lastPath) return;
+      const stillExists = repositories.some((r) => r.path === lastPath);
+      if (stillExists) void handleSelectRepo(lastPath);
+    });
+  }, [visible, repositories]);
+
+  const handleSelectRepo = async (path: string) => {
+    setSelectedRepoPath(path);
+    setInitError(null);
+    setLoadingBranches(true);
+    try {
+      const fetchedBranches = await GitService.getBranches(path);
+      setBranches(fetchedBranches);
+      const currentBranch = fetchedBranches.find((b) => b.isCurrent);
+      setBranch(currentBranch?.name || 'main');
+    } catch {
+      setBranches([]);
+    } finally {
+      setLoadingBranches(false);
+    }
+    HapticService.selection();
+  };
+
+  /**
+   * Called when the user taps an unadded GitHub repo in the list. Auto-adds
+   * it to the store then immediately proceeds to branch selection — the same
+   * flow as picking an already-added repo, just with a transparent add step.
+   */
+  const handlePickUnaddedGithubRepo = async (fullName: string) => {
+    setIsAddingRepoPath(fullName);
+    setInitError(null);
+    try {
+      await addRepository(fullName, undefined, 'github', { allowUnverifiedWrite: true });
+      HapticService.success();
+      await handleSelectRepo(fullName);
+    } catch (error) {
+      HapticService.error();
+      const detail = error instanceof Error ? error.message : 'Unknown error';
+      setInitError(`Couldn't add ${fullName}. ${detail}`);
+    } finally {
+      setIsAddingRepoPath(null);
+    }
+  };
+
+  const handleBranchSelect = (branchName: string) => {
+    setBranch(branchName);
+    setShowBranchPicker(false);
+    setInitError(null);
+    HapticService.selection();
+  };
+
+  const handleConfirm = async () => {
+    if (!selectedRepoPath) return;
+
+    setIsInitializing(true);
+    setInitError(null);
+    try {
+      await ThoughtDumpRepoPreferenceService.set(selectedRepoPath, branch);
+      HapticService.success();
+      onSelected(selectedRepoPath, branch);
+    } catch (error) {
+      console.error('[ThoughtDumpRepoPickerModal] Error saving repo preference:', error);
+      HapticService.error();
+      const detail = error instanceof Error ? error.message : 'Unknown error';
+      setInitError(
+        `Couldn't save to ${selectedRepoPath}. ${detail}. Check network and repository write access, then tap Retry.`,
+      );
+    } finally {
+      setIsInitializing(false);
+    }
+  };
+
+  const renderRepoRow = (repo: DisplayRepo) => {
+    const isSelected = repo.path === selectedRepoPath;
+    const isAddingThis = isAddingRepoPath === repo.path;
+    const disabled = isAddingThis || isInitializing || isAddingRepoPath !== null;
+    return (
+      <TouchableOpacity
+        key={`${repo.isAdded ? 'added' : 'avail'}:${repo.path}`}
+        testID="thought-dump-repo-picker.button.select-repo"
+        onPress={() =>
+          repo.isAdded
+            ? handleSelectRepo(repo.path)
+            : void handlePickUnaddedGithubRepo(repo.path)
+        }
+        disabled={disabled}
+        className="mb-2"
+        style={disabled && !isAddingThis ? { opacity: 0.5 } : undefined}
+      >
+        <Surface
+          elevation="flat"
+          inset={isSelected}
+          radius="md"
+          className="flex-row items-center justify-between p-3.5"
+          style={[
+            isSelected && { borderColor: colors.primary, borderWidth: 1 },
+            !isSelected && { borderWidth: 1, borderColor: 'transparent' },
+          ]}
+        >
+          <View className="flex-1 mr-2">
+            <Text
+              className="text-md font-medium text-text"
+              numberOfLines={1}
+              style={!repo.isAdded ? { color: colors.text } : undefined}
+            >
+              {repo.path}
+            </Text>
+          </View>
+          {isAddingThis ? (
+            <ActivityIndicator size="small" color={colors.primary} />
+          ) : isSelected ? (
+            <Ionicons name="checkmark-circle" size={24} color={colors.primary} />
+          ) : repo.isAdded ? (
+            <Ionicons name="document-outline" size={20} color={colors.textSecondary} />
+          ) : (
+            <Ionicons name="add-circle-outline" size={22} color={colors.primary} />
+          )}
+        </Surface>
+      </TouchableOpacity>
+    );
+  };
+
+  const isEmpty = repositories.length === 0 && githubRepos.length === 0 && !isLoadingGithubRepos;
+  const noLocalButHasGithub = repositories.length === 0 && githubRepos.length > 0;
+
+  return (
+    <Modal
+      visible={visible}
+      onRequestClose={onClose}
+      bottomSheet
+      contentStyle={{ height: '85%' }}
+    >
+      <View className="flex-1">
+        <View className="flex-row items-center justify-between px-4 py-3.5 border-b border-border" style={{ borderBottomWidth: StyleSheet.hairlineWidth }}>
+          <View className="w-8 items-end">
+            {(visible && (isLoadingGithubRepos || isAuthenticated)) && (
+              <TouchableOpacity
+                testID="thought-dump-repo-picker.button.refresh"
+                onPress={() => void fetchGithubRepos()}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                disabled={isLoadingGithubRepos}
+                accessibilityLabel="Refresh repositories"
+              >
+                <Ionicons
+                  name="refresh-outline"
+                  size={22}
+                  color={isLoadingGithubRepos ? colors.textSecondary : colors.primary}
+                />
+              </TouchableOpacity>
+            )}
+          </View>
+          <Text className="flex-1 text-md font-semibold text-center text-text" numberOfLines={1}>
+            {t('thoughtDump.repoPickerTitle')}
+          </Text>
+          <TouchableOpacity
+            testID="thought-dump-repo-picker.button.close"
+            onPress={onClose}
+            disabled={isInitializing}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            className="w-8 items-end"
+          >
+            <Ionicons name="close" size={24} color={colors.textSecondary} />
+          </TouchableOpacity>
+        </View>
+
+        <View className="flex-1 px-4 pt-4">
+          <Text className="text-sm mb-4 text-text-secondary" style={{ lineHeight: 20 }}>
+            {t('thoughtDump.repoPickerDescription')}
+          </Text>
+
+          {isEmpty && isAuthenticated ? (
+            <View className="items-center py-10">
+              <Ionicons
+                name="folder-open-outline"
+                size={48}
+                color={colors.textSecondary}
+                style={{ marginBottom: spacing[4] }}
+              />
+              <Text className="text-md text-center mb-2 text-text-secondary">
+                No repositories found on your GitHub account.
+              </Text>
+              {githubFetchError && (
+                <Text className="text-sm text-center mb-4 text-error">
+                  {githubFetchError}
+                </Text>
+              )}
+              <Text className="text-sm text-center mb-6 text-text-secondary">
+                Create a repository on GitHub, then tap the refresh icon above — or go to Settings to add one manually.
+              </Text>
+              <View className="flex-row gap-2">
+                <TouchableOpacity
+                  testID="thought-dump-repo-picker.button.retry-fetch"
+                  onPress={() => void fetchGithubRepos()}
+                  disabled={isLoadingGithubRepos}
+                  style={{
+                    flex: 1,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 6,
+                    paddingHorizontal: 16,
+                    paddingVertical: 12,
+                    borderRadius: 12,
+                    backgroundColor: colors.primary,
+                    opacity: isLoadingGithubRepos ? 0.6 : 1,
+                  }}
+                >
+                  {isLoadingGithubRepos ? (
+                    <ActivityIndicator size="small" color="#fff" />
+                  ) : (
+                    <Ionicons name="refresh-outline" size={18} color="#fff" />
+                  )}
+                  <Text style={{ color: '#fff', fontSize: 15, fontWeight: '600' }}>Reload</Text>
+                </TouchableOpacity>
+                {onGoToSettings && (
+                  <Button
+                    testID="thought-dump-repo-picker.button.go-settings"
+                    variant="secondary"
+                    onPress={onGoToSettings}
+                  >
+                    {t('thoughtDump.goToSettings')}
+                  </Button>
+                )}
+              </View>
+            </View>
+          ) : isEmpty && !isAuthenticated ? (
+            <View className="items-center py-10">
+              <Ionicons
+                name="lock-closed-outline"
+                size={48}
+                color={colors.textSecondary}
+                style={{ marginBottom: spacing[4] }}
+              />
+              <Text className="text-md text-center mb-6 text-text-secondary">
+                Connect your GitHub account in Settings to choose a repository.
+              </Text>
+              {onGoToSettings && (
+                <Button variant="primary" onPress={onGoToSettings} testID="thought-dump-repo-picker.button.go-settings">
+                  {t('thoughtDump.goToSettings')}
+                </Button>
+              )}
+            </View>
+          ) : (
+            <>
+              <View className="mb-3">
+                <SearchBar
+                  value={searchQuery}
+                  onChangeText={setSearchQuery}
+                  placeholder="Search repositories..."
+                />
+              </View>
+
+              {noLocalButHasGithub && !searchQuery.trim() && (
+                <Text className="text-xs font-semibold uppercase tracking-wide mb-2 text-text-secondary">
+                  Available on GitHub — tap to add
+                </Text>
+              )}
+
+              <ScrollView
+                className="flex-1"
+                contentContainerStyle={{ paddingBottom: 8 }}
+                keyboardShouldPersistTaps="handled"
+              >
+                {filteredRepos.map(renderRepoRow)}
+                {filteredRepos.length === 0 && (
+                  <Text className="text-center py-5 text-sm text-text-secondary">
+                    No matching repositories
+                  </Text>
+                )}
+              </ScrollView>
+
+              {selectedRepoPath && (
+                <View className="flex-row items-center mt-3 mb-1">
+                  <Text className="text-md font-medium mr-2.5 text-text">Branch:</Text>
+                  <TouchableOpacity
+                    testID="thought-dump-repo-picker.button.select-branch"
+                    className="flex-1 flex-row items-center justify-between px-3 py-2.5 rounded-lg border border-border min-h-11"
+                    onPress={() => setShowBranchPicker(true)}
+                    disabled={loadingBranches}
+                  >
+                    {loadingBranches ? (
+                      <ActivityIndicator size="small" color={colors.primary} />
+                    ) : (
+                      <>
+                        <Text className="text-md flex-1 text-text">{branch}</Text>
+                        <Ionicons name="chevron-down" size={16} color={colors.textSecondary} />
+                      </>
+                    )}
+                  </TouchableOpacity>
+                </View>
+              )}
+            </>
+          )}
+        </View>
+
+        <View
+          className="px-4 pt-3 pb-1 border-t border-border"
+          style={{
+            borderTopWidth: StyleSheet.hairlineWidth,
+            paddingBottom: Math.max(insets.bottom, 16),
+          }}
+        >
+          {initError && (
+            <View
+              className="flex-row items-start gap-2 p-2.5 rounded-lg mb-2.5"
+              style={{
+                backgroundColor: colors.error + '1A',
+                borderWidth: StyleSheet.hairlineWidth,
+                borderColor: colors.error,
+              }}
+            >
+              <Ionicons name="alert-circle" size={18} color={colors.error} />
+              <Text
+                testID="thought-dump-repo-picker.text.error"
+                className="flex-1 text-sm text-error"
+                style={{ lineHeight: 18 }}
+              >
+                {initError}
+              </Text>
+            </View>
+          )}
+          <Button
+            testID="thought-dump-repo-picker.button.confirm"
+            variant="primary"
+            onPress={handleConfirm}
+            disabled={!selectedRepoPath || isInitializing}
+          >
+            {isInitializing
+              ? 'Saving...'
+              : initError
+                ? 'Retry'
+                : 'Confirm Selection'}
+          </Button>
+        </View>
+      </View>
+
+      {/* Branch Picker Modal */}
+      <Modal visible={showBranchPicker} onRequestClose={() => setShowBranchPicker(false)} bottomSheet contentStyle={{ height: '50%' }}>
+        <View className="flex-row items-center justify-between px-4 py-3.5 border-b border-border" style={{ borderBottomWidth: StyleSheet.hairlineWidth }}>
+          <Text className="text-md font-semibold text-text">Select Branch</Text>
+          <TouchableOpacity onPress={() => setShowBranchPicker(false)} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+            <Ionicons name="close" size={24} color={colors.textSecondary} />
+          </TouchableOpacity>
+        </View>
+        <FlatList
+          data={branches}
+          keyExtractor={(item) => item.name}
+          contentContainerStyle={{ paddingBottom: 8 }}
+          keyboardShouldPersistTaps="handled"
+          renderItem={({ item }) => {
+            const isSelected = item.name === branch;
+            return (
+              <TouchableOpacity
+                testID={`thought-dump-repo-picker.button.branch-${item.name}`}
+                className="flex-row items-center justify-between px-4 py-3.5 border-b border-border"
+                style={{ borderBottomWidth: StyleSheet.hairlineWidth }}
+                onPress={() => handleBranchSelect(item.name)}
+              >
+                <View className="flex-row items-center gap-2.5 flex-1">
+                  <Ionicons name="git-branch-outline" size={18} color={isSelected ? colors.primary : colors.textSecondary} />
+                  <Text className="text-md text-text">{item.name}</Text>
+                  {item.isCurrent && (
+                    <View className="px-1.5 py-0.5 rounded" style={{ backgroundColor: colors.primary + '20' }}>
+                      <Text className="text-xs font-semibold text-primary">default</Text>
+                    </View>
+                  )}
+                </View>
+                {isSelected && <Ionicons name="checkmark" size={20} color={colors.primary} />}
+              </TouchableOpacity>
+            );
+          }}
+        />
+      </Modal>
+    </Modal>
+  );
+};

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -837,7 +837,20 @@
     "justNow": "gerade eben",
     "voiceInput": "Spracheingabe",
     "voiceUnavailable": "Spracheingabe nicht verfügbar",
-    "voiceDump": "Sprachablage"
+    "voiceDump": "Sprachablage",
+    "repo": "Speichern in",
+    "chooseRepo": "Wählen, wo gespeichert werden soll",
+    "repoPickerTitle": "Speicherort wählen",
+    "repoPickerDescription": "Gedankenablagen werden als Markdown im Ordner thoughts/ des ausgewählten Repositorys gespeichert.",
+    "noRepoConfiguredTitle": "Kein Repository eingerichtet",
+    "noRepoConfiguredBody": "Füge ein GitHub-Repository hinzu, um Gedankenablagen zu speichern.",
+    "noAuthTitle": "GitHub-Konto verbinden",
+    "noAuthBody": "Melde dich an, um Gedankenablagen in einem Repository zu speichern.",
+    "errorNotAuthenticated": "Melde dich bei deinem GitHub-Konto an, um Gedankenablagen zu speichern.",
+    "errorNoRepo": "Kein Repository ausgewählt. Wähle, wo Gedankenablagen gespeichert werden.",
+    "errorWriteFailed": "Gedankenablage konnte nicht gespeichert werden. Prüfe dein Netzwerk und den Schreibzugriff auf das Repository.",
+    "errorInvalidRepo": "Das ausgewählte Repository ist nicht mehr verfügbar. Wähle einen anderen Speicherort.",
+    "goToSettings": "Zu den Einstellungen"
   },
   "reminders": {
     "title": "New Reminder",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -871,7 +871,20 @@
     "justNow": "just now",
     "voiceInput": "Voice input",
     "voiceUnavailable": "Voice input not available",
-    "voiceDump": "Voice dump"
+    "voiceDump": "Voice dump",
+    "repo": "Save to",
+    "chooseRepo": "Choose where to save",
+    "repoPickerTitle": "Choose save location",
+    "repoPickerDescription": "Thought dumps are saved as Markdown in the thoughts/ folder of the selected repository.",
+    "noRepoConfiguredTitle": "No repository set up",
+    "noRepoConfiguredBody": "Add a GitHub repository to start saving thought dumps.",
+    "noAuthTitle": "Connect your GitHub account",
+    "noAuthBody": "Sign in to save thought dumps to a repository.",
+    "errorNotAuthenticated": "Sign in to your GitHub account to save thought dumps.",
+    "errorNoRepo": "No repository selected. Choose where thought dumps are saved.",
+    "errorWriteFailed": "Couldn't save the thought dump. Check your network and repository write access.",
+    "errorInvalidRepo": "The selected repository is no longer available. Choose another save location.",
+    "goToSettings": "Go to Settings"
   },
   "paywall": {
     "title": "GitNotēs Pro",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -837,7 +837,20 @@
     "justNow": "ahora mismo",
     "voiceInput": "Entrada de voz",
     "voiceUnavailable": "Entrada de voz no disponible",
-    "voiceDump": "Vaciado de voz"
+    "voiceDump": "Vaciado de voz",
+    "repo": "Guardar en",
+    "chooseRepo": "Elige dónde guardar",
+    "repoPickerTitle": "Elegir ubicación de guardado",
+    "repoPickerDescription": "Los vaciados de pensamientos se guardan como Markdown en la carpeta thoughts/ del repositorio seleccionado.",
+    "noRepoConfiguredTitle": "No hay ningún repositorio configurado",
+    "noRepoConfiguredBody": "Añade un repositorio de GitHub para empezar a guardar vaciados de pensamientos.",
+    "noAuthTitle": "Conecta tu cuenta de GitHub",
+    "noAuthBody": "Inicia sesión para guardar vaciados de pensamientos en un repositorio.",
+    "errorNotAuthenticated": "Inicia sesión en tu cuenta de GitHub para guardar vaciados de pensamientos.",
+    "errorNoRepo": "No hay ningún repositorio seleccionado. Elige dónde se guardan los vaciados de pensamientos.",
+    "errorWriteFailed": "No se pudo guardar el vaciado de pensamientos. Comprueba tu red y el acceso de escritura al repositorio.",
+    "errorInvalidRepo": "El repositorio seleccionado ya no está disponible. Elige otra ubicación de guardado.",
+    "goToSettings": "Ir a Ajustes"
   },
   "reminders": {
     "title": "New Reminder",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -837,7 +837,20 @@
     "justNow": "à l'instant",
     "voiceInput": "Saisie vocale",
     "voiceUnavailable": "Saisie vocale non disponible",
-    "voiceDump": "Vidage vocal"
+    "voiceDump": "Vidage vocal",
+    "repo": "Enregistrer dans",
+    "chooseRepo": "Choisir où enregistrer",
+    "repoPickerTitle": "Choisir l'emplacement d'enregistrement",
+    "repoPickerDescription": "Les vidages de pensées sont enregistrés en Markdown dans le dossier thoughts/ du dépôt sélectionné.",
+    "noRepoConfiguredTitle": "Aucun dépôt configuré",
+    "noRepoConfiguredBody": "Ajoutez un dépôt GitHub pour commencer à enregistrer des vidages de pensées.",
+    "noAuthTitle": "Connectez votre compte GitHub",
+    "noAuthBody": "Connectez-vous pour enregistrer des vidages de pensées dans un dépôt.",
+    "errorNotAuthenticated": "Connectez-vous à votre compte GitHub pour enregistrer des vidages de pensées.",
+    "errorNoRepo": "Aucun dépôt sélectionné. Choisissez où les vidages de pensées sont enregistrés.",
+    "errorWriteFailed": "Impossible d'enregistrer le vidage de pensées. Vérifiez votre réseau et l'accès en écriture au dépôt.",
+    "errorInvalidRepo": "Le dépôt sélectionné n'est plus disponible. Choisissez un autre emplacement d'enregistrement.",
+    "goToSettings": "Aller aux réglages"
   },
   "reminders": {
     "title": "New Reminder",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -837,7 +837,20 @@
     "justNow": "たった今",
     "voiceInput": "音声入力",
     "voiceUnavailable": "音声入力を利用できません",
-    "voiceDump": "音声ダンプ"
+    "voiceDump": "音声ダンプ",
+    "repo": "保存先",
+    "chooseRepo": "保存先を選択",
+    "repoPickerTitle": "保存場所を選択",
+    "repoPickerDescription": "思考ダンプは、選択したリポジトリの thoughts/ フォルダに Markdown として保存されます。",
+    "noRepoConfiguredTitle": "リポジトリが設定されていません",
+    "noRepoConfiguredBody": "思考ダンプの保存を開始するには、GitHub リポジトリを追加してください。",
+    "noAuthTitle": "GitHub アカウントを接続",
+    "noAuthBody": "思考ダンプをリポジトリに保存するには、サインインしてください。",
+    "errorNotAuthenticated": "思考ダンプを保存するには、GitHub アカウントにサインインしてください。",
+    "errorNoRepo": "リポジトリが選択されていません。思考ダンプの保存先を選択してください。",
+    "errorWriteFailed": "思考ダンプを保存できませんでした。ネットワークとリポジトリへの書き込み権限を確認してください。",
+    "errorInvalidRepo": "選択したリポジトリは利用できなくなりました。別の保存場所を選択してください。",
+    "goToSettings": "設定へ移動"
   },
   "reminders": {
     "title": "New Reminder",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -837,7 +837,20 @@
     "justNow": "방금 전",
     "voiceInput": "음성 입력",
     "voiceUnavailable": "음성 입력을 사용할 수 없습니다",
-    "voiceDump": "음성 덤프"
+    "voiceDump": "음성 덤프",
+    "repo": "저장 위치",
+    "chooseRepo": "저장할 위치 선택",
+    "repoPickerTitle": "저장 위치 선택",
+    "repoPickerDescription": "생각 덤프는 선택한 리포지토리의 thoughts/ 폴더에 Markdown으로 저장됩니다.",
+    "noRepoConfiguredTitle": "설정된 리포지토리가 없음",
+    "noRepoConfiguredBody": "생각 덤프 저장을 시작하려면 GitHub 리포지토리를 추가하세요.",
+    "noAuthTitle": "GitHub 계정 연결",
+    "noAuthBody": "생각 덤프를 리포지토리에 저장하려면 로그인하세요.",
+    "errorNotAuthenticated": "생각 덤프를 저장하려면 GitHub 계정에 로그인하세요.",
+    "errorNoRepo": "선택된 리포지토리가 없습니다. 생각 덤프가 저장될 위치를 선택하세요.",
+    "errorWriteFailed": "생각 덤프를 저장할 수 없습니다. 네트워크와 리포지토리 쓰기 권한을 확인하세요.",
+    "errorInvalidRepo": "선택한 리포지토리를 더 이상 사용할 수 없습니다. 다른 저장 위치를 선택하세요.",
+    "goToSettings": "설정으로 이동"
   },
   "reminders": {
     "title": "New Reminder",

--- a/src/screens/ThoughtDumpScreen.tsx
+++ b/src/screens/ThoughtDumpScreen.tsx
@@ -11,11 +11,16 @@ import { useTokens } from '../contexts/ThemeContext';
 import { RootStackParamList } from '../navigation/types';
 import { ThoughtDumpService } from '../services/ThoughtDumpService';
 import { StorageService } from '../services/StorageService';
+import { ThoughtDumpRepoPreferenceService } from '../services/ThoughtDumpRepoPreferenceService';
+import { LastUsedRepoService } from '../services/LastUsedRepoService';
+import { GitHubService } from '../services/GitHubService';
+import type { GitRepository } from '../services/GitService';
 import { ThoughtDump } from '../models/ThoughtDump';
 import { gitOperationRegistry } from '../stores/gitOperationStore';
 import { ScreenHeader, Button, Input, EmptyState, Modal } from '../components/ui';
 import { useScreenHeaderHeight } from '../components/ui';
 import VoiceInputModal from '../components/VoiceInputModal';
+import { ThoughtDumpRepoPickerModal } from '../components/thoughts/ThoughtDumpRepoPickerModal';
 import { indexDump, removeDump } from '../services/ai/thoughtDumpIndexing';
 import { SwipeableListItem } from '../components/list/SwipeableListItem';
 import { BulkActionBar } from '../components/list/BulkActionBar';
@@ -43,6 +48,9 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
   const [repoPath, setRepoPath] = useState('');
   const [branch, setBranch] = useState<string | undefined>();
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [savedRepos, setSavedRepos] = useState<GitRepository[]>([]);
+  const [isAuthenticated, setIsAuthenticated] = useState(true);
   const [showVoiceModal, setShowVoiceModal] = useState(false);
 
   const selectionMode = selectedIds.size > 0;
@@ -62,11 +70,33 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
     setIsLoading(true);
     try {
       const repos = await StorageService.getSavedRepositories();
-      if (repos.length > 0) {
-        setRepoPath(repos[0].path);
-        setBranch(repos[0].branch);
+      setSavedRepos(repos);
+      setIsAuthenticated(GitHubService.isAuthenticated());
+
+      const preference = await ThoughtDumpRepoPreferenceService.get();
+      const lastUsed = await LastUsedRepoService.get();
+
+      let resolvedRepoPath = '';
+      let resolvedBranch: string | undefined;
+
+      if (preference && repos.some((r) => r.path === preference.repoPath)) {
+        resolvedRepoPath = preference.repoPath;
+        resolvedBranch =
+          preference.branch ?? repos.find((r) => r.path === preference.repoPath)?.branch;
+      } else if (lastUsed && repos.some((r) => r.path === lastUsed)) {
+        resolvedRepoPath = lastUsed;
+        resolvedBranch = repos.find((r) => r.path === lastUsed)?.branch;
+      } else if (repos.length > 0) {
+        resolvedRepoPath = repos[0].path;
+        resolvedBranch = repos[0].branch;
       }
-      const result = await ThoughtDumpService.list();
+
+      setRepoPath(resolvedRepoPath);
+      setBranch(resolvedBranch);
+
+      const result = await ThoughtDumpService.list(
+        resolvedRepoPath ? { repoPath: resolvedRepoPath, branch: resolvedBranch } : undefined,
+      );
       setDumps(result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()));
     } catch {
       // silently handled
@@ -95,19 +125,37 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
     const trimmed = text.trim();
     if (!trimmed) return;
 
+    if (!repoPath || !isAuthenticated || savedRepos.length === 0) {
+      setPickerVisible(true);
+      return;
+    }
+
     setIsSaving(true);
     try {
-      const dump = await ThoughtDumpService.create(trimmed);
-      if (dump) {
+      const result = await ThoughtDumpService.create(trimmed, { repoPath, branch });
+      if (result.ok) {
         setText('');
-        setDumps((prev) => [dump, ...prev]);
-        indexDump(dump);
-        onDumpChange?.(dump);
+        setDumps((prev) => [result.dump, ...prev]);
+        indexDump(result.dump);
+        onDumpChange?.(result.dump);
       } else {
-        Alert.alert(t('common.error'), t('thoughtDump.error'));
+        switch (result.reason) {
+          case 'not-authenticated':
+            Alert.alert(t('common.error'), t('thoughtDump.errorNotAuthenticated'));
+            break;
+          case 'no-repos':
+            Alert.alert(t('common.error'), t('thoughtDump.errorNoRepo'));
+            break;
+          case 'invalid-repo':
+            Alert.alert(t('common.error'), t('thoughtDump.errorInvalidRepo'));
+            break;
+          case 'write-failed':
+            Alert.alert(t('common.error'), t('thoughtDump.errorWriteFailed'));
+            break;
+        }
       }
     } catch {
-      Alert.alert(t('common.error'), t('thoughtDump.error'));
+      Alert.alert(t('common.error'), t('thoughtDump.errorWriteFailed'));
     } finally {
       setIsSaving(false);
     }
@@ -243,6 +291,40 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
 
   const renderEmpty = () => {
     if (isLoading) return null;
+    if (!isAuthenticated) {
+      return (
+        <View style={styles.emptyContainer}>
+          <EmptyState
+            icon="lock-closed"
+            title={t('thoughtDump.noAuthTitle')}
+            subtitle={t('thoughtDump.noAuthBody')}
+          />
+          <Button
+            testID="thought-dump-empty-action"
+            label={t('thoughtDump.goToSettings')}
+            variant="primary"
+            onPress={() => navigation.navigate('MainTabs', { screen: 'SettingsTab' })}
+          />
+        </View>
+      );
+    }
+    if (savedRepos.length === 0) {
+      return (
+        <View style={styles.emptyContainer}>
+          <EmptyState
+            icon="folder-open"
+            title={t('thoughtDump.noRepoConfiguredTitle')}
+            subtitle={t('thoughtDump.noRepoConfiguredBody')}
+          />
+          <Button
+            testID="thought-dump-empty-action"
+            label={t('thoughtDump.goToSettings')}
+            variant="primary"
+            onPress={() => navigation.navigate('MainTabs', { screen: 'SettingsTab' })}
+          />
+        </View>
+      );
+    }
     return (
       <EmptyState
         icon="bulb"
@@ -259,6 +341,33 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={[]}>
       <View style={{ flex: 1, paddingTop: headerHeight }}>
         <View style={[styles.composer, { padding: spacing[4] }]}>
+          <Pressable
+            testID="thought-dump-repo-picker"
+            accessibilityRole="button"
+            onPress={() => setPickerVisible(true)}
+            style={[
+              styles.repoPicker,
+              {
+                backgroundColor: colors.surface,
+                borderColor: colors.border,
+                padding: spacing[3],
+                marginBottom: spacing[3],
+              },
+            ]}
+          >
+            <Text style={[styles.repoPickerLabel, { color: colors.textSecondary }]}>
+              {t('thoughtDump.repo')}
+            </Text>
+            <View style={styles.repoPickerValueRow}>
+              <Text
+                style={[styles.repoPickerValue, { color: colors.text }]}
+                numberOfLines={1}
+              >
+                {repoPath ? (branch ? `${repoPath} · ${branch}` : repoPath) : t('thoughtDump.chooseRepo')}
+              </Text>
+              <Ionicons name="chevron-forward" size={16} color={colors.textSecondary} />
+            </View>
+          </Pressable>
           <Input
             testID="thought-dump-input"
             multiline
@@ -347,6 +456,21 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
         onClose={() => setShowVoiceModal(false)}
       />
 
+      <ThoughtDumpRepoPickerModal
+        visible={pickerVisible}
+        onClose={() => setPickerVisible(false)}
+        onSelected={(rp, br) => {
+          setRepoPath(rp);
+          setBranch(br);
+          setPickerVisible(false);
+          loadDumps();
+        }}
+        onGoToSettings={() => {
+          setPickerVisible(false);
+          navigation.navigate('MainTabs', { screen: 'SettingsTab' });
+        }}
+      />
+
       <ScreenHeader
         title={t('thoughtDump.title')}
         onBack={() => navigation.goBack()}
@@ -360,6 +484,29 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   composer: {},
+  repoPicker: {
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  repoPickerLabel: {
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  repoPickerValueRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  repoPickerValue: {
+    flex: 1,
+    fontSize: 15,
+    marginRight: 8,
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 24,
+    paddingHorizontal: 16,
+  },
   dumpItem: {
     borderRadius: 8,
   },

--- a/src/services/ThoughtDumpRepoPreferenceService.ts
+++ b/src/services/ThoughtDumpRepoPreferenceService.ts
@@ -1,0 +1,45 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY = '@gitnotes:thought_dump_repo';
+
+export interface ThoughtDumpTarget {
+  repoPath: string;
+  branch?: string;
+}
+
+// Remembers the repo the user last dumped a thought into, so the next
+// thought dump can pre-select that repo (and branch) instead of falling
+// back to the first saved repository.
+export class ThoughtDumpRepoPreferenceService {
+  static async get(): Promise<ThoughtDumpTarget | null> {
+    const raw = await AsyncStorage.getItem(KEY);
+    if (!raw) return null;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null) return null;
+
+    const target = parsed as ThoughtDumpTarget;
+    if (typeof target.repoPath !== 'string' || target.repoPath.length === 0) {
+      return null;
+    }
+
+    return {
+      repoPath: target.repoPath,
+      branch: typeof target.branch === 'string' ? target.branch : undefined,
+    };
+  }
+
+  static async set(repoPath: string, branch?: string): Promise<void> {
+    await AsyncStorage.setItem(KEY, JSON.stringify({ repoPath, branch }));
+  }
+
+  static async clear(): Promise<void> {
+    await AsyncStorage.removeItem(KEY);
+  }
+}

--- a/src/services/ThoughtDumpService.ts
+++ b/src/services/ThoughtDumpService.ts
@@ -41,6 +41,14 @@ export interface ThoughtDumpCreateOptions {
   provider?: GitHostProvider;
 }
 
+export type ThoughtDumpCreateResult =
+  | { ok: true; dump: ThoughtDump }
+  | {
+      ok: false;
+      reason: 'not-authenticated' | 'no-repos' | 'invalid-repo' | 'write-failed';
+      error?: string;
+    };
+
 export interface ThoughtDumpDeleteOptions {
   repoPath: string;
   branch?: string;
@@ -57,8 +65,10 @@ async function getFirstRepo(): Promise<{ repoPath: string; branch?: string; prov
 }
 
 export class ThoughtDumpService {
-  static async create(text: string, options?: ThoughtDumpCreateOptions): Promise<ThoughtDump | null> {
-    if (!GitHubService.isAuthenticated()) return null;
+  static async create(text: string, options?: ThoughtDumpCreateOptions): Promise<ThoughtDumpCreateResult> {
+    if (!GitHubService.isAuthenticated()) {
+      return { ok: false, reason: 'not-authenticated' };
+    }
 
     let repoPath: string;
     let branch: string;
@@ -68,13 +78,13 @@ export class ThoughtDumpService {
       branch = await resolveBranch(repoPath, options.branch);
     } else {
       const repo = await getFirstRepo();
-      if (!repo) return null;
+      if (!repo) return { ok: false, reason: 'no-repos' };
       repoPath = repo.repoPath;
       branch = repo.branch ?? 'main';
     }
 
     const repoInfo = parseRepoPath(repoPath);
-    if (!repoInfo) return null;
+    if (!repoInfo) return { ok: false, reason: 'invalid-repo' };
 
     const dump = createThoughtDump(text);
     const content = serializeThoughtDump(dump);
@@ -91,10 +101,10 @@ export class ThoughtDumpService {
 
     if (!writeResult.success) {
       console.warn('[ThoughtDumpService] create failed:', writeResult.error);
-      return null;
+      return { ok: false, reason: 'write-failed', error: writeResult.error };
     }
 
-    return dump;
+    return { ok: true, dump };
   }
 
   static async list(options?: { repoPath?: string; branch?: string; provider?: GitHostProvider }): Promise<ThoughtDump[]> {


### PR DESCRIPTION
## Summary

Thought dumps previously saved to the first saved repo with only a generic error alert. This PR lets users choose exactly where dumps are saved and surfaces proper errors when saving fails.

**Repo/branch selection**
- New `ThoughtDumpRepoPreferenceService` (@gitnotes:thought_dump_repo) persists the chosen target as `{ repoPath, branch }`.
- `ThoughtDumpScreen` now shows a \`Save to \`<repo> \`· \`<branch>\`\` row above the composer; tapping opens a new `ThoughtDumpRepoPickerModal` (search, added + GitHub repos, auto-add for unadded repos, branch picker).
- Target resolution order: saved preference → last-used repo → first saved repo (each validated against saved repos).
- The chosen target feeds `ThoughtDumpService.create/list/delete`.

**Distinct error handling**
- `ThoughtDumpService.create` now returns `ThoughtDumpCreateResult`: `{ ok: true, dump }` | `{ ok: false, reason: 'not-authenticated' | 'no-repos' | 'invalid-repo' | 'write-failed', error? }`.
- Screen shows a specific message per reason instead of one generic alert.
- Saving with no repo configured opens the picker instead of failing silently.

**Empty-state fixes**
- The list now distinguishes: connect your GitHub account → no repository set up (both with a Go-to-Settings action) → no thought dumps yet.

**Docs/tests**
- Wiki page: docs/wiki/thought-dump-repo-picker.md (+ index entry).
- New tests: picker modal, preference service; updated service, staging-rewire, screen, e2e, i18n-parity suites. Full suite green (2751+ passed; only pre-existing repo-wide lint warnings).
- 13 new i18n keys in all 6 locales.

**Verification**
- `yarn ts:check` clean · `yarn jest` passes · `yarn eslint .` 0 errors.
- Note: unrelated uncommitted working-tree changes on `src/components/git/FloatingStageButton.tsx`, `src/components/ai/ModelSelector.tsx`, `src/screens/ChatScreen.tsx`, `src/screens/RenderStyleEditorScreen.tsx` were intentionally left out of this branch.