### PR TITLE
fix(sync): hide floating push button after a successful push

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@
 # RevenueCat initialization until real keys are provided.
 EXPO_PUBLIC_REVENUECAT_API_KEY_IOS=appl_<PLACEHOLDER>
 EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID=goog_<PLACEHOLDER>
+
+# Personal access token for the git E2E / real-repo test suite (docs/wiki/e2e-sync-testing.md).
+# Read by tests from the environment at runtime; never commit a real token.
+GITHUB_TEST_TOKEN=<PLACEHOLDER>

--- a/__tests__/services/StagingService.test.ts
+++ b/__tests__/services/StagingService.test.ts
@@ -110,7 +110,7 @@ jest.mock('../../src/stores/githubActivityStore', () => ({
 }));
 
 import { __resetImportDedupForTest } from '../../src/services/RepoImportService';
-import { StagingService } from '../../src/services/git/StagingService';
+import { StagingService, subscribeStagedChanged } from '../../src/services/git/StagingService';
 import type { StagedItem } from '../../src/services/git/StagingService';
 import { NoteSyncQueueService } from '../../src/services/NoteSyncQueueService';
 import { LocalGitWriter } from '../../src/services/git/LocalGitWriter';
@@ -752,6 +752,78 @@ getCommitOid.mockResolvedValue(null);
 
       capturedOnProgress?.({ phase: 'Writing objects', loaded: 0, total: 0 });
       expect(onProgress).toHaveBeenCalledWith(null);
