### PR TITLE
fix(ci): sync-wiki workflow — use absolute path to docs/wiki/

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -27,6 +27,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           COMMIT_SHA: ${{ github.sha }}
+          WIKI_SRC: ${{ github.workspace }}/docs/wiki
         run: |
           set -euo pipefail
 
@@ -58,7 +59,7 @@ jobs:
           }
 
           # Sync each docs/wiki/*.md → wiki/, renaming index.md → Home.md
-          for f in ../../docs/wiki/*.md; do
+          for f in "${WIKI_SRC}"/*.md; do
             bn="$(basename "$f")"
             if [ "$bn" = "index.md" ]; then
               tmp="$(mktemp)"
@@ -78,7 +79,7 @@ jobs:
             if [ "$existing" = "Home.md" ]; then
               bn_in_docs="index.md"
             fi
-            if [ ! -f "../../docs/wiki/$bn_in_docs" ]; then
+            if [ ! -f "${WIKI_SRC}/${bn_in_docs}" ]; then
               rm "$existing"
             fi
           done


### PR DESCRIPTION
## Bug

The `sync-wiki` workflow added in #1049 failed on first run because of a relative-path mistake:

```
cp: cannot stat '../../docs/wiki/*.md': No such file or directory
```

The workflow clones the wiki to `/tmp/tmp.xxxx/` (a fresh `mktemp -d`), then iterates `../../docs/wiki/*.md`. From the wiki's tmp location, `../../` is the runner's `/home/runner/...` parent — **not** the repo checkout.

## Fix

Pass `${GITHUB_WORKSPACE}/docs/wiki` to the script as an env var (`WIKI_SRC`) and use absolute paths instead of `../../docs/wiki/`. No other behavior changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update