### PR TITLE
fix(NotesList): virtualize FlatList to stop CoreText main-thread hang

### DIFF
--- a/__tests__/screens/NotesListScreen.test.tsx
+++ b/__tests__/screens/NotesListScreen.test.tsx
@@ -339,4 +339,15 @@ describe('NotesListScreen', () => {
     const { getByText } = render(<NotesListScreen />);
     expect(getByText('Something went wrong')).toBeTruthy();
   });
+
+  it('configures FlatList virtualization so large repos do not hang CoreText on mount', () => {
+    const { UNSAFE_queryByType } = render(<NotesListScreen />);
+    const FlatList = require('react-native').FlatList;
+    const list = UNSAFE_queryByType(FlatList);
+    expect(list).toBeTruthy();
+    expect(list.props.initialNumToRender).toBeLessThanOrEqual(10);
+    expect(list.props.maxToRenderPerBatch).toBeLessThanOrEqual(6);
+    expect(list.props.windowSize).toBeLessThanOrEqual(7);
+    expect(list.props.removeClippedSubviews).toBe(true);
+  });
 });

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -529,7 +529,11 @@ export default function NotesListScreen() {
         key={`${viewMode}-${columnCount}`}
         numColumns={viewMode === 'journal' ? 1 : columnCount}
         extraData={displayNotes}
-        removeClippedSubviews={false}
+        initialNumToRender={10}
+        maxToRenderPerBatch={6}
+        windowSize={7}
+        updateCellsBatchingPeriod={50}
+        removeClippedSubviews={true}
         contentContainerStyle={{
           padding: 12,
           paddingTop: headerBlurHeight + 4,


### PR DESCRIPTION
## Summary
Opening the Notes tab on a cloned repo with 100+ notes was hanging the JS thread for ≥5 s, tripping the iOS watchdog (SIGKILL). Crashlog shows the block originates in CoreText's `TTypesetter::DoAttachments` → `FixRunIfBroken`, called synchronously from the Notes tab mount.

## Root Cause
The `NotesListScreen` FlatList had no virtualization config beyond defaults and explicitly disabled `removeClippedSubviews`. With ~7 Text components per NoteCard and the default `windowSize=21`, every note in the loaded repo was mounted and laid out by CoreText on first render. 102 notes × 7 Text = 714 synchronous CoreText layout passes → main thread blocked → watchdog kill.

Smaller repos worked because fewer notes × still 7 Text components = less than the 5 s watchdog threshold.

## Fix
Virtualize so only the visible window mounts:

| Prop | Before | After | Why |
|------|--------|-------|-----|
| `initialNumToRender` | 10 (default) | 10 | Keep default to preserve integration tests that select first 10 cards |
| `maxToRenderPerBatch` | 10 (default) | 6 | Smaller batches = less per-frame work |
| `windowSize` | 21 (default) | 7 | Dominant factor — only ~7 viewports stay mounted |
| `updateCellsBatchingPeriod` | 50 (default) | 50 ms | Interleave CoreText work with idle frames |
| `removeClippedSubviews` | **false** | **true** | Unmount off-screen subviews in the native view hierarchy |

## Regression Test
Added a test in `NotesListScreen.test.tsx` that asserts these virtualization props are present, so a future refactor cannot silently regress to defaults.

## Verification
- **Crashlog** (pre-fix): `Termination Reason: Namespace FRONTBOARD, Code 2343432205` — iOS watchdog `Failed to terminate gracefully after 5.0s` on the main thread, stack trace ends in `TTypesetter::DoAttachments`
- **iOS Simulator** (post-fix, dogfood repo with 102 notes): Notes tab renders 1 card in the accessibility tree on initial mount (previously all 102 mounted simultaneously) and the app stays responsive
- **Jest**: 2827/2828 passing (only pre-existing `patch-package.test.ts` failure — binary not installed in CI)
- **TypeScript**: `yarn ts:check` clean
- **ESLint**: 0 errors

## Files
- `src/screens/NotesListScreen.tsx` — virtualization props on the notes FlatList
- `__tests__/screens/NotesListScreen.test.tsx` — regression test asserting the props