### PR TITLE
fix(settings): keep inputs above iOS keyboard + group Daily Quote settings

### DIFF
--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -32,6 +32,7 @@
 | [iPad Multi-Column Card Collapse Fix](./ipad-multicolumn-card-collapse-fix.md) | SwipeableListItem root `width: '100%'` so multi-column FlatList cards fill their column (#940, #941) |
 | [Add Repo Picker — Clone Progress & First-Connect Fixes](./add-repo-picker-clone-progress.md) | Inline clone progress in the repo picker (no stacked native modal), manual-Add spinner padding, connectHost hydrating GitHubService, delete-note false-failure fix (#953, QA #932) |
 | [Thought Dump Repo Picker](./thought-dump-repo-picker.md) | "Save to \<repo\> · \<branch\>" picker row + repo/branch modal, `ThoughtDumpRepoPreferenceService` persistence, distinct save errors, and empty-state disambiguation |
+| [Settings Keyboard & Quote Grouping](./settings-keyboard-quote-grouping.md) | iOS keyboard no longer covers inputs in Settings/AI (ModelSelector KAV, RenderStyleEditor scroll insets, ChatScreen persist-taps) + Daily Quote settings grouped under their own section |
 
 ## Quick Start
 

--- a/docs/wiki/settings-keyboard-quote-grouping.md
+++ b/docs/wiki/settings-keyboard-quote-grouping.md
@@ -1,0 +1,40 @@
+# Settings Keyboard & Quote Grouping Fix
+
+Fixes iOS keyboard coverage of text inputs in Settings/AI screens and groups all Daily Quote settings together.
+
+## Problem
+
+- **Keyboard coverage:** On iOS, text inputs near the bottom of the screen were covered by the software keyboard in the Settings tab and the AI section.
+  - `ModelSelector` (bottom-sheet modal) had no `KeyboardAvoidingView`, so its search box could be obscured.
+  - `RenderStyleEditorScreen` hex-color inputs sat in a plain `ScrollView` with no keyboard handling.
+  - `ChatScreen`'s message list did not persist taps while the keyboard was open.
+- **Scattered quote settings:** In Settings → Artificial Intelligence, the three Daily Quote rows (enable, personalization, show sources) were interleaved with non-quote rows (Enable AI, AI Personalization, GitHub Tools), making quote options hard to find.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `src/components/ai/ModelSelector.tsx` | Wrapped the bottom-sheet overlay in `KeyboardAvoidingView` (`behavior="padding"` on iOS), matching the existing `ProviderConfigModal` pattern. Sheet now rises above the keyboard. |
+| `src/screens/RenderStyleEditorScreen.tsx` | Added `keyboardShouldPersistTaps="handled"` + `automaticallyAdjustKeyboardInsets` to the main `ScrollView` so hex-color inputs scroll above the keyboard. |
+| `src/screens/ChatScreen.tsx` | Added `keyboardShouldPersistTaps="handled"` to the message `FlatList` so taps register while the keyboard is open. |
+| `src/components/settings/SettingsContent.tsx` | Extracted the three Daily Quote rows into a dedicated **Daily Quote** group (title from `settings.dailyQuote.title`) placed directly after the Artificial Intelligence group. All `testID`s, toggles, pro-gating, and disabled logic preserved verbatim. |
+
+## Behavior after fix
+
+- **ModelSelector:** search field and model list stay visible when the keyboard opens.
+- **RenderStyleEditorScreen:** hex inputs are scrollable into view above the keyboard.
+- **ChatScreen:** tapping messages / hint chips works while the keyboard is open.
+- **Settings:** quote options live together under their own "Daily Quote" group header for ease of access; AI group retains Enable AI, AI Personalization, GitHub Tools.
+
+## No data/model changes
+
+Quote settings remain persisted in the `ai-settings` AsyncStorage blob — no migration needed. All row `testID`s unchanged, so the pro-gate test suite (`SettingsContent.pro-gate.test.tsx`) passes without edits.
+
+## Testing
+
+```bash
+yarn ts:check
+yarn jest __tests__/components/settings/SettingsContent.pro-gate.test.tsx --no-coverage --forceExit
+yarn jest __tests__/ModelSelector.search.test.tsx --no-coverage --forceExit
+yarn eslint src/components/ai/ModelSelector.tsx src/screens/RenderStyleEditorScreen.tsx src/screens/ChatScreen.tsx src/components/settings/SettingsContent.tsx
+```

--- a/src/components/ai/ModelSelector.tsx
+++ b/src/components/ai/ModelSelector.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   StyleSheet,
   ActivityIndicator,
+  KeyboardAvoidingView,
   Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -123,7 +124,10 @@ export function ModelSelector({ visible, onClose }: ModelSelectorProps) {
 
   return (
     <Modal visible={visible} transparent animationType="slide">
-      <View style={styles.modalOverlay}>
+      <KeyboardAvoidingView
+        style={styles.modalOverlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
         <View style={[styles.modalSheet, { backgroundColor: colors.surface }]}>
           <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
             <Text style={[styles.modalTitle, { color: colors.text }]}>Select AI Model</Text>
@@ -259,7 +263,7 @@ export function ModelSelector({ visible, onClose }: ModelSelectorProps) {
               })}
           </ScrollView>
         </View>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -852,34 +852,6 @@ onSetSyncIntervalSeconds,
           <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.enableAI')}</Text>
         </GroupRow>
         <GroupRow
-          testID={isPro ? 'settings.row.daily-quote' : 'settings.row.ai-locked-daily-quote'}
-          onPress={isPro ? undefined : () => promptProUpgrade(t, onOpenPaywall)}
-          trailing={
-            isPro ? (
-              <View className="flex-row items-center gap-2">
-                <Toggle
-                  testID="settings.toggle.daily-quote"
-                  value={isAIEnabled ? dailyQuoteEnabled : false}
-                  onValueChange={onToggleDailyQuote}
-                  disabled={!isAIEnabled}
-                />
-                <HintIcon hintKey="hints.settings.dailyQuote" testID="hint.daily-quote" />
-              </View>
-            ) : (
-              <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
-            )
-          }
-        >
-          <View>
-            <Text style={[styles.settingLabel, { color: colors.text }]}>
-              {t('settings.dailyQuote.title', { defaultValue: 'Daily Quote' })}
-            </Text>
-            <Text style={[styles.settingValue, { color: colors.textSecondary, fontSize: 12, marginTop: 2 }]}>
-              {t('settings.dailyQuoteDescription', { defaultValue: 'Show a personal philosopher quote on Home' })}
-            </Text>
-          </View>
-        </GroupRow>
-        <GroupRow
           testID={isPro ? 'settings.row.ai-personalization' : 'settings.row.ai-locked-personalization'}
           onPress={isPro ? undefined : () => promptProUpgrade(t, onOpenPaywall)}
           trailing={
@@ -932,6 +904,37 @@ onSetSyncIntervalSeconds,
             </Text>
             <Text style={[styles.settingValue, { color: colors.textSecondary, fontSize: 12, marginTop: 2 }]}>
               {t('settings.githubTools.description', { defaultValue: "Let AI manage issues, PRs, and repos via your active GitHub account." })}
+            </Text>
+          </View>
+        </GroupRow>
+      </Group>
+
+      <Group title={t('settings.dailyQuote.title', { defaultValue: 'Daily Quote' })}>
+        <GroupRow
+          testID={isPro ? 'settings.row.daily-quote' : 'settings.row.ai-locked-daily-quote'}
+          onPress={isPro ? undefined : () => promptProUpgrade(t, onOpenPaywall)}
+          trailing={
+            isPro ? (
+              <View className="flex-row items-center gap-2">
+                <Toggle
+                  testID="settings.toggle.daily-quote"
+                  value={isAIEnabled ? dailyQuoteEnabled : false}
+                  onValueChange={onToggleDailyQuote}
+                  disabled={!isAIEnabled}
+                />
+                <HintIcon hintKey="hints.settings.dailyQuote" testID="hint.daily-quote" />
+              </View>
+            ) : (
+              <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
+            )
+          }
+        >
+          <View>
+            <Text style={[styles.settingLabel, { color: colors.text }]}>
+              {t('settings.dailyQuote.title', { defaultValue: 'Daily Quote' })}
+            </Text>
+            <Text style={[styles.settingValue, { color: colors.textSecondary, fontSize: 12, marginTop: 2 }]}>
+              {t('settings.dailyQuoteDescription', { defaultValue: 'Show a personal philosopher quote on Home' })}
             </Text>
           </View>
         </GroupRow>

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -118,6 +118,7 @@ export default function ChatScreen() {
         <View className="flex-1">
           <FlatList
             ref={flatListRef}
+            keyboardShouldPersistTaps="handled"
             data={messages}
             keyExtractor={(item) => item.id}
             extraData={isStreaming}

--- a/src/screens/RenderStyleEditorScreen.tsx
+++ b/src/screens/RenderStyleEditorScreen.tsx
@@ -195,7 +195,11 @@ export default function RenderStyleEditorScreen() {
         </TouchableOpacity>
       </View>
 
-      <ScrollView contentContainerClassName="pb-8">
+      <ScrollView
+        contentContainerClassName="pb-8"
+        keyboardShouldPersistTaps="handled"
+        automaticallyAdjustKeyboardInsets
+      >
         <Text className="text-xs font-semibold uppercase tracking-wide px-4 mt-4 mb-2" style={{ color: colors.textSecondary, letterSpacing: 0.5 }}>Live preview</Text>
         <View className="rounded-sm mx-3 p-4 border" style={{ backgroundColor: colors.surface, borderColor: colors.border }}>
           <MarkdownPreview value={sample} format={format} overrides={localOverrides} />


### PR DESCRIPTION
## What
Two related fixes for the Settings tab and AI section.

### 1. iOS keyboard no longer covers text inputs
Text boxes near the bottom of the screen (Settings + AI section) were covered by the software keyboard:

- **`ModelSelector`** (`src/components/ai/ModelSelector.tsx`) — bottom-sheet modal had no `KeyboardAvoidingView`, so the search box could be obscured. Wrapped the sheet in `KeyboardAvoidingView` (`behavior="padding"` on iOS), matching the existing `ProviderConfigModal` pattern.
- **`RenderStyleEditorScreen`** (`src/screens/RenderStyleEditorScreen.tsx`) — hex-color inputs sat in a plain `ScrollView` with no keyboard handling. Added `keyboardShouldPersistTaps="handled"` + `automaticallyAdjustKeyboardInsets`.
- **`ChatScreen`** (`src/screens/ChatScreen.tsx`) — message `FlatList` lacked `keyboardShouldPersistTaps`, so taps didn't register while the keyboard was open.

### 2. Daily Quote settings grouped together
The three quote rows (Daily Quote, Daily Quote Personalization, Show Sources) were scattered through the "Artificial Intelligence" group, interleaved with non-quote rows. Extracted them into their own **Daily Quote** group placed directly after the AI group, so quote options are kept together for ease of access.

Every `testID`, toggle wiring, disabled condition, pro-gate, and `HintIcon` preserved verbatim — no behavior change.

## Verification
- `yarn ts:check` ✅
- 107 Jest tests pass (settings, HomeScreen.dailyQuote, aiStore, RenderStyle, ChatScreen suites) ✅
- ESLint: 0 errors (8 pre-existing warnings, unchanged) ✅
- lint-staged (ESLint + Prettier) passed on all commits ✅

## Wiki
Documented in `docs/wiki/settings-keyboard-quote-grouping.md` (added to index).