### PR TITLE
perf(http): yield packfile chunks instead of merging into one buffer (#982)

### DIFF
--- a/__tests__/services/git/gitHttp.test.ts
+++ b/__tests__/services/git/gitHttp.test.ts
@@ -80,6 +80,43 @@ describe('gitHttp.request streaming (issue #790)', () => {
     expect(resp.statusCode).toBe(200);
   });
 
+  test('Case A2: preserves chunk granularity instead of merging into one buffer (#982)', async () => {
+    const chunk1 = new Uint8Array([1, 2, 3, 4]);
+    const chunk2 = new Uint8Array([5, 6, 7, 8]);
+    const chunk3 = new Uint8Array([9, 10, 11, 12]);
+    const chunks = [chunk1, chunk2, chunk3];
+    let i = 0;
+    const reader = {
+      read: jest.fn().mockImplementation(async () => {
+        if (i >= chunks.length) return { done: true, value: undefined };
+        return { done: false, value: chunks[i++] };
+      }),
+      cancel: jest.fn().mockResolvedValue(undefined),
+    };
+    const responseBody = { getReader: () => reader };
+    const mockHeaders = { forEach: (_cb: (v: string, k: string) => void) => {} };
+
+    (globalThis as { fetch?: typeof fetch }).fetch = jest
+      .fn()
+      .mockResolvedValue({
+        url: 'https://example.git/info/refs',
+        status: 200,
+        statusText: 'OK',
+        headers: mockHeaders,
+        body: responseBody,
+        arrayBuffer: jest.fn(),
+      }) as unknown as typeof fetch;
+
+    const resp = await gitHttp.request(buildRequest('https://example.git/info/refs'));
+    const yielded: Uint8Array[] = [];
+    for await (const ch of resp.body!) yielded.push(ch);
+
+    expect(yielded).toHaveLength(3);
+    expect(yielded[0]).toEqual(chunk1);
+    expect(yielded[1]).toEqual(chunk2);
+    expect(yielded[2]).toEqual(chunk3);
+  });
+
   test('Case B: falls back to arrayBuffer when response.body is null', async () => {
     const mockHeaders = { forEach: (_cb: (v: string, k: string) => void) => {} };
     const arrayBuffer = jest

--- a/docs/wiki/git-http-packfile-buffering.md
+++ b/docs/wiki/git-http-packfile-buffering.md
@@ -1,0 +1,48 @@
+# gitHttp Packfile Buffering — Remove Redundant Copy (#982)
+
+> `gitHttp.request` read a large clone/fetch response in streaming chunks but then merged them all into **one contiguous `Uint8Array`** before handing the body to isomorphic-git — a second full-size copy of the packfile held in the JS heap on top of the chunks already collected. On memory-constrained devices (iOS simulator, older phones) a multi-hundred-MB initial clone could exhaust the heap.
+
+## Root cause
+
+`src/services/git/gitHttp.ts` (the isomorphic-git `HttpClient`):
+
+1. `response.body.getReader()` streams the network body in chunks (the #790 fix) — good.
+2. **But** the chunks were then merged via `new Uint8Array(total)` + `set()` into one buffer, and the body was wrapped in `yieldOnce(bytes)` — a single yield of the merged buffer.
+3. Peak memory therefore held **two** full packfile copies (the chunk array + the merged buffer), plus whatever isomorphic-git itself needs.
+
+## Why not stream to a temp file (the issue's suggested fix)?
+
+Verified against **isomorphic-git 1.40.0** (installed): the library itself collects the entire packfile into memory on the fetch path —
+
+```js
+// isomorphic-git index.cjs:10172 (parseUploadPackResponse)
+const packfile = Buffer.from(await collect(response.packfile));
+```
+
+— with its own `TODO: ... a) NOT concatenate the entire packfile into memory ...` right above the `fs.write`. True file-backed streaming therefore requires patching isomorphic-git (its `GitPackIndex.fromPack` also reads via synchronous `pack.slice()`/`pack.byteLength`), which is a separate high-risk change against a third-party dependency. Out of scope for this fix.
+
+## Change
+
+`src/services/git/gitHttp.ts`:
+
+1. New `yieldChunks(chunks)` — yields the raw read chunks in order instead of merging them.
+2. The streaming branch now returns `body: yieldChunks(chunks)`; the `arrayBuffer()` fallback keeps `yieldOnce`.
+3. The redundant merge (`new Uint8Array(total)` + copies) is deleted.
+
+Net effect: peak memory for a large clone/fetch drops from ~2× the packfile size to ~1× (isomorphic-git still buffers on its side — unavoidable without patching it). Byte-for-byte identical stream content, so the #790 "Packfile trailer mismatch" fix is preserved.
+
+| Risk | Reversible | Verified |
+|---|---|---|
+| Low — same bytes, same order; only chunk granularity changes (isomorphic-git's demuxers buffer partial pkt-lines across chunk boundaries) | Yes | `__tests__/services/git/gitHttp.test.ts` (5/5: streaming merge, **chunk-granularity preservation (#982)**, arrayBuffer fallback, read-error cancel, abort timeout) + all `__tests__/services/git` (136/136) |
+
+## Follow-up
+
+True disk-backed streaming (write chunks to `FileSystem.cacheDirectory` and index from disk) is blocked by isomorphic-git's internal `collect()` — tracked as a follow-up that would require a `patch-package` on isomorphic-git (`parseUploadPackResponse` + a file-backed `GitPackIndex.fromPack` reader). The repo already patches isomorphic-git in `scripts/patch-isomorphic-git-umd.js` postinstall, so that path is viable but deliberately out of scope here.
+
+## Verification
+
+```bash
+yarn jest __tests__/services/git/gitHttp.test.ts --no-coverage --forceExit
+yarn jest __tests__/services/git --no-coverage --forceExit
+yarn ts:check
+```

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -52,6 +52,7 @@
 | [LFS Pointer Scan — Parallel Walk](./lfs-scan-parallel-walk.md) | `scanForPointers` walks the working tree with bounded concurrency (`SCAN_CONCURRENCY=16` via `mapLimit`) instead of one serial bridge round-trip per file (#980) |
 | [Todo Pull Parse Errors — Silent Data Loss Fix](./todo-pull-parse-fix.md) | `pullTodosFromRepo` no longer silently swallows todo JSON parse errors: `{`-content guard skips non-JSON files silently, genuine failures log `error` with the file path, and a skipped-count summary surfaces the loss (#1008) |
 | [ForegroundSync Watchdog — Sync Health Surfacing](./foreground-sync-health.md) | `ForegroundSyncService` now tracks `syncHealth` (`idle/syncing/ok/failed/timedout` + failure count), exposed via `getForegroundSyncHealth()` / `useForegroundSyncHealth()` and a Settings → Sync status row — a stalled pull is no longer invisible (#1007) |
+| [gitHttp Packfile Buffering — Remove Redundant Copy](./git-http-packfile-buffering.md) | `gitHttp` yields raw response chunks instead of merging them into one `Uint8Array`, halving peak packfile memory on large clones; true disk streaming blocked by isomorphic-git's internal `collect()` (follow-up) (#982) |
 
 ## Quick Start
 

--- a/src/services/git/gitHttp.ts
+++ b/src/services/git/gitHttp.ts
@@ -6,6 +6,17 @@ async function* yieldOnce(bytes: Uint8Array): AsyncIterableIterator<Uint8Array> 
   yield bytes;
 }
 
+// Yields response chunks as they were read instead of merging them into one
+// contiguous buffer. isomorphic-git still collects the packfile into memory
+// on its side (`Buffer.from(await collect(response.packfile))` in 1.40.0),
+// but skipping our own merge removes a second full-size copy of the packfile
+// from peak memory during a large clone/fetch (#982).
+async function* yieldChunks(chunks: Uint8Array[]): AsyncIterableIterator<Uint8Array> {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
 async function consumeBody(
   body: GitHttpRequest['body'],
 ): Promise<Uint8Array | undefined> {
@@ -62,12 +73,11 @@ export const gitHttp: HttpClient = {
     // Try to stream the response body when the environment supports
     // ReadableStream (iOS/Android modern RN, Web). Falls back to
     // `arrayBuffer()` for environments without streaming support
-    // (legacy RN, older Hermes). Streaming bounds memory to incremental
-    // chunks (typically ~64KB from isomorphic-git) instead of materialising
-    // a 100MB+ packfile as one ArrayBuffer — fixing "Packfile trailer
-    // mismatch" errors on large repos (issue #790).
-    let bytes: Uint8Array;
-
+    // (legacy RN, older Hermes). Chunks are yielded as read (never merged
+    // into one contiguous buffer) so a large packfile is not held twice in
+    // memory (#982) — fixing "Packfile trailer mismatch" errors on large
+    // repos (issue #790).
+    let outBody: AsyncIterableIterator<Uint8Array>;
     const responseBody = response.body as (ReadableStream<Uint8Array> & { getReader?: () => ReadableStreamDefaultReader<Uint8Array> }) | null;
     const hasStreaming = !!responseBody && typeof responseBody.getReader === 'function';
 
@@ -93,14 +103,7 @@ export const gitHttp: HttpClient = {
       }
 
       clearTimeout(timeoutId);
-      let total = 0;
-      for (const c of chunks) total += c.length;
-      bytes = new Uint8Array(total);
-      let off = 0;
-      for (const c of chunks) {
-        bytes.set(c, off);
-        off += c.length;
-      }
+      outBody = yieldChunks(chunks);
     } else {
       let buffer: ArrayBuffer;
       try {
@@ -113,7 +116,7 @@ export const gitHttp: HttpClient = {
         throw arrayBufferError;
       }
       clearTimeout(timeoutId);
-      bytes = new Uint8Array(buffer);
+      outBody = yieldOnce(new Uint8Array(buffer));
     }
 
     const responseHeaders: Record<string, string> = {};
@@ -127,7 +130,7 @@ export const gitHttp: HttpClient = {
       headers: responseHeaders,
       statusCode: response.status,
       statusMessage: response.statusText,
-      body: yieldOnce(bytes),
+      body: outBody,
     };
   },
 };


### PR DESCRIPTION
Closes #982 (also supersedes the now-closed duplicates #992/#1003)

## Problem
`gitHttp.request` read large clone/fetch responses in streaming chunks (the #790 fix) but then merged them all into **one contiguous `Uint8Array`** before handing the body to isomorphic-git — a second full-size copy of the packfile in the JS heap on top of the chunks already collected. A multi-hundred-MB initial clone could exhaust the heap on memory-constrained devices.

## Key finding: true disk streaming is blocked by isomorphic-git
Verified against **isomorphic-git 1.40.0**: the library itself buffers the packfile —
`parseUploadPackResponse` does `Buffer.from(await collect(response.packfile))` (index.cjs:10172), with its own TODO admitting "NOT concatenate the entire packfile into memory". `GitPackIndex.fromPack` also reads via synchronous `pack.slice()`/`pack.byteLength`. So file-backed streaming requires patching isomorphic-git itself — out of scope here, tracked as a follow-up (the repo already uses `patch-package` for isomorphic-git).

## Change
`src/services/git/gitHttp.ts`:
- New `yieldChunks(chunks)` — yields raw read chunks in order.
- Streaming branch returns `body: yieldChunks(chunks)`; `arrayBuffer()` fallback keeps `yieldOnce`.
- The redundant `new Uint8Array(total)` merge is deleted.

**Result:** peak memory for a large clone/fetch drops from ~2× to ~1× the packfile size. Byte-for-byte identical stream content — the #790 "Packfile trailer mismatch" fix is preserved.

## Tests
`__tests__/services/git/gitHttp.test.ts` — 5/5, incl. new **Case A2** asserting chunk granularity is preserved (the #982 regression guard). All `__tests__/services/git` — 136/136 pass.

## Verification
- `yarn jest __tests__/services/git --no-coverage --forceExit` → 136 pass
- `yarn ts:check` → clean
- `yarn eslint` on changed files → 0 errors

## Wiki
`docs/wiki/git-http-packfile-buffering.md` + index.md entry.
