### PR TITLE
fix(git): normalize leading-slash filePaths so folder-backed updates stage

### DIFF
--- a/__tests__/services/git/localGitWriter.real-repo.test.ts
+++ b/__tests__/services/git/localGitWriter.real-repo.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Empirical UPDATE-scenario test for LocalGitWriter.
+ *
+ * The existing localGitWriter.test.ts mocks `isomorphic-git` wholesale, so it
+ * can never observe what `git.status` actually returns after `git.add` for an
+ * UPDATE (content change to an existing tracked file). This suite runs the REAL
+ * isomorphic-git against the project's real `gitFs` adapter backed by an
+ * in-memory expo-file-system, so the `hasTreeChange` guard in writeAndCommit is
+ * exercised with real git behavior.
+ */
+
+// ---- In-memory expo-file-system mock that actually stores content ----
+// Stores: uri -> { kind: 'b64' | 'utf8', value: string }
+const mockMemory = new Map<string, { kind: 'b64' | 'utf8'; value: string }>();
+(globalThis as unknown as { __lgwRealFs: Map<string, { kind: 'b64' | 'utf8'; value: string }> }).__lgwRealFs = mockMemory;
+
+jest.mock('expo-file-system/legacy', () => {
+  const EncodingType = { Base64: 'base64', UTF8: 'utf8' };
+
+  function encode64(s: string): string {
+    return Buffer.from(s, 'utf8').toString('base64');
+  }
+  function decode64(s: string): string {
+    return Buffer.from(s, 'base64').toString('utf8');
+  }
+
+  return {
+    __esModule: true,
+    documentDirectory: 'file:///doc/',
+    EncodingType,
+    async getInfoAsync(uri: string) {
+      const key = uri.endsWith('/') ? uri : uri + '/';
+      const entry = mockMemory.get(uri);
+      if (entry) return { exists: true, uri, isDirectory: false, size: entry.value.length, modificationTime: 100 };
+      if ([...mockMemory.keys()].some((k) => k.startsWith(key))) return { exists: true, uri, isDirectory: true, size: 0, modificationTime: 100 };
+      return { exists: false, uri };
+    },
+    async writeAsStringAsync(uri: string, content: string, opts?: { encoding?: string }) {
+      if (opts?.encoding === EncodingType.Base64) {
+        // Keep the RAW base64 string so binary round-trips byte-exact.
+        mockMemory.set(uri, { kind: 'b64', value: content });
+      } else {
+        mockMemory.set(uri, { kind: 'utf8', value: content });
+      }
+    },
+    async readAsStringAsync(uri: string, opts?: { encoding?: string }) {
+      const entry = mockMemory.get(uri);
+      if (!entry) return '';
+      if (opts?.encoding === EncodingType.Base64) {
+        return entry.kind === 'b64' ? entry.value : encode64(entry.value);
+      }
+      return entry.kind === 'b64' ? decode64(entry.value) : entry.value;
+    },
+    async deleteAsync(_uri: string, _opts?: { idempotent?: boolean }) {
+      mockMemory.delete(_uri);
+    },
+    async makeDirectoryAsync(_uri: string) {
+      // dirs are implicit
+    },
+    async readDirectoryAsync(uri: string) {
+      const prefix = uri.endsWith('/') ? uri : uri + '/';
+      const entries = new Set<string>();
+      for (const k of mockMemory.keys()) {
+        if (k.startsWith(prefix)) {
+          const rest = k.slice(prefix.length);
+          const top = rest.split('/')[0];
+          entries.add(top);
+        }
+      }
+      return [...entries];
+    },
+  };
+});
+
+// Real isomorphic-git, NOT mocked.
+import { LocalGitWriter } from '../../../src/services/git/LocalGitWriter';
+
+const author = { name: 'Test', email: 'test@example.com' };
+
+// Bootstrap a clone: init + initial commit, then write the remote-tracking ref
+// so the state mirrors a freshly-cloned repo whose HEAD == origin.
+async function bootstrapRepo(): Promise<{ dir: string; fs: ReturnType<typeof import('../../../src/services/git/gitFs')['makeGitFs']> }> {
+  // Directly use the real gitFs adapter the app uses, rooted at the doc dir.
+  const { makeGitFs } = require('../../../src/services/git/gitFs');
+  const git = require('isomorphic-git');
+  const root = 'file:///doc/GitNotes/';
+  const fs = makeGitFs(root);
+  const dir = '/me/repo';
+
+  mockMemory.clear();
+  mockMemory.set(root, { kind: 'utf8', value: '' });
+
+  // init
+  await git.init({ fs, dir, defaultBranch: 'main' });
+  // seed an initial file so the repo has HEAD content
+  mockMemory.set('file:///doc/GitNotes/me/repo/notes/foo.md', { kind: 'utf8', value: '# Original\n' });
+  await git.add({ fs, dir, filepath: 'notes/foo.md' });
+  const initialOid = await git.commit({
+    fs,
+    dir,
+    message: 'initial',
+    author,
+  });
+  // write remote-tracking ref = HEAD (fresh clone, nothing unpushed)
+  await git.writeRef({ fs, dir, ref: 'refs/remotes/origin/main', value: initialOid });
+
+  return { dir, fs };
+}
+
+describe('LocalGitWriter UPDATE vs ADD vs DELETE (real git pipeline)', () => {
+  test('UPDATE of a tracked file produces a commit (git.status != unmodified)', async () => {
+    const { fs, dir } = await bootstrapRepo();
+    const git = require('isomorphic-git');
+
+    // Simulate the user editing notes/foo.md and saving via writeAndCommit.
+    const result = await LocalGitWriter.writeAndCommit({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: 'notes/foo.md',
+      content: '# Updated\nNew body here\n',
+      message: 'Update note: foo',
+      author,
+      push: false,
+    });
+
+    expect(result.success).toBe(true);
+
+    // The commit must have been created: HEAD should now differ from origin.
+    const head = await git.resolveRef({ fs, dir, ref: 'refs/heads/main' });
+    const origin = await git.resolveRef({ fs, dir, ref: 'refs/remotes/origin/main' });
+    expect(head).not.toBe(origin);
+  });
+
+  test('ADD of a new file also produces a commit (control)', async () => {
+    const { fs, dir } = await bootstrapRepo();
+    const git = require('isomorphic-git');
+
+    const result = await LocalGitWriter.writeAndCommit({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: 'notes/bar.md',
+      content: '# Brand new\n',
+      message: 'Create note: bar',
+      author,
+      push: false,
+    });
+
+    expect(result.success).toBe(true);
+    const head = await git.resolveRef({ fs, dir, ref: 'refs/heads/main' });
+    const origin = await git.resolveRef({ fs, dir, ref: 'refs/remotes/origin/main' });
+    expect(head).not.toBe(origin);
+  });
+
+  test('UPDATE with a LEADING-SLASH filePath (editor style) still commits', async () => {
+    const { fs, dir } = await bootstrapRepo();
+    const git = require('isomorphic-git');
+
+    // The note editor passes existingFilePath for folder-backed notes as
+    // '/notes/foo.md'. LocalGitWriter must normalize it before writing/adding.
+    const result = await LocalGitWriter.writeAndCommit({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: '/notes/foo.md',
+      content: '# Updated\nNew body here\n',
+      message: 'Update note: foo',
+      author,
+      push: false,
+    });
+
+    expect(result.success).toBe(true);
+    const head = await git.resolveRef({ fs, dir, ref: 'refs/heads/main' });
+    const origin = await git.resolveRef({ fs, dir, ref: 'refs/remotes/origin/main' });
+    expect(head).not.toBe(origin);
+  });
+
+  test('ADD with a LEADING-SLASH filePath (editor style) still commits', async () => {
+    const { fs, dir } = await bootstrapRepo();
+    const git = require('isomorphic-git');
+
+    const result = await LocalGitWriter.writeAndCommit({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: '/notes/bar.md',
+      content: '# Brand new\n',
+      message: 'Create note: bar',
+      author,
+      push: false,
+    });
+
+    expect(result.success).toBe(true);
+    const head = await git.resolveRef({ fs, dir, ref: 'refs/heads/main' });
+    const origin = await git.resolveRef({ fs, dir, ref: 'refs/remotes/origin/main' });
+    expect(head).not.toBe(origin);
+  });
+});

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -21,6 +21,7 @@
 | [Importers](./importers.md) | Removed Google Keep and Apple Notes importers, for later re-integration |
 | [Git Core Hardening](./git-core-hardening.md) | git-core test-campaign fixes: binary decode integrity, case collisions, auth/preflight, API batch writes, pull/reconcile fixes (#876–#892) |
 | [Stage → Push UX](./stage-push-ux.md) | no row locks, vanish-immediate deletes, spinner-free grayed push buttons, determinate progress ring, body-text notifications, resume-on-foreground |
+| [Push Button Missing on Folder-Backed Updates](./push-button-update-fix.md) | `LocalGitWriter` normalizes leading-slash `filePath`s so folder-backed note/canvas/todo updates commit locally and surface the push button |
 | [Token Removal Repo Cascade](./repo-removal-cascade.md) | removing a token also removes its synced repos, with a confirmation warning |
 | [Token Scope Error Messaging](./token-scope-error-messaging.md) | 403s surface needed token scopes in the sync message and token-add UI |
 | [Pro Paywall & Monetization](./paywall-pro.md) | StoreKit 2 revenue model: 30-day trial / $2.99 mo / $40 lifetime, grandfathering, show-locked feature UX, gating map, impressions & analytics, restore flow, intro-eligibility policy, legal links, bento grid layout (#921), store setup checklist |

--- a/docs/wiki/push-button-update-fix.md
+++ b/docs/wiki/push-button-update-fix.md
@@ -1,0 +1,50 @@
+# Push Button Missing After Updating Folder-Backed Notes
+
+> Fix: `LocalGitWriter` now normalizes leading-slash `filePath`s so folder-backed note/canvas/todo updates produce a real local commit and the floating push button appears.
+
+## Symptom
+
+In clone mode, after **updating** a note (or any git-hosted item) that lives in a **folder**, the floating push button does not appear — the change never surfaces as staged. Creating a new note in the repo root (`notes/foo.md`) and deleting notes worked, which made the update path look like the odd one out.
+
+## Root cause
+
+The note/canvas editors build a file path from `folderPath`, which carries a **leading slash**:
+
+- `folderPath` = `'/notes'` (folder model paths start with `/`)
+- `syncPath` = `existingFilePath ?? \`${folderPath}/${slug}\`` → `'/notes/foo.md'`
+
+`StagingService.stageUpsert` forwards that path verbatim to `LocalGitWriter.writeAndCommit`. Two things then went wrong:
+
+1. **On-disk write diverges from the git path.**
+   - `writeAsStringAsync` wrote to `…/GitNotes/owner/repo//notes/foo.md` (double slash — `dir + '/' + '/notes/foo.md'`).
+   - `git.add`/`git.status` read `…/GitNotes/owner/repo/notes/foo.md` (single slash — isomorphic-git joins `dir` + normalized relative path).
+   - The new content never landed where git looked, so git saw the *original* HEAD content.
+
+2. **isomorphic-git rejected the absolute path.**
+   - `git.add({ filepath: '/notes/foo.md' })` threw `path should be a \`path.relative()\`d string, but got "/notes"`.
+   - `writeAndCommit` returned `{ success: false, error: … }` → **no local commit created** → `StagingService.listStaged()` found no unpushed commit for the repo → `pendingCount` stayed `0` → `FloatingStageButton` returned `null`.
+
+Root-level notes (`notes/foo.md`, no leading slash) never hit this, which is why "add works, update doesn't".
+
+## Fix
+
+`src/services/git/LocalGitWriter.ts` — new `toRepoRelativePath()` strips leading slashes from `filePath` at the writer boundary (the single choke point between app paths and isomorphic-git's repo-relative paths). Applied in:
+
+- `writeAndCommit` — path used for `absVirtual`/`absUri`, `ensureParentDirs`, `git.add`, `git.status`, and the corruption-replay branch.
+- `deleteAndCommit` — path used for `absUri`, `git.remove`, and the replay branch.
+
+The stored note metadata is unchanged (`/notes/foo.md` remains the display path); only the git boundary normalizes.
+
+## Verification
+
+`__tests__/services/git/localGitWriter.real-repo.test.ts` runs the **real** isomorphic-git pipeline against the project's `gitFs` adapter (in-memory expo-file-system) — no git mocks — and asserts:
+
+- UPDATE of a tracked file produces a commit (HEAD advances past `refs/remotes/origin/main`).
+- UPDATE with a leading-slash `filePath` (`/notes/foo.md`) still commits.
+- ADD with a leading-slash `filePath` still commits.
+
+`yarn ts:check`, `yarn eslint`, and the git/StagingService/editor/stageStore suites all pass.
+
+## Related
+
+- [#925](https://github.com/gedwolmen/gitnotes/issues/925) — clone staging never surfaced the push button (fixed by emitting `notifyStagedChanged`); this fix covers the folder-backed-update failure mode that slipped past it.

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -63,6 +63,18 @@ function repoDirVirtual(owner: string, repo: string): string {
   return `/${owner}/${repo}`;
 }
 
+/**
+ * App callers (note/canvas editors) build filePath from a folderPath that
+ * carries a leading slash ('/notes/foo.md'). isomorphic-git requires
+ * repo-relative paths ('notes/foo.md'): a leading slash makes the on-disk
+ * write land at 'repo//notes/foo.md' while git reads 'repo/notes/foo.md' and
+ * throws "path should be a `path.relative()`d string" — the write never
+ * becomes a commit, so nothing surfaces on the Stage screen.
+ */
+function toRepoRelativePath(filePath: string): string {
+  return filePath.replace(/^\/+/, '');
+}
+
 function makeRepoFs() {
   return buildGitFs(clonesRoot());
 }
@@ -239,6 +251,8 @@ static async writeAndCommit(opts: WriteOpts): Promise<LocalGitWriterResult> {
       return { success: false, error: `Refusing to write file exceeding 5 MB (${Math.round(opts.content.length / 1024 / 1024)} MB) — possible data corruption` };
     }
 
+    const filePath = toRepoRelativePath(opts.filePath);
+
     try {
       return await handleCorruptionAndRetry(opts.repoPath, opts.branch, opts.token, async () => {
         const dir = repoDirVirtual(info.owner, info.repo);
@@ -247,14 +261,14 @@ static async writeAndCommit(opts: WriteOpts): Promise<LocalGitWriterResult> {
 
         await ensureOnBranch(fs, dir, opts.branch, opts.token);
 
-        const absVirtual = `${dir}/${opts.filePath}`;
+        const absVirtual = `${dir}/${filePath}`;
         const absUri = `${fsRoot}${absVirtual.replace(/^\//, '')}`;
         await ensureParentDirs(fsRoot, absVirtual);
         await FileSystem.writeAsStringAsync(absUri, opts.content);
 
-        await git.add({ fs, dir, filepath: opts.filePath });
+        await git.add({ fs, dir, filepath: filePath });
 
-        const fileStatus = await git.status({ fs, dir, filepath: opts.filePath });
+        const fileStatus = await git.status({ fs, dir, filepath: filePath });
         const hasTreeChange = fileStatus !== 'unmodified';
         if (hasTreeChange) {
           await git.commit({
@@ -298,8 +312,8 @@ static async writeAndCommit(opts: WriteOpts): Promise<LocalGitWriterResult> {
                 await ensureOnBranch(fs, dir, opts.branch, opts.token);
                 await ensureParentDirs(fsRoot, absVirtual);
                 await FileSystem.writeAsStringAsync(absUri, opts.content);
-                await git.add({ fs, dir, filepath: opts.filePath });
-                const replayStatus = await git.status({ fs, dir, filepath: opts.filePath });
+                await git.add({ fs, dir, filepath: filePath });
+                const replayStatus = await git.status({ fs, dir, filepath: filePath });
                 if (replayStatus !== 'unmodified') {
                   await git.commit({
                     fs,
@@ -356,6 +370,8 @@ static async deleteAndCommit(opts: DeleteOpts): Promise<LocalGitWriterResult> {
     const info = parseRepoPath(opts.repoPath);
     if (!info) return { success: false, error: `Invalid repo path: ${opts.repoPath}` };
 
+    const filePath = toRepoRelativePath(opts.filePath);
+
     try {
       return await handleCorruptionAndRetry(opts.repoPath, opts.branch, opts.token, async () => {
         const dir = repoDirVirtual(info.owner, info.repo);
@@ -374,11 +390,11 @@ static async deleteAndCommit(opts: DeleteOpts): Promise<LocalGitWriterResult> {
           console.warn('[LocalGitWriter] deleteAndCommit pull failed (continuing):', pullError);
         }
 
-        const absUri = `${fsRoot}${info.owner}/${info.repo}/${opts.filePath}`;
+        const absUri = `${fsRoot}${info.owner}/${info.repo}/${filePath}`;
         await FileSystem.deleteAsync(absUri, { idempotent: true });
 
         try {
-          await git.remove({ fs, dir, filepath: opts.filePath });
+          await git.remove({ fs, dir, filepath: filePath });
         } catch (removeError) {
           const code = (removeError as { code?: string }).code;
           const errorMsg = removeError instanceof Error ? removeError.message : String(removeError);
@@ -427,9 +443,9 @@ static async deleteAndCommit(opts: DeleteOpts): Promise<LocalGitWriterResult> {
                 await GitFsService.removeRepo({ repoPath: opts.repoPath });
                 await GitFsService.clone({ repoPath: opts.repoPath, branch: opts.branch, token: opts.token });
                 await ensureOnBranch(fs, dir, opts.branch, opts.token);
-                const absUri = `${fsRoot}${info.owner}/${info.repo}/${opts.filePath}`;
+                const absUri = `${fsRoot}${info.owner}/${info.repo}/${filePath}`;
                 await FileSystem.deleteAsync(absUri, { idempotent: true });
-                await git.remove({ fs, dir, filepath: opts.filePath });
+                await git.remove({ fs, dir, filepath: filePath });
                 await git.commit({
                   fs,
                   dir,


### PR DESCRIPTION
## Problem

In clone mode, after **updating** a note (or any git-hosted item) that lives in a **folder**, the floating push button never appears — the change never surfaces as staged. Creating a root-level note and deleting notes worked, masking the failure.

## Root cause

The note/canvas editors build `filePath` from `folderPath`, which carries a leading slash (`folderPath = '/notes'` → `syncPath = '/notes/foo.md'`). `StagingService.stageUpsert` forwarded it verbatim to `LocalGitWriter.writeAndCommit`, where:

1. **Write/git path divergence** — `writeAsStringAsync` wrote to `…/repo//notes/foo.md` (double slash) while `git.add`/`git.status` read `…/repo/notes/foo.md` (single slash), so git never saw the new content.
2. **isomorphic-git rejected the absolute path** — `git.add({ filepath: '/notes/foo.md' })` threw `path should be a \`path.relative()\`d string, but got \"/notes\"` → `writeAndCommit` returned `success: false` → **no local commit** → `listStaged()` found no unpushed commits → `pendingCount` stayed 0 → `FloatingStageButton` rendered `null`.

## Fix

`src/services/git/LocalGitWriter.ts`: new `toRepoRelativePath()` strips leading slashes at the writer boundary (the single choke point between app paths and isomorphic-git's repo-relative paths). Applied in `writeAndCommit` and `deleteAndCommit` (main + corruption-replay branches). Stored note metadata is unchanged.

## Verification

- New `__tests__/services/git/localGitWriter.real-repo.test.ts` runs the **real** isomorphic-git pipeline against the project's `gitFs` adapter (in-memory expo-file-system, no git mocks): UPDATE of a tracked file commits; leading-slash UPDATE/ADD now commit (HEAD advances past origin).
- `yarn ts:check` ✅ · ESLint clean ✅ · git (104), StagingService (34), editor (8), stageStore (12) suites ✅.
- Wiki: `docs/wiki/push-button-update-fix.md` + index row.

Refs: follow-up to #925 (clone staging never surfaced push).