### PR TITLE
fix(ui): restore AI button hold animation — stop collision stack overflow

### DIFF
--- a/__tests__/floatingButtonLayout.test.ts
+++ b/__tests__/floatingButtonLayout.test.ts
@@ -148,4 +148,22 @@ describe('button rect registry', () => {
 
     expect(seenRects).toHaveLength(2);
   });
+
+  it('does not recurse infinitely when a subscriber publishes during notification', () => {
+    publishButtonRect('stage', { x: 16, y: 168, size: 56 });
+    const subscriberCalls: number[] = [];
+    const unsubscribe = subscribeButtonRects(() => {
+      const ai = getButtonRect('ai');
+      const stage = getButtonRect('stage');
+      if (ai === null || stage === null) return;
+      subscriberCalls.push(subscriberCalls.length);
+      publishButtonRect('stage', { x: ai.x + 40, y: ai.y + 40, size: 56 });
+    });
+
+    publishButtonRect('ai', { x: 16, y: 168, size: 56 });
+
+    // Without the re-entrancy guard this would blow the stack.
+    expect(subscriberCalls).toEqual([0]);
+    unsubscribe();
+  });
 });

--- a/docs/wiki/floating-button-collision-crash-fix.md
+++ b/docs/wiki/floating-button-collision-crash-fix.md
@@ -1,0 +1,65 @@
+# Floating Button Collision — Infinite-Recursion Crash Fix
+
+## Symptom
+
+The floating AI button's press-and-hold affordance (hold-progress ring + press
+scale) disappeared. When both the AI button and the stage push button were on
+screen and their rects overlapped, the app threw `Maximum call stack size
+exceeded` in `src/components/floatingButtonLayout.ts`, crashing the whole
+floating-button tree.
+
+## Root Cause
+
+Commit `f2af17a5` ("prevent floating buttons overlapping with collision
+avoidance") added `useFloatingButtonCollision('stage', ...)`. The stage
+button's subscriber runs on every rect publish; when it detects an overlap it
+resolves a new position, springs the shared value, and calls
+`publishButtonRect('stage', ...)` again:
+
+```ts
+return subscribeButtonRects(() => {
+  const other = getButtonRect(otherId);
+  if (other === null || dragActive.value) return;
+  const current = { x: translateX.value, y: translateY.value };
+  ...
+  translateX.value = withSpring(resolved.x, COLLISION_SPRING);
+  publishButtonRect(id, { x: resolved.x, y: resolved.y, size });
+});
+```
+
+`publishButtonRect` iterates all listeners synchronously, including the very
+subscriber that just published. Because `translateX.value = withSpring(...)`
+does not update `.value` synchronously, the re-entrant listener reads the stale
+position, still sees an overlap, resolves again, and publishes again — an
+infinite `publish → notify → publish → notify` cycle that overflows the JS
+stack.
+
+The crash explains the user-visible regression: the AI button's hold animation
+depends on these shared values and gestures, so the fatal error killed the
+entire floating-button layer whenever both FABs coexisted with overlapping
+rects.
+
+## Fix
+
+`src/components/floatingButtonLayout.ts`:
+
+1. **Re-entrancy guard on `publishButtonRect`.** A `notifying` flag prevents a
+   publish triggered from inside a subscriber from re-notifying all listeners.
+   The rect registry is still updated first, so subsequent top-level publishes
+   see fresh positions.
+2. **Collision listener reads the published rect, not the stale shared value.**
+   The stage subscriber now takes `getButtonRect(id)` (the last published
+   position) as its current position, falling back to `translateX/translateY`
+   only when nothing has been published yet. Once a resolution has been
+   published, the next notification sees the resolved (non-overlapping)
+   position and returns early. It also skips publishing when the resolved
+   position equals the current one.
+
+Both changes together make collision resolution converge instead of recursing.
+
+## Tests
+
+`__tests__/floatingButtonLayout.test.ts` gains a regression test that publishes
+from inside a subscriber and asserts the notification loop terminates (the
+pre-fix code would blow the stack). The full suite (`yarn jest`,
+`yarn ts:check`, `yarn eslint . --ext .ts,.tsx`) passes.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -33,6 +33,7 @@
 | [Add Repo Picker — Clone Progress & First-Connect Fixes](./add-repo-picker-clone-progress.md) | Inline clone progress in the repo picker (no stacked native modal), manual-Add spinner padding, connectHost hydrating GitHubService, delete-note false-failure fix (#953, QA #932) |
 | [Thought Dump Repo Picker](./thought-dump-repo-picker.md) | "Save to \<repo\> · \<branch\>" picker row + repo/branch modal, `ThoughtDumpRepoPreferenceService` persistence, distinct save errors, and empty-state disambiguation |
 | [Settings Keyboard & Quote Grouping](./settings-keyboard-quote-grouping.md) | iOS keyboard no longer covers inputs in Settings/AI (ModelSelector KAV, RenderStyleEditor scroll insets, ChatScreen persist-taps) + Daily Quote settings grouped under their own section |
+| [Floating Button Collision — Crash Fix](./floating-button-collision-crash-fix.md) | Re-entrancy guard on `publishButtonRect` + collision listener reads published rect so both FABs coexist without a stack-overflow recursion killing the AI button's hold animation |
 
 ## Quick Start
 

--- a/src/components/floatingButtonLayout.ts
+++ b/src/components/floatingButtonLayout.ts
@@ -26,13 +26,28 @@ const rects: Record<FloatingButtonId, FloatingButtonRect | null> = {
 
 const listeners = new Set<() => void>();
 
+let notifying = false;
+
 export function publishButtonRect(
   id: FloatingButtonId,
   rect: FloatingButtonRect,
 ): void {
   rects[id] = rect;
-  for (const listener of listeners) {
-    listener();
+  // Collision resolution publishes the yielding button's new rect from
+  // inside a subscriber. Guard against re-entrant notification so a
+  // publish→notify→publish cycle cannot recurse into a stack overflow
+  // (the other button's rect is already updated, so the next top-level
+  // publish still sees the fresh positions).
+  if (notifying) {
+    return;
+  }
+  notifying = true;
+  try {
+    for (const listener of listeners) {
+      listener();
+    }
+  } finally {
+    notifying = false;
   }
 }
 
@@ -182,10 +197,12 @@ export function useFloatingButtonCollision(
     return subscribeButtonRects(() => {
       const other = getButtonRect(otherId);
       if (other === null || dragActive.value) return;
-      const current = { x: translateX.value, y: translateY.value };
+      const published = getButtonRect(id);
+      const current = published ?? { x: translateX.value, y: translateY.value };
       const currentRect: FloatingButtonRect = { x: current.x, y: current.y, size };
       if (!rectsOverlap(currentRect, other, COLLISION_GAP)) return;
       const resolved = resolveNonOverlapping(id, current, size, geometry);
+      if (resolved.x === current.x && resolved.y === current.y) return;
       translateX.value = withSpring(resolved.x, COLLISION_SPRING);
       translateY.value = withSpring(resolved.y, COLLISION_SPRING);
       publishButtonRect(id, { x: resolved.x, y: resolved.y, size });


### PR DESCRIPTION
## Problem

The floating AI button's press-and-hold animation (hold-progress ring + press scale) disappeared. It turned out the whole floating-button layer was crashing with **`Maximum call stack size exceeded`** whenever the AI button and the stage push button were both on screen with overlapping rects.

## Root cause

`f2af17a5` added collision avoidance between the two floating buttons. The stage button's collision subscriber runs inside `publishButtonRect`'s listener loop and, on overlap, publishes the stage button's new resolved rect — re-entering `publishButtonRect` synchronously. Because `translateX.value = withSpring(...)` does not update the shared value synchronously, the re-entrant listener re-reads the stale position, still sees an overlap, resolves again, and publishes again. Result: an unbounded `publish → notify → publish` recursion and a fatal JS stack overflow that took down the entire floating-button tree.

## Fix (`src/components/floatingButtonLayout.ts`)

1. **Re-entrancy guard on `publishButtonRect`** — a `notifying` flag prevents a publish triggered from inside a subscriber from re-notifying all listeners (the rect registry is still updated first).
2. **Collision listener reads the last published rect** (`getButtonRect(id)`) instead of the stale `translateX/translateY` shared value, and skips publishing when the resolved position equals the current one — so collision resolution converges instead of recursing.

## Verification

- Regression test: `__tests__/floatingButtonLayout.test.ts` publishes from inside a subscriber and asserts the notification loop terminates (pre-fix code blows the stack).
- On-simulator: both FABs coexist, the stage button auto-yields to the AI button, and the AI button's hold ring fills during a long press.
- `yarn ts:check`, `yarn jest` (2752 tests), `yarn eslint . --ext .ts,.tsx` all pass.
- Wiki: `docs/wiki/floating-button-collision-crash-fix.md`.