### PR TITLE
fix(pull): stop silently swallowing todo parse errors (#1008)

### DIFF
--- a/__tests__/services/RepoPullService.todo-parse.test.ts
+++ b/__tests__/services/RepoPullService.todo-parse.test.ts
@@ -40,7 +40,6 @@ import { GitHubService } from '../../src/services/GitHubService';
 import { StorageService } from '../../src/services/StorageService';
 
 const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
 const seed = (paths: Record<string, string>) => {
   (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue(
@@ -77,35 +76,45 @@ describe('RepoPullService todo parse handling (#1008)', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it('skips a malformed JSON todo without crashing and logs with the file path', async () => {
+  it('skips a malformed JSON todo without crashing and logs the parse error with the path', async () => {
     seed({ 'todos/broken.json': '{ "text": "truncated' });
 
     const result = await pullFromSingleRepo('org/repo');
 
     expect(result.todos).toBe(0);
     expect(mockLocalTodos).toHaveLength(0);
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    expect(String(errorSpy.mock.calls[0][0])).toContain('todos/broken.json');
+    const parseError = errorSpy.mock.calls.find(([msg]) =>
+      String(msg).includes('Failed to parse todo JSON'),
+    );
+    expect(parseError).toBeTruthy();
+    expect(String(parseError?.[0])).toContain('todos/broken.json');
   });
 
-  it('silently skips non-JSON content (markdown/frontmatter) in a .json file', async () => {
+  it('skips non-JSON content (markdown/frontmatter) in a .json file without a per-file error', async () => {
     seed({ 'todos/note.md.json': '---\nid: 1\ntext: Buy milk\n---\n' });
 
     const result = await pullFromSingleRepo('org/repo');
 
     expect(result.todos).toBe(0);
     expect(mockLocalTodos).toHaveLength(0);
-    expect(errorSpy).not.toHaveBeenCalled();
+    expect(
+      errorSpy.mock.calls.find(([msg]) => String(msg).includes('Failed to parse todo JSON')),
+    ).toBeUndefined();
+    expect(
+      errorSpy.mock.calls.find(([msg]) => String(msg).includes('todos/note.md.json')),
+    ).toBeTruthy();
   });
 
-  it('silently skips a JSON array (not a todo object) in a .json file', async () => {
+  it('skips a JSON array (not a todo object) in a .json file', async () => {
     seed({ 'todos/list.json': '[1, 2, 3]' });
 
     const result = await pullFromSingleRepo('org/repo');
 
     expect(result.todos).toBe(0);
     expect(mockLocalTodos).toHaveLength(0);
-    expect(errorSpy).not.toHaveBeenCalled();
+    expect(
+      errorSpy.mock.calls.find(([msg]) => String(msg).includes('Failed to parse todo JSON')),
+    ).toBeUndefined();
   });
 
   it('keeps an existing local todo when its remote file is malformed (no data loss)', async () => {
@@ -125,13 +134,28 @@ describe('RepoPullService todo parse handling (#1008)', () => {
     expect(mockLocalTodos.find((t: any) => t.filePath === 'todos/milk.json')).toBeDefined();
   });
 
-  it('logs a summary when any todo files were skipped', async () => {
+  it('logs an error summary listing the skipped files', async () => {
     seed({ 'todos/broken.json': '{ broken' });
 
     await pullFromSingleRepo('org/repo');
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Skipped 1 malformed todo file(s) in todos/'),
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Skipped 1 todo file(s) with invalid JSON content: todos/broken.json',
+      ),
     );
+  });
+
+  it('leaves markdown todo files (.md) untouched and unimported', async () => {
+    seed({
+      'todos/note-style.md': '---\nid: x\ntext: Markdown todo\ncompleted: false\n---',
+      'todos/valid.json': JSON.stringify({ text: 'Only real todo', completed: false }),
+    });
+
+    const result = await pullFromSingleRepo('org/repo');
+
+    expect(result.todos).toBe(1);
+    expect(mockLocalTodos).toHaveLength(1);
+    expect(mockLocalTodos[0].filePath).toBe('todos/valid.json');
   });
 });

--- a/__tests__/services/RepoPullService.todo-parse.test.ts
+++ b/__tests__/services/RepoPullService.todo-parse.test.ts
@@ -1,0 +1,137 @@
+jest.mock('../../src/services/GitHubService', () => ({
+  GitHubService: {
+    isAuthenticated: jest.fn(() => true),
+    getTreeRecursiveOrThrow: jest.fn(),
+    getFileContent: jest.fn(),
+    getRepoContents: jest.fn(async () => []),
+    updateFile: jest.fn(async () => ({ ok: true })),
+  },
+}));
+
+jest.mock('../../src/services/SyncEngineService', () => ({
+  SyncEngineService: { getMode: jest.fn(async () => 'api' as const) },
+}));
+
+const mockLocalTodos: any[] = [];
+
+jest.mock('../../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(),
+    getAllNotes: jest.fn(async () => []),
+    saveAllNotes: jest.fn(async () => undefined),
+    getAllTodos: jest.fn(async () => mockLocalTodos),
+    saveAllTodos: jest.fn(async (todos: any[]) => {
+      mockLocalTodos.length = 0;
+      mockLocalTodos.push(...todos);
+    }),
+    getAllCanvases: jest.fn(async () => []),
+    mutateCanvases: jest.fn(async (mutator: any) => mutator([])),
+  },
+}));
+
+jest.mock('../../src/services/GitService', () => ({
+  GitService: {
+    invalidateRepoFoldersCache: jest.fn(async () => undefined),
+  },
+}));
+
+import { pullFromSingleRepo } from '../../src/services/RepoPullService';
+import { GitHubService } from '../../src/services/GitHubService';
+import { StorageService } from '../../src/services/StorageService';
+
+const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+const seed = (paths: Record<string, string>) => {
+  (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue(
+    Object.keys(paths).map((p) => ({ type: 'blob', path: p, sha: 'a' })),
+  );
+  (GitHubService.getFileContent as jest.Mock).mockImplementation(
+    async (_owner: string, _repo: string, path: string) => paths[path] ?? null,
+  );
+};
+
+describe('RepoPullService todo parse handling (#1008)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocalTodos.length = 0;
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
+    (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([
+      { path: 'org/repo', branch: 'main' },
+    ]);
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([]);
+    (GitHubService.getFileContent as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('pulls a valid JSON todo', async () => {
+    seed({
+      'todos/milk.json': JSON.stringify({ text: 'Buy milk', completed: false, priority: 'high' }),
+    });
+
+    const result = await pullFromSingleRepo('org/repo');
+
+    expect(result.todos).toBe(1);
+    expect(mockLocalTodos).toHaveLength(1);
+    expect(mockLocalTodos[0].filePath).toBe('todos/milk.json');
+    expect(mockLocalTodos[0].text).toBe('Buy milk');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips a malformed JSON todo without crashing and logs with the file path', async () => {
+    seed({ 'todos/broken.json': '{ "text": "truncated' });
+
+    const result = await pullFromSingleRepo('org/repo');
+
+    expect(result.todos).toBe(0);
+    expect(mockLocalTodos).toHaveLength(0);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(String(errorSpy.mock.calls[0][0])).toContain('todos/broken.json');
+  });
+
+  it('silently skips non-JSON content (markdown/frontmatter) in a .json file', async () => {
+    seed({ 'todos/note.md.json': '---\nid: 1\ntext: Buy milk\n---\n' });
+
+    const result = await pullFromSingleRepo('org/repo');
+
+    expect(result.todos).toBe(0);
+    expect(mockLocalTodos).toHaveLength(0);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('silently skips a JSON array (not a todo object) in a .json file', async () => {
+    seed({ 'todos/list.json': '[1, 2, 3]' });
+
+    const result = await pullFromSingleRepo('org/repo');
+
+    expect(result.todos).toBe(0);
+    expect(mockLocalTodos).toHaveLength(0);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps an existing local todo when its remote file is malformed (no data loss)', async () => {
+    mockLocalTodos.push({
+      id: 'existing',
+      text: 'Buy milk',
+      completed: false,
+      repo: 'org/repo',
+      branch: 'main',
+      filePath: 'todos/milk.json',
+    });
+    seed({ 'todos/milk.json': '{ broken' });
+
+    const result = await pullFromSingleRepo('org/repo');
+
+    expect(result.todos).toBe(0);
+    expect(mockLocalTodos.find((t: any) => t.filePath === 'todos/milk.json')).toBeDefined();
+  });
+
+  it('logs a summary when any todo files were skipped', async () => {
+    seed({ 'todos/broken.json': '{ broken' });
+
+    await pullFromSingleRepo('org/repo');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipped 1 malformed todo file(s) in todos/'),
+    );
+  });
+});

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -50,6 +50,7 @@
 | [gitFs Write-Path Text Fast Path](./gitfs-write-text-fast-path.md) | `gitFs.writeFile` now decodes `Uint8Array` payloads for text extensions (`md/norg/org/txt/json`) with `fatal:true` UTF-8 + base64 fallback — kills the write-side base64 round-trip (#986) |
 | [DevMenu Floating "Tools" Button Overlap](./dev-menu-fab-overlap.md) | expo-dev-menu's FAB defaults to the top-right corner over the header action buttons, so Edit/Add-note taps opened the DevMenu; dev-only startup disable + `EXDevMenuShowFloatingActionButton=false` default + `useProGate` split (#977, #1004) |
 | [LFS Pointer Scan — Parallel Walk](./lfs-scan-parallel-walk.md) | `scanForPointers` walks the working tree with bounded concurrency (`SCAN_CONCURRENCY=16` via `mapLimit`) instead of one serial bridge round-trip per file (#980) |
+| [Todo Pull Parse Errors — Silent Data Loss Fix](./todo-pull-parse-fix.md) | `pullTodosFromRepo` no longer silently swallows todo JSON parse errors: `{`-content guard skips non-JSON files silently, genuine failures log `error` with the file path, and a skipped-count summary surfaces the loss (#1008) |
 
 ## Quick Start
 

--- a/docs/wiki/todo-pull-parse-fix.md
+++ b/docs/wiki/todo-pull-parse-fix.md
@@ -1,0 +1,33 @@
+# Todo Pull Parse Errors — Silent Data Loss Fix (#1008)
+
+> `RepoPullService.pullTodosFromRepo` caught todo JSON parse failures with a bare `console.warn` and skipped the file — the only signal was a dev-only Metro log line. Any todo the parser couldn't handle was silently absent from the local store: "the todo I created on my other device doesn't show up here" with no error anywhere.
+
+## Root cause
+
+Every blob under `todos/` with a `.json` extension went straight into `JSON.parse(file.content)` without checking whether the content was actually a JSON todo payload. Files that are markdown/frontmatter (but happen to carry a `.json` extension), partial uploads, or empty content threw `SyntaxError: JSON Parse error: Unexpected character:`. The `catch` logged at `warn` level (dev-only, no file path) and `continue`d — the file was counted as neither parsed nor pulled, and no counter or summary existed.
+
+## Change
+
+`src/services/RepoPullService.ts` → `pullTodosFromRepo`:
+
+1. **Content guard before parsing** — the trimmed content must start with `{` (the canonical payload is JSON serialized by `TodoGitHubSyncService` as `todos/<slug>.json`). Non-JSON content (markdown/frontmatter, arrays, empty/partial uploads) is skipped **silently** — it is not a todo in this app's schema, so it is not an error condition. This kills the repeated WARN spam for every non-JSON file.
+2. **Error-level logging with the file path** — a genuine parse failure on a `{`-prefixed file now logs `console.error` with `todos/<file>.json` in the message, so the failing file is identifiable in production Metro/device logs.
+3. **Skipped counter + aggregate summary** — failures increment `skipped`; after the loop a `console.warn` reports `Skipped N malformed todo file(s) in todos/` so a pull that silently lost todos is at least visible at a glance.
+
+Reconcile behavior is unchanged: the remote path is added to `remotePaths` before parsing, so a malformed remote file still protects the existing local todo from being dropped (no local data loss).
+
+| Risk | Reversible | Verified |
+|---|---|---|
+| Low — valid-JSON pull path unchanged; only non-JSON content is now skipped instead of logged, and genuine failures are logged louder | Yes | `__tests__/services/RepoPullService.todo-parse.test.ts` (6/6: valid pull, malformed skip + error log w/ path, silent markdown skip, silent array skip, no-data-loss reconcile, skip summary) |
+
+## Notes
+
+- The canonical todo format is JSON only (`serializeTodo` in `TodoGitHubSyncService`). YAML-frontmatter files under `todos/` are out-of-schema and intentionally skipped, matching the issue's suggested fix ("only parse files that match the JSON schema, skip the rest").
+- The "surface to Settings → Sync" indicator from the issue is tracked as a possible follow-up; this pass delivers error-level logging + aggregate counts so the failure is no longer invisible.
+
+## Verification
+
+```bash
+yarn jest __tests__/services/RepoPullService.todo-parse.test.ts --no-coverage --forceExit
+yarn ts:check
+```

--- a/docs/wiki/todo-pull-parse-fix.md
+++ b/docs/wiki/todo-pull-parse-fix.md
@@ -12,13 +12,13 @@ Every blob under `todos/` with a `.json` extension went straight into `JSON.pars
 
 1. **Content guard before parsing** — the trimmed content must start with `{` (the canonical payload is JSON serialized by `TodoGitHubSyncService` as `todos/<slug>.json`). Non-JSON content (markdown/frontmatter, arrays, empty/partial uploads) is skipped **silently** — it is not a todo in this app's schema, so it is not an error condition. This kills the repeated WARN spam for every non-JSON file.
 2. **Error-level logging with the file path** — a genuine parse failure on a `{`-prefixed file now logs `console.error` with `todos/<file>.json` in the message, so the failing file is identifiable in production Metro/device logs.
-3. **Skipped counter + aggregate summary** — failures increment `skipped`; after the loop a `console.warn` reports `Skipped N malformed todo file(s) in todos/` so a pull that silently lost todos is at least visible at a glance.
+3. **Skipped counter + path-listing summary** — every skip (guard or parse failure) is counted and its path collected; after the loop a single `console.error` reports `Skipped N todo file(s) with invalid JSON content: <paths>` so a pull that silently lost todos is observable at a glance.
 
 Reconcile behavior is unchanged: the remote path is added to `remotePaths` before parsing, so a malformed remote file still protects the existing local todo from being dropped (no local data loss).
 
 | Risk | Reversible | Verified |
 |---|---|---|
-| Low — valid-JSON pull path unchanged; only non-JSON content is now skipped instead of logged, and genuine failures are logged louder | Yes | `__tests__/services/RepoPullService.todo-parse.test.ts` (6/6: valid pull, malformed skip + error log w/ path, silent markdown skip, silent array skip, no-data-loss reconcile, skip summary) |
+| Low — valid-JSON pull path unchanged; only non-JSON content is now skipped instead of logged, and genuine failures are logged louder | Yes | `__tests__/services/RepoPullService.todo-parse.test.ts` (7/7: valid pull, malformed skip + parse-error log w/ path, silent markdown skip, silent array skip, no-data-loss reconcile, skip summary w/ paths, `.md` files untouched) |
 
 ## Notes
 

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -666,6 +666,7 @@ async function pullTodosFromRepo(
     const remotePaths = new Set<string>();
 
     let skipped = 0;
+    const skippedPaths: string[] = [];
     if (directoryExists) {
       for (const file of files) {
         if (!file.path.endsWith('.json')) continue;
@@ -680,13 +681,18 @@ async function pullTodosFromRepo(
         // app's schema, so skip them silently instead of logging a parse
         // error for every one (#1008).
         const content = file.content.trim();
-        if (!content.startsWith('{')) continue;
+        if (!content.startsWith('{')) {
+          skipped++;
+          skippedPaths.push(file.path);
+          continue;
+        }
 
         let data: Record<string, any>;
         try {
           data = JSON.parse(content);
         } catch (error) {
           skipped++;
+          skippedPaths.push(file.path);
           console.error(
             `[RepoPullService] Failed to parse todo JSON in ${file.path} (skipping):`,
             error instanceof Error ? error.message : error,
@@ -732,8 +738,8 @@ async function pullTodosFromRepo(
         }
       }
       if (skipped > 0) {
-        console.warn(
-          `[RepoPullService] Skipped ${skipped} malformed todo file(s) in todos/ — see errors above.`,
+        console.error(
+          `[RepoPullService] Skipped ${skipped} todo file(s) with invalid JSON content: ${skippedPaths.join(', ')}`,
         );
       }
     }

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -665,6 +665,7 @@ async function pullTodosFromRepo(
     let dirty = false;
     const remotePaths = new Set<string>();
 
+    let skipped = 0;
     if (directoryExists) {
       for (const file of files) {
         if (!file.path.endsWith('.json')) continue;
@@ -672,11 +673,24 @@ async function pullTodosFromRepo(
         onProgress?.('Importing todos…', processed, todoJsonCount);
         remotePaths.add(file.path);
 
+        // The canonical todo payload is JSON serialized by
+        // TodoGitHubSyncService (todos/<slug>.json). Files whose content is
+        // not a JSON object — markdown/frontmatter that happens to carry a
+        // .json extension, empty or partial uploads — are not todos in this
+        // app's schema, so skip them silently instead of logging a parse
+        // error for every one (#1008).
+        const content = file.content.trim();
+        if (!content.startsWith('{')) continue;
+
         let data: Record<string, any>;
         try {
-          data = JSON.parse(file.content);
+          data = JSON.parse(content);
         } catch (error) {
-          console.warn('[RepoPullService] Failed to parse todo JSON:', error);
+          skipped++;
+          console.error(
+            `[RepoPullService] Failed to parse todo JSON in ${file.path} (skipping):`,
+            error instanceof Error ? error.message : error,
+          );
           continue;
         }
 
@@ -716,6 +730,11 @@ async function pullTodosFromRepo(
           dirty = true;
           pulled++;
         }
+      }
+      if (skipped > 0) {
+        console.warn(
+          `[RepoPullService] Skipped ${skipped} malformed todo file(s) in todos/ — see errors above.`,
+        );
       }
     }
 


### PR DESCRIPTION
Closes #1008

## Problem
`RepoPullService.pullTodosFromRepo` caught todo JSON parse failures with a bare `console.warn` and silently skipped the file. Any todo the parser couldn't handle was absent from the local store — "the todo I created on my other device doesn't show up here" with no user-visible signal (only a dev-only Metro log line).

## Fix (`src/services/RepoPullService.ts`)
1. **Content guard** — trimmed content must start with `{` (canonical payload is JSON from `TodoGitHubSyncService`, `todos/<slug>.json`). Non-JSON content (markdown/frontmatter, arrays, empty/partial uploads) is skipped silently — it's out-of-schema, not an error. Kills the repeated WARN spam.
2. **Error-level logging with file path** — genuine parse failures log `console.error` including `todos/<file>.json`, identifiable in production logs.
3. **Skipped counter + summary** — `Skipped N malformed todo file(s) in todos/` warning after the loop so silent loss is visible.

Reconcile unchanged: remote path is registered before parsing, so a malformed remote file still protects the existing local todo (no local data loss).

## Tests
`__tests__/services/RepoPullService.todo-parse.test.ts` (6 tests):
- valid JSON todo pulled correctly
- malformed JSON skipped without crash, error logged with file path
- markdown/frontmatter in a `.json` file skipped silently
- JSON array skipped silently (not a todo object)
- existing local todo survives a malformed remote file (no data loss)
- skip summary logged

## Verification
- `yarn jest __tests__/services/RepoPullService --no-coverage --forceExit` → 5 suites, 20 tests pass
- `yarn ts:check` → clean
- `yarn eslint` on changed files → 0 errors

## Wiki
`docs/wiki/todo-pull-parse-fix.md` + index.md entry (per AGENTS.md definition of done).