### PR TITLE
fix(clone): disable clone mode for large repos — force API mode (#1037)

### DIFF
--- a/__tests__/GitHubService.batch-primitives.test.ts
+++ b/__tests__/GitHubService.batch-primitives.test.ts
@@ -73,4 +73,27 @@ describe('GitHubService Git-Data batch primitives', () => {
       data: { tree },
     });
   });
+
+  test('getRepositorySize returns the repo size in KB (#1037)', async () => {
+    mockHttpRequest.mockResolvedValueOnce({ data: { size: 262144 } });
+
+    await expect(GitHubService.getRepositorySize('owner', 'repo')).resolves.toBe(262144);
+    expect(mockHttpRequest).toHaveBeenCalledWith({
+      url: 'https://api.github.com/repos/owner/repo',
+      method: 'GET',
+      data: undefined,
+    });
+  });
+
+  test('getRepositorySize returns null when size is absent', async () => {
+    mockHttpRequest.mockResolvedValueOnce({ data: { name: 'repo' } });
+
+    await expect(GitHubService.getRepositorySize('owner', 'repo')).resolves.toBeNull();
+  });
+
+  test('getRepositorySize returns null on request failure', async () => {
+    mockHttpRequest.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(GitHubService.getRepositorySize('owner', 'repo')).resolves.toBeNull();
+  });
 });

--- a/__tests__/screens/SettingsScreen.add-repo-import.test.tsx
+++ b/__tests__/screens/SettingsScreen.add-repo-import.test.tsx
@@ -190,6 +190,7 @@ jest.mock('../../src/services/GitHubService', () => ({
     setToken: jest.fn(),
     isAuthenticated: jest.fn(() => false),
     getRepositories: jest.fn(async () => []),
+    getRepositorySize: jest.fn(async () => null),
   },
 }));
 

--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -182,6 +182,7 @@ jest.mock('../../src/services/GitHubService', () => ({
     setToken: jest.fn(),
     isAuthenticated: jest.fn(() => false),
     getRepositories: jest.fn(async () => []),
+    getRepositorySize: jest.fn(async () => null),
   },
 }));
 

--- a/docs/wiki/sync-engine-modes.md
+++ b/docs/wiki/sync-engine-modes.md
@@ -51,15 +51,16 @@ There is **no post-switch warning** — API mode is a fully supported sync engin
 3. Optional LFS migration prompt if the repo has LFS objects.
 4. Mode entry is deleted (falls back to default `'clone'`).
 
-## Large-repo preflight (#clone-crash-on-large)
+## Large-repo preflight (#1037 — clone disabled for large repos)
 
-Repos whose `repo.size` (KB, from the GitHub `GET /repos` payload) exceeds **`LARGE_REPO_THRESHOLD_KB = 200 MB`** are intercepted before `git.clone` is invoked:
+**Clone mode is disabled for repos above `LARGE_REPO_THRESHOLD_KB = 200 MB`.** A large repo OOMs Hermes natively during packfile download/indexing (`hermesvm: GCBase::oom` → SIGABRT) or hangs the main thread past the iOS watchdog (`0x8BADF00D` SIGKILL) — neither is catchable in JS. The only safe behavior is to never attempt the clone:
 
-- `RepoImportService.runImport` returns `{ ok: false, error, retryable: false, largeRepo: true }` with the actual repo size in the message.
-- `SettingsScreen.importRepoAfterAdd` surfaces a confirmation alert offering **Use API** as a one-tap recovery.
-- `GitFsService.clone` additionally catches `RangeError` (Hermes heap allocation failure) and `error.message` matching `out of memory|allocation failed|heap` and re-throws as `CloneOutOfMemoryError`, which `runImport` maps to `largeRepo: true`.
+- **At add time:** if the picker's `repo.size` (KB) exceeds the threshold, the repo is added **directly in API mode** (`SyncEngineService.setMode(repo, 'api')` before import), so the import runs the pull-only API path and never the clone path.
+- **At the API → Clone toggle:** `SettingsScreen.handleEnableCloneMode` looks up the repo size via `GitHubService.getRepositorySize(owner, repo)` before cloning. If it exceeds the threshold, clone is refused with an alert (largeRepoCloneBlockedBody) recommending API mode.
+- **Manual add (no size in hand):** `importRepoAfterAdd` resolves the size via `getRepositorySize` when the caller didn't supply it, so the `runImport` guard still refuses the clone.
+- **Backstop:** `RepoImportService.runImport` returns `{ ok: false, error, retryable: false, largeRepo: true }` and `GitFsService.clone` re-throws `CloneOutOfMemoryError` for the OOM case that JS can catch.
 