+    });
+
+    test('successful clone push broadcasts staged-changed so the floating push button hides', async () => {
+      getMode.mockResolvedValue('clone');
+      getSavedRepositories.mockResolvedValue([
+        { id: '1', name: 'repo', path: 'owner/repo', branch: 'main' },
+      ]);
+      getCommitOid.mockImplementation(
+        async ({ ref }: { ref: string }) =>
+          ref.startsWith('refs/heads') ? 'local-oid' : 'remote-oid',
+      );
+
+      const listener = jest.fn();
+      const unsubscribe = subscribeStagedChanged(listener);
+
+      try {
+        const result = await StagingService.pushStaged('owner/repo', 'main');
+
+        expect(result).toEqual({ success: true });
+        expect(writerPush).toHaveBeenCalledTimes(1);
+        expect(listener).toHaveBeenCalledTimes(1);
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    test('failed clone push does NOT broadcast staged-changed (button stays)', async () => {
+      getMode.mockResolvedValue('clone');
+      getSavedRepositories.mockResolvedValue([
+        { id: '1', name: 'repo', path: 'owner/repo', branch: 'main' },
+      ]);
+      getCommitOid.mockImplementation(
+        async ({ ref }: { ref: string }) =>
+          ref.startsWith('refs/heads') ? 'local-oid' : 'remote-oid',
+      );
+      writerPush.mockResolvedValue({ success: false, error: 'push rejected' });
+
+      const listener = jest.fn();
+      const unsubscribe = subscribeStagedChanged(listener);
+
+      try {
+        const result = await StagingService.pushStaged('owner/repo', 'main');
+
+        expect(result).toEqual({ success: false, error: 'push rejected' });
+        expect(listener).not.toHaveBeenCalled();
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    test('api-mode push does NOT broadcast staged-changed (queue notify covers it)', async () => {
+      queueGetAll.mockResolvedValue([
+        queueItem('note.upsert', {
+          repo: 'owner/repo',
+          branch: 'main',
+          filePath: 'notes/a.md',
+          title: 'A',
+        }),
+      ]);
+      getMode.mockResolvedValue('api');
+
+      const listener = jest.fn();
+      const unsubscribe = subscribeStagedChanged(listener);
+
+      try {
+        const result = await StagingService.pushStaged();
+
+        expect(result).toEqual({ success: true });
+        expect(listener).not.toHaveBeenCalled();
+      } finally {
+        unsubscribe();
+      }
     });
   });
 });

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -22,6 +22,7 @@
 | [Git Core Hardening](./git-core-hardening.md) | git-core test-campaign fixes: binary decode integrity, case collisions, auth/preflight, API batch writes, pull/reconcile fixes (#876–#892) |
 | [Stage → Push UX](./stage-push-ux.md) | no row locks, vanish-immediate deletes, spinner-free grayed push buttons, determinate progress ring, body-text notifications, resume-on-foreground |
 | [Push Button Missing on Folder-Backed Updates](./push-button-update-fix.md) | `LocalGitWriter` normalizes leading-slash `filePath`s so folder-backed note/canvas/todo updates commit locally and surface the push button |
+| [Floating Push Button Not Hiding After Push](./push-button-hide-after-push.md) | `pushStaged` broadcasts `notifyStagedChanged()` after a successful clone push so `pendingCount` drops to 0 and the button hides immediately |
 | [Token Removal Repo Cascade](./repo-removal-cascade.md) | removing a token also removes its synced repos, with a confirmation warning |
 | [Token Scope Error Messaging](./token-scope-error-messaging.md) | 403s surface needed token scopes in the sync message and token-add UI |
 | [Pro Paywall & Monetization](./paywall-pro.md) | StoreKit 2 revenue model: 30-day trial / $2.99 mo / $40 lifetime, grandfathering, show-locked feature UX, gating map, impressions & analytics, restore flow, intro-eligibility policy, legal links, bento grid layout (#921), store setup checklist |

--- a/docs/wiki/push-button-hide-after-push.md
+++ b/docs/wiki/push-button-hide-after-push.md
@@ -1,0 +1,41 @@
+# Floating Push Button Not Hiding After a Successful Push
+
+> `StagingService.pushStaged` now broadcasts `notifyStagedChanged()` after the clone-mode push loop succeeds, so `stageStore.loadStaged()` re-runs and `pendingCount` drops to 0 — the floating push button hides immediately instead of lingering until the Stage screen is opened.
+
+## Symptom
+
+In clone mode, after a successful push (press-and-hold the floating button, Push / Push-all on the Stage screen, or the 3-minute idle auto-push), the floating push button sometimes stays visible with its stale badge. Opening the Staged Changes screen forces it to hide.
+
+## Root cause
+
+The button renders `null` only when `useStageStore.pendingCount === 0` (`FloatingStageButton.tsx`). `pendingCount` is recomputed *only* inside `stageStore.loadStaged()`, which re-reads `StagingService.listStaged()` (local HEAD vs `refs/remotes/origin/<branch>`).
+
+The push chain in clone mode:
+
+1. `drainPushQueue` → `StagingService.pushStaged(repo, branch)`.
+2. `pushStaged` calls `NoteSyncQueueService.drain()` first, then `LocalGitWriter.push()` for each clone key.
+3. `drain()` ends with `saveAll()` → `notify()` → stageStore's queue subscription → `loadStaged()`. **But this fires before the clone pushes run** — at that instant `refs/heads/<branch>` is still ahead of `refs/remotes/origin/<branch>`, so `listStaged()` still returns the `(unpushed commits)` row and `pendingCount` stays > 0.
+4. After `LocalGitWriter.push()` succeeds, nothing re-fires `loadStaged()`: `LocalGitWriter` emits no event, and `notifyStagedChanged()` was only ever called on *staging* (clone-mode `stageUpsert`/`stageDelete`), never on *push completion*.
+
+So the store keeps the pre-push snapshot until something else calls `loadStaged()` — the Stage screen does on mount (and pull-to-refresh), which is why opening it "fixes" the button. The "sometimes" is the race: if the drain-triggered `loadStaged()` happens to complete after the push lands (slow ref reads), the count refreshes correctly.
+
+## Fix
+
+`src/services/git/StagingService.ts` — `pushStaged()` now calls `notifyStagedChanged()` after the clone push loop succeeds (only when `cloneKeys.size > 0` and all pushes report success). The stage store already subscribes to this emitter (`subscribeStagedChanged` → `loadStaged()`), so `pendingCount` is recomputed against post-push refs and the button hides.
+
+- Broadcast happens only on **success**: a failed clone push leaves the commits staged and the button visible.
+- API-mode pushes do **not** broadcast here — their drain already notifies the queue subscription (notifying both would double-load the stage store, per the existing emitter contract comment).
+
+## Verification
+
+`__tests__/services/StagingService.test.ts` — three new `pushStaged` cases:
+
+- successful clone push fires the staged-changed listener exactly once (button hides),
+- failed clone push does not fire it (button stays),
+- api-mode push does not fire it (queue notify already covers the refresh).
+
+`yarn ts:check`, the full `yarn jest` suite (2838 tests), and eslint all pass; the single pre-existing `patch-package` ENOENT failure is an environment issue (binary absent from `node_modules`), unrelated to this change.
+
+## Related
+
+- [#925](https://github.com/gedwolmen/gitnotes/issues/925) — clone staging never surfaced the push button (fixed by emitting `notifyStagedChanged` on staging); this fix covers the opposite direction: surfacing the *disappearance* after a push.

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -344,6 +344,12 @@ export class StagingService {
         if (failures.length > 0) {
           return { success: false, error: failures.join('; ') };
         }
+        // Clone-mode pushes moved refs/heads/<branch> to origin — the only
+        // store refresh that fired during this call (the sync-queue notify
+        // from drain()) ran BEFORE these pushes, so the stage store still
+        // shows the just-pushed commits as staged. Broadcast so subscribers
+        // reload and the floating push button hides after a successful push.
+        notifyStagedChanged();
       }
 
       return { success: true };


### PR DESCRIPTION
## Problem

In clone mode, after a successful push the floating push button sometimes stays visible with its stale badge. The user has to open the Staged Changes screen (or pull-to-refresh it) to make the button disappear.

## Root cause

`FloatingStageButton` renders `null` only when `pendingCount === 0`, and `pendingCount` is only recomputed by `stageStore.loadStaged()` (re-reads `StagingService.listStaged()`). The push chain in `pushStaged()`:

1. `NoteSyncQueueService.drain()` fires the only in-flight store refresh — but **before** the clone pushes run, when `refs/heads/<branch>` is still ahead of origin → `pendingCount` stays > 0.
2. `LocalGitWriter.push()` then lands the refs on origin, but **nothing re-fires `loadStaged()`** after it completes. `notifyStagedChanged()` was only ever emitted on staging, never on push completion.

So the store keeps the pre-push snapshot until something else calls `loadStaged()` — the Stage screen does on mount, which is why opening it "fixes" the button. The "sometimes" is a race between the drain-triggered refresh and the push landing.

## Fix

`StagingService.pushStaged()` now emits `notifyStagedChanged()` after the clone push loop succeeds. The stage store already subscribes to that emitter → `loadStaged()` → `pendingCount` drops to 0 → button hides immediately.

- Broadcast **only on success** — a failed push keeps commits staged and the button visible.
- Broadcast **only for clone keys** — API-mode drain already notifies the queue subscription; notifying both would double-load (per the emitter's contract comment).

## Tests

3 new `pushStaged` cases in `__tests__/services/StagingService.test.ts`:
- successful clone push fires the staged-changed listener exactly once (button hides)
- failed clone push does **not** fire it (button stays)
- api-mode push does **not** fire it (queue notify covers the refresh)

## Verification

- `yarn ts:check` ✓
- `yarn jest` — 2838 passed; single pre-existing `patch-package` ENOENT failure (binary absent from local `node_modules`, unrelated to this change)
- `yarn eslint` on changed files — 0 errors

Also adds `GITHUB_TEST_TOKEN` to `.env.example` (used by the git E2E / real-repo test suite) and a wiki page documenting the fix.