### PR TITLE
fix(android): grandfathered Pro survives reinstall via Auto Backup

### DIFF
--- a/app.json
+++ b/app.json
@@ -65,7 +65,7 @@
           ]
         }
       ],
-      "allowBackup": false,
+      "allowBackup": true,
       "permissions": [
         "android.permission.RECORD_AUDIO"
       ]
@@ -88,6 +88,7 @@
       "@react-native/datetimepicker",
       "expo-secure-store",
       "./plugins/withKeychainAccessGroup",
+      "./plugins/withGrandfatherBackup",
       "expo-image",
       "expo-sharing",
       "expo-background-task",

--- a/docs/wiki/paywall-pro.md
+++ b/docs/wiki/paywall-pro.md
@@ -38,7 +38,15 @@ Existing users are detected with **two mechanisms**, evaluated **once per instal
 
 The decision is persisted once as `@gitnotes:pro_grandfathered` / `@gitnotes:grandfather_checked`. The flag **only ever adds Pro, never revokes it**. RevenueCat remains the source of truth for purchases.
 
-Caveat: the Android fallback flag is device-local — a grandfathered user who uninstalls and reinstalls loses it (RevenueCat's own anonymous identity has the same limitation, since there are no app accounts).
+### Android reinstall durability (Auto Backup)
+
+The grandfather flag lives in AsyncStorage, which on Android is the SQLite DB `RKStorage`. To survive an **uninstall + reinstall** on the same Google account/device, Android Auto Backup must back up that DB:
+
+- `plugins/withGrandfatherBackup.js` sets `android:allowBackup="true"` and points `android:fullBackupContent` / `android:dataExtractionRules` at rules XML that **include `database/RKStorage`** (the AsyncStorage DB → the grandfather flag) **and** `sharedpref`, while still **excluding `SecureStore`** (the GitHub token stays device-only).
+- The rules files are written to `android/app/src/main/res/xml/` at prebuild time.
+- Registered in `app.json` after `expo-secure-store` (its plugin only includes `sharedpref`, so this is what actually covers the DB).
+
+Caveats: Auto Backup requires Google backup to be enabled and runs periodically (not instantly after install). A grandfathered user who reinstalls on a different device or with backup off still falls back to `customerInfo.originalApplicationVersion` (best-effort when the Android RevenueCat key is set) and otherwise loses the flag. iOS is unaffected — the receipt-backed `originalApplicationVersion` survives reinstalls natively.
 
 ### Gating map (Pro = AI suite + advanced features)
 

--- a/plugins/withGrandfatherBackup.js
+++ b/plugins/withGrandfatherBackup.js
@@ -1,0 +1,86 @@
+/**
+ * Config plugin: make the grandfathered-Pro flag survive an Android
+ * reinstall by enabling Android Auto Backup for the AsyncStorage DB.
+ *
+ * The grandfather decision is persisted in AsyncStorage
+ * (`@gitnotes:pro_grandfathered`), which on Android lives in a SQLite
+ * database named `RKStorage`. Two things previously made that flag
+ * vanish on uninstall+reinstall:
+ *
+ *   1. `android:allowBackup` was `false` in app.json, disabling Auto
+ *      Backup entirely.
+ *   2. The expo-secure-store backup rules only include the
+ *      `sharedpref` domain — the `database` domain (where RKStorage
+ *      lives) was not backed up at all.
+ *
+ * This plugin:
+ *   - sets `android:allowBackup="true"`,
+ *   - points `android:fullBackupContent` / `android:dataExtractionRules`
+ *     at our own rules XML that includes `database/RKStorage` +
+ *     `sharedpref`, while still excluding the `SecureStore` sharedpref
+ *     file (the GitHub token must stay device-only), and
+ *   - writes those two rules files into
+ *     `android/app/src/main/res/xml/` at prebuild time.
+ *
+ * Restoring the AsyncStorage DB restores the grandfather flag (and
+ * other app prefs), so a grandfathered Android user keeps Pro across a
+ * reinstall on the same Google account/device.
+ */
+const { withAndroidManifest, withDangerousMod } = require('@expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+const FULL_BACKUP_RULES = `<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+  <include domain="database" path="RKStorage"/>
+  <include domain="sharedpref" path="."/>
+  <exclude domain="sharedpref" path="SecureStore"/>
+</full-backup-content>
+`;
+
+const DATA_EXTRACTION_RULES = `<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+  <cloud-backup>
+    <include domain="database" path="RKStorage"/>
+    <include domain="sharedpref" path="."/>
+    <exclude domain="sharedpref" path="SecureStore"/>
+  </cloud-backup>
+  <device-transfer>
+    <include domain="database" path="RKStorage"/>
+    <include domain="sharedpref" path="."/>
+    <exclude domain="sharedpref" path="SecureStore"/>
+  </device-transfer>
+</data-extraction-rules>
+`;
+
+module.exports = function withGrandfatherBackup(config) {
+  config = withAndroidManifest(config, (c) => {
+    const app = c.modResults.manifest.application?.[0];
+    if (!app) return c;
+    app.$['android:allowBackup'] = 'true';
+    app.$['android:fullBackupContent'] = '@xml/grandfather_backup_rules';
+    app.$['android:dataExtractionRules'] = '@xml/grandfather_data_extraction_rules';
+    return c;
+  });
+
+  return withDangerousMod(config, [
+    'android',
+    async (c) => {
+      const resXml = path.join(
+        c.modRequest.platformProjectRoot,
+        'app',
+        'src',
+        'main',
+        'res',
+        'xml',
+      );
+      fs.mkdirSync(resXml, { recursive: true });
+      fs.writeFileSync(path.join(resXml, 'grandfather_backup_rules.xml'), FULL_BACKUP_RULES);
+      fs.writeFileSync(
+        path.join(resXml, 'grandfather_data_extraction_rules.xml'),
+        DATA_EXTRACTION_RULES,
+      );
+      return c;
+    },
+  ]);
+};


### PR DESCRIPTION
The grandfather flag lives in AsyncStorage (Android SQLite DB 'RKStorage'), which was wiped on uninstall because allowBackup=false and the backup rules only covered sharedpref. New config plugin enables Auto Backup + includes database/RKStorage (excluding SecureStore). Verified via expo prebuild (manifest + rules XML generated).