### PR TITLE
feat(stage): add discard-changes button and fix staged-change display

### DIFF
--- a/__tests__/services/StagingService.listStaged.test.ts
+++ b/__tests__/services/StagingService.listStaged.test.ts
@@ -26,6 +26,7 @@ jest.mock('../../src/services/git/GitFsService', () => ({
   GitFsService: {
     getCommitOid: jest.fn(async () => null),
     findMergeBase: jest.fn(async () => null),
+    getChangedFilesBetweenRefs: jest.fn(async () => []),
   },
 }));
 

--- a/__tests__/services/StagingService.staged-changed.test.ts
+++ b/__tests__/services/StagingService.staged-changed.test.ts
@@ -27,6 +27,7 @@ jest.mock('../../src/services/git/GitFsService', () => ({
   GitFsService: {
     getCommitOid: jest.fn(async () => null),
     findMergeBase: jest.fn(async () => null),
+    getChangedFilesBetweenRefs: jest.fn(async () => []),
   },
 }));
 

--- a/__tests__/services/StagingService.test.ts
+++ b/__tests__/services/StagingService.test.ts
@@ -56,6 +56,7 @@ jest.mock('../../src/services/git/GitFsService', () => ({
   GitFsService: {
     getCommitOid: jest.fn(async () => null),
     findMergeBase: jest.fn(async () => null),
+    getChangedFilesBetweenRefs: jest.fn(async () => []),
   },
 }));
 

--- a/__tests__/sync-locking.integration.test.ts
+++ b/__tests__/sync-locking.integration.test.ts
@@ -102,6 +102,7 @@ jest.mock('../src/services/git/GitFsService', () => ({
     getCommitOid: jest.fn(async () => null),
     removeRepo: jest.fn(async () => undefined),
     readBlobAtRef: jest.fn(async () => null),
+    getChangedFilesBetweenRefs: jest.fn(async () => []),
   },
 }));
 

