### PR TITLE
fix: bug-hunt round 2 — 10 fixes (background-sync no-op, cross-account token leak, undo keystroke drop, write-through race)

### DIFF
--- a/__tests__/ForegroundSyncService.test.ts
+++ b/__tests__/ForegroundSyncService.test.ts
@@ -1,8 +1,13 @@
+let mockNetInfoListener: ((state: NetInfoState) => void) | undefined;
+
 jest.mock('@react-native-community/netinfo', () => ({
   __esModule: true,
   NetInfoStateType: { wifi: 'wifi', none: 'none' },
   default: {
-    addEventListener: jest.fn(() => jest.fn()),
+    addEventListener: jest.fn((listener: (state: NetInfoState) => void) => {
+      mockNetInfoListener = listener;
+      return jest.fn();
+    }),
     fetch: jest.fn(),
   },
 }));
@@ -379,5 +384,19 @@ describe('ForegroundSyncService', () => {
 
     randomSpy.mockRestore();
     logSpy.mockRestore();
+  });
+
+  test('does NOT pull when NetInfo fires reachable=true while app is backgrounded', async () => {
+    startForegroundWatcher({ syncFrequentlyEnabled: false, syncIntervalSeconds: 0 });
+    expect(mockNetInfoListener).toBeDefined();
+    mockNetInfoListener!(offlineState);
+    await Promise.resolve();
+    pullMock.mockClear();
+    mockNetInfoListener!(reachableState);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(0);
+    expect(pullMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/GitLabService.test.ts
+++ b/__tests__/GitLabService.test.ts
@@ -106,14 +106,30 @@ describe('GitLabService', () => {
     expect(await svc.getDefaultBranch('x', 'y')).toBeNull();
   });
 
-  it('setBaseUrl updates the API base for subsequent calls', async () => {
+  it('setToken with a baseUrl uses that baseUrl', async () => {
     primeAuthAndEndpoint({ id: 1, username: 'me', name: 'Me' });
     const svc = new GitLabService();
-    svc.setBaseUrl('https://gitlab.example.com/api/v4');
-    await svc.setToken('glpat-abc');
+    await svc.setToken('glpat-abc', 'https://gitlab.example.com/api/v4');
     expect(mockFetch).toHaveBeenCalledWith(
       'https://gitlab.example.com/api/v4/user',
       expect.any(Object),
     );
+  });
+
+  it('setToken without baseUrl resets to default (not stale from previous connection)', async () => {
+    primeAuthAndEndpoint({ id: 1, username: 'me', name: 'Me' });
+    const svc = new GitLabService();
+    svc.setBaseUrl('https://self-hosted-gitlab.example.com/api/v4');
+    await svc.setToken('glpat-abc');
+
+    mockFetch.mockReset();
+    primeAuthAndEndpoint({ id: 2, username: 'saas-user', name: 'SaaS' });
+    await svc.setToken('glpat-saas');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://gitlab.com/api/v4/user',
+      expect.any(Object),
+    );
+    expect(svc.getBaseUrl()).toBe('https://gitlab.com/api/v4');
   });
 });

--- a/__tests__/contexts/AccountsContext.switchAccount.test.tsx
+++ b/__tests__/contexts/AccountsContext.switchAccount.test.tsx
@@ -1,0 +1,119 @@
+const mockSetToken = jest.fn();
+const mockClearToken = jest.fn();
+
+jest.mock('../../src/services/GitHubService', () => ({
+  GitHubService: {
+    setToken: (...args: unknown[]) => mockSetToken(...args),
+    clearToken: (...args: unknown[]) => mockClearToken(...args),
+    initialize: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock('../../src/services/AuthService', () => ({
+  AuthService: {
+    switchAccount: jest.fn(async (accountId: string) => {
+      if (accountId === 'acc-A') {
+        return {
+          ok: true,
+          isAuthenticated: true,
+          token: 'token-A',
+          user: { login: 'alice', id: 1, name: 'Alice' },
+          accountId: 'acc-A',
+          activeHostId: 'host-A',
+        };
+      }
+      if (accountId === 'acc-B') {
+        return {
+          ok: true,
+          isAuthenticated: true,
+          token: 'token-B',
+          user: { login: 'bob', id: 2, name: 'Bob' },
+          accountId: 'acc-B',
+          activeHostId: 'host-B',
+        };
+      }
+      return { ok: false };
+    }),
+    switchToHost: jest.fn(async () => ({ ok: true })),
+    removeAccount: jest.fn(async () => undefined),
+    connectHost: jest.fn(async () => null),
+    clearToken: jest.fn(async () => undefined),
+    checkAuthState: jest.fn(async () => ({
+      isAuthenticated: true,
+      token: 'token-A',
+      user: { login: 'alice', id: 1, name: 'Alice' },
+    })),
+    listAccountSummaries: jest.fn(async () => []),
+    getActiveSummary: jest.fn(async () => null),
+  },
+}));
+
+jest.mock('../../src/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    setAuthState: jest.fn(),
+  }),
+}));
+
+jest.mock('../../src/services/ChatStorageService', () => ({
+  setChatRepoAccount: jest.fn(async () => undefined),
+  clearChatRepoIfOrphaned: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const mem: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (k: string) => (k in mem ? mem[k] : null)),
+      setItem: jest.fn(async (k: string, v: string) => {
+        mem[k] = v;
+      }),
+      removeItem: jest.fn(async (k: string) => {
+        delete mem[k];
+      }),
+      clear: jest.fn(async () => {
+        for (const k of Object.keys(mem)) delete mem[k];
+      }),
+    },
+  };
+});
+
+import { renderHook, act } from '@testing-library/react-native';
+import { AccountsProvider, useAccounts } from '../../src/contexts/AccountsContext';
+
+beforeEach(() => {
+  mockSetToken.mockReset();
+  mockClearToken.mockReset();
+  mockSetToken.mockResolvedValue(null);
+  mockClearToken.mockResolvedValue(undefined);
+});
+
+function useAccountsWithProvider() {
+  return renderHook(() => useAccounts(), { wrapper: AccountsProvider });
+}
+
+describe('AccountsContext.switchAccount re-syncs GitHubService singleton', () => {
+  it('calls GitHubService.setToken with the new account token after switching', async () => {
+    const { result } = useAccountsWithProvider();
+    await act(async () => {
+      await result.current.switchAccount('acc-B');
+    });
+    expect(mockSetToken).toHaveBeenCalledWith('token-B', expect.objectContaining({ login: 'bob' }));
+  });
+
+  it('does NOT leak the previous account token: setToken is called with the NEW token, not the old one', async () => {
+    const { result } = useAccountsWithProvider();
+    await act(async () => {
+      await result.current.switchAccount('acc-A');
+    });
+    expect(mockSetToken).toHaveBeenCalledWith('token-A', expect.objectContaining({ login: 'alice' }));
+    mockSetToken.mockClear();
+
+    await act(async () => {
+      await result.current.switchAccount('acc-B');
+    });
+    const calledWith = mockSetToken.mock.calls.map((c) => c[0]);
+    expect(calledWith).toContain('token-B');
+    expect(calledWith).not.toContain('token-A');
+  });
+});

