### PR TITLE
fix(chat): guard header back on deep-linked roots, center New Chat label, drop explore hub branch chip

### DIFF
--- a/__tests__/hooks/useSafeBack.test.tsx
+++ b/__tests__/hooks/useSafeBack.test.tsx
@@ -1,0 +1,41 @@
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+const mockCanGoBack = jest.fn(() => true);
+const mockNavigation = {
+  navigate: mockNavigate,
+  goBack: mockGoBack,
+  canGoBack: mockCanGoBack,
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => mockNavigation,
+}));
+
+import { act, renderHook } from '@testing-library/react-native';
+import { useSafeBack } from '../../src/hooks/useSafeBack';
+
+describe('useSafeBack', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCanGoBack.mockReturnValue(true);
+  });
+
+  it('pops via goBack when there is a previous screen', () => {
+    const { result } = renderHook(() => useSafeBack());
+
+    act(() => result.current());
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to MainTabs when the screen is the stack root (deep link)', () => {
+    mockCanGoBack.mockReturnValue(false);
+    const { result } = renderHook(() => useSafeBack());
+
+    act(() => result.current());
+
+    expect(mockNavigate).toHaveBeenCalledWith('MainTabs');
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/ui/Button.test.tsx
+++ b/__tests__/ui/Button.test.tsx
@@ -77,6 +77,17 @@ describe('Button', () => {
     expect(UNSAFE_getByType(require('../../src/components/ui/Button').Button)).toBeTruthy();
   });
 
+  it('keeps the label optically centered when a leading icon is present with iconAlign="edge"', () => {
+    const { UNSAFE_getByType } = render(
+      <TestThemeProvider>
+        <Button label="New Chat" variant="primary" fullWidth leadingIcon="+" iconAlign="edge" />
+      </TestThemeProvider>,
+    );
+    // Same equal-side-spacer trick as the trailing-icon case: with the leading
+    // icon pinned to the left edge, the equal spacers keep the label centered.
+    expect(UNSAFE_getByType(require('../../src/components/ui/Button').Button)).toBeTruthy();
+  });
+
   it('secondary variant keeps theme text color on the surface background', () => {
     const { getByText, UNSAFE_getByType } = render(
       <TestThemeProvider>

--- a/docs/wiki/explore-repo-hub.md
+++ b/docs/wiki/explore-repo-hub.md
@@ -81,3 +81,12 @@ Eight new `explore.*` keys added to all six locales (en/es/fr/de/ja/ko): `pullRe
 - `src/i18n/{en,es,fr,de,ja,ko}.json` — 14 new keys each (8 from the feature + 6 from the polish: `permissionTitle`, `loadErrorTitle`, `browseFilesSub`, `pullRequestsSub`, `issuesSub`, `openSettings`)
 - `__tests__/services/git/gitHost-issues-pulls.test.ts` — host tests
 - `__tests__/hooks/useGitHostQueries.test.ts` — hook tests
+
+## Hub header — branch chip removed
+
+The repo-hub page's top-right branch chip (`explore.hub.branch-picker`, an
+`actions` slot on the hub `ScreenHeader`) was removed — the hub header now
+shows only the repo name + back button. Branch selection remains available
+from the file-tree view (`explore.button.branch-picker`), so no branch-picker
+functionality was lost; only the redundant header chip is gone.
+

--- a/docs/wiki/goback-deep-link-root-fix.md
+++ b/docs/wiki/goback-deep-link-root-fix.md
@@ -1,0 +1,41 @@
+# GO_BACK Unhandled — Deep-Linked Root Screens
+
+`The action 'GO_BACK' was not handled by any navigator.` fired (dev-only) when
+the user tapped a header back button on a screen that was the **root of the
+root stack** — most visibly the Chat thread list opened via the
+`gitnotes://chat` deep link (reproduced on simulator: cold-open the deep link,
+tap the header Back arrow → error banner).
+
+## Root cause
+
+Every deep-linkable screen passed an unconditional `onBack={() =>
+navigation.goBack()}` to `ScreenHeader`. `ScreenHeader` renders the back arrow
+whenever `onBack` is provided, so the arrow appeared even when the stack had
+no previous screen. React Navigation then rejected the `GO_BACK` action with
+the dev-only error. Affected screens (all in the `gitnotes://` linking config):
+
+- `ChatThreadList` (`gitnotes://chat`) — the reported case
+- `ChatScreen` (`gitnotes://chat/:threadId`)
+- `ThoughtDump` (`gitnotes://thought-dump`)
+- `Stage` (`gitnotes://stage`)
+- `Conflicts` (aliases `SyncStatusScreen`, `gitnotes://conflicts`)
+- `NoteEditor` preview mode (`gitnotes://note/:noteId`)
+- `CanvasEditor` (`gitnotes://canvas/:canvasId`)
+
+## Fix
+
+New hook `src/hooks/useSafeBack.ts`: returns a header-back handler that pops
+via `navigation.goBack()` when `canGoBack()`, otherwise falls back to
+`navigation.navigate('MainTabs')` (the same fallback `useProScreenGuard` uses
+for cold-deep-link cancel). The hook only calls `canGoBack()` at press time,
+so render-time mocks that omit it keep working.
+
+All seven deep-linkable screens now use `useSafeBack()` for their header back
+button. Non-deep-linkable screens (viewers, ConflictResolver, render-style,
+template manager, AddReminder) are always pushed and keep their plain
+`goBack()`; AddReminderScreen already guarded with `canGoBack`.
+
+## Tests
+
+- `__tests__/hooks/useSafeBack.test.tsx`: pops via `goBack` when a previous
+  screen exists; navigates to `MainTabs` when the screen is the stack root.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -60,6 +60,8 @@
 | [Todo Pull Parse Errors — Silent Data Loss Fix](./todo-pull-parse-fix.md) | `pullTodosFromRepo` no longer silently swallows todo JSON parse errors: `{`-content guard skips non-JSON files silently, genuine failures log `error` with the file path, and a skipped-count summary surfaces the loss (#1008) |
 | [ForegroundSync Watchdog — Sync Health Surfacing](./foreground-sync-health.md) | `ForegroundSyncService` now tracks `syncHealth` (`idle/syncing/ok/failed/timedout` + failure count), exposed via `getForegroundSyncHealth()` / `useForegroundSyncHealth()` and a Settings → Sync status row — a stalled pull is no longer invisible (#1007) |
 | [gitHttp Packfile Buffering — Remove Redundant Copy](./git-http-packfile-buffering.md) | `gitHttp` yields raw response chunks instead of merging them into one `Uint8Array`, halving peak packfile memory on large clones; true disk streaming blocked by isomorphic-git's internal `collect()` (follow-up) (#982) |
+| [New Chat Button — Label Centering](./new-chat-button-centering.md) | `Button` edge mode now handles leading icons (pinned `absolute left-5` + equal side spacers), so the full-width New Chat button's label sits at the button's true center instead of ~half-an-icon right |
+| [GO_BACK Unhandled — Deep-Linked Root Screens](./goback-deep-link-root-fix.md) | `The action 'GO_BACK' was not handled by any navigator` when tapping the header back button on a deep-link root screen (`gitnotes://chat` et al.); `useSafeBack()` hook pops when possible, falls back to MainTabs |
 
 ## Quick Start
 

--- a/docs/wiki/new-chat-button-centering.md
+++ b/docs/wiki/new-chat-button-centering.md
@@ -1,0 +1,30 @@
+# New Chat Button — Label Centering Fix
+
+The Chat list's **New Chat** button rendered its label off-center: with the
+leading `+` icon, the icon+label pair was centered as a unit, so "New Chat"
+sat ~half-an-icon **right** of the button's true center.
+
+Root cause: `Button`'s optical-centering logic only handled the trailing-icon
+case. `iconAlign="edge"` pins the trailing icon to the right edge and wraps the
+label in a flex-row with **equal-width spacers** on both sides, keeping the
+text dead-center (the onboarding "Next" bug). The same shift applies to a
+leading icon, but `Button` never treated `leadingIcon` as an edge case —
+`useEdgeIcon` was gated on `hasTrailingIcon` alone.
+
+Fix:
+
+- `src/components/ui/Button.tsx`: edge mode now triggers on a leading **or**
+  trailing icon. A leading icon is pinned `absolute left-5` (mirroring the
+  trailing `right-5`), and the centered label row reserves the same 20px
+  spacer on both sides, so the label stays at the button's true center.
+- `src/screens/ChatThreadListScreen.tsx`: the New Chat button opts into the
+  edge alignment with `iconAlign="edge"` (it is full-width, so the pinned icon
+  has room).
+
+Behavior is unchanged for `iconAlign="inline"` (default): narrow buttons keep
+the icon inline next to the label.
+
+## Tests
+
+- `__tests__/ui/Button.test.tsx`: leading-icon + `iconAlign="edge"` renders
+  through the centeredContent spacer path (mirrors the trailing-icon test).

--- a/src/components/canvas/CanvasEditorContent.tsx
+++ b/src/components/canvas/CanvasEditorContent.tsx
@@ -59,6 +59,7 @@ import type { RootStackParamList } from '../../navigation/types';
 import { DraftLayerRenderer } from './DraftLayerRenderer';
 import { AcceptDiscardBar } from './AcceptDiscardBar';
 import { useLongPressForVision } from '../../hooks/useLongPressForVision';
+import { useSafeBack } from '../../hooks/useSafeBack';
 import type { DraftCommand } from '../../stores/draftStore';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'CanvasEditor'>;
@@ -383,6 +384,7 @@ function convertDraftToElement(cmd: DraftCommand): CanvasElement | null {
 
 export default function CanvasEditorContent() {
   const navigation = useNavigation<NavigationProp>();
+  const safeBack = useSafeBack();
   const route = useRoute<RouteType>();
   const { canvasId, canvasWidth, canvasTitle } = route.params;
 
@@ -1506,7 +1508,7 @@ export default function CanvasEditorContent() {
       <View style={styles.header}>
         <TouchableOpacity
           testID="canvas-editor.button.back"
-          onPress={() => navigation.goBack()}
+          onPress={safeBack}
           style={styles.backBtn}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
           accessibilityRole="button"

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -96,25 +96,33 @@ export function Button(props: ButtonProps) {
     </View>
   );
 
-  // A trailing icon optically shifts the centered label: the icon adds width
-  // to one side, so the text sits left of the button's true center. Pin the
-  // trailing icon to the right edge (absolute) and reserve the same space on
-  // the left so the label stays dead-center (onboarding "Next" bug).
+  // An edge icon (leading or trailing) optically shifts the centered label:
+  // the icon adds width to one side, so the text sits off the button's true
+  // center. Pin the icon(s) to the edge (absolute) and reserve the same space
+  // on both sides so the label stays dead-center. This fixes the trailing
+  // onboarding "Next" bug and the leading-icon "New Chat" button, which
+  // rendered its label ~half-an-icon right of center with inline alignment.
   //
   // iconAlign="edge" keeps that behavior for wide/fullWidth buttons where the
   // pinned icon has room. iconAlign="inline" (default) renders the icon next
   // to the label in the flex row instead — needed for narrow buttons (e.g. the
   // header "Save" button) where the absolutely-pinned icon overlaps the text.
+  const hasLeadingIcon = leadingIcon != null;
   const hasTrailingIcon = trailingIcon != null;
-  const useEdgeIcon = hasTrailingIcon && iconAlign === 'edge';
+  const useEdgeIcon = (hasLeadingIcon || hasTrailingIcon) && iconAlign === 'edge';
   const centeredContent = (
     <View className="flex-row items-center justify-center">
-      <View style={{ width: hasTrailingIcon ? 20 : 0 }} />
+      <View style={{ width: hasLeadingIcon || hasTrailingIcon ? 20 : 0 }} />
       {labelNode}
       {childrenNode}
-      <View style={{ width: hasTrailingIcon ? 20 : 0 }} />
+      <View style={{ width: hasLeadingIcon || hasTrailingIcon ? 20 : 0 }} />
     </View>
   );
+  const edgeLeadingIcon = hasLeadingIcon ? (
+    <View className="absolute left-5">
+      {leadingIcon}
+    </View>
+  ) : null;
   const edgeIcon = hasTrailingIcon ? (
     <View className="absolute right-5">
       {trailingIcon}
@@ -144,6 +152,7 @@ export function Button(props: ButtonProps) {
         {useEdgeIcon ? (
           <>
             {centeredContent}
+            {edgeLeadingIcon}
             {edgeIcon}
           </>
         ) : content}
@@ -182,6 +191,7 @@ export function Button(props: ButtonProps) {
             {useEdgeIcon ? (
               <>
                 {centeredContent}
+                {edgeLeadingIcon}
                 {edgeIcon}
               </>
             ) : content}

--- a/src/hooks/useSafeBack.ts
+++ b/src/hooks/useSafeBack.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../navigation/types';
+
+/**
+ * Header-back handler that never dispatches an unhandled GO_BACK action.
+ *
+ * Screens reachable as the ROOT of the root stack (deep links such as
+ * `gitnotes://chat`, `gitnotes://note/:noteId`, `gitnotes://stage`) have no
+ * previous screen; an unguarded `navigation.goBack()` there throws
+ * "The action 'GO_BACK' was not handled by any navigator." When there is a
+ * previous screen it pops normally; otherwise it falls back to MainTabs (the
+ * same fallback `useProScreenGuard` uses for cold-deep-link cancel).
+ */
+export function useSafeBack(): () => void {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  return useCallback(() => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    } else {
+      navigation.navigate('MainTabs');
+    }
+  }, [navigation]);
+}

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -20,6 +20,7 @@ import { useChatScreenController } from '../components/chat/useChatScreenControl
 import { useAIStore } from '../stores/aiStore';
 import { useTranslation } from 'react-i18next';
 import { useProScreenGuard } from '../hooks/useProScreenGuard';
+import { useSafeBack } from '../hooks/useSafeBack';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'ChatScreen'>;
 type ChatScreenRouteProp = RouteProp<RootStackParamList, 'ChatScreen'>;
@@ -27,6 +28,7 @@ type ChatScreenRouteProp = RouteProp<RootStackParamList, 'ChatScreen'>;
 export default function ChatScreen() {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
+  const safeBack = useSafeBack();
   const route = useRoute<ChatScreenRouteProp>();
   const { colors, spacing, type } = useTokens();
   const headerHeight = useScreenHeaderHeight({ subtitle: true });
@@ -227,7 +229,7 @@ export default function ChatScreen() {
       <ScreenHeader
         title={thread?.title ?? t('chat.title')}
         subtitle={thread ? t('chat.messageCount', { count: messages.length }) : t('chat.loadingConversation')}
-        onBack={() => navigation.goBack()}
+        onBack={safeBack}
       />
     </SafeAreaView>
   );

--- a/src/screens/ChatThreadListScreen.tsx
+++ b/src/screens/ChatThreadListScreen.tsx
@@ -325,6 +325,7 @@ export default function ChatThreadListScreen() {
             onPress={handleNewChat}
             variant="primary"
             leadingIcon={<Ionicons name="add" size={20} color={colors.accent} />}
+            iconAlign="edge"
             fullWidth
           />
         </View>

--- a/src/screens/ChatThreadListScreen.tsx
+++ b/src/screens/ChatThreadListScreen.tsx
@@ -21,12 +21,14 @@ import { ChatThreadContextMenu } from '../components/chat/ChatThreadContextMenu'
 import { HapticService } from '../utils/haptics';
 import { useTranslation } from 'react-i18next';
 import { useProScreenGuard } from '../hooks/useProScreenGuard';
+import { useSafeBack } from '../hooks/useSafeBack';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 export default function ChatThreadListScreen() {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
+  const safeBack = useSafeBack();
   const { colors, spacing } = useTokens();
   const headerHeight = useScreenHeaderHeight();
   const tabBarHeight = useTabBarHeight();
@@ -369,7 +371,7 @@ export default function ChatThreadListScreen() {
 
       <ScreenHeader
         title={t('chat.title')}
-        onBack={() => navigation.goBack()}
+        onBack={safeBack}
       />
     </SafeAreaView>
   );

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -429,20 +429,6 @@ export default function ExploreScreen() {
         <ScreenHeader
           title={selectedRepo.name}
           onBack={handleBack}
-          actions={
-            <TouchableOpacity
-              testID="explore.hub.branch-picker"
-              className="flex-row items-center gap-1.5 rounded-full px-3 py-1.5"
-              style={{ backgroundColor: colors.primary + '15' }}
-              onPress={openBranchPicker}
-              activeOpacity={0.7}
-            >
-              <Ionicons name="git-branch-outline" size={14} color={colors.primary} />
-              <Text className="text-xs font-semibold" style={{ color: colors.primary }} numberOfLines={1}>
-                {selectedBranch ?? selectedRepo.branch ?? t('settings.branchDefault')}
-              </Text>
-            </TouchableOpacity>
-          }
         />
       </SafeAreaView>
     );

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -27,6 +27,7 @@ import { useNoteEditorDocument } from '../components/editor/useNoteEditorDocumen
 import { useNoteEditorPreview } from '../components/editor/useNoteEditorPreview';
 import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 import { useTranslation } from 'react-i18next';
+import { useSafeBack } from '../hooks/useSafeBack';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'NoteEditor'>;
 type NoteEditorRouteProp = RouteProp<RootStackParamList, 'NoteEditor'>;
@@ -42,6 +43,7 @@ export default function NoteEditorScreen() {
 function NoteEditorScreenInner() {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
+  const safeBack = useSafeBack();
   const route = useRoute<NoteEditorRouteProp>();
   const { colors, isDark } = useTheme();
   const { authState, activeAccountId } = useAuth();
@@ -134,7 +136,7 @@ function NoteEditorScreenInner() {
         isSpeaking={preview.isSpeaking}
         tocEntries={preview.tocEntries}
         showToc={preview.showToc}
-        onBack={() => navigation.goBack()}
+        onBack={safeBack}
         onToggleToc={() => preview.setShowToc(true)}
         onToggleSpeak={preview.handleToggleSpeak}
         onEdit={() => document.setIsEditing(true)}

--- a/src/screens/StageScreen.tsx
+++ b/src/screens/StageScreen.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { FlatList, RefreshControl, Text, TouchableOpacity, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTheme } from '../contexts/ThemeContext';
 import { ScreenHeader, useScreenHeaderHeight } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
@@ -9,9 +7,9 @@ import { groupStaged, useStageStore, type StageGroup } from '../stores/stageStor
 import { drainPushQueue } from '../services/StagePushScheduler';
 import { useGitHubActivityStore } from '../stores/githubActivityStore';
 import type { StagedItem } from '../services/git/StagingService';
-import type { RootStackParamList } from '../navigation/types';
 import { readDeleteFailures, parseDeleteFailureKey } from '../services/git/deleteFailures';
 import { retryDeleteFailure } from '../services/git/retryDeleteFailure';
+import { useSafeBack } from '../hooks/useSafeBack';
 
 const UPSERT_COLOR = '#22c55e';
 
@@ -75,7 +73,7 @@ function StageRow({ item }: { item: StagedItem }) {
 
 export default function StageScreen() {
   const { colors } = useTheme();
-  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const safeBack = useSafeBack();
   const staged = useStageStore((s) => s.staged);
   const isPushing = useStageStore((s) => s.isPushing);
   const globalPushing = useStageStore((s) => s.globalPushing);
@@ -242,7 +240,7 @@ export default function StageScreen() {
     <SafeAreaView edges={[]} className="flex-1" style={{ backgroundColor: colors.background }}>
       <ScreenHeader
         title="Staged Changes"
-        onBack={() => navigation.goBack()}
+        onBack={safeBack}
         onLayout={(event) => setHeaderBlurHeight(event.nativeEvent.layout.height)}
         footer={
           visible ? (

--- a/src/screens/SyncStatusScreen.tsx
+++ b/src/screens/SyncStatusScreen.tsx
@@ -12,6 +12,7 @@ import type { FileConflict } from '../services/conflict/types';
 import type { RootStackParamList } from '../navigation/types';
 import { ScreenHeader } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
+import { useSafeBack } from '../hooks/useSafeBack';
 
 const MANAGE_THRESHOLD = 5;
 
@@ -60,6 +61,7 @@ interface SyncStatusScreenProps {
 export default function SyncStatusScreen({ onAiFixRemaining }: SyncStatusScreenProps = {}) {
   const { colors } = useTheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const safeBack = useSafeBack();
   const route = useRoute<RouteProp<RootStackParamList, 'Conflicts'>>();
   const conflicts = useConflictStore((s) => s.conflicts);
   const hasAiModel = useAIStore((s) => s.getSelectedModel() !== undefined);
@@ -223,7 +225,7 @@ export default function SyncStatusScreen({ onAiFixRemaining }: SyncStatusScreenP
     <SafeAreaView className="flex-1" style={{ backgroundColor: colors.background }}>
       <ScreenHeader
         title={isManageMode ? 'Manage Conflicts' : 'Sync Conflicts'}
-        onBack={() => navigation.goBack()}
+        onBack={safeBack}
         actions={
           hasAiModel ? (
             <TouchableOpacity

--- a/src/screens/ThoughtDumpScreen.tsx
+++ b/src/screens/ThoughtDumpScreen.tsx
@@ -25,6 +25,7 @@ import { indexDump, removeDump } from '../services/ai/thoughtDumpIndexing';
 import { SwipeableListItem } from '../components/list/SwipeableListItem';
 import { BulkActionBar } from '../components/list/BulkActionBar';
 import { useProScreenGuard } from '../hooks/useProScreenGuard';
+import { useSafeBack } from '../hooks/useSafeBack';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -35,6 +36,7 @@ interface Props {
 export default function ThoughtDumpScreen({ onDumpChange }: Props) {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
+  const safeBack = useSafeBack();
   const route = useRoute<RouteProp<RootStackParamList, 'ThoughtDump'>>();
   const { colors, spacing } = useTokens();
   const headerHeight = useScreenHeaderHeight();
@@ -473,7 +475,7 @@ export default function ThoughtDumpScreen({ onDumpChange }: Props) {
 
       <ScreenHeader
         title={t('thoughtDump.title')}
-        onBack={() => navigation.goBack()}
+        onBack={safeBack}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
## What

Three small chat/explore UI fixes from a QA session on the chat flow:

### 1. GO_BACK unhandled on deep-linked root screens (the reported error)
`The action 'GO_BACK' was not handled by any navigator.` fired when tapping the header back button on a screen opened as the **root** of the root stack via a `gitnotes://` deep link (repro: `gitnotes://chat` → tap Back → error).

**Fix:** new `src/hooks/useSafeBack.ts` — pops via `goBack()` when `canGoBack()`, otherwise falls back to `navigate('MainTabs')` (the same fallback `useProScreenGuard` uses for cold-deep-link cancel). Applied to all seven deep-linkable screens:
- `ChatThreadList` (`gitnotes://chat`) — the reported case
- `ChatScreen` (`gitnotes://chat/:threadId`)
- `ThoughtDump` (`gitnotes://thought-dump`)
- `Stage` (`gitnotes://stage`)
- `SyncStatus` / `Conflicts` (`gitnotes://conflicts`)
- `NoteEditor` preview (`gitnotes://note/:noteId`)
- `CanvasEditor` (`gitnotes://canvas/:canvasId`)

### 2. New Chat button label off-center
`Button` edge-centering only handled trailing icons; with the leading `+` icon the label sat ~half-an-icon right of center. Edge mode now pins a leading icon too (equal side spacers), and the full-width New Chat button opts into `iconAlign="edge"`.

### 3. Explore repo-hub header branch chip removed
The repo-hub page's top-right branch chip duplicated the branch selector in the file-tree view, so the header chip is dropped (branch selection still available from the file-tree view).

## Verification
- Reproduced the GO_BACK error on the simulator (cold `gitnotes://chat` + header back), then confirmed the fix navigates to MainTabs with no error.
- Confirmed the hub chip is gone on the simulator.
- `yarn ts:check` clean; new hook test (2) + Button (9) + ExploreScreen (5) + ai-screens pro-gate suites pass; full suite green except the pre-existing `patch-package` environment failure (missing `node_modules/.bin/patch-package`).
- Wiki: `new-chat-button-centering.md`, `goback-deep-link-root-fix.md` added; `explore-repo-hub.md` updated; index table updated.

## Commits
- `fix(ui): center New Chat button label with a leading icon`
- `fix(navigation): guard header back on deep-linked root screens`
- `feat(explore): drop the repo-hub header branch chip`