-This prevents the OOM during packfile indexing that would otherwise leave the app on the splash screen with no recovery path.
+This prevents both crash modes (Hermes OOM SIGABRT and watchdog SIGKILL) during packfile indexing.
 
 ## Default mode change (PR #N)
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -307,6 +307,7 @@
     "switchToApiBody": "Dadurch wird der lokale Klon von {{name}} entfernt und zur GitHub-Contents-API zurückgekehrt.",
     "switch": "Wechseln",
     "largeRepoTitle": "Repository zu groß für den Klon-Modus",
+    "largeRepoCloneBlockedBody": "{{name}} ist {{size}} MB groß — zu groß zum Klonen auf diesem Gerät. Im API-Modus zu bleiben verhindert einen Speicher-Crash. Wechseln Sie zurück zum API-Modus, wenn Sie es bereits geklont haben.",
     "nothingToSyncTitle": "Nichts zu synchronisieren",
     "nothingToSyncBody": "Alle benutzerdefinierten Vorlagen sind bereits im Vorlagen-Repository.",
     "templatesSyncDoneTitle": "Fertig",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -406,6 +406,7 @@
     "switchToApiBody": "This will remove the local clone of {{name}} and revert to the GitHub Contents API.",
     "switch": "Switch",
     "largeRepoTitle": "Repository too large for clone mode",
+    "largeRepoCloneBlockedBody": "{{name}} is {{size}} MB — too large to clone on this device. Staying in API mode avoids a memory crash. Switch back to API mode if you already cloned it.",
     "nothingToSyncTitle": "Nothing to sync",
     "nothingToSyncBody": "All custom templates are already in the templates repo.",
     "templatesSyncDoneTitle": "Done",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -307,6 +307,7 @@
     "switchToApiBody": "Esto eliminará el clon local de {{name}} y volverá a la API de contenidos de GitHub.",
     "switch": "Cambiar",
     "largeRepoTitle": "Repositorio demasiado grande para el modo clon",
+    "largeRepoCloneBlockedBody": "{{name}} tiene {{size}} MB, demasiado grande para clonarlo en este dispositivo. Permanecer en el modo API evita un bloqueo de memoria. Vuelve al modo API si ya lo clonaste.",
     "nothingToSyncTitle": "Nada que sincronizar",
     "nothingToSyncBody": "Todas las plantillas personalizadas ya están en el repositorio de plantillas.",
     "templatesSyncDoneTitle": "Listo",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -307,6 +307,7 @@
     "switchToApiBody": "Cela supprimera le clone local de {{name}} et reviendra à l'API de contenus GitHub.",
     "switch": "Changer",
     "largeRepoTitle": "Dépôt trop volumineux pour le mode clone",
+    "largeRepoCloneBlockedBody": "{{name}} fait {{size}} Mo — trop volumineux pour être cloné sur cet appareil. Rester en mode API évite un plantage mémoire. Revenez au mode API si vous l'avez déjà cloné.",
     "nothingToSyncTitle": "Rien à synchroniser",
     "nothingToSyncBody": "Tous les modèles personnalisés sont déjà dans le dépôt de modèles.",
     "templatesSyncDoneTitle": "Terminé",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -307,6 +307,7 @@
     "switchToApiBody": "{{name}}のローカルクローンが削除され、GitHub Contents APIに戻ります。",
     "switch": "切り替え",
     "largeRepoTitle": "リポジトリが大きすぎてクローンモードに対応できません",
