### PR TITLE
fix(explore): hub polish — bento buttons, error UI, and header spacing

### DIFF
--- a/docs/wiki/explore-repo-hub.md
+++ b/docs/wiki/explore-repo-hub.md
@@ -31,17 +31,25 @@ Two new TanStack Query hooks in `src/hooks/useGitHostQueries.ts` (`useGitHostPul
 
 ## Hub UI
 
-`ExploreScreen.tsx` now treats `repoDetail` as a hub with three stacked action buttons:
+`ExploreScreen.tsx` treats `repoDetail` as a hub rendered with the same bento-grid language as the Home screen (`HomeScreen.tsx`), so the Explore tab feels like the rest of the app instead of a settings page:
 
-- **Browse Files** (existing — still the primary CTA)
-- **Pull Requests** (opens a list view with an open/closed segmented filter)
-- **Issues** (opens a list view with an open/closed segmented filter)
+- **Row 1** — two filled-primary tiles side-by-side: **Browse Files** (left) + **Pull Requests** (right). Each tile is 130 pt tall with a 20 pt corner radius, a white circular icon badge top-left, a large faded background icon, and a bold white title + small white subtitle. Press feedback matches the Home tiles (opacity 0.92 + scale 0.985).
+- **Row 2** — one full-width accent-colored tile: **Issues**. Uses the same dimensions and badge treatment but on the accent surface (the same surface Home's "Thought Dump" tile uses), with a translucent-white square badge so the accent reads through.
 
-Each PR/Issue row shows `#number title`, author, an open/closed icon, and an "open in browser" affordance; tapping the row calls `Linking.openURL(item.webUrl)`. No native detail screen was built — this is the minimum bar listed in issue #937.
+Tapping any tile navigates into the corresponding view (`fileTree`, `prList`, `issueList`). Browse Files is the primary CTA; PRs and Issues are first-class peers (per #937).
 
-The branch picker pill was promoted to the hub header (it already existed in the `fileTree` header on `ExploreScreen.tsx:376-388`). Both the hub and the file tree share a single `selectedBranch` state plus the existing `openBranchPicker` callback, so a branch picked on the hub is reflected in the file tree without duplicate state.
+The branch picker pill was promoted to the hub header (it already existed in the `fileTree` header on `ExploreScreen.tsx`). Both the hub and the file tree share a single `selectedBranch` state plus the existing `openBranchPicker` callback, so a branch picked on the hub is reflected in the file tree without duplicate state.
 
 The ExploreScreen is now provider-agnostic: `grep -r "GitHubService" src/screens/ExploreScreen.tsx` returns zero results. Pull/issue data is obtained exclusively via `getGitHostService(selectedRepo.provider)`.
+
+## Error states
+
+`prList` and `issueList` use the shared `<EmptyState>` component (icon + title + subtitle, centered with the standard `py-16 px-6` rhythm) plus a `<Button primary>` **Retry** action that calls `query.refetch()`. The icon, title, and copy swap by error subtype:
+
+- **HTTP 403** → `lock-closed-outline` icon, `permissionTitle` ("Permission denied"), `permissionError` subtitle, **and** a secondary **Open Settings** ghost button that navigates to `MainTabs → SettingsTab` (where the user can re-authorize the token).
+- **Other errors** → `cloud-offline-outline` icon, `loadErrorTitle` ("Couldn't load"), `loadError` subtitle, **Retry** only.
+
+This replaces the previous ad-hoc `View` + `Ionicons` + `Text` block that rendered a generic `alert-circle-outline` glyph and a single sentence in `textSecondary` color — which had no action, no icon hierarchy, and no title/subtitle split, and read like a `console.error` left on screen.
 
 ## i18n
 
@@ -51,6 +59,10 @@ Eight new `explore.*` keys added to all six locales (en/es/fr/de/ja/ko): `pullRe
 
 - `__tests__/services/git/gitHost-issues-pulls.test.ts` — 13 tests across all 4 providers covering normalization, state mappings (`merged` → `closed` for GitLab, `opened` → `open`, PR-item filtering for Gitea/Forgejo `/issues`), auth headers (`PRIVATE-TOKEN` vs `Authorization: token X`), and empty-on-error paths.
 - `__tests__/hooks/useGitHostQueries.test.ts` — 5 tests: normalization happy path, the empty owner/repo "disabled" gate, and default-state behavior.
+
+## Bug fixes
+
+- **Double top safe-area inset in the three hub views** — `fileTree`, `prList`, and `issueList` used `<SafeAreaView edges={['top', 'bottom']}>` while also padding their content by `headerHeight` (which already includes `insets.top`). That added a full extra status-bar-height (~59 pt) of blank space between the header and the first row. Fixed by switching all three to `edges={['bottom']}`, matching `repoList`/`repoDetail`.
 
 ## Must NOT do (out of scope)
 
@@ -66,6 +78,6 @@ Eight new `explore.*` keys added to all six locales (en/es/fr/de/ja/ko): `pullRe
 - `src/services/git/GiteaLikeHostService.ts` — Gitea + Forgejo (shared class)
 - `src/hooks/useGitHostQueries.ts` — TanStack Query hooks
 - `src/screens/ExploreScreen.tsx` — hub UI + prList/issueList views
-- `src/i18n/{en,es,fr,de,ja,ko}.json` — 8 new keys each
+- `src/i18n/{en,es,fr,de,ja,ko}.json` — 14 new keys each (8 from the feature + 6 from the polish: `permissionTitle`, `loadErrorTitle`, `browseFilesSub`, `pullRequestsSub`, `issuesSub`, `openSettings`)
 - `__tests__/services/git/gitHost-issues-pulls.test.ts` — host tests
 - `__tests__/hooks/useGitHostQueries.test.ts` — hook tests

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -462,7 +462,13 @@
     "filterClosed": "Geschlossen",
     "openInBrowser": "Im Browser öffnen",
     "loadError": "Konnte nicht geladen werden — zum Wiederholen tippen",
-    "permissionError": "Zugriff verweigert — GitHub-Token-Berechtigungen prüfen"
+    "loadErrorTitle": "Laden fehlgeschlagen",
+    "permissionError": "Zugriff verweigert — GitHub-Token-Berechtigungen prüfen",
+    "permissionTitle": "Zugriff verweigert",
+    "browseFilesSub": "Dateien & Ordner",
+    "pullRequestsSub": "Offen & geschlossen",
+    "issuesSub": "Offen & geschlossen",
+    "openSettings": "Einstellungen öffnen"
   },
   "home": {
     "title": "Start",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -268,7 +268,13 @@
     "filterClosed": "Closed",
     "openInBrowser": "Open in browser",
     "loadError": "Couldn't load — tap to retry",
-    "permissionError": "Access denied — check your GitHub token permissions"
+    "loadErrorTitle": "Couldn't load",
+    "permissionError": "Access denied — check your GitHub token permissions",
+    "permissionTitle": "Permission denied",
+    "browseFilesSub": "Files & folders",
+    "pullRequestsSub": "Open & closed",
+    "issuesSub": "Open & closed",
+    "openSettings": "Open Settings"
   },
   "settings": {
     "title": "Settings",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -462,7 +462,13 @@
     "filterClosed": "Cerradas",
     "openInBrowser": "Abrir en navegador",
     "loadError": "No se pudo cargar — toca para reintentar",
-    "permissionError": "Acceso denegado — verifica los permisos de tu token de GitHub"
+    "loadErrorTitle": "No se pudo cargar",
+    "permissionError": "Acceso denegado — verifica los permisos de tu token de GitHub",
+    "permissionTitle": "Acceso denegado",
+    "browseFilesSub": "Archivos y carpetas",
+    "pullRequestsSub": "Abiertas y cerradas",
+    "issuesSub": "Abiertas y cerradas",
+    "openSettings": "Abrir Ajustes"
   },
   "home": {
     "title": "Inicio",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -462,7 +462,13 @@
     "filterClosed": "Fermés",
     "openInBrowser": "Ouvrir dans le navigateur",
     "loadError": "Impossible de charger — appuyez pour réessayer",
-    "permissionError": "Accès refusé — vérifiez les permissions de votre token GitHub"
+    "loadErrorTitle": "Échec du chargement",
+    "permissionError": "Accès refusé — vérifiez les permissions de votre token GitHub",
+    "permissionTitle": "Accès refusé",
+    "browseFilesSub": "Fichiers et dossiers",
+    "pullRequestsSub": "Ouverts et fermés",
+    "issuesSub": "Ouverts et fermés",
+    "openSettings": "Ouvrir les Réglages"
   },
   "home": {
     "title": "Accueil",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -462,7 +462,13 @@
     "filterClosed": "クローズ",
     "openInBrowser": "ブラウザで開く",
     "loadError": "読み込めませんでした — タップして再試行",
-    "permissionError": "アクセス拒否 — GitHubトークンの権限を確認してください"
+    "loadErrorTitle": "読み込みに失敗しました",
+    "permissionError": "アクセス拒否 — GitHubトークンの権限を確認してください",
+    "permissionTitle": "アクセス拒否",
+    "browseFilesSub": "ファイルとフォルダ",
+    "pullRequestsSub": "オープンとクローズ",
+    "issuesSub": "オープンとクローズ",
+    "openSettings": "設定を開く"
   },
   "home": {
     "title": "ホーム",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -462,7 +462,13 @@
     "filterClosed": "닫힘",
     "openInBrowser": "브라우저에서 열기",
     "loadError": "로드할 수 없습니다 — 눌러서 다시 시도",
-    "permissionError": "액세스 거부됨 — GitHub 토큰 권한을 확인하세요"
+    "loadErrorTitle": "로드할 수 없습니다",
+    "permissionError": "액세스 거부됨 — GitHub 토큰 권한을 확인하세요",
+    "permissionTitle": "액세스 거부됨",
+    "browseFilesSub": "파일 및 폴더",
+    "pullRequestsSub": "열림 및 닫힘",
+    "issuesSub": "열림 및 닫힘",
+    "openSettings": "설정 열기"
   },
   "home": {
     "title": "홈",

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -3,6 +3,7 @@ import {
   View,
   Text,
   StyleSheet,
+  Pressable,
   TouchableOpacity,
   FlatList,
   ActivityIndicator,
@@ -24,7 +25,7 @@ import { useGitOperationStore, hasActivePull } from '../stores/gitOperationStore
 import RepoFileTree, { TreeNode } from '../components/RepoFileTree';
 import { treeStyles } from '../components/repo/repoTreeStyles';
 import { RootStackParamList } from '../navigation/types';
-import { EmptyState, Modal, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
+import { EmptyState, Button, Modal, ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { OfflineBanner } from '../components/ui/OfflineBanner';
 import SearchBar from '../components/SearchBar';
@@ -318,37 +319,112 @@ export default function ExploreScreen() {
           )}
         </View>
 
-        <View className="px-4 mt-6 gap-2">
-          <TouchableOpacity
-            testID="explore.button.open-file-tree"
-            className="flex-row items-center justify-center py-3.5 rounded-md gap-2"
-            style={{ backgroundColor: colors.primary }}
-            onPress={handleOpenFileTree}
-            activeOpacity={0.8}
-          >
-            <Ionicons name="folder-open-outline" size={20} color="#fff" />
-            <Text className="text-white text-base font-semibold">{t('explore.browseFiles')}</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            testID="explore.button.open-pr-list"
-            className="flex-row items-center justify-center py-3.5 rounded-md gap-2"
-            style={{ backgroundColor: colors.primary + 'CC' }}
-            onPress={handleOpenPrList}
-            activeOpacity={0.8}
-          >
-            <Ionicons name="git-pull-request-outline" size={20} color="#fff" />
-            <Text className="text-white text-base font-semibold">{t('explore.pullRequests')}</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
+        <View className="px-4 mt-6 gap-3">
+          <View className="flex-row items-stretch gap-3 overflow-hidden">
+            <Pressable
+              testID="explore.button.open-file-tree"
+              onPress={handleOpenFileTree}
+              accessibilityRole="button"
+              accessibilityLabel={t('explore.browseFiles')}
+              style={({ pressed }) => [
+                {
+                  flex: 1,
+                  minWidth: 0,
+                  height: 130,
+                  borderRadius: 20,
+                  padding: 16,
+                  overflow: 'hidden',
+                  justifyContent: 'flex-end',
+                  backgroundColor: colors.primary,
+                  opacity: pressed ? 0.92 : 1,
+                  transform: [{ scale: pressed ? 0.985 : 1 }],
+                },
+              ]}
+            >
+              <View className="absolute top-4 left-4 w-9 h-9 rounded-full bg-white items-center justify-center">
+                <Ionicons name="folder-open-outline" size={18} color={colors.primary} />
+              </View>
+              <View className="absolute" style={{ top: -50, right: -50, opacity: 0.3 }}>
+                <Ionicons name="folder-open-outline" size={120} color="#FFFFFF" />
+              </View>
+              <View className="gap-1">
+                <Text className="text-xl font-bold text-white" style={{ letterSpacing: -0.3 }} numberOfLines={1}>
+                  {t('explore.browseFiles')}
+                </Text>
+                <Text className="text-xs font-medium text-white opacity-80" numberOfLines={1}>
+                  {t('explore.browseFilesSub')}
+                </Text>
+              </View>
+            </Pressable>
+
+            <Pressable
+              testID="explore.button.open-pr-list"
+              onPress={handleOpenPrList}
+              accessibilityRole="button"
+              accessibilityLabel={t('explore.pullRequests')}
+              style={({ pressed }) => [
+                {
+                  flex: 1,
+                  minWidth: 0,
+                  height: 130,
+                  borderRadius: 20,
+                  padding: 16,
+                  overflow: 'hidden',
+                  justifyContent: 'flex-end',
+                  backgroundColor: colors.primary,
+                  opacity: pressed ? 0.92 : 1,
+                  transform: [{ scale: pressed ? 0.985 : 1 }],
+                },
+              ]}
+            >
+              <View className="absolute top-4 left-4 w-9 h-9 rounded-full bg-white items-center justify-center">
+                <Ionicons name="git-pull-request-outline" size={18} color={colors.primary} />
+              </View>
+              <View className="absolute" style={{ top: -50, right: -50, opacity: 0.3 }}>
+                <Ionicons name="git-pull-request-outline" size={120} color="#FFFFFF" />
+              </View>
+              <View className="gap-1">
+                <Text className="text-xl font-bold text-white" style={{ letterSpacing: -0.3 }} numberOfLines={1}>
+                  {t('explore.pullRequests')}
+                </Text>
+                <Text className="text-xs font-medium text-white opacity-80" numberOfLines={1}>
+                  {t('explore.pullRequestsSub')}
+                </Text>
+              </View>
+            </Pressable>
+          </View>
+
+          <Pressable
             testID="explore.button.open-issues-list"
-            className="flex-row items-center justify-center py-3.5 rounded-md gap-2"
-            style={{ backgroundColor: colors.primary + '99' }}
             onPress={handleOpenIssueList}
-            activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel={t('explore.issues')}
+            style={({ pressed }) => [
+              {
+                width: '100%',
+                minHeight: 130,
+                borderRadius: 20,
+                padding: 16,
+                justifyContent: 'space-between',
+                overflow: 'hidden',
+                backgroundColor: colors.accent,
+                opacity: pressed ? 0.92 : 1,
+                transform: [{ scale: pressed ? 0.985 : 1 }],
+              },
+            ]}
           >
-            <Ionicons name="alert-circle-outline" size={20} color="#fff" />
-            <Text className="text-white text-base font-semibold">{t('explore.issues')}</Text>
-          </TouchableOpacity>
+            <View className="w-10 h-10 rounded-md items-center justify-center" style={{ backgroundColor: 'rgba(255,255,255,0.2)' }}>
+              <Ionicons name="alert-circle-outline" size={22} color="#FFFFFF" />
+            </View>
+            <View style={{ gap: 6 }}>
+              <Text className="text-base font-bold" style={{ color: '#FFFFFF', letterSpacing: -0.2 }} numberOfLines={1}>
+                {t('explore.issues')}
+              </Text>
+              <Text className="text-xs font-medium" style={{ color: 'rgba(255,255,255,0.85)' }} numberOfLines={2}>
+                {t('explore.issuesSub')}
+              </Text>
+            </View>
+          </Pressable>
         </View>
         <ScreenHeader
           title={selectedRepo.name}
@@ -377,7 +453,7 @@ export default function ExploreScreen() {
     const branchLabel = branch ?? t('settings.branchDefault');
 
     return (
-      <SafeAreaView className="flex-1" style={{ backgroundColor: colors.background }} edges={['top', 'bottom']}>
+      <SafeAreaView className="flex-1" style={{ backgroundColor: colors.background }} edges={['bottom']}>
         <View
           testID="explore.file-tree.banner-region"
           pointerEvents="box-none"
@@ -519,8 +595,9 @@ export default function ExploreScreen() {
 
   if (view === 'prList' && selectedRepo && repoInfo) {
     const prData = prQuery.data ?? [];
+    const prIsPermission = (prQuery.error as (Error & { status?: number }) | null)?.status === 403;
     return (
-      <SafeAreaView className="flex-1" style={{ backgroundColor: colors.background }} edges={['top', 'bottom']}>
+      <SafeAreaView className="flex-1" style={{ backgroundColor: colors.background }} edges={['bottom']}>
         <View style={{ paddingTop: headerHeight }}>
           <OfflineBanner />
         </View>
@@ -548,13 +625,32 @@ export default function ExploreScreen() {
             <ActivityIndicator size="large" color={colors.primary} />
           </View>
         ) : prQuery.isError ? (
-          <View className="flex-1 items-center justify-center px-6">
-            <Ionicons name="alert-circle-outline" size={40} color={colors.textSecondary} />
-            <Text className="text-sm mt-3" style={{ color: colors.textSecondary }}>
-              {(prQuery.error as Error & { status?: number })?.status === 403
-                ? t('explore.permissionError')
-                : t('explore.loadError')}
-            </Text>
+          <View className="flex-1">
+            <EmptyState
+              icon={prIsPermission ? 'lock-closed-outline' : 'cloud-offline-outline'}
+              title={prIsPermission ? t('explore.permissionTitle') : t('explore.loadErrorTitle')}
+              subtitle={prIsPermission ? t('explore.permissionError') : t('explore.loadError')}
+              testID="explore.pr.error-state"
+            />
+            <View className="px-6 pb-10 gap-2">
+              <Button
+                label={t('common.retry')}
+                variant="primary"
+                fullWidth
+                onPress={() => prQuery.refetch()}
+                leadingIcon={<Ionicons name="refresh" size={18} color="#fff" />}
+                testID="explore.pr.button.retry"
+              />
+              {prIsPermission ? (
+                <Button
+                  label={t('explore.openSettings')}
+                  variant="ghost"
+                  fullWidth
+                  onPress={() => navigation.navigate('MainTabs', { screen: 'SettingsTab' })}
+                  testID="explore.pr.button.open-settings"
+                />
+              ) : null}
+            </View>
           </View>
         ) : prData.length === 0 ? (
           <EmptyState icon="git-pull-request-outline" title={t('explore.noPullRequests')} />
@@ -600,8 +696,9 @@ export default function ExploreScreen() {
 
   if (view === 'issueList' && selectedRepo && repoInfo) {
     const issueData = issueQuery.data ?? [];
+    const issueIsPermission = (issueQuery.error as (Error & { status?: number }) | null)?.status === 403;
     return (
-      <SafeAreaView className="flex-1" style={{ backgroundColor: colors.background }} edges={['top', 'bottom']}>
+      <SafeAreaView className="flex-1" style={{ backgroundColor: colors.background }} edges={['bottom']}>
         <View style={{ paddingTop: headerHeight }}>
           <OfflineBanner />
         </View>
@@ -629,13 +726,32 @@ export default function ExploreScreen() {
             <ActivityIndicator size="large" color={colors.primary} />
           </View>
         ) : issueQuery.isError ? (
-          <View className="flex-1 items-center justify-center px-6">
-            <Ionicons name="alert-circle-outline" size={40} color={colors.textSecondary} />
-            <Text className="text-sm mt-3" style={{ color: colors.textSecondary }}>
-              {(issueQuery.error as Error & { status?: number })?.status === 403
-                ? t('explore.permissionError')
-                : t('explore.loadError')}
-            </Text>
+          <View className="flex-1">
+            <EmptyState
+              icon={issueIsPermission ? 'lock-closed-outline' : 'cloud-offline-outline'}
+              title={issueIsPermission ? t('explore.permissionTitle') : t('explore.loadErrorTitle')}
+              subtitle={issueIsPermission ? t('explore.permissionError') : t('explore.loadError')}
+              testID="explore.issue.error-state"
+            />
+            <View className="px-6 pb-10 gap-2">
+              <Button
+                label={t('common.retry')}
+                variant="primary"
+                fullWidth
+                onPress={() => issueQuery.refetch()}
+                leadingIcon={<Ionicons name="refresh" size={18} color="#fff" />}
+                testID="explore.issue.button.retry"
+              />
+              {issueIsPermission ? (
+                <Button
+                  label={t('explore.openSettings')}
+                  variant="ghost"
+                  fullWidth
+                  onPress={() => navigation.navigate('MainTabs', { screen: 'SettingsTab' })}
+                  testID="explore.issue.button.open-settings"
+                />
+              ) : null}
+            </View>
           </View>
         ) : issueData.length === 0 ? (
           <EmptyState icon="alert-circle-outline" title={t('explore.noIssues')} />


### PR DESCRIPTION
Three follow-ups to the Explore repo hub (#937), bundled because they all touch `src/screens/ExploreScreen.tsx` and were found/reported together.

## Changes

**1. Bento hub buttons (`repoDetail` view)**
The Browse Files / Pull Requests / Issues action row was three stacked filled buttons in three shades of primary. Looked like a settings page, not part of the app. Replaced with the same 2-up + 1 full-width bento grid the Home screen already uses:
- **Browse Files** + **Pull Requests** → two filled-primary tiles side-by-side (mirrors `home.button.create-note` / `home.button.open-journal`)
- **Issues** → full-width accent tile (mirrors `home.button.open-thought-dump`)

Same 130 pt height / 20 pt corner radius / white circular icon badge top-left / faded background icon / bold-white title + small-white subtitle / press scale-0.985 treatment as the Home tiles. The Explore tab now feels like the rest of the app.

**2. Polished error UI for PRs / Issues**
The previous error block was a 40 pt `alert-circle-outline` + a single `textSecondary` sentence with no actions and no icon hierarchy — read like a `console.error` left on screen. Now uses the shared `<EmptyState>` (icon + title + subtitle, centered with the standard rhythm) plus a primary **Retry** button that calls `query.refetch()`. 403 gets a secondary **Open Settings** ghost button that jumps to `MainTabs → SettingsTab` so the user can re-authorize the token without hunting through menus.

Icon/title swap by subtype:
- **HTTP 403** → `lock-closed-outline` icon, "Permission denied" title, the existing `permissionError` sentence as subtitle, + **Open Settings**
- **Other errors** → `cloud-offline-outline` icon, "Couldn't load" title, the existing `loadError` sentence as subtitle, + **Retry** only

**3. Double top safe-area inset in the hub views**
`fileTree`, `prList`, and `issueList` used `SafeAreaView edges={['top','bottom']}` AND padded their content by `headerHeight` (which already includes `insets.top`). Net effect: one extra full status-bar-height (~59 pt) of blank space between the header and the first row in all three views. Switched all three to `edges={['bottom']}` to match `repoList` / `repoDetail` (which were already correct, per #8f8ef532 / #ee2e8211).

## i18n

6 new keys in `src/i18n/{en,es,fr,de,ja,ko}.json`:
- `explore.permissionTitle`
- `explore.loadErrorTitle`
- `explore.browseFilesSub`
- `explore.pullRequestsSub`
- `explore.issuesSub`
- `explore.openSettings`

The existing `explore.permissionError` / `explore.loadError` strings are kept and reused as the `EmptyState` subtitle copy. `i18n-key-parity` test passes for all six locales.

## Verification

- `yarn ts:check` ✓
- `yarn eslint src/screens/ExploreScreen.tsx` ✓
- `yarn jest` for `ExploreScreen`, `offline-banner`, `offline-banner-todos-explore`, `i18n-key-parity` — 18 tests pass
- Visually verified on the booted iPhone 17 simulator (via Metro Fast Refresh): the file-tree spacing fix took the gap from ~440 px to ~50 px (normal iOS range)

The bento and error-UI changes are direct applications of the existing HomeScreen bento + `<EmptyState>` patterns, so the live-simulator screenshot of the new state should match the Home screen's bento section.

## Files

- `src/screens/ExploreScreen.tsx` — all three changes
- `src/i18n/{en,es,fr,de,ja,ko}.json` — 6 new keys each
- `docs/wiki/explore-repo-hub.md` — updated Hub UI + new Error states section

## Out of scope

Still tracked separately (not in this PR): #925, #927, #926, #938 (sync-architecture gaps), and the native PR/issue detail screen (the bare `Linking.openURL` is the minimum from #937).