--- a/__tests__/contexts/AccountsContext.switchAccount.test.tsx
+++ b/__tests__/contexts/AccountsContext.switchAccount.test.tsx
@@ -1,6 +1,8 @@
 const mockSetToken = jest.fn();
 const mockClearToken = jest.fn();
 
+let mockActiveAccountId: string | null = null;
+
 jest.mock('../../src/services/GitHubService', () => ({
   GitHubService: {
     setToken: (...args: unknown[]) => mockSetToken(...args),
@@ -12,37 +14,33 @@ jest.mock('../../src/services/GitHubService', () => ({
 jest.mock('../../src/services/AuthService', () => ({
   AuthService: {
     switchAccount: jest.fn(async (accountId: string) => {
-      if (accountId === 'acc-A') {
-        return {
-          ok: true,
-          isAuthenticated: true,
-          token: 'token-A',
-          user: { login: 'alice', id: 1, name: 'Alice' },
-          accountId: 'acc-A',
-          activeHostId: 'host-A',
-        };
+      if (accountId === 'acc-A' || accountId === 'acc-B') {
+        mockActiveAccountId = accountId;
+        return { ok: true, summary: { account: { id: accountId } } };
       }
-      if (accountId === 'acc-B') {
-        return {
-          ok: true,
-          isAuthenticated: true,
-          token: 'token-B',
-          user: { login: 'bob', id: 2, name: 'Bob' },
-          accountId: 'acc-B',
-          activeHostId: 'host-B',
-        };
-      }
-      return { ok: false };
+      return { ok: false, reason: 'not-found' };
     }),
     switchToHost: jest.fn(async () => ({ ok: true })),
     removeAccount: jest.fn(async () => undefined),
     connectHost: jest.fn(async () => null),
     clearToken: jest.fn(async () => undefined),
-    checkAuthState: jest.fn(async () => ({
-      isAuthenticated: true,
-      token: 'token-A',
-      user: { login: 'alice', id: 1, name: 'Alice' },
-    })),
+    checkAuthState: jest.fn(async () => {
+      if (mockActiveAccountId === 'acc-A') {
+        return {
+          isAuthenticated: true,
+          token: 'token-A',
+          user: { login: 'alice', id: 1, name: 'Alice' },
+        };
+      }
+      if (mockActiveAccountId === 'acc-B') {
+        return {
+          isAuthenticated: true,
+          token: 'token-B',
+          user: { login: 'bob', id: 2, name: 'Bob' },
+        };
+      }
+      return { isAuthenticated: false, token: null, user: null };
+    }),
     listAccountSummaries: jest.fn(async () => []),
     getActiveSummary: jest.fn(async () => null),
   },
@@ -86,6 +84,7 @@ beforeEach(() => {
   mockClearToken.mockReset();
   mockSetToken.mockResolvedValue(null);
   mockClearToken.mockResolvedValue(undefined);
+  mockActiveAccountId = null;
 });
 
 function useAccountsWithProvider() {

--- a/__tests__/screens/NotesListScreen.test.tsx
+++ b/__tests__/screens/NotesListScreen.test.tsx
@@ -302,6 +302,14 @@ describe('NotesListScreen', () => {
     expect(getByText('Try adjusting your search or filters')).toBeTruthy();
   });
 
+  it('FlatList has onScrollToIndexFailed so search nav works for offscreen matches', () => {
+    const { UNSAFE_queryByType } = render(<NotesListScreen />);
+    const { FlatList } = require('react-native');
+    const list = UNSAFE_queryByType(FlatList);
+    expect(list).toBeTruthy();
+    expect(typeof list.props.onScrollToIndexFailed).toBe('function');
+  });
+
   it('renders a list of notes', () => {
     mockNotesSeed = [
       createNote({ id: 'n1', title: 'First Note' }),

--- a/__tests__/services/AccountStorage.hosts.test.ts
+++ b/__tests__/services/AccountStorage.hosts.test.ts
@@ -293,6 +293,16 @@ describe('AuthService.switchToHost / switchAccount', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe('not-found');
   });
+
+  it('makeHostId normalizes trailing slashes in instanceBaseUrl (bug-hunt 2026-08 loop2 #10)', () => {
+    const id1 = makeHostId('acc-1', 'github', 'https://github.com');
+    const id2 = makeHostId('acc-1', 'github', 'https://github.com/');
+    expect(id1).toBe(id2);
+
+    const id3 = makeHostId('acc-1', 'gitlab', 'https://gitlab.example.com/api/v4');
+    const id4 = makeHostId('acc-1', 'gitlab', 'https://gitlab.example.com/api/v4/');
+    expect(id3).toBe(id4);
+  });
 });
 
 describe('AuthService.listAccountSummaries', () => {

--- a/__tests__/services/AccountStorage.hosts.test.ts
+++ b/__tests__/services/AccountStorage.hosts.test.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
 
 jest.mock('expo-secure-store', () => {
   const mem: Record<string, string> = {};
@@ -303,6 +304,95 @@ describe('AuthService.listAccountSummaries', () => {
     expect(summaries[0].hosts).toHaveLength(1);
     expect(summaries[0].hosts[0].provider).toBe('github');
     expect(summaries[0].activeHostId).toBe(summaries[0].hosts[0].id);
+  });
+});
+
+describe('AccountStorage.removeHostConnection clears AI state when account is dropped', () => {
+  it('clears ai-settings blob and ai-provider-key-* SecureStore entries when last host disconnect drops the account', async () => {
+    const account = await AccountStorage.addAccount('gh-tok', {
+      login: 'octocat',
+      name: 'Octo Cat',
+      email: 'octo@example.com',
+      avatarUrl: 'https://example.com/octo.png',
+    });
+    const host = await AccountStorage.upsertHostConnection({
+      accountId: account.id,
+      provider: 'github',
+      instanceBaseUrl: null,
+      hostLogin: 'octocat',
+      hostUserId: 42,
+      hostDisplayName: 'Octo Cat',
+      hostAvatarUrl: 'https://example.com/octo.png',
+      token: 'gh-host-tok',
+    });
+
+    await AsyncStorage.setItem(
+      'ai-settings',
+      JSON.stringify({
+        providers: [
+          { id: 'openai-key', apiKey: 'sk-OAI' },
+          { id: 'anthropic-key', apiKey: 'sk-ANT' },
+        ],
+      }),
+    );
+    await SecureStore.setItemAsync('ai-provider-key-openai-key', 'sk-OAI');
+    await SecureStore.setItemAsync('ai-provider-key-anthropic-key', 'sk-ANT');
+
+    expect(await SecureStore.getItemAsync('ai-provider-key-openai-key')).toBe('sk-OAI');
+    expect(await AsyncStorage.getItem('ai-settings')).not.toBeNull();
+
+    await AccountStorage.removeHostConnection(host.id);
+
+    const remainingAccounts = await AccountStorage.listAccounts();
+    expect(remainingAccounts.find((a) => a.id === account.id)).toBeUndefined();
+
+    expect(await SecureStore.getItemAsync('ai-provider-key-openai-key')).toBeNull();
+    expect(await SecureStore.getItemAsync('ai-provider-key-anthropic-key')).toBeNull();
+    expect(await AsyncStorage.getItem('ai-settings')).toBeNull();
+  });
+
+  it('does NOT clear AI state when disconnecting a non-last host (account still has other hosts)', async () => {
+    const account = await AccountStorage.addAccount('gh-tok', {
+      login: 'octocat',
+      name: 'Octo Cat',
+      email: 'octo@example.com',
+      avatarUrl: 'https://example.com/octo.png',
+    });
+    const host1 = await AccountStorage.upsertHostConnection({
+      accountId: account.id,
+      provider: 'github',
+      instanceBaseUrl: null,
+      hostLogin: 'octocat',
+      hostUserId: 42,
+      hostDisplayName: 'GitHub',
+      hostAvatarUrl: 'https://example.com/octo.png',
+      token: 'gh-host-tok-1',
+    });
+    const host2 = await AccountStorage.upsertHostConnection({
+      accountId: account.id,
+      provider: 'gitlab',
+      instanceBaseUrl: 'https://gitlab.example.com',
+      hostLogin: 'octocat',
+      hostUserId: 42,
+      hostDisplayName: 'GitLab',
+      hostAvatarUrl: 'https://example.com/octo.png',
+      token: 'gl-host-tok',
+    });
+
+    await AsyncStorage.setItem(
+      'ai-settings',
+      JSON.stringify({ providers: [{ id: 'openai-key', apiKey: 'sk-OAI' }] }),
+    );
+    await SecureStore.setItemAsync('ai-provider-key-openai-key', 'sk-OAI');
+
+    await AccountStorage.removeHostConnection(host1.id);
+
+    const remainingAccounts = await AccountStorage.listAccounts();
+    expect(remainingAccounts.find((a) => a.id === account.id)).toBeDefined();
+    expect(remainingAccounts.find((a) => a.id === account.id)?.hostIds).toEqual([host2.id]);
+
+    expect(await SecureStore.getItemAsync('ai-provider-key-openai-key')).toBe('sk-OAI');
+    expect(await AsyncStorage.getItem('ai-settings')).not.toBeNull();
   });
 });
 

--- a/__tests__/services/BackgroundSyncService.test.ts
+++ b/__tests__/services/BackgroundSyncService.test.ts
@@ -34,6 +34,7 @@ jest.mock('../../src/services/StorageService', () => ({
 jest.mock('../../src/services/GitHubService', () => ({
   GitHubService: {
     isAuthenticated: jest.fn(() => true),
+    initialize: jest.fn(async () => undefined),
   },
 }));
 
@@ -116,5 +117,21 @@ describe('BackgroundSyncService notification decision', () => {
     expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
     expect(pullAllFromRepos).not.toHaveBeenCalled();
     expect(NotificationService.schedulePushProgress).not.toHaveBeenCalled();
+  });
+
+  test('calls GitHubService.initialize before checking isAuthenticated (cold-launch)', async () => {
+    (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(false);
+    (GitHubService.initialize as jest.Mock).mockImplementation(async () => {
+      (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
+    });
+    (pullAllFromRepos as jest.Mock).mockResolvedValue({
+      repos: 1, notes: 5, canvases: 0, todos: 0, templates: 0,
+    });
+
+    const result = await runTask();
+
+    expect(GitHubService.initialize).toHaveBeenCalledTimes(1);
+    expect(pullAllFromRepos).toHaveBeenCalledTimes(1);
+    expect(result).toBe(BackgroundTask.BackgroundTaskResult.Success);
   });
 });

--- a/__tests__/services/DailyQuoteService.emptyQuotes.test.ts
+++ b/__tests__/services/DailyQuoteService.emptyQuotes.test.ts
@@ -1,0 +1,46 @@
+jest.mock('../../src/data/philosopher_quotes.json', () => []);
+
+const mockAIStoreState = {
+  dailyQuoteEnabled: true,
+  dailyQuotePersonalizationEnabled: false,
+  aiPersonalizationEnabled: false,
+  selectedModelId: null as string | null,
+};
+
+jest.mock('../../src/stores/aiStore', () => ({
+  useAIStore: Object.assign(jest.fn(), {
+    getState: () => ({
+      dailyQuoteEnabled: mockAIStoreState.dailyQuoteEnabled,
+      dailyQuotePersonalizationEnabled: mockAIStoreState.dailyQuotePersonalizationEnabled,
+      aiPersonalizationEnabled: mockAIStoreState.aiPersonalizationEnabled,
+      getSelectedModel: () => undefined,
+    }),
+  }),
+}));
+
+jest.mock('../../src/services/AIService', () => ({
+  initializeModel: jest.fn(),
+}));
+
+jest.mock('ai', () => ({
+  generateText: jest.fn(),
+}));
+
+jest.mock('../../src/stores/proStore', () => ({
+  useProStore: { getState: () => ({}) },
+  selectIsPro: () => true,
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { dailyQuoteService } from '../../src/services/DailyQuoteService';
+
+describe('DailyQuoteService with empty quotes dataset', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear?.();
+  });
+
+  it('returns null instead of crashing when quotes array is empty', async () => {
+    const result = await dailyQuoteService.getDailyQuote([], []);
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/services/git/StagingService.writeThroughPush.test.ts
+++ b/__tests__/services/git/StagingService.writeThroughPush.test.ts
@@ -1,0 +1,102 @@
+import { writeThroughPush, SYNC_SAVE_WAIT_MS } from '../../../src/services/git/StagingService';
+
+const mockReleaseCycle = jest.fn();
+const mockBegin = jest.fn();
+const mockEnd = jest.fn();
+const mockDrain = jest.fn();
+const mockGetAll = jest.fn();
+const mockOnDropped = jest.fn();
+const mockEmitDropped = jest.fn();
+const mockPullFromSingleRepo = jest.fn();
+const mockRefreshStores = jest.fn();
+
+jest.mock('../../../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    drain: (...args: unknown[]) => mockDrain(...args),
+    getAll: () => mockGetAll(),
+    onDroppedMutation: (cb: (event: { mutation: { id: string } }) => void) => {
+      mockOnDropped(cb);
+      return mockEmitDropped;
+    },
+    emitDroppedMutation: (event: unknown) => mockEmitDropped(event),
+  },
+}));
+
+jest.mock('../../../src/services/git/GitSyncGate', () => ({
+  GitSyncGate: {
+    acquireCycle: jest.fn(async () => mockReleaseCycle),
+  },
+}));
+
+jest.mock('../../../src/stores/githubActivityStore', () => ({
+  githubActivity: {
+    begin: (...args: unknown[]) => mockBegin(...args),
+    end: (...args: unknown[]) => mockEnd(...args),
+  },
+}));
+
+jest.mock('../../../src/services/RepoPullService', () => ({
+  pullFromSingleRepo: (...args: unknown[]) => mockPullFromSingleRepo(...args),
+}));
+
+describe('writeThroughPush unsubDrop race (C4 bug-hunt 2026-08)', () => {
+  let droppedCallback: ((event: { mutation: { id: string } }) => void) | null = null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    droppedCallback = null;
+    mockOnDropped.mockImplementation((cb) => {
+      droppedCallback = cb;
+    });
+    mockEmitDropped.mockReset();
+    mockGetAll.mockResolvedValue([]);
+    mockPullFromSingleRepo.mockResolvedValue({ repos: 1, notes: 0, canvases: 0, todos: 0, templates: 0 });
+    mockRefreshStores.mockResolvedValue(undefined);
+    mockBegin.mockReturnValue(undefined);
+    mockEnd.mockReturnValue(undefined);
+  });
+
+  it('keeps drop listener active after timeout so late drops are still detected', async () => {
+    jest.useFakeTimers();
+    let resolveDrain: (value: unknown) => void = () => undefined;
+    mockDrain.mockImplementation(
+      () => new Promise((resolve) => {
+        resolveDrain = resolve;
+      }),
+    );
+
+    const promise = writeThroughPush('/repo', 'mutation-123');
+
+    // Let the timeout fire (45s race timeout)
+    await jest.advanceTimersByTimeAsync(SYNC_SAVE_WAIT_MS);
+
+    // After timeout, the function should have returned pendingSync:true
+    const result = await promise;
+    expect(result).toEqual({ success: true, pendingSync: true });
+
+    // SECURITY: at this point, the drop listener should STILL be active.
+    // The chain continues detached — if the mutation is dropped now,
+    // the chain must detect it (otherwise the user is told "will sync"
+    // when the mutation was permanently dropped).
+    expect(mockEmitDropped).not.toHaveBeenCalled();
+
+    // Emit a drop event AFTER the timeout (simulating a late drop while
+    // the chain is still running detached).
+    expect(droppedCallback).not.toBeNull();
+    droppedCallback!({ mutation: { id: 'mutation-123' } });
+
+    // Now let the chain complete (drain resolves)
+    resolveDrain({ succeeded: 0, failed: 0, remaining: 0 });
+    // Let pending microtasks settle
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The chain should have detected the drop and returned droppedConflict
+    // (which skips pullFromSingleRepo). If pullFromSingleRepo was called,
+    // it means the drop was missed.
+    expect(mockPullFromSingleRepo).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+});

--- a/__tests__/utils/useUndo.test.ts
+++ b/__tests__/utils/useUndo.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useUndo } from '../../src/utils/useUndo';
+
+describe('useUndo', () => {
+  it('does NOT drop the first setState call after undo (B4 bug-hunt 2026-08)', () => {
+    const { result } = renderHook(() => useUndo('initial'));
+
+    act(() => {
+      result.current.setState('A');
+    });
+    act(() => {
+      result.current.setState('B');
+    });
+    expect(result.current.state).toBe('B');
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.state).toBe('A');
+
+    act(() => {
+      result.current.setState('C');
+    });
+    expect(result.current.state).toBe('C');
+  });
+
+  it('does NOT drop the first setState call after redo', () => {
+    const { result } = renderHook(() => useUndo('initial'));
+
+    act(() => {
+      result.current.setState('A');
+    });
+    act(() => {
+      result.current.setState('B');
+    });
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.state).toBe('A');
+
+    act(() => {
+      result.current.redo();
+    });
+    expect(result.current.state).toBe('B');
+
+    act(() => {
+      result.current.setState('C');
+    });
+    expect(result.current.state).toBe('C');
+  });
+
+  it('does NOT drop the first setState call after reset', () => {
+    const { result } = renderHook(() => useUndo('initial'));
+
+    act(() => {
+      result.current.setState('A');
+    });
+    act(() => {
+      result.current.reset('reset-value');
+    });
+    expect(result.current.state).toBe('reset-value');
+
+    act(() => {
+      result.current.setState('after-reset');
+    });
+    expect(result.current.state).toBe('after-reset');
+  });
+});

--- a/src/contexts/AccountsContext.tsx
+++ b/src/contexts/AccountsContext.tsx
@@ -229,6 +229,14 @@ export function AccountsProvider({ children }: { children: ReactNode }) {
     async (accountId: string): Promise<boolean> => {
       const result = await AuthService.switchAccount(accountId);
       if (!result.ok) return false;
+      // SECURITY: re-sync GitHubService singleton with the new account's
+      // token — without this, the previous account's token is still in
+      // memory and direct GitHubService calls run as the wrong user.
+      if (result.token) {
+        await GitHubService.setToken(result.token, result.user as unknown as GhSetTokenUser).catch(
+          () => undefined,
+        );
+      }
       await refreshAccounts();
       return true;
     },

--- a/src/contexts/AccountsContext.tsx
+++ b/src/contexts/AccountsContext.tsx
@@ -232,8 +232,9 @@ export function AccountsProvider({ children }: { children: ReactNode }) {
       // SECURITY: re-sync GitHubService singleton with the new account's
       // token — without this, the previous account's token is still in
       // memory and direct GitHubService calls run as the wrong user.
-      if (result.token) {
-        await GitHubService.setToken(result.token, result.user as unknown as GhSetTokenUser).catch(
+      const state = await AuthService.checkAuthState();
+      if (state.isAuthenticated && state.token) {
+        await GitHubService.setToken(state.token, state.user as unknown as GhSetTokenUser).catch(
           () => undefined,
         );
       }

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -528,6 +528,24 @@ export default function NotesListScreen() {
         windowSize={7}
         updateCellsBatchingPeriod={50}
         removeClippedSubviews={true}
+        onScrollToIndexFailed={({ index, highestMeasuredFrameIndex, averageItemLength }) => {
+          // Without this, scrollToIndex for a search match beyond the
+          // measured window silently fails — search nav appears broken.
+          const offset = Math.max(
+            0,
+            (highestMeasuredFrameIndex < index
+              ? highestMeasuredFrameIndex
+              : index - 1) * averageItemLength,
+          );
+          listRef.current?.scrollToOffset({ offset, animated: true });
+          setTimeout(() => {
+            listRef.current?.scrollToIndex({
+              index,
+              animated: true,
+              viewPosition: 0.4,
+            });
+          }, 250);
+        }}
         contentContainerStyle={{
           padding: 12,
           paddingTop: headerBlurHeight + 4,

--- a/src/services/AccountStorage.ts
+++ b/src/services/AccountStorage.ts
@@ -483,6 +483,12 @@ export class AccountStorage {
       const stillActive = accountsToKeep.find((a) => a.id === activeAccountId);
       await this.setActiveHostId(stillActive?.hostIds[0] ?? null);
     }
+
+    // SECURITY: clear AI keys only when the account is actually dropped
+    // (not on every host disconnect), mirroring removeAccount.
+    if (removedAccountIds.length > 0) {
+      await this.clearAccountAiState();
+    }
   }
 
   // ── Legacy ───────────────────────────────────────────────────────────

--- a/src/services/AccountStorage.ts
+++ b/src/services/AccountStorage.ts
@@ -60,7 +60,8 @@ export function makeHostId(
   provider: GitHostProvider,
   instanceBaseUrl: string | null,
 ): string {
-  const instanceKey = (instanceBaseUrl ?? 'default').replace(/[^a-zA-Z0-9._-]/g, '_');
+  const normalized = instanceBaseUrl ? instanceBaseUrl.replace(/\/+$/, '') : null;
+  const instanceKey = (normalized ?? 'default').replace(/[^a-zA-Z0-9._-]/g, '_');
   return `${accountId}:${provider}:${instanceKey}`;
 }
 

--- a/src/services/BackgroundSyncService.ts
+++ b/src/services/BackgroundSyncService.ts
@@ -21,6 +21,9 @@ let taskRegistered = false;
 // what re-registers the handler.
 TaskManager.defineTask(TASK_NAME, async () => {
   try {
+    // SECURITY: load token from storage first — on OS cold-launch the
+    // singleton hasn't been initialized, so the auth check would silently no-op.
+    await GitHubService.initialize();
     if (!GitHubService.isAuthenticated()) {
       return BackgroundTask.BackgroundTaskResult.Success;
     }

--- a/src/services/DailyQuoteService.ts
+++ b/src/services/DailyQuoteService.ts
@@ -61,7 +61,8 @@ function resolveDescription(reason: FallbackReason): string {
   return FALLBACK_DESCRIPTIONS[reason];
 }
 
-function makeFallbackQuote(reason: FallbackReason): DailyQuote {
+function makeFallbackQuote(reason: FallbackReason): DailyQuote | null {
+  if (quotes.length === 0) return null;
   const random = quotes[Math.floor(Math.random() * quotes.length)];
   return {
     quoteId: random.id,

--- a/src/services/ForegroundSyncService.ts
+++ b/src/services/ForegroundSyncService.ts
@@ -272,6 +272,9 @@ function handleAppStateChange(state: AppStateStatus): void {
 }
 
 function handleNetInfo(reachable: boolean): void {
+  // SECURITY: don't pull while backgrounded — the OS suspends JS mid-pull,
+  // leaving inFlight stuck true and the cycle held for ~10 minutes.
+  if (lastAppState !== 'active') return;
   const cameOnline = lastNetReachable === false && reachable === true;
   lastNetReachable = reachable;
   if (cameOnline) void runPull('online');

--- a/src/services/git/GitLabService.ts
+++ b/src/services/git/GitLabService.ts
@@ -133,10 +133,11 @@ export class GitLabService implements GitHostService, GitHostWriteService {
   async setToken(token: string, baseUrl?: string): Promise<GitLabUser | null> {
     this.token = token;
     await AsyncStorage.setItem(GITLAB_TOKEN_KEY, token);
-    if (baseUrl) {
-      this.setBaseUrl(baseUrl);
-      await AsyncStorage.setItem(GITLAB_BASE_KEY, this.baseUrl);
-    }
+    // SECURITY: always reset baseUrl so a SaaS connect after a self-hosted
+    // connect doesn't verify the token against the stale self-hosted instance.
+    const nextBaseUrl = (baseUrl ?? GITLAB_BASE_DEFAULT).replace(/\/+$/, '');
+    this.baseUrl = nextBaseUrl;
+    await AsyncStorage.setItem(GITLAB_BASE_KEY, nextBaseUrl);
     const user = await this.fetchUser();
     this.user = user;
     if (user) {

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -84,7 +84,7 @@ const UNPUSHED_COMMITS_PLACEHOLDER = '(unpushed commits)';
  * carries `pendingSync: true` and the chain continues detached — its
  * `finally` block releases the cycle so the mutex is never leaked.
  */
-const SYNC_SAVE_WAIT_MS = 45_000;
+export const SYNC_SAVE_WAIT_MS = 45_000;
 
 async function resolveStageAuthor(): Promise<{ name: string; email: string }> {
   const user: GitHostUser | null = await getGitHostService('github').getAuthenticatedUser();
@@ -110,7 +110,7 @@ async function refreshStoresAfterPull(): Promise<void> {
  * returns `pendingSync: true` but lets the chain continue detached —
  * its `finally` block releases the cycle so the mutex is never leaked.
  */
-async function writeThroughPush(
+export async function writeThroughPush(
   repoPath: string,
   mutationId: string,
 ): Promise<StagingResult> {
@@ -148,22 +148,19 @@ async function writeThroughPush(
       }
     } finally {
       releaseCycle();
+      unsubDrop();
     }
   })();
 
-  try {
-    return await Promise.race([
-      chain,
-      new Promise<StagingResult>((resolve) =>
-        setTimeout(
-          () => resolve({ success: true, pendingSync: true }),
-          SYNC_SAVE_WAIT_MS,
-        ),
+  return await Promise.race([
+    chain,
+    new Promise<StagingResult>((resolve) =>
+      setTimeout(
+        () => resolve({ success: true, pendingSync: true }),
+        SYNC_SAVE_WAIT_MS,
       ),
-    ]);
-  } finally {
-    unsubDrop();
-  }
+    ),
+  ]);
 }
 
 /**

--- a/src/utils/useUndo.ts
+++ b/src/utils/useUndo.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 
 interface HistoryState<T> {
   past: T[];
@@ -25,16 +25,9 @@ export function useUndo<T>(initialState: T): UseUndoReturn<T> {
     future: [],
   });
 
-  const skipNextUpdate = useRef(false);
-
   const setState = useCallback((newState: T | ((prev: T) => T)) => {
-    if (skipNextUpdate.current) {
-      skipNextUpdate.current = false;
-      return;
-    }
-
     setHistory((prev) => {
-      const resolvedNewState = typeof newState === 'function' 
+      const resolvedNewState = typeof newState === 'function'
         ? (newState as (prev: T) => T)(prev.present)
         : newState;
 
@@ -62,8 +55,6 @@ export function useUndo<T>(initialState: T): UseUndoReturn<T> {
       const newPast = [...prev.past];
       const previousState = newPast.pop()!;
 
-      skipNextUpdate.current = true;
-
       return {
         past: newPast,
         present: previousState,
@@ -78,8 +69,6 @@ export function useUndo<T>(initialState: T): UseUndoReturn<T> {
 
       const [nextState, ...newFuture] = prev.future;
 
-      skipNextUpdate.current = true;
-
       return {
         past: [...prev.past, prev.present],
         present: nextState,
@@ -89,7 +78,6 @@ export function useUndo<T>(initialState: T): UseUndoReturn<T> {
   }, []);
 
   const reset = useCallback((newState: T) => {
-    skipNextUpdate.current = true;
     setHistory({
       past: [],
       present: newState,


### PR DESCRIPTION
## Summary

Bug-hunt round 2 (post-#1048) across 6 parallel explore agents found ~60 candidates. This PR ships the 10 highest-impact fixes, each RED→GREEN verified. Full suite: **2878 passed, 7 skipped, 0 failed**; tsc clean; eslint 0 errors.

## Fixes

### Security / Data Integrity
1. **`AccountStorage.removeHostConnection` now wipes AI provider keys when an account is dropped** (`ec120417`) — disconnecting a host dropped the account row but skipped `clearAccountAiState`, leaking `ai-provider-key-*` in SecureStore and the `ai-settings` blob to a re-added account.
2. **GitLabService baseUrl reset on every setToken** (`493eab07`) — SaaS connect after self-hosted connect verified tokens against the stale self-hosted instance.
3. **switchAccount re-syncs GitHubService singleton** (`92e4ef57` + `93b8d062`) — switching accounts left the previous user's token in memory; direct GitHubService calls ran as the wrong user.
4. **makeHostId normalizes trailing slashes** (`91cf876b`) — same host connected with/without trailing `/` produced duplicate host rows.

### Silent data loss
5. **useUndo: first keystroke after undo/redo no longer swallowed** (`6e397f6d`) — `skipNextUpdate` was designed for web-style onChange echoes that don't exist in RN controlled TextInputs.
6. **writeThroughPush: drop listener stays active until chain completes** (`676b5a9c`) — after the 45s timeout, a late mutation drop was invisible: caller told "will sync" while it was permanently dropped.

### Reliability
7. **BackgroundSyncService loads token from storage** (`b76eeae1`) — OS cold-launch never mounted React, so `isAuthenticated()` read a null token and every background sync run silently no-oped.
8. **NetInfo-triggered pulls gated on foreground state** (`5c844a6e`) — background WiFi reconnects started pulls that the OS suspended mid-flight, wedging `inFlight` for ~10 minutes.

### Crashes / UX
9. **DailyQuoteService guards empty quotes dataset** (`34818e95`) — corrupted/empty dataset crashed Home + Journal screens.
10. **NotesListScreen handles scrollToIndex failure** (`04721701`) — search next/prev silently did nothing for matches beyond the measured window.

## Test plan
- Each fix has a new or updated test asserting the post-fix contract (RED captured before each fix).
- Full suite green: 2878 passed / 0 failed / 7 skipped (316 suites).
- `yarn ts:check` clean; `yarn eslint .` 0 errors.

🤖 Generated with [opencode](https://opencode.ai)