--- a/src/screens/StageScreen.tsx
+++ b/src/screens/StageScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { FlatList, RefreshControl, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, FlatList, RefreshControl, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import { ScreenHeader, useScreenHeaderHeight } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
@@ -81,6 +82,7 @@ export default function StageScreen() {
   const registerQueueSubscription = useStageStore((s) => s.registerQueueSubscription);
   const requestPush = useStageStore((s) => s.requestPush);
   const pushAll = useStageStore((s) => s.pushAll);
+  const discardStaged = useStageStore((s) => s.discardStaged);
   const { progress, visible, label } = useGitHubActivityStore();
   const [refreshing, setRefreshing] = useState(false);
   const headerHeight = useScreenHeaderHeight();
@@ -134,6 +136,24 @@ export default function StageScreen() {
     void drainPushQueue('manual');
   }, [pushAll]);
 
+  const handleDiscardGroup = useCallback(
+    (group: StageGroup) => {
+      Alert.alert(
+        'Discard Changes',
+        `Discard all staged changes for ${repoName(group.repoPath)} / ${group.branch}? This cannot be undone.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Discard',
+            style: 'destructive',
+            onPress: () => void discardStaged(group.repoPath, group.branch),
+          },
+        ],
+      );
+    },
+    [discardStaged],
+  );
+
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
@@ -148,7 +168,7 @@ export default function StageScreen() {
       const pushing = isPushing[item.key] ?? false;
       return (
         <View>
-          <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+          <View className="flex-row items-center gap-2 px-4 pt-4 pb-2">
             <View className="flex-1 mr-3">
               <Text className="text-sm font-bold" style={{ color: colors.text }} numberOfLines={1}>
                 {repoName(item.repoPath)}
@@ -170,6 +190,17 @@ export default function StageScreen() {
                 Push
               </Text>
             </TouchableOpacity>
+            <TouchableOpacity
+              testID={`stage.discard.${item.key}`}
+              onPress={() => handleDiscardGroup(item)}
+              disabled={pushing}
+              accessibilityRole="button"
+              accessibilityState={{ disabled: pushing }}
+              className="px-3 py-1.5 rounded-md"
+              style={{ backgroundColor: pushing ? colors.border : colors.error }}
+            >
+              <Ionicons name="trash" size={13} color="#ffffff" />
+            </TouchableOpacity>
           </View>
           {item.items.map((row) => (
             <StageRow key={`${item.key}:${row.filePath}:${row.localCommitOid ?? ''}`} item={row} />
@@ -177,7 +208,7 @@ export default function StageScreen() {
         </View>
       );
     },
-    [colors, handlePushGroup, isPushing],
+    [colors, handlePushGroup, handleDiscardGroup, isPushing],
   );
 
   const renderEmpty = useCallback(
@@ -256,19 +287,49 @@ export default function StageScreen() {
           ) : null
         }
         actions={
-          <TouchableOpacity
-            testID="stage.push-all"
-            onPress={handlePushAll}
-            disabled={pushAllDisabled}
-            accessibilityRole="button"
-            accessibilityState={{ disabled: pushAllDisabled }}
-            className="px-3 py-1.5 rounded-md"
-            style={{ backgroundColor: pushAllDisabled ? colors.border : colors.primary }}
-          >
-            <Text className="text-xs font-bold" style={{ color: '#ffffff' }}>
-              Push all
-            </Text>
-          </TouchableOpacity>
+          <>
+            <TouchableOpacity
+              testID="stage.discard-all"
+              onPress={() => {
+                Alert.alert(
+                  'Discard All Changes',
+                  'Discard all staged changes across all repositories? This cannot be undone.',
+                  [
+                    { text: 'Cancel', style: 'cancel' },
+                    {
+                      text: 'Discard All',
+                      style: 'destructive',
+                      onPress: async () => {
+                        for (const group of groups) {
+                          await discardStaged(group.repoPath, group.branch);
+                        }
+                      },
+                    },
+                  ],
+                );
+              }}
+              disabled={pushAllDisabled}
+              accessibilityRole="button"
+              accessibilityState={{ disabled: pushAllDisabled }}
+              className="px-3 py-1.5 rounded-md"
+              style={{ backgroundColor: pushAllDisabled ? colors.border : colors.error }}
+            >
+              <Ionicons name="trash" size={13} color="#ffffff" />
+            </TouchableOpacity>
+            <TouchableOpacity
+              testID="stage.push-all"
+              onPress={handlePushAll}
+              disabled={pushAllDisabled}
+              accessibilityRole="button"
+              accessibilityState={{ disabled: pushAllDisabled }}
+              className="px-3 py-1.5 rounded-md"
+              style={{ backgroundColor: pushAllDisabled ? colors.border : colors.primary }}
+            >
+              <Text className="text-xs font-bold" style={{ color: '#ffffff' }}>
+                Push all
+              </Text>
+            </TouchableOpacity>
+          </>
         }
       />
 

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -502,6 +502,51 @@ export class GitFsService {
     }
   }
 
+  static async getChangedFilesBetweenRefs(opts: {
+    repoPath: string;
+    fromRef: string;
+    toRef: string;
+    maxCommits?: number;
+  }): Promise<string[]> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) return [];
+    const dir = repoDirVirtual(info.owner, info.repo);
+    const fs = makeRepoFs();
+    const files = new Set<string>();
+    const depth = opts.maxCommits ?? 20;
+
+    try {
+      const commits = await git.log({ fs, dir, ref: opts.toRef, depth });
+      for (const commit of commits) {
+        if (commit.oid === opts.fromRef) break;
+        const tree = await git.readTree({ fs, dir, oid: commit.commit.tree });
+        const parentOid = commit.commit.parent[0] ?? null;
+        if (parentOid) {
+          const parentTree = await git.readTree({ fs, dir, oid: parentOid });
+          const parentMap = new Map(parentTree.tree.map((e) => [e.path, e.oid]));
+          for (const entry of tree.tree) {
+            const prevOid = parentMap.get(entry.path);
+            if (!prevOid || prevOid !== entry.oid) {
+              files.add(entry.path);
+            }
+          }
+          for (const entry of parentTree.tree) {
+            if (!tree.tree.find((e) => e.path === entry.path)) {
+              files.add(entry.path);
+            }
+          }
+        } else {
+          for (const entry of tree.tree) {
+            files.add(entry.path);
+          }
+        }
+      }
+    } catch {
+      // Shallow clone may not have full history; return empty to trigger placeholder
+    }
+    return [...files];
+  }
+
   static async mergeCommit(opts: {
     repoPath: string;
     branch: string;

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -489,13 +489,54 @@ static async deleteAndCommit(opts: DeleteOpts): Promise<LocalGitWriterResult> {
   }
 
   /**
+   * Discard all unpushed local commits by resetting the local branch to
+   * origin/<branch>. This is a hard reset — any working-tree changes are
+   * also discarded. Used by the "Discard changes" button on the Stage screen.
+   */
+  static async resetToRemote(opts: {
+    repoPath: string;
+    branch: string;
+    token?: string;
+  }): Promise<LocalGitWriterResult> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) return { success: false, error: `Invalid repo path: ${opts.repoPath}` };
+
+    const dir = repoDirVirtual(info.owner, info.repo);
+    const fs = makeRepoFs();
+
+    try {
+      await ensureOnBranch(fs, dir, opts.branch, opts.token);
+
+      const remoteRef = `refs/remotes/origin/${opts.branch}`;
+      const remoteOid = await GitFsService.getCommitOid({ repoPath: opts.repoPath, ref: remoteRef });
+      if (remoteOid === null) {
+        return { success: false, error: `No remote ref found for ${opts.branch}; cannot discard without an origin to reset to.` };
+      }
+
+      await git.branch({
+        fs,
+        dir,
+        ref: `refs/heads/${opts.branch}`,
+        object: remoteOid,
+        force: true,
+        checkout: true,
+      });
+      return { success: true };
+    } catch (e) {
+      const raw = e instanceof Error ? e.message : String(e);
+      console.warn('[LocalGitWriter] resetToRemote failed:', raw);
+      return { success: false, error: raw };
+    }
+  }
+
+  /**
    * Push pending local commits to the remote without staging or committing
    * anything new. Used by `NoteSyncQueueService.drain` to flush a coalesced
    * batch of write calls that ran with `push: false` (issue #565 phase
    * B.1). On non-fast-forward rejection we pull once and retry the push,
    * mirroring the pattern in `writeAndCommit` / `deleteAndCommit`.
    */
-static async push(opts: {
+  static async push(opts: {
     repoPath: string;
     branch: string;
     token?: string;

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -285,14 +285,35 @@ export class StagingService {
         continue;
       }
 
-      items.push({
+      const remoteRef = hasRemote ? `refs/remotes/origin/${repoBranch}` : `refs/heads/${repoBranch}`;
+      const changedFiles = await GitFsService.getChangedFilesBetweenRefs({
         repoPath: repo.path,
-        branch: repoBranch,
-        filePath: UNPUSHED_COMMITS_PLACEHOLDER,
-        kind: 'upsert',
-        mode: 'clone',
-        localCommitOid: localOid ?? undefined,
+        fromRef: mergeBase ?? remoteRef,
+        toRef: `refs/heads/${repoBranch}`,
+        maxCommits: 20,
       });
+
+      if (changedFiles.length === 0) {
+        items.push({
+          repoPath: repo.path,
+          branch: repoBranch,
+          filePath: UNPUSHED_COMMITS_PLACEHOLDER,
+          kind: 'upsert',
+          mode: 'clone',
+          localCommitOid: localOid ?? undefined,
+        });
+      } else {
+        for (const filePath of changedFiles) {
+          items.push({
+            repoPath: repo.path,
+            branch: repoBranch,
+            filePath,
+            kind: 'upsert',
+            mode: 'clone',
+            localCommitOid: localOid ?? undefined,
+          });
+        }
+      }
     }
 
     return items;
@@ -359,6 +380,36 @@ export class StagingService {
         notifyStagedChanged();
       }
 
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  /**
+   * Discard all staged local changes for a given repo/branch by resetting
+   * the local branch to origin. Used by the "Discard changes" button on the
+   * Stage screen.
+   */
+  static async discardStaged(
+    repoPath: string,
+    branch: string,
+  ): Promise<StagingResult> {
+    try {
+      const mode = await SyncEngineService.getMode(repoPath);
+      if (mode !== 'clone') {
+        return { success: false, error: 'Discard is only supported in clone sync mode.' };
+      }
+
+      const token = await AuthService.getToken();
+      const result = await LocalGitWriter.resetToRemote({
+        repoPath,
+        branch,
+        token: token ?? undefined,
+      });
+      if (!result.success) return { success: false, error: result.error };
+
+      notifyStagedChanged();
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : String(error) };

--- a/src/stores/stageStore.ts
+++ b/src/stores/stageStore.ts
@@ -33,6 +33,7 @@ interface StageActions {
   setGlobalPushing: (bool: boolean) => void;
   setPushProgress: (fraction: number | null) => void;
   pushAll: () => void;
+  discardStaged: (repoPath: string, branch: string) => Promise<void>;
   dequeueNext: () => string | null;
   shiftQueue: () => void;
   registerQueueSubscription: () => void;
@@ -138,6 +139,15 @@ export const useStageStore = create<StageState & StageActions>()((set, get) => (
       }
     }
     set({ pushQueue });
+  },
+
+  discardStaged: async (repoPath: string, branch: string) => {
+    const { StagingService } = await import('../services/git/StagingService');
+    const result = await StagingService.discardStaged(repoPath, branch);
+    if (!result.success) {
+      console.warn('[stageStore] discardStaged failed:', result.error);
+    }
+    void get().loadStaged();
   },
 
   dequeueNext: () => get().pushQueue[0] ?? null,


### PR DESCRIPTION
## Summary

### Discard Changes Button
Adds a red trash-icon **Discard** button to the Staged Changes screen:
- Per-group discard next to the existing Push button (with `Alert.alert` confirmation)
- Header-level "Discard all" button to the left of "Push all"

Implementation: `LocalGitWriter.resetToRemote()` uses `git.branch({ force: true, checkout: true })` to hard-reset the local branch to `origin/<branch>`, discarding all unpushed commits and working-tree changes. Wired through `StagingService.discardStaged()` → `stageStore.discardStaged()`.

### Fix Staged-Change Display
Previously, clone-mode unpushed commits showed as a single `(unpushed commits)` placeholder row per repo/branch — the actual file paths were invisible.

Now `GitFsService.getChangedFilesBetweenRefs()` walks commits from merge-base to local HEAD using `git.log` + `git.readTree`, returning the actual changed file paths. `StagingService.listStaged()` surfaces individual `StagedItem` rows per file. Falls back to the placeholder when history is unavailable (shallow clone).

## Changes

| File | Change |
|------|--------|
| `src/screens/StageScreen.tsx` | Discard buttons, `gap-2` spacing fix |
| `src/services/git/LocalGitWriter.ts` | `resetToRemote()` method |
| `src/services/git/StagingService.ts` | `discardStaged()`, fixed `listStaged` for clone mode |
| `src/services/git/GitFsService.ts` | `getChangedFilesBetweenRefs()` |
| `src/stores/stageStore.ts` | `discardStaged` action |
| `__tests__/*.ts` | Mock updates for `getChangedFilesBetweenRefs` |

## Test Results
- `tsc --noEmit` ✅
- `jest` — 311 suites, 2852 tests ✅
- `eslint` — 0 errors ✅