### PR TITLE
chore: remove stray empty plist file

### DIFF
--- a/--
+++ b/--
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict></dict></plist>


### PR DESCRIPTION
Remove a stray file named '--' (empty XML plist) accidentally committed in 267536bc (#1040). It's a shell byproduct with no content or purpose.