### PR TITLE
fix(clone): lower large-repo clone threshold to 100MB (#1037)

### DIFF
--- a/docs/wiki/sync-engine-modes.md
+++ b/docs/wiki/sync-engine-modes.md
@@ -53,7 +53,7 @@ There is **no post-switch warning** — API mode is a fully supported sync engin
 
 ## Large-repo preflight (#1037 — clone disabled for large repos)
 
-**Clone mode is disabled for repos above `LARGE_REPO_THRESHOLD_KB = 200 MB`.** A large repo OOMs Hermes natively during packfile download/indexing (`hermesvm: GCBase::oom` → SIGABRT) or hangs the main thread past the iOS watchdog (`0x8BADF00D` SIGKILL) — neither is catchable in JS. The only safe behavior is to never attempt the clone:
+**Clone mode is disabled for repos above `LARGE_REPO_THRESHOLD_KB = 100 MB`.** A large repo OOMs Hermes natively during packfile download/indexing (`hermesvm: GCBase::oom` → SIGABRT) or hangs the main thread past the iOS watchdog (`0x8BADF00D` SIGKILL) — neither is catchable in JS. The only safe behavior is to never attempt the clone:
 
 - **At add time:** if the picker's `repo.size` (KB) exceeds the threshold, the repo is added **directly in API mode** (`SyncEngineService.setMode(repo, 'api')` before import), so the import runs the pull-only API path and never the clone path.
 - **At the API → Clone toggle:** `SettingsScreen.handleEnableCloneMode` looks up the repo size via `GitHubService.getRepositorySize(owner, repo)` before cloning. If it exceeds the threshold, clone is refused with an alert (largeRepoCloneBlockedBody) recommending API mode.

--- a/src/services/RepoImportService.ts
+++ b/src/services/RepoImportService.ts
@@ -21,7 +21,7 @@ const EMPTY_REPO_COUNTS: PullResult = { repos: 1, notes: 0, canvases: 0, todos: 
  * for the long tail of repos where the initial packfile can OOM the JS
  * heap even with the streaming + batched-checkout mitigations.
  */
-export const LARGE_REPO_THRESHOLD_KB = 200 * 1024;
+export const LARGE_REPO_THRESHOLD_KB = 100 * 1024;
 
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 const NON_RETRYABLE_STATUS = new Set([401, 403, 404, 410]);


### PR DESCRIPTION
The 'notes' repo crashed at 136MB (Hermes OOM SIGABRT + watchdog SIGKILL). The 200MB threshold never blocked it. Lower LARGE_REPO_THRESHOLD_KB to 100MB so repos that OOM the simulator heap are forced into API mode.