### PR TITLE
docs(wiki): promote GitHub Wiki to the public-facing main wiki

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,94 @@
+name: Sync Wiki
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/wiki/**', '.github/workflows/sync-wiki.yml']
+  workflow_dispatch:
+
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync docs/wiki/ → GitHub Wiki
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Sync
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Configure git identity (required for the wiki commit)
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Clone the wiki as a separate working tree
+          WIKI_DIR="$(mktemp -d)"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.wiki.git" "$WIKI_DIR"
+
+          cd "$WIKI_DIR"
+
+          # Patch the CHANGELOG.md link in copied index.md → Home.md to an absolute
+          # GitHub URL. In docs/wiki/, the relative path ../../CHANGELOG.md resolves
+          # to repo root; in the GitHub Wiki (flat namespace) it does not.
+          patch_changelog_link() {
+            sed -i 's|\.\./\.\./CHANGELOG\.md|https://github.com/'"${REPO}"'/blob/main/CHANGELOG.md|g' "$1"
+          }
+
+          # Copy a source file to its wiki target only if content differs (avoids
+          # no-op rewrite commits when docs/wiki/ hasn't changed).
+          sync_file() {
+            local src="$1" dst="$2"
+            if [ -f "$dst" ] && diff -q "$src" "$dst" > /dev/null 2>&1; then
+              return 0
+            fi
+            cp "$src" "$dst"
+          }
+
+          # Sync each docs/wiki/*.md → wiki/, renaming index.md → Home.md
+          for f in ../../docs/wiki/*.md; do
+            bn="$(basename "$f")"
+            if [ "$bn" = "index.md" ]; then
+              tmp="$(mktemp)"
+              cp "$f" "$tmp"
+              patch_changelog_link "$tmp"
+              sync_file "$tmp" "Home.md"
+              rm "$tmp"
+            else
+              sync_file "$f" "$bn"
+            fi
+          done
+
+          # Remove wiki pages that no longer exist in docs/wiki/
+          for existing in *.md; do
+            [ -f "$existing" ] || continue
+            bn_in_docs="$existing"
+            if [ "$existing" = "Home.md" ]; then
+              bn_in_docs="index.md"
+            fi
+            if [ ! -f "../../docs/wiki/$bn_in_docs" ]; then
+              rm "$existing"
+            fi
+          done
+
+          # Skip commit if there are no changes
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No wiki changes to sync"
+            exit 0
+          fi
+
+          git add -A
+          git commit -m "docs(wiki): sync from docs/wiki/ @ ${COMMIT_SHA:0:7}"
+          git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,9 @@ Open issues tracking current gaps against this truth: #925 (clone staging never 
 There are two documentation surfaces, and they serve different purposes:
 
 - **`CHANGELOG.md`** (repo root) — **single-PR fixes and narrow bug-fix entries**. Grouped by date descending, one section per entry: title, area (conventional-commit prefix), 2-4 line summary, PR reference. Default location for any new fix.
-- **`docs/wiki/`** — **architecture, services, contributor guides, feature deep-dives, post-mortems, and multi-PR campaigns**. A new wiki page is appropriate only when the change crosses architectural boundaries (new service, new major feature, cross-cutting refactor) or teaches something contributors need to understand the system. Each new wiki page MUST be added to `docs/wiki/index.md`.
+- **GitHub Wiki** ([gedwolmen/gitnotes/wiki](https://github.com/gedwolmen/gitnotes/wiki)) — **the public-facing main wiki**. Architecture, services, contributor guides, feature deep-dives, post-mortems, and multi-PR campaigns. A new wiki page is appropriate only when the change crosses architectural boundaries (new service, new major feature, cross-cutting refactor) or teaches something contributors need to understand the system.
 
-Pre-2026-08 fixes lived in single-PR wiki pages. Those pages were retired; their full content is preserved in git history via `git log -p -- docs/wiki/<file>.md`.
+Editing the wiki: write the page in `docs/wiki/<name>.md` (this repo, source-controlled), add it to `docs/wiki/index.md`, and open a PR. The CI sync workflow (`.github/workflows/sync-wiki.yml`) mirrors `docs/wiki/` → GitHub Wiki on every merge to `main`. Manual edits on `github.com/gedwolmen/gitnotes/wiki` will be overwritten on the next sync.
 
 Wiki documentation is part of the definition of done for **architecture-level changes only**.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 > **Format**: loosely based on [Keep a Changelog](https://keepachangelog.com/), grouped by date descending. Each entry references the originating PR (when available) and names the area from the conventional-commit prefix.
 >
-> **Wiki**: `docs/wiki/` is reserved for architecture, services, contributor guides, and feature deep-dives. New single-PR fixes should be added here, not as new wiki pages.
+> **Wiki**: the [GitHub Wiki](https://github.com/gedwolmen/gitnotes/wiki) is the public-facing main wiki — architecture, services, contributor guides, and feature deep-dives. Source-controlled editing surface is `docs/wiki/` in this repo; CI (`.github/workflows/sync-wiki.yml`) mirrors it to the GitHub Wiki on every merge to `main`. New single-PR fixes should be added here, not as new wiki pages.
 >
-> **History**: prior fixes (pre-2026-08) lived in single-PR wiki pages. Those pages were retired in [#1046-era cleanup]; their full diagnostic content is preserved in git history via `git log -p -- docs/wiki/<file>.md`.
+> **History**: prior fixes (pre-2026-08) lived in single-PR wiki pages. Those pages were retired in [#1047](https://github.com/gedwolmen/gitnotes/pull/1047); their full diagnostic content is preserved in git history via `git log -p -- docs/wiki/<file>.md`.
 
 ## 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - Notes, todos, journals, and Excalidraw-style canvases — all backed by Git
 - Folders, tags, colors, pins, wiki-links, backlinks, custom templates
 - Multiple GitHub accounts; per-repo API or full-clone sync modes
-- Deprecated importers (Google Keep, Apple Notes) are documented in the wiki: docs/wiki/importers.md
+- Deprecated importers (Google Keep, Apple Notes) are documented in the [wiki: importers](https://github.com/gedwolmen/gitnotes/wiki/importers)
 - Optional AI chat layer (Anthropic, OpenAI-compatible providers, Apple Intelligence, on-device Llama)
 - Biometric lock, multilingual UI (EN, ES, FR, DE, JA, KO), light / dark / system themes
 
@@ -49,7 +49,7 @@ Expo SDK 56 · React Native 0.85 · TypeScript 5.7 · isomorphic-git · React Na
 
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, and commit guidelines.
 
-For a full project knowledge base see docs/wiki/
+For a full project knowledge base see [the GitHub Wiki](https://github.com/gedwolmen/gitnotes/wiki)
 
 For bugs or feature requests, [open an issue](https://github.com/gedwolmen/gitnotes/issues/new/choose).
 


### PR DESCRIPTION
## Description

Promotes the [GitHub Wiki](https://github.com/gedwolmen/gitnotes/wiki) to the public-facing main wiki and adds an automated sync workflow.

The GitHub Wiki had become stale at 11 pages while `docs/wiki/` had grown to 30, with the two surfaces diverging. This PR:

1. **Updates references**: README, AGENTS.md, and CHANGELOG.md now point to the GitHub Wiki URL as the public-facing wiki surface.
2. **Adds `.github/workflows/sync-wiki.yml`**: on every merge to main (or workflow_dispatch), the workflow mirrors `docs/wiki/` → GitHub Wiki.
3. **Initial sync already pushed**: the wiki repo at `gedwolmen/gitnotes.wiki` is now at commit `bc2d09b` with all 30 pages mirrored (Home.md = docs/wiki/index.md, others = same names). The CHANGELOG.md link in Home.md is patched to an absolute GitHub URL since wiki pages live at the root of a flat namespace.

## Source-of-truth model

| Surface | Purpose | Edit path |
|---|---|---|
| `docs/wiki/*.md` | **Source of truth** — version-controlled, PR-reviewed | Add file in PR, update `docs/wiki/index.md` |
| GitHub Wiki | **Public-facing main wiki** — `github.com/gedwolmen/gitnotes/wiki` | Auto-synced from `docs/wiki/` by CI on every merge to main |

Manual edits on the GitHub Wiki directly will be overwritten by the next sync (AGENTS.md rule documents this).

## Why this approach

- **PR review on docs**: contributors still propose doc changes via PR; reviewers see diffs in `docs/wiki/`.
- **Public discoverability**: GitHub Wiki is more discoverable than `/tree/main/docs/wiki/` and is what users find first.
- **No drift**: the workflow keeps the two surfaces in sync, eliminating the previous 4-month gap.
- **Reversible**: disabling the GitHub Wiki feature (repo settings) is one click if we ever change our mind.

## Verification

- Wiki repo: 30 pages present (commit `bc2d09b`).
- Workflow: `.github/workflows/sync-wiki.yml` triggers on push to main with paths filter on `docs/wiki/**` or the workflow file itself.
- Permissions: `contents: write` granted to the workflow token.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Self-review performed
- [x] Documentation updated
- [x] No new warnings
- [x] Tests pass (docs only — no source code changes)