### PR TITLE
fix(Explore): show permission error for 403 responses from GitHub API

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -461,7 +461,8 @@
     "filterOpen": "Offen",
     "filterClosed": "Geschlossen",
     "openInBrowser": "Im Browser öffnen",
-    "loadError": "Konnte nicht geladen werden — zum Wiederholen tippen"
+    "loadError": "Konnte nicht geladen werden — zum Wiederholen tippen",
+    "permissionError": "Zugriff verweigert — GitHub-Token-Berechtigungen prüfen"
   },
   "home": {
     "title": "Start",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -267,7 +267,8 @@
     "filterOpen": "Open",
     "filterClosed": "Closed",
     "openInBrowser": "Open in browser",
-    "loadError": "Couldn't load — tap to retry"
+    "loadError": "Couldn't load — tap to retry",
+    "permissionError": "Access denied — check your GitHub token permissions"
   },
   "settings": {
     "title": "Settings",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -461,7 +461,8 @@
     "filterOpen": "Abiertas",
     "filterClosed": "Cerradas",
     "openInBrowser": "Abrir en navegador",
-    "loadError": "No se pudo cargar — toca para reintentar"
+    "loadError": "No se pudo cargar — toca para reintentar",
+    "permissionError": "Acceso denegado — verifica los permisos de tu token de GitHub"
   },
   "home": {
     "title": "Inicio",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -461,7 +461,8 @@
     "filterOpen": "Ouverts",
     "filterClosed": "Fermés",
     "openInBrowser": "Ouvrir dans le navigateur",
-    "loadError": "Impossible de charger — appuyez pour réessayer"
+    "loadError": "Impossible de charger — appuyez pour réessayer",
+    "permissionError": "Accès refusé — vérifiez les permissions de votre token GitHub"
   },
   "home": {
     "title": "Accueil",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -461,7 +461,8 @@
     "filterOpen": "オープン",
     "filterClosed": "クローズ",
     "openInBrowser": "ブラウザで開く",
-    "loadError": "読み込めませんでした — タップして再試行"
+    "loadError": "読み込めませんでした — タップして再試行",
+    "permissionError": "アクセス拒否 — GitHubトークンの権限を確認してください"
   },
   "home": {
     "title": "ホーム",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -461,7 +461,8 @@
     "filterOpen": "열림",
     "filterClosed": "닫힘",
     "openInBrowser": "브라우저에서 열기",
-    "loadError": "로드할 수 없습니다 — 눌러서 다시 시도"
+    "loadError": "로드할 수 없습니다 — 눌러서 다시 시도",
+    "permissionError": "액세스 거부됨 — GitHub 토큰 권한을 확인하세요"
   },
   "home": {
     "title": "홈",

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -550,7 +550,11 @@ export default function ExploreScreen() {
         ) : prQuery.isError ? (
           <View className="flex-1 items-center justify-center px-6">
             <Ionicons name="alert-circle-outline" size={40} color={colors.textSecondary} />
-            <Text className="text-sm mt-3" style={{ color: colors.textSecondary }}>{t('explore.loadError')}</Text>
+            <Text className="text-sm mt-3" style={{ color: colors.textSecondary }}>
+              {(prQuery.error as Error & { status?: number })?.status === 403
+                ? t('explore.permissionError')
+                : t('explore.loadError')}
+            </Text>
           </View>
         ) : prData.length === 0 ? (
           <EmptyState icon="git-pull-request-outline" title={t('explore.noPullRequests')} />
@@ -627,7 +631,11 @@ export default function ExploreScreen() {
         ) : issueQuery.isError ? (
           <View className="flex-1 items-center justify-center px-6">
             <Ionicons name="alert-circle-outline" size={40} color={colors.textSecondary} />
-            <Text className="text-sm mt-3" style={{ color: colors.textSecondary }}>{t('explore.loadError')}</Text>
+            <Text className="text-sm mt-3" style={{ color: colors.textSecondary }}>
+              {(issueQuery.error as Error & { status?: number })?.status === 403
+                ? t('explore.permissionError')
+                : t('explore.loadError')}
+            </Text>
           </View>
         ) : issueData.length === 0 ? (
           <EmptyState icon="alert-circle-outline" title={t('explore.noIssues')} />

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -408,15 +408,10 @@ class GitHubServiceClass {
     repo: string,
     state: GitHubItemState = 'open',
   ): Promise<GitHubIssue[]> {
-    try {
-      const data = await this.request(
-        `https://api.github.com/repos/${owner}/${repo}/issues?state=${state}&per_page=50`
-      );
-      return Array.isArray(data) ? data : [];
-    } catch (error) {
-      console.warn('[GitHubService] Failed to get issues:', error);
-      return [];
-    }
+    const data = await this.request(
+      `https://api.github.com/repos/${owner}/${repo}/issues?state=${state}&per_page=50`
+    );
+    return Array.isArray(data) ? data : [];
   }
 
   async getPullRequests(
@@ -424,15 +419,10 @@ class GitHubServiceClass {
     repo: string,
     state: GitHubItemState = 'open',
   ): Promise<GitHubPullRequest[]> {
-    try {
-      const data = await this.request(
-        `https://api.github.com/repos/${owner}/${repo}/pulls?state=${state}&per_page=50`
-      );
-      return Array.isArray(data) ? data : [];
-    } catch (error) {
-      console.warn('[GitHubService] Failed to get pull requests:', error);
-      return [];
-    }
+    const data = await this.request(
+      `https://api.github.com/repos/${owner}/${repo}/pulls?state=${state}&per_page=50`
+    );
+    return Array.isArray(data) ? data : [];
   }
 
   async createPullRequest(opts: {


### PR DESCRIPTION
## Summary
- Removes try/catch from `GitHubService.getIssues()` and `getPullRequests()` so 403 errors propagate to TanStack Query instead of silently returning `[]`
- Adds 403-specific error detection in `ExploreScreen` showing `'explore.permissionError'` instead of generic `'explore.loadError'`
- Adds `'explore.permissionError'` locale key to all 6 locale files

## Bug Fixed
When GitHub API returned 403 (permission denied) on the Explore tab, the error was caught and silently swallowed, showing an empty state instead of the actual error. Users had no way to know their token lacked permissions.

## Testing
- TypeScript check passes
- All 309 test suites pass (2826 tests)
- ESLint + Prettier pass via lint-staged

## Related Issues
- Issue #1016: Clone cancel button non-functional (separate)
- Issue #1017: Tab navigation unresponsive from Settings (separate)