### PR TITLE
fix: useProGate split (#1004) + hide expo-dev-menu FAB (#977)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -51,6 +51,7 @@ import { LastSelectionPreferenceService } from './src/services/LastSelectionPref
 import { useProStore } from './src/stores/proStore';
 import * as PushNotificationService from './src/services/PushNotificationService';
 import * as StagePushScheduler from './src/services/StagePushScheduler';
+import { hideDevMenuFloatingActionButton } from './src/utils/devMenuFab';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -60,6 +61,10 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+if (__DEV__) {
+  hideDevMenuFloatingActionButton();
+}
 
 export default function App() {
   const [showOnboarding, setShowOnboarding] = useState<boolean | null>(null);

--- a/__tests__/FloatingAIButton.global-gesture.test.tsx
+++ b/__tests__/FloatingAIButton.global-gesture.test.tsx
@@ -12,6 +12,11 @@ jest.mock('../src/stores/aiStore', () => ({
 }));
 
 jest.mock('../src/hooks/useProGate', () => ({
+  useProStatus: () => ({
+    isPro: true,
+    status: 'pro',
+    loading: false,
+  }),
   useProGate: () => ({
     isPro: true,
     status: 'pro',

--- a/__tests__/FloatingAIButton.hub.test.tsx
+++ b/__tests__/FloatingAIButton.hub.test.tsx
@@ -58,6 +58,11 @@ jest.mock('../src/stores/aiStore', () => ({
 }));
 
 jest.mock('../src/hooks/useProGate', () => ({
+  useProStatus: () => ({
+    isPro: mockIsPro,
+    status: mockIsPro ? 'pro' : 'free',
+    loading: false,
+  }),
   useProGate: () => ({
     isPro: mockIsPro,
     status: mockIsPro ? 'pro' : 'free',

--- a/__tests__/FloatingAIButton.test.tsx
+++ b/__tests__/FloatingAIButton.test.tsx
@@ -87,6 +87,11 @@ jest.mock('../src/stores/aiStore', () => ({
 }));
 
 jest.mock('../src/hooks/useProGate', () => ({
+  useProStatus: () => ({
+    isPro: mockIsPro,
+    status: mockIsPro ? 'pro' : 'free',
+    loading: false,
+  }),
   useProGate: () => ({
     isPro: mockIsPro,
     status: mockIsPro ? 'pro' : 'free',

--- a/__tests__/hooks/useProGate.test.tsx
+++ b/__tests__/hooks/useProGate.test.tsx
@@ -6,7 +6,7 @@ jest.mock('@react-navigation/native', () => ({
 import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
-import { useProGate } from '../../src/hooks/useProGate';
+import { useProGate, useProStatus } from '../../src/hooks/useProGate';
 import { __setProState } from '../../src/stores/proStore';
 
 function Harness() {
@@ -16,6 +16,16 @@ function Harness() {
       <Text testID="isPro">{String(isPro)}</Text>
       <Text testID="loading">{String(loading)}</Text>
       <TouchableOpacity testID="open" onPress={openPaywall} />
+    </View>
+  );
+}
+
+function StatusHarness() {
+  const { isPro, loading } = useProStatus();
+  return (
+    <View>
+      <Text testID="status-isPro">{String(isPro)}</Text>
+      <Text testID="status-loading">{String(loading)}</Text>
     </View>
   );
 }
@@ -61,5 +71,19 @@ describe('useProGate', () => {
     const { getByTestId } = render(<Harness />);
     fireEvent.press(getByTestId('open'));
     expect(mockNavigate).toHaveBeenCalledWith('Paywall');
+  });
+});
+
+describe('useProStatus', () => {
+  it('reports pro status without requiring navigation', () => {
+    const { getByTestId } = render(<StatusHarness />);
+    expect(getByTestId('status-isPro').props.children).toBe('true');
+    expect(getByTestId('status-loading').props.children).toBe('false');
+  });
+
+  it('reports loading state', () => {
+    __setProState({ status: 'loading', entitlementActive: false, isGrandfathered: false });
+    const { getByTestId } = render(<StatusHarness />);
+    expect(getByTestId('status-loading').props.children).toBe('true');
   });
 });

--- a/__tests__/utils/devMenuFab.test.ts
+++ b/__tests__/utils/devMenuFab.test.ts
@@ -1,0 +1,31 @@
+const mockSetPreferencesAsync = jest.fn().mockResolvedValue(undefined);
+let mockRequireNativeModule: jest.Mock;
+
+jest.mock('expo-modules-core', () => ({
+  requireNativeModule: jest.fn((name: string) => {
+    if (name === 'DevMenuPreferences') {
+      return { setPreferencesAsync: mockSetPreferencesAsync };
+    }
+    throw new Error(`Unknown native module: ${name}`);
+  }),
+}));
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+import { requireNativeModule } from 'expo-modules-core';
+import { hideDevMenuFloatingActionButton } from '../../src/utils/devMenuFab';
+
+describe('hideDevMenuFloatingActionButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireNativeModule = requireNativeModule as jest.Mock;
+  });
+
+  it('disables the floating action button in development on iOS', () => {
+    hideDevMenuFloatingActionButton();
+    expect(mockRequireNativeModule).toHaveBeenCalledWith('DevMenuPreferences');
+    expect(mockSetPreferencesAsync).toHaveBeenCalledWith({ showFloatingActionButton: false });
+  });
+});

--- a/app.json
+++ b/app.json
@@ -39,7 +39,8 @@
         ],
         "UIFileSharingEnabled": true,
         "LSSupportsOpeningDocumentsInPlace": true,
-        "NSDocumentsFolderUsageDescription": "GitNot\u0113s stores your cloned repositories and note files here so you can browse and back them up from the Files app."
+        "NSDocumentsFolderUsageDescription": "GitNot\u0113s stores your cloned repositories and note files here so you can browse and back them up from the Files app.",
+        "EXDevMenuShowFloatingActionButton": false
       }
     },
     "android": {

--- a/docs/wiki/dev-menu-fab-overlap.md
+++ b/docs/wiki/dev-menu-fab-overlap.md
@@ -1,0 +1,40 @@
+# DevMenu Floating "Tools" Button Overlaps Header Actions (#977)
+
+> In iOS development builds, tapping the **Edit** (pencil) button on a note or the **Add note** (+) button opened the React Native DevMenu instead of running the action. Reported as blocking API-mode write-through testing.
+
+## Root cause
+
+Two compounding issues produced the symptom:
+
+1. **expo-dev-menu's floating "Tools" action button (FAB) overlapped the header buttons.** The FAB (`DevMenuFABView`, a draggable gear-shaped pill) **defaults to the top-right corner** of the screen:
+   `x = bounds.width - fabSize.width - margin/2`, `y = safeArea.top`.
+   Its frame (≈ x 325–397, y 59–131 on iPhone 17) **completely covers** the Notes header's Add-note button (x 350–386, y 74–110) and partially the Sync button. A tap on the FAB calls `onOpenMenu()` → DevMenu opens with the exact "Runtime version: 1.5.0 / TOOLS menu" contents the reporter described. The position is persisted in `UserDefaults` (`DevMenuFAB.positionX/Y`) and draggable, so it stays wherever it lands.
+2. **`useProGate`'s conditional `useNavigation()` violated the Rules of Hooks** (see `v1.5.0-app-store-rejection.md`). Every screen using it triggered a React hooks-order violation → **LogBox full-screen error panel** that blocked the UI, so taps never reached the buttons and a dev overlay appeared "instead of their actions".
+
+## Change
+
+- **`src/utils/devMenuFab.ts`** (new) — `hideDevMenuFloatingActionButton()`: a dev-only (`__DEV__` + iOS) startup call that disables the FAB via the `DevMenuPreferences` native module:
+  `requireNativeModule('DevMenuPreferences').setPreferencesAsync({ showFloatingActionButton: false })`.
+  This fixes already-installed dev builds without a native rebuild (the preference is re-applied at every launch). The DevMenu's "Tools button" toggle still lets developers re-enable it.
+- **`App.tsx`** — calls `hideDevMenuFloatingActionButton()` at module scope in `__DEV__`.
+- **`app.json`** — `ios.infoPlist.EXDevMenuShowFloatingActionButton: false` so fresh dev builds default to the FAB hidden (read by `DevMenuPreferences.setup()`).
+- **`useProGate.ts`** — split into `useProGate()` / `useProStatus()` so no consumer hits the conditional-hook LogBox violation (see `v1.5.0-app-store-rejection.md`).
+
+## Verification (iPhone 17 simulator, dev build)
+
+- Add-note (+) → opens the NoteEditor ("New Note") — previously opened DevMenu.
+- Open note → Edit (pencil) → enters edit mode ("Edit Note") — previously opened DevMenu.
+- No `gearshape.fill` FAB at top-right; no LogBox hooks-order warnings on any screen.
+
+## Notes
+
+- The FAB is a developer tool; this fix only reverts the *default* (and re-applies the hidden state at each dev launch). Developers who want the FAB can re-enable it from the DevMenu.
+- The 3-finger long-press, shake, and Cmd+D DevMenu triggers are untouched.
+
+## Tests
+
+```bash
+yarn jest __tests__/utils/devMenuFab.test.ts --no-coverage --forceExit
+yarn jest __tests__/hooks/useProGate.test.tsx __tests__/FloatingAIButton.test.tsx --no-coverage --forceExit
+yarn ts:check
+```

--- a/docs/wiki/foreground-sync-busy-loop.md
+++ b/docs/wiki/foreground-sync-busy-loop.md
@@ -17,7 +17,7 @@
 
 | Risk | Reversible | Verified |
 |---|---|---|
-| Low — pull semantics unchanged (`shouldPull` gate, coalesce, failure backoff all preserved); only skip logging + interval cadence under busy conditions changed | Yes | `__tests__/ForegroundSyncService.test.ts` (11/12 pass; one new back-off test iterating) |
+| Low — pull semantics unchanged (`shouldPull` gate, coalesce, failure backoff all preserved); only skip logging + interval cadence under busy conditions changed | Yes | `__tests__/ForegroundSyncService.test.ts` (12/12 pass: throttling + back-off + recovery) |
 
 ## Notes
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -43,12 +43,13 @@
 | [Pro Dev Override](./pro-dev-override.md) | `__DEV__`-only iOS-simulator override that forces Pro gate for QA — NOT a payment bypass; RevenueCat unchanged; gate triple `__DEV__ && Platform.OS==='ios' && !Device.isDevice` |
 | [E2E Sync Testing](./e2e-sync-testing.md) | E2E test harness: 6 scenarios × 2 modes, timing instrumentation, push-trigger verification, staged-visibility sub-checks, blocking overlay, remote verification |
 | [Clone-Perf Optimization](./clone-perf-optimization.md) | Five ordered patches closing the simulator freeze gap: `noCheckout` + batched full checkout, 3-concurrent-pull dedup, LFS-after-clone, UTF-8 fast path, depth-3 floor measurement flag |
-| [v1.5.0 App Store Rejection](./v1.5.0-app-store-rejection.md) | 2.1.0 App Completeness SIGABRT on first launch — root cause: `useNavigation()` outside `NavigationContainer` in `useProGate.ts`; fix already on `main` (`c5362e86`); build from `main HEAD` to resubmit |
+| [v1.5.0 App Store Rejection](./v1.5.0-app-store-rejection.md) | 2.1.0 App Completeness SIGABRT on first launch — root cause: `useNavigation()` outside `NavigationContainer` in `useProGate.ts`; fix on `main` (`c5362e86`) then hardened by splitting `useProGate` into `useProGate()`/`useProStatus()` (#1004) |
 | [Git Test E2E Report](./git-test-e2e-report.md) | Live round-trip timings against `test-notes` for all 12 scenarios (6 clone-mode + 6 API-mode) with per-action breakdown, syncTiming instrumentation seam, and Mac vs simulator scope |
 | [Git Test Big Repo](./git-test-big-repo.md) | Same 12-scenario matrix on a 429-file / 11MB / 28-commit synthetic repo (local bare remote) — linear scaling, no quadratic blowup; small-vs-big comparison table |
 | [ForegroundSync Busy-Loop](./foreground-sync-busy-loop.md) | `ForegroundSync` skip-spam fix (#984): log throttle (10s window), busy-skip `consecutiveSkips` counter, jittered exponential interval back-off via self-scheduling `setTimeout` |
 | [gitFs Write-Path Text Fast Path](./gitfs-write-text-fast-path.md) | `gitFs.writeFile` now decodes `Uint8Array` payloads for text extensions (`md/norg/org/txt/json`) with `fatal:true` UTF-8 + base64 fallback — kills the write-side base64 round-trip (#986) |
 | [LFS Pointer Scan — Parallel Walk](./lfs-scan-parallel-walk.md) | `scanForPointers` walks the working tree with bounded concurrency (`SCAN_CONCURRENCY=16` via `mapLimit`) instead of one serial bridge round-trip per file (#980) |
+| [DevMenu Floating "Tools" Button Overlap](./dev-menu-fab-overlap.md) | expo-dev-menu's FAB defaults to the top-right corner over the header action buttons, so Edit/Add-note taps opened the DevMenu; dev-only startup disable + `EXDevMenuShowFloatingActionButton=false` default (#977) |
 
 ## Quick Start
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -48,8 +48,8 @@
 | [Git Test Big Repo](./git-test-big-repo.md) | Same 12-scenario matrix on a 429-file / 11MB / 28-commit synthetic repo (local bare remote) — linear scaling, no quadratic blowup; small-vs-big comparison table |
 | [ForegroundSync Busy-Loop](./foreground-sync-busy-loop.md) | `ForegroundSync` skip-spam fix (#984): log throttle (10s window), busy-skip `consecutiveSkips` counter, jittered exponential interval back-off via self-scheduling `setTimeout` |
 | [gitFs Write-Path Text Fast Path](./gitfs-write-text-fast-path.md) | `gitFs.writeFile` now decodes `Uint8Array` payloads for text extensions (`md/norg/org/txt/json`) with `fatal:true` UTF-8 + base64 fallback — kills the write-side base64 round-trip (#986) |
+| [DevMenu Floating "Tools" Button Overlap](./dev-menu-fab-overlap.md) | expo-dev-menu's FAB defaults to the top-right corner over the header action buttons, so Edit/Add-note taps opened the DevMenu; dev-only startup disable + `EXDevMenuShowFloatingActionButton=false` default + `useProGate` split (#977, #1004) |
 | [LFS Pointer Scan — Parallel Walk](./lfs-scan-parallel-walk.md) | `scanForPointers` walks the working tree with bounded concurrency (`SCAN_CONCURRENCY=16` via `mapLimit`) instead of one serial bridge round-trip per file (#980) |
-| [DevMenu Floating "Tools" Button Overlap](./dev-menu-fab-overlap.md) | expo-dev-menu's FAB defaults to the top-right corner over the header action buttons, so Edit/Add-note taps opened the DevMenu; dev-only startup disable + `EXDevMenuShowFloatingActionButton=false` default (#977) |
 
 ## Quick Start
 

--- a/docs/wiki/v1.5.0-app-store-rejection.md
+++ b/docs/wiki/v1.5.0-app-store-rejection.md
@@ -159,17 +159,18 @@ The `try/catch` swallows the `useNavigation()` throw on the first call (when Onb
 2. **Smoke-test the onboarding flow on a fresh iOS simulator install.** Watch the simulator log for `RCTExceptionsManager reportFatal` — should be silent.
 3. **Submit to App Store.** Reference the new build in Resolution Center and ask for re-review.
 
-## Follow-up: harden the guard
+## Follow-up: harden the guard — DONE (option b)
 
-The `c5362e86` fix works in practice but is fragile (a `useNavigation()` inside `try/catch` is a Rules-of-Hooks smell; the `eslint-disable-next-line react-hooks/rules-of-hooks` suppresses the very rule the guard depends on). If the component's mount context ever changes between renders (e.g., OnboardingScreen remounts inside a container after some future refactor), React will throw "Rendered more hooks than during the previous render".
+The `c5362e86` fix worked in practice but was fragile (a `useNavigation()` inside `try/catch` is a Rules-of-Hooks smell; the `eslint-disable-next-line react-hooks/rules-of-hooks` suppresses the very rule the guard depends on). It was reproduced live in the iOS dev build: because `useNavigation` was called only on the first render (`navigation.current` was already set on later renders), every consumer (`NotesListScreen`, `FloatingAIButton`, `HomeScreen`) triggered a React "change in the order of Hooks" violation → LogBox full-screen error panel that blocked the UI (also the trigger for #977's broken buttons).
 
-Recommended improvements (any one is sufficient):
+**Implemented: option (b) — split `useProGate` into two hooks** (`src/hooks/useProGate.ts`):
 
-- **(a) Move `<OnboardingScreen>` inside `<NavigationContainer>`.** Simplest, removes the need for the guard entirely.
-- **(b) Split `useProGate` into two hooks** — `useProGateStatus()` (just `selectIsPro` + `status`, no navigation) and `useProGateNav()` (adds navigation). OnboardingScreen calls only `useProGateStatus()`; paywall callers flows only calls the nav version.
-- **(c) Replace `try/catch useNavigation` with a small `<NavigationAvailable.Provider>`** so OnboardingScreen's mount explicitly opts out of the navigation context.
+- `useProStatus()` — `{ isPro, status, loading }` from `useProStore` only; **never touches navigation**. Used by `OnboardingScreen` (renders outside `NavigationContainer` — the original crash site) and `FloatingAIButton`.
+- `useProGate()` — `useProStatus()` + unconditional `useNavigation()` + `openPaywall`. Used by all nav-stack consumers (`NotesListScreen`, `HomeScreen`, `SettingsScreen`, `CanvasListScreen`, `TemplateSelector`, `useProScreenGuard`).
 
-Not blockers for the App Store resubmit; should be addressed before the next release.
+The hook order is now fixed and deterministic — no guard, no conditional hook, no `eslint-disable`. The original SIGABRT path (`OnboardingScreen` → `useNavigation()` outside a container) is eliminated structurally.
+
+**Verified** on iPhone 17 simulator: no hooks-order violations on any screen, onboarding/render flows clean. Tests: `__tests__/hooks/useProGate.test.tsx` covers both hooks; `__tests__/FloatingAIButton*.test.tsx` mocks updated.
 
 ## See also
 

--- a/src/components/ai/FloatingAIButton.tsx
+++ b/src/components/ai/FloatingAIButton.tsx
@@ -11,7 +11,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useAIStore } from '../../stores/aiStore';
 import { useAIHubStore } from '../../stores/aiHubStore';
-import { useProGate } from '../../hooks/useProGate';
+import { useProStatus } from '../../hooks/useProGate';
 import { useTheme } from '../../contexts/ThemeContext';
 import { HapticService } from '../../utils/haptics';
 import { Surface } from '../ui/Surface';
@@ -41,7 +41,7 @@ interface FloatingAIButtonProps {
 
 export function FloatingAIButton({ currentRouteName }: FloatingAIButtonProps) {
   const { isEnabled } = useAIStore();
-  const { isPro } = useProGate();
+  const { isPro } = useProStatus();
   const { colors } = useTheme();
   const [reduceMotionEnabled, setReduceMotionEnabled] = useState(true);
   const [reduceMotionResolved, setReduceMotionResolved] = useState(false);

--- a/src/hooks/useProGate.ts
+++ b/src/hooks/useProGate.ts
@@ -1,41 +1,25 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { selectIsPro, useProStore } from '../stores/proStore';
 import type { RootStackParamList } from '../navigation/types';
 
 /**
- * Returns true when the component is likely mounted inside a NavigationContainer.
- * useNavigation() throws when called outside a container, so this guard lets
- * callers (e.g. OnboardingScreen) use useProGate safely in both the main
- * navigator and the onboarding flow (which renders outside NavigationContainer).
+ * Pro status without navigation access. Safe to call outside a
+ * NavigationContainer (OnboardingScreen, FloatingAIButton) — it never
+ * touches the navigation context, so no useNavigation guard is needed.
  */
-function useIsInNavigationContext(): boolean {
-  try {
-    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-    return true;
-  } catch {
-    return false;
-  }
+export function useProStatus() {
+  const isPro = useProStore(selectIsPro);
+  const status = useProStore((s) => s.status);
+  return { isPro, status, loading: status === 'loading' };
 }
 
 export function useProGate() {
-  const isPro = useProStore(selectIsPro);
-  const status = useProStore((s) => s.status);
-  const isInNavigation = useIsInNavigationContext();
-  const navigation = useRef<NativeStackNavigationProp<RootStackParamList> | null>(null);
-
-  if (isInNavigation && !navigation.current) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const nav = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-    navigation.current = nav;
-  }
-
+  const { isPro, status, loading } = useProStatus();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const openPaywall = useCallback(() => {
-    if (navigation.current) {
-      navigation.current.navigate('Paywall');
-    }
-  }, []);
-
-  return { isPro, status, loading: status === 'loading', openPaywall };
+    navigation.navigate('Paywall');
+  }, [navigation]);
+  return { isPro, status, loading, openPaywall };
 }

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -17,7 +17,7 @@ import { OnboardingService } from '../services/OnboardingService';
 import { AuthService } from '../services/AuthService';
 import { GitHubService } from '../services/GitHubService';
 import { useAIStore } from '../stores/aiStore';
-import { useProGate } from '../hooks/useProGate';
+import { useProStatus } from '../hooks/useProGate';
 import { Button, Input, Surface } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 
@@ -67,7 +67,7 @@ const TOTAL_STEPS = INFO_STEPS.length + 3;
 export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScreenProps) {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { isPro } = useProGate();
+  const { isPro } = useProStatus();
   const [currentStep, setCurrentStep] = useState(0);
   const [token, setToken] = useState('');
   const [isVerifying, setIsVerifying] = useState(false);

--- a/src/utils/devMenuFab.ts
+++ b/src/utils/devMenuFab.ts
@@ -1,0 +1,19 @@
+import { Platform } from 'react-native';
+import { requireNativeModule } from 'expo-modules-core';
+
+/**
+ * Hides the expo-dev-menu floating "Tools" button in development builds.
+ * The FAB defaults to the top-right corner of the screen — directly over the
+ * header action buttons (Edit / Add note) — so taps open the DevMenu instead
+ * of running the action (#977). The toggle stays available in the DevMenu.
+ */
+export function hideDevMenuFloatingActionButton(): void {
+  if (!__DEV__ || Platform.OS !== 'ios') return;
+  try {
+    requireNativeModule('DevMenuPreferences')
+      .setPreferencesAsync({ showFloatingActionButton: false })
+      .catch(() => undefined);
+  } catch {
+    // DevMenuPreferences is only registered by expo-dev-menu.
+  }
+}


### PR DESCRIPTION
## Summary

Two fixes, both verified on the iPhone 17 simulator:

### #1004 — useProGate split (App Store SIGABRT hardening)
- Split `useProGate` into `useProGate()` (always calls `useNavigation`, for nav-stack consumers) and `useProStatus()` (never touches navigation; used by `OnboardingScreen` — the original outside-`NavigationContainer` crash site — and `FloatingAIButton`).
- The `c5362e86` try/catch guard was reproduced live as a React **Rules-of-Hooks violation**: `useNavigation` was called only on the first render (`navigation.current` set on later renders), so every consumer triggered a hooks-order change → LogBox full-screen error panel that blocked the UI (also a trigger for #977).
- Hook order is now fixed/deterministic — no guard, no conditional hook, no `eslint-disable`.

### #977 — DevMenu opened by Edit/Add-note taps
- Root cause: expo-dev-menu's floating **Tools FAB** defaults to the top-right corner (frame ≈ x 325-397, y 59-131 on iPhone 17), **completely covering** the Notes header Add-note button (x 350-386, y 74-110) and NoteViewer's Edit pencil. Tap → DevMenu (`Runtime version: 1.5.0 / TOOLS menu` — matches the report).
- Fix: `src/utils/devMenuFab.ts` disables the FAB at startup in dev builds via `DevMenuPreferences.setPreferencesAsync({ showFloatingActionButton: false })`; `app.json` sets `EXDevMenuShowFloatingActionButton: false` for fresh dev builds. The DevMenu toggle still lets developers re-enable it.

## Verification
- Simulator: Add-note → NoteEditor, Edit → edit mode; no DevMenu, no LogBox hooks-order violations on any screen.
- `yarn ts:check` clean; `yarn jest` — 65/65 pass across the touched suites (useProGate, devMenuFab, FloatingAIButton, NotesListScreen).

## Wiki
- `docs/wiki/dev-menu-fab-overlap.md` (new), `docs/wiki/v1.5.0-app-store-rejection.md` (split-hook marked DONE), `docs/wiki/foreground-sync-busy-loop.md` (test-count update), `docs/wiki/index.md` (rows).