### PR TITLE
chore(release): bump version to 1.5.1

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "GitNot\u0113s",
     "slug": "gitnotes",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "orientation": "portrait",
     "icon": "./assets/generated/icon.png",
     "userInterfaceStyle": "automatic",
@@ -12,7 +12,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.xaventra.gitnotes",
-      "buildNumber": "9",
+      "buildNumber": "10",
       "scheme": "gitnotes",
       "icon": "./assets/generated/icon.png",
       "infoPlist": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnotes",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MPL-2.0",
   "main": "expo/AppEntry.js",
   "engines": {


### PR DESCRIPTION
Sync release version to 1.5.1 across package.json + app.json, bump iOS buildNumber to 10. Ships the sync fixes (#1035/#1036) and the large-repo clone guard (#1037/#1038/#1039).