### PR TITLE
fix(keyboard): add KeyboardAvoidingView to fullWidth modals with text inputs

### DIFF
--- a/--
+++ b/--
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict></dict></plist>

--- a/src/components/FolderSelectionDialog.tsx
+++ b/src/components/FolderSelectionDialog.tsx
@@ -9,6 +9,7 @@ import {
   Platform,
   ScrollView,
   ActivityIndicator,
+  KeyboardAvoidingView,
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -240,7 +241,11 @@ export default function FolderSelectionDialog({
       fullWidth
       contentStyle={styles.modalContent}
     >
-      <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={['top', 'left', 'right']}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={{ flex: 1 }}
+      >
+        <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={['top', 'left', 'right']}>
         <View style={[styles.header, { borderBottomColor: colors.border }]}> 
           <View style={styles.headerSide}>
             <TouchableOpacity testID="folder-selection.button.close" onPress={onClose} hitSlop={8} style={styles.headerActionButton}>
@@ -351,6 +356,7 @@ export default function FolderSelectionDialog({
           )}
         </ScrollView>
       </SafeAreaView>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/src/components/MoveNoteDialog.tsx
+++ b/src/components/MoveNoteDialog.tsx
@@ -10,6 +10,8 @@ import {
   Alert,
   TextInput,
   Keyboard,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -467,8 +469,12 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
       fullWidth
       contentStyle={exploreStyles.modalContent}
     >
-      <DragDropBoundary>
-        <SafeAreaView style={[exploreStyles.container, { backgroundColor: colors.background }]} edges={['top', 'bottom']}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={{ flex: 1 }}
+      >
+        <DragDropBoundary>
+          <SafeAreaView style={[exploreStyles.container, { backgroundColor: colors.background }]} edges={['top', 'bottom']}>
           <View style={[exploreStyles.header, { borderBottomColor: colors.border }]}>
             <TouchableOpacity testID="move-note.button.close" onPress={onClose} style={exploreStyles.headerBtn}>
               <Text style={[exploreStyles.headerBtnText, { color: colors.primary }]}>Cancel</Text>
@@ -583,7 +589,8 @@ export default function MoveNoteDialog({ visible, note, onClose, onMoved }: Move
             </ListDropContainer>
           )}
         </SafeAreaView>
-      </DragDropBoundary>
+        </DragDropBoundary>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/src/components/RepoFolderPickerModal.tsx
+++ b/src/components/RepoFolderPickerModal.tsx
@@ -9,6 +9,8 @@ import {
   ActivityIndicator,
   ScrollView,
   Alert,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -579,32 +581,37 @@ export default function RepoFolderPickerModal({
         )}
 
         <Modal visible={showNewFolderModal} onRequestClose={() => { setShowNewFolderModal(false); setNewFolderName(''); }}>
-          <Text style={[styles.modalTitle, { color: colors.text }]}>New Folder</Text>
-          <TextInput
-            style={[styles.modalInput, { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
-            placeholder="Folder name"
-            placeholderTextColor={colors.textSecondary}
-            value={newFolderName}
-            onChangeText={setNewFolderName}
-            autoFocus
-            autoCapitalize="none"
-            autoCorrect={false}
-          />
-          <View style={styles.modalButtons}>
-            <TouchableOpacity
-              style={[styles.modalBtn, { backgroundColor: colors.surface, borderColor: colors.border }]}
-              onPress={() => { setShowNewFolderModal(false); setNewFolderName(''); }}
-            >
-              <Text style={[styles.modalBtnText, { color: colors.text }]}>Cancel</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[styles.modalBtn, { backgroundColor: colors.primary }, !newFolderName.trim() && styles.useButtonDisabled]}
-              onPress={handleCreateFolder}
-              disabled={!newFolderName.trim() || isLoading}
-            >
-              <Text style={styles.modalBtnText}>Create</Text>
-            </TouchableOpacity>
-          </View>
+          <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+            style={{ flex: 1 }}
+          >
+            <Text style={[styles.modalTitle, { color: colors.text }]}>New Folder</Text>
+            <TextInput
+              style={[styles.modalInput, { color: colors.text, backgroundColor: colors.surfaceSecondary, borderColor: colors.border }]}
+              placeholder="Folder name"
+              placeholderTextColor={colors.textSecondary}
+              value={newFolderName}
+              onChangeText={setNewFolderName}
+              autoFocus
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+            <View style={styles.modalButtons}>
+              <TouchableOpacity
+                style={[styles.modalBtn, { backgroundColor: colors.surface, borderColor: colors.border }]}
+                onPress={() => { setShowNewFolderModal(false); setNewFolderName(''); }}
+              >
+                <Text style={[styles.modalBtnText, { color: colors.text }]}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modalBtn, { backgroundColor: colors.primary }, !newFolderName.trim() && styles.useButtonDisabled]}
+                onPress={handleCreateFolder}
+                disabled={!newFolderName.trim() || isLoading}
+              >
+                <Text style={styles.modalBtnText}>Create</Text>
+              </TouchableOpacity>
+            </View>
+          </KeyboardAvoidingView>
         </Modal>
       </SafeAreaView>
     </Modal>

--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -6,6 +6,8 @@ import {
   TouchableOpacity,
   FlatList,
   TextInput,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { ActivityIndicator } from 'react-native';
@@ -104,7 +106,11 @@ export default function TemplateSelector({ visible, onClose, onSelect }: Templat
       fullWidth
       contentStyle={styles.modalContent}
     >
-      <View style={[styles.container, { backgroundColor: colors.elevated }]}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={{ flex: 1 }}
+      >
+        <View style={[styles.container, { backgroundColor: colors.elevated }]}>
         <View style={[styles.header, { backgroundColor: colors.elevated, borderBottomColor: colors.border }]}>
           <Text style={[styles.headerTitle, { color: colors.text }]}>Choose a Template</Text>
           <TouchableOpacity onPress={onClose}>
@@ -161,6 +167,7 @@ export default function TemplateSelector({ visible, onClose, onSelect }: Templat
           }
         />
       </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -7,6 +7,8 @@ import {
   Alert,
   Modal,
   TextInput,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -249,7 +251,11 @@ export default function CanvasListScreen() {
           accessible={false}
           onPress={() => setShowSizePicker(false)}
         >
-          <View className="w-full rounded-lg p-5" style={{ backgroundColor: colors.surface }} onStartShouldSetResponder={() => true}>
+          <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+            style={{ width: '100%' }}
+          >
+            <View className="w-full rounded-lg p-5" style={{ backgroundColor: colors.surface }} onStartShouldSetResponder={() => true}>
             <Text className="text-lg font-bold text-center mb-3" style={{ color: colors.text }}>{t('canvases.newCanvas')}</Text>
 
             <TextInput
@@ -328,6 +334,7 @@ export default function CanvasListScreen() {
               <Text className="text-base" style={{ color: colors.textSecondary }}>{t('common.cancel')}</Text>
             </TouchableOpacity>
           </View>
+          </KeyboardAvoidingView>
         </TouchableOpacity>
       </Modal>
       <ScreenHeader


### PR DESCRIPTION
## What

Add missing `KeyboardAvoidingView` to every fullWidth/centered modal that contains an auto-focusing `TextInput`. The shared `ui/Modal` only wraps `bottomSheet` variants in KAV — all `fullWidth`/centered variants were exposed.

## Why

When the keyboard opens on an auto-focused text input inside a centered modal, the keyboard covers the input with no avoidance. The user cannot see what they're typing.

## How

Each affected modal now wraps its content in `KeyboardAvoidingView` with `behavior={Platform.OS === 'ios' ? 'padding' : undefined}` — matching the established pattern in the codebase.

## Files changed

| File | What was fixed |
|------|----------------|
| `RepoFolderPickerModal.tsx` | Inner "New Folder" dialog — settings-reachable via Reminders → Add Reminder → pick folder |
| `MoveNoteDialog.tsx` | Inline folder creation input row |
| `FolderSelectionDialog.tsx` | Inline folder creation input |
| `TemplateSelector.tsx` | Search TextInput |
| `CanvasListScreen.tsx` | New-canvas size-picker modal (raw RN `Modal`) |

## Testing

- `yarn ts:check` ✅
- `yarn jest` ✅ (311 suites, 2852 tests)
- Manual: open each affected flow and verify the text input is visible above the keyboard