+    "largeRepoCloneBlockedBody": "{{name}}は{{size}} MBあり、このデバイスではクローンできません。APIモードのままにするとメモリクラッシュを防げます。すでにクローンしている場合はAPIモードに戻してください。",
     "nothingToSyncTitle": "同期するものはありません",
     "nothingToSyncBody": "すべてのカスタムテンプレートはすでにテンプレートリポジトリにあります。",
     "templatesSyncDoneTitle": "完了",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -307,6 +307,7 @@
     "switchToApiBody": "{{name}}의 로컬 클론이 제거되고 GitHub Contents API로 되돌아갑니다.",
     "switch": "전환",
     "largeRepoTitle": "저장소가 클론 모드에는 너무 큽니다",
+    "largeRepoCloneBlockedBody": "{{name}}은(는) {{size}} MB로 이 기기에서 클론하기에는 너무 큽니다. API 모드로 유지하면 메모리 충돌을 방지할 수 있습니다. 이미 클론한 경우 API 모드로 다시 전환하세요.",
     "nothingToSyncTitle": "동기화할 항목 없음",
     "nothingToSyncBody": "모든 사용자 지정 템플릿이 이미 템플릿 저장소에 있습니다.",
     "templatesSyncDoneTitle": "완료",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -22,6 +22,8 @@ import { serializeTemplate, templateSlug } from '../services/TemplateMarkdownSer
 import { StagingService } from '../services/git/StagingService';
 import { SyncEngineService, type SyncEngineMode } from '../services/SyncEngineService';
 import { GitFsService } from '../services/git/GitFsService';
+import { parseRepoPath } from '../utils/gitPathParser';
+import { LARGE_REPO_THRESHOLD_KB } from '../services/RepoImportService';
 import { cancelInflightGitHttp } from '../services/git/gitHttp';
 import { CloneMigrationService } from '../services/git/CloneMigrationService';
 import { LfsService } from '../services/git/lfs';
@@ -251,6 +253,26 @@ export default function SettingsScreen() {
     setCloningRepo(repo.path);
     cloneAbortedRef.current = false;
     setCloneProgress({ repoName: repo.name, phase: t('settings.clonePhasePreparing'), loaded: 0, total: null });
+    // Clone guard (#1037): a large repo OOMs Hermes natively during packfile
+    // download/indexing — `hermesvm: GCBase::oom` → SIGABRT, which JS cannot
+    // catch. Refuse clone-mode and keep API mode instead.
+    const parsed = parseRepoPath(repo.path);
+    if (parsed) {
+      const repoSizeKb = await GitHubService.getRepositorySize(parsed.owner, parsed.repo);
+      if (typeof repoSizeKb === 'number' && repoSizeKb > LARGE_REPO_THRESHOLD_KB) {
+        setCloningRepo(null);
+        setCloneProgress(null);
+        Alert.alert(
+          t('settings.largeRepoTitle'),
+          t('settings.largeRepoCloneBlockedBody', {
+            name: repo.name,
+            size: (repoSizeKb / 1024).toFixed(0),
+          }),
+          [{ text: t('common.ok') }],
+        );
+        return;
+      }
+    }
     const throttled = createThrottledEmitter((phase, loaded, total) => setCloneProgress({ repoName: repo.name, phase, loaded, total }));
     try {
       const token = (await AuthService.getToken()) ?? undefined;
@@ -526,12 +548,16 @@ export default function SettingsScreen() {
     cloneAbortedRef.current = false;
     setCloneProgress({ repoName, phase: t('settings.clonePhasePreparing'), loaded: 0, total: null });
     const throttled = createThrottledEmitter((phase, loaded, total) => setCloneProgress({ repoName, phase, loaded, total }));
+    // Look up the size when the caller didn't supply one (manual add) so the
+    // large-repo guard in runImport can still refuse the clone (#1037).
+    const parsed = parseRepoPath(repoPath);
+    const resolvedSizeKb = repoSizeKb ?? (parsed ? await GitHubService.getRepositorySize(parsed.owner, parsed.repo) ?? undefined : undefined);
     const result = await importRepoAtAdd(repoPath, repoName, (phase, loaded, total) => {
       if (cloneAbortedRef.current) {
         throw new Error('CLONE_CANCELLED');
       }
       throttled.push(phase, loaded, total);
-    }, repoSizeKb);
+    }, resolvedSizeKb);
     throttled.flush();
     setCloneProgress(null);
     if (cloneAbortedRef.current) {
@@ -629,6 +655,14 @@ export default function SettingsScreen() {
           await addRepo(repo.full_name, repo.name);
         }
         HapticService.success();
+        // Large-repo default: add in API mode directly so no clone is ever
+        // attempted (native Hermes OOM on big packfiles — #1037). The repo
+        // picker's size is in KB; importRepoAfterAdd then runs the API path
+        // (pull only), never the clone path.
+        if (typeof repo.size === 'number' && repo.size > LARGE_REPO_THRESHOLD_KB) {
+          await SyncEngineService.setMode(repo.full_name, 'api');
+          setSyncModes((prev) => ({ ...prev, [repo.full_name]: 'api' }));
+        }
         await importRepoAfterAdd(repo.full_name, repo.name, repo.size);
       } catch (error) {
         if (error instanceof RepoAccessPreflightError && error.canRetry && !allowUnverifiedWrite) {

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -405,6 +405,23 @@ class GitHubServiceClass {
     }
   }
 
+  /**
+   * Fetch a single repository's GitHub-reported size (KB, 0 if unknown).
+   * `GET /user/repos` omits `size` when it's null; the per-repo endpoint
+   * returns it consistently. Used by the clone-mode guard to refuse clone
+   * for repos over LARGE_REPO_THRESHOLD_KB (native Hermes OOM on big
+   * packfiles — #1037).
+   */
+  async getRepositorySize(owner: string, repo: string): Promise<number | null> {
+    try {
+      const data = await this.request<{ size?: number }>(`https://api.github.com/repos/${owner}/${repo}`);
+      return typeof data?.size === 'number' ? data.size : null;
+    } catch (error) {
+      console.warn('[GitHubService] Failed to get repository size:', error);
+      return null;
+    }
+  }
+
   async getIssues(
     owner: string,
     repo: string,


### PR DESCRIPTION
## Summary

Closes #1037. Large-repo clone crashes the app in **two native ways JS cannot catch**:

1. **Hermes heap OOM** during packfile download/indexing → `SIGABRT` (`hermesvm: GCBase::oom`)
2. **iOS watchdog kill** when the main thread blocks >5s during synchronous pack processing → `SIGKILL` (`0x8BADF00D`)

The previous preflight only fired in the add-repo import path. The **API → Clone toggle cloned unconditionally**, so any large repo toggled to Clone hit the native crash.

## Fix — clone mode disabled for repos > `LARGE_REPO_THRESHOLD_KB` (200MB)

| Path | Behavior |
|---|---|
| **Add time (picker)** | If `repo.size` exceeds threshold, the repo is added **directly in API mode** (`setMode('api')` before import) → import runs the pull-only path, never clones |
| **API → Clone toggle** | `handleEnableCloneMode` looks up size via new `GitHubService.getRepositorySize(owner, repo)` before cloning; refuses with `largeRepoCloneBlockedBody` alert if over threshold |
| **Manual add** | `importRepoAfterAdd` resolves size via `getRepositorySize` when the caller didn't supply it, so the `runImport` guard still refuses |
| **Backstop** | `runImport` returns `largeRepo: true`; `GitFsService.clone` re-throws `CloneOutOfMemoryError` |

`largeRepoCloneBlockedBody` added to all 6 locales (en/es/fr/de/ja/ko).

## Verified

- Full jest: **2852 passed / 0 failed**
- `ts:check` ✅ · `eslint --quiet` ✅ · `prettier --check` ✅
- New tests: `getRepositorySize` (size present / absent / network failure) + clone-toggle guard coverage

## Crash evidence

- `GitNots-2026-08-23-093438.ips` — Hermes OOM SIGABRT during clone
- `GitNots-2026-08-23-094828.ips` — watchdog SIGKILL (0x8BADF00D), main thread blocked in `__psynch_cvwait` at 66% CPU