### PR TITLE
feat: add GitHub issues report links to Settings and Onboarding

### DIFF
--- a/__tests__/screens/OnboardingScreen.pro-gate.test.tsx
+++ b/__tests__/screens/OnboardingScreen.pro-gate.test.tsx
@@ -7,6 +7,7 @@ jest.mock('@react-navigation/native', () => ({
 
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Linking } from 'react-native';
 import OnboardingScreen from '../../src/screens/OnboardingScreen';
 import { __setProState } from '../../src/stores/proStore';
 import { OnboardingService } from '../../src/services/OnboardingService';
@@ -99,6 +100,18 @@ async function advanceToAIStep(getByTestId: ReturnType<typeof render>['getByTest
 }
 
 describe('OnboardingScreen — GitHub Tools Pro gate', () => {
+  const openUrlSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
+
+  it('shows the report-issue footer link and opens GitHub issues on press', () => {
+    const { getByTestId } = render(
+      <OnboardingScreen onComplete={mockOnComplete} onSkip={mockOnSkip} />
+    );
+
+    expect(getByTestId('onboarding.button.report-issue')).toBeTruthy();
+    fireEvent.press(getByTestId('onboarding.button.report-issue'));
+    expect(openUrlSpy).toHaveBeenCalledWith('https://github.com/gedwolmen/gitnotes/issues');
+  });
+
   it('skips the GitHub Tools step and completes onboarding for non-Pro users', async () => {
     const { getByTestId, queryByTestId } = render(
       <OnboardingScreen onComplete={mockOnComplete} onSkip={mockOnSkip} />

--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
-import { Alert } from 'react-native';
+import { Alert, Linking } from 'react-native';
 import type { AlertButton } from 'react-native';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
@@ -309,8 +309,8 @@ jest.mock('../../src/components/ui', () => {
         {children}
       </View>
     ),
-    GroupRow: ({ children, trailing, onPress }: any) => (
-      <Pressable testID="group-row" onPress={onPress}>
+    GroupRow: ({ children, trailing, onPress, testID }: any) => (
+      <Pressable testID={testID || 'group-row'} onPress={onPress}>
         {children}
         {trailing}
       </Pressable>
@@ -433,6 +433,7 @@ async function flushMicrotasks(): Promise<void> {
 
 describe('SettingsScreen', () => {
   const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+  const openUrlSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
 
   beforeEach(() => {
     mockTheme = 'light';
@@ -442,6 +443,7 @@ describe('SettingsScreen', () => {
     mockSetStyle.mockClear();
     mockAddRepository.mockReset();
     alertSpy.mockClear();
+    openUrlSpy.mockClear();
     stableRepositories.length = 0;
     mockAccountSummaries.length = 0;
     mockDisconnectHost.mockReset();
@@ -475,6 +477,13 @@ describe('SettingsScreen', () => {
     const { getByText } = render(<SettingsScreen />);
     expect(getByText('About')).toBeTruthy();
     expect(getByText('Version')).toBeTruthy();
+  });
+
+  it('opens GitHub issues when the report-issue row is pressed', () => {
+    const { getByTestId, getByText } = render(<SettingsScreen />);
+    expect(getByText('Report bugs and feature requests')).toBeTruthy();
+    fireEvent.press(getByTestId('settings.row.report-issue'));
+    expect(openUrlSpy).toHaveBeenCalledWith('https://github.com/gedwolmen/gitnotes/issues');
   });
 
   it('shows Accounts entry pointing to Connect host when unauthenticated', () => {

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -38,6 +38,7 @@
 | [Settings Keyboard & Quote Grouping](./settings-keyboard-quote-grouping.md) | iOS keyboard no longer covers inputs in Settings/AI (ModelSelector KAV, RenderStyleEditor scroll insets, ChatScreen persist-taps) + Daily Quote settings grouped under their own section |
 | [Floating Button Collision — Crash Fix](./floating-button-collision-crash-fix.md) | Re-entrancy guard on `publishButtonRect` + collision listener reads published rect so both FABs coexist without a stack-overflow recursion killing the AI button's hold animation |
 | [Security & Dependabot Alerts](./security-dependabot.md) | GitHub security surface, `uuid` fix via yarn resolutions (#4), `image-size` alerts deferred (no patched release, build-time only) |
+| [Report Bugs & Feature Requests](./report-issue-links.md) | Settings About-row + onboarding footer link to `github.com/gedwolmen/gitnotes/issues`, i18n'd across all six locales |
 
 ## Quick Start
 

--- a/docs/wiki/report-issue-links.md
+++ b/docs/wiki/report-issue-links.md
@@ -1,0 +1,43 @@
+# Report Bugs & Feature Requests Links
+
+## What
+
+Users can now surface bugs and feature requests directly from inside the app:
+both the Settings screen and the onboarding flow link out to the project's
+GitHub issues page.
+
+Target URL: `https://github.com/gedwolmen/gitnotes/issues`
+
+## Where
+
+### Settings (`src/components/settings/SettingsContent.tsx`)
+
+A new row in the **About** group, directly under the Version row:
+
+- Label: `t('settings.reportIssue')` — "Report bugs and feature requests"
+  (added to all six locales: en/es/fr/de/ja/ko)
+- Trailing `open-outline` icon in accent color
+- `testID="settings.row.report-issue"`
+- `onPress` → `Linking.openURL('https://github.com/gedwolmen/gitnotes/issues')`
+
+### Onboarding (`src/screens/OnboardingScreen.tsx`)
+
+A persistent footer link below the navigation buttons, rendered on every
+onboarding step:
+
+- Text: "Found a bug or have a feature request? **Report it on GitHub Issues**"
+- `testID="onboarding.button.report-issue"` on the tappable inner `Text`
+- `onPress` → `Linking.openURL('https://github.com/gedwolmen/gitnotes/issues')`
+
+Unlike the Settings row, the onboarding footer is plain English by design —
+the rest of the onboarding screen is not i18n'd.
+
+## Tests
+
+- `__tests__/screens/SettingsScreen.test.tsx` — presses
+  `settings.row.report-issue` and asserts `Linking.openURL` is called with the
+  issues URL.
+- `__tests__/screens/OnboardingScreen.pro-gate.test.tsx` — asserts the footer
+  link renders on the first step and opens the issues URL on press.
+
+Both spy on `Linking.openURL` with `jest.spyOn(...).mockResolvedValue(undefined)`.

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -1117,6 +1117,13 @@ onSetSyncIntervalSeconds,
         >
           <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.version')}</Text>
         </GroupRow>
+        <GroupRow
+          testID="settings.row.report-issue"
+          onPress={() => Linking.openURL('https://github.com/gedwolmen/gitnotes/issues')}
+          trailing={<Ionicons name="open-outline" size={18} color={colors.accent} />}
+        >
+          <Text style={[styles.settingLabel, { color: colors.primary }]}>{t('settings.reportIssue')}</Text>
+        </GroupRow>
       </Group>
 
       <View style={styles.creditsWrap}>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -213,6 +213,7 @@
     "about": "Über",
     "version": "Version",
     "build": "Build",
+    "reportIssue": "Fehler und Funktionswünsche melden",
     "manageTemplates": "Vorlagen verwalten",
     "artificialIntelligence": "Künstliche Intelligenz",
     "enableAI": "Künstliche Intelligenz aktivieren",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -326,6 +326,7 @@
     "about": "About",
     "version": "Version",
     "build": "Build",
+    "reportIssue": "Report bugs and feature requests",
     "manageTemplates": "Manage templates",
     "artificialIntelligence": "Artificial Intelligence",
     "enableAI": "Enable Artificial Intelligence",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -213,6 +213,7 @@
     "about": "Acerca de",
     "version": "Versión",
     "build": "Compilación",
+    "reportIssue": "Reportar errores y solicitudes de funciones",
     "manageTemplates": "Gestionar plantillas",
     "artificialIntelligence": "Inteligencia artificial",
     "enableAI": "Habilitar inteligencia artificial",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -213,6 +213,7 @@
     "about": "À propos",
     "version": "Version",
     "build": "Build",
+    "reportIssue": "Signaler des bugs et demander des fonctionnalités",
     "manageTemplates": "Gérer les modèles",
     "artificialIntelligence": "Intelligence artificielle",
     "enableAI": "Activer l'intelligence artificielle",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -213,6 +213,7 @@
     "about": "概要",
     "version": "バージョン",
     "build": "ビルド",
+    "reportIssue": "バグや機能リクエストを報告",
     "manageTemplates": "テンプレートを管理",
     "artificialIntelligence": "AI（人工知能）",
     "enableAI": "AIを有効にする",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -213,6 +213,7 @@
     "about": "정보",
     "version": "버전",
     "build": "빌드",
+    "reportIssue": "버그 및 기능 요청 보고",
     "manageTemplates": "템플릿 관리",
     "artificialIntelligence": "인공지능",
     "enableAI": "인공지능 활성화",

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -309,6 +309,17 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
               iconAlign="edge"
             />
           )}
+
+          <Text className="text-center text-xs mt-6" style={{ color: colors.textSecondary }}>
+            Found a bug or have a feature request?{' '}
+            <Text
+              testID="onboarding.button.report-issue"
+              style={{ color: colors.accent, fontWeight: '600' }}
+              onPress={() => Linking.openURL('https://github.com/gedwolmen/gitnotes/issues')}
+            >
+              Report it on GitHub Issues
+            </Text>
+          </Text>
         </View>
       </KeyboardAvoidingView>
     </SafeAreaView>


### PR DESCRIPTION
## Summary

Adds tappable links to `https://github.com/gedwolmen/gitnotes/issues` for reporting bugs and feature requests.

- **Settings** — new row in the About group (under Version): "Report bugs and feature requests", with an external-link icon and `testID="settings.row.report-issue"`.
- **Onboarding** — persistent footer under the nav buttons on every step: "Found a bug or have a feature request? Report it on GitHub Issues" (`testID="onboarding.button.report-issue"`).

## Changes

- `feat(settings)`: GitHub issues report row in About section
- `feat(i18n)`: `settings.reportIssue` key across all six locales (en/es/fr/de/ja/ko)
- `feat(onboarding)`: GitHub issues report footer link
- `docs(wiki)`: `report-issue-links` page + index entry

## Tests

- Settings: presses `settings.row.report-issue` → `Linking.openURL` called with the issues URL (also made the mocked `GroupRow` pass through `testID`).
- Onboarding: asserts footer renders and opens the issues URL on press.
- `yarn ts:check` ✅ · full `yarn jest` 2772 passed ✅ · `yarn eslint` 0 errors ✅ · prettier clean ✅