### PR TITLE
fix(git): bug-hunt round 4 — clone-mode push recovery + GitLab branch resolution

### DIFF
--- a/__tests__/services/git/branchResolver.provider.test.ts
+++ b/__tests__/services/git/branchResolver.provider.test.ts
@@ -1,0 +1,87 @@
+jest.mock('../../../src/services/git/GitFsService', () => ({
+  GitFsService: {
+    getCurrentBranch: jest.fn(async () => null),
+  },
+}));
+
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+jest.mock('../../../src/services/git/activeHost', () => ({
+  getActiveGitHost: jest.fn(async () => null),
+  clearActiveGitHostCache: jest.fn(),
+}));
+
+jest.mock('../../../src/services/AuthService', () => ({
+  __esModule: true,
+  default: {
+    getToken: jest.fn(async () => 'tok'),
+  },
+  AuthService: {
+    getToken: jest.fn(async () => 'tok'),
+    getActiveSummary: jest.fn(async () => null),
+  },
+}));
+
+import { resolveBranch, fetchGitLabDefaultBranch, __resetBranchCacheForTests } from '../../../src/services/git/branchResolver';
+import { getActiveGitHost } from '../../../src/services/git/activeHost';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+beforeEach(() => {
+  __resetBranchCacheForTests();
+  mockFetch.mockReset();
+  (getActiveGitHost as jest.Mock).mockResolvedValue(null);
+  (AsyncStorage.getItem as jest.Mock) = jest.fn(async () => null);
+});
+
+describe('resolveBranch provider routing + GitLab auth (bug-hunt loop4 #16)', () => {
+  it('routes to the GitLab resolver when the active host is gitlab', async () => {
+    (getActiveGitHost as jest.Mock).mockResolvedValue({
+      provider: 'gitlab',
+      baseUrl: 'https://gitlab.com/api/v4',
+      token: 'glpat-x',
+    });
+    mockFetch.mockResolvedValue(jsonResponse({ default_branch: 'trunk' }));
+
+    const branch = await resolveBranch('owner/repo');
+    expect(branch).toBe('trunk');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('gitlab.com/api/v4/projects/'),
+      expect.any(Object),
+    );
+  });
+
+  it('sends PRIVATE-TOKEN header for authenticated GitLab repos', async () => {
+    (getActiveGitHost as jest.Mock).mockResolvedValue({
+      provider: 'gitlab',
+      baseUrl: 'https://gitlab.example.com/api/v4',
+      token: 'glpat-secret',
+    });
+    await AsyncStorage.setItem('@gitnotes:gitlab_base_url', 'https://gitlab.example.com/api/v4/');
+    mockFetch.mockResolvedValue(jsonResponse({ default_branch: 'main' }));
+
+    const branch = await fetchGitLabDefaultBranch('owner/private-repo');
+    expect(branch).toBe('main');
+
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)['PRIVATE-TOKEN']).toBe('glpat-secret');
+  });
+
+  it('still uses the GitHub resolver when no host is active or provider is github', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ default_branch: 'develop' }));
+    const branch = await resolveBranch('owner/repo');
+    expect(branch).toBe('develop');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('api.github.com/repos/'),
+      expect.any(Object),
+    );
+  });
+});

--- a/__tests__/services/git/localGitWriter.recovery.test.ts
+++ b/__tests__/services/git/localGitWriter.recovery.test.ts
@@ -1,0 +1,117 @@
+jest.mock('isomorphic-git', () => {
+  const mocks = {
+    add: jest.fn(async () => undefined),
+    remove: jest.fn(async () => undefined),
+    commit: jest.fn(async () => 'commit-sha-1'),
+    push: jest.fn(async () => ({ ok: true })),
+    currentBranch: jest.fn(async () => 'main'),
+    checkout: jest.fn(async () => undefined),
+    fetch: jest.fn(async () => undefined),
+    status: jest.fn(async () => 'modified'),
+  };
+  (globalThis as any).__lgw2GitMocks = mocks;
+  return { __esModule: true, default: mocks };
+});
+
+jest.mock('expo-file-system/legacy', () => {
+  const fsStore = new Map<string, { type: 'file' | 'dir' }>();
+  (globalThis as any).__lgw2FsStore = fsStore;
+  return {
+    __esModule: true,
+    documentDirectory: 'file:///doc/',
+    EncodingType: { Base64: 'base64', UTF8: 'utf8' },
+    async getInfoAsync(uri: string) {
+      const e = fsStore.get(uri);
+      return e ? { exists: true, uri, isDirectory: e.type === 'dir' } : { exists: false, uri };
+    },
+    async writeAsStringAsync(uri: string) {
+      fsStore.set(uri, { type: 'file' });
+    },
+    async deleteAsync(uri: string) {
+      fsStore.delete(uri);
+    },
+    async makeDirectoryAsync(uri: string) {
+      fsStore.set(uri, { type: 'dir' });
+    },
+  };
+});
+
+jest.mock('../../../src/services/git/GitFsService', () => ({
+  GitFsService: {
+    pullWithFastForward: jest.fn(async () => ({ ok: true })),
+    removeRepo: jest.fn(async () => undefined),
+    clone: jest.fn(async () => undefined),
+  },
+}));
+
+import { LocalGitWriter } from '../../../src/services/git/LocalGitWriter';
+import { GitFsService } from '../../../src/services/git/GitFsService';
+
+function getGitMocks() {
+  return (globalThis as any).__lgw2GitMocks as {
+    add: jest.Mock;
+    commit: jest.Mock;
+    push: jest.Mock;
+    currentBranch: jest.Mock;
+    status: jest.Mock;
+  };
+}
+
+const author = { name: 'Test', email: 'test@example.com' };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (globalThis as any).__lgw2FsStore.clear();
+});
+
+describe('LocalGitWriter push-rejected recovery (bug-hunt loop4 #15)', () => {
+  test('writeAndCommit surfaces unknown pull failure instead of blind retry push', async () => {
+    getGitMocks().push
+      .mockRejectedValueOnce(new Error('push rejected non-fast-forward'))
+      .mockResolvedValue({ ok: true });
+    (GitFsService.pullWithFastForward as jest.Mock).mockResolvedValue({
+      ok: false,
+      reason: 'unknown',
+      error: 'network timeout during fetch',
+    });
+
+    const result = await LocalGitWriter.writeAndCommit({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: 'notes/foo.md',
+      content: 'hello',
+      message: 'm',
+      author,
+      token: 'tok',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/network timeout/);
+    // The stale-branch retry must not run when the refresh pull failed.
+    expect(getGitMocks().push).toHaveBeenCalledTimes(1);
+  });
+
+  test('deleteAndCommit surfaces unknown pull failure (parity with existing behavior)', async () => {
+    getGitMocks().push
+      .mockRejectedValueOnce(new Error('push rejected non-fast-forward'))
+      .mockResolvedValue({ ok: true });
+    (GitFsService.pullWithFastForward as jest.Mock).mockResolvedValue({
+      ok: false,
+      reason: 'unknown',
+      error: 'packfile checksum mismatch',
+    });
+
+    const result = await LocalGitWriter.deleteAndCommit({
+      repoPath: 'me/repo',
+      branch: 'main',
+      filePath: 'notes/old.md',
+      message: 'Delete note: old',
+      author,
+      token: 'tok',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/packfile checksum mismatch|Push failed/);
+    expect(getGitMocks().push).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -304,7 +304,7 @@ static async writeAndCommit(opts: WriteOpts): Promise<LocalGitWriterResult> {
                 if (hasLocal) {
                   throw new Error(
                     `Clone corruption detected with unpushed local commits in ${opts.repoPath}@${opts.branch}. ` +
-                    `Please push your changes or reset before continuing.`,
+                      `Please push your changes or reset before continuing.`,
                   );
                 }
                 await GitFsService.removeRepo({ repoPath: opts.repoPath });
@@ -334,6 +334,8 @@ static async writeAndCommit(opts: WriteOpts): Promise<LocalGitWriterResult> {
               } else if (ffResult.reason === 'diverged') {
                 await surfaceConflictsOnDiverged(opts.repoPath, opts.branch);
                 return { success: false, error: 'conflict-detected' };
+              } else {
+                throw new Error(`Push failed: ${ffError || ffResult.reason}`);
               }
             }
             await git.push({

--- a/src/services/git/branchResolver.ts
+++ b/src/services/git/branchResolver.ts
@@ -2,12 +2,24 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { parseRepoPath } from '../../utils/gitPathParser';
 import { GitFsService } from './GitFsService';
 import AuthService from '../AuthService';
+import { getActiveGitHost } from './activeHost';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 const GITLAB_API_BASE = 'https://gitlab.com/api/v4';
 const FALLBACK_BRANCH = 'main';
 
 const sessionCache = new Map<string, string>();
+
+async function resolveActiveProvider(): Promise<'github' | 'gitlab' | null> {
+  try {
+    const host = await getActiveGitHost();
+    if (!host) return null;
+    if (host.provider === 'github' || host.provider === 'gitlab') return host.provider;
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Best-effort resolution of the branch to use for a repo. Order:
@@ -34,7 +46,11 @@ export async function resolveBranch(
     return local;
   }
 
-  const remote = await fetchGitHubDefaultBranch(repoPath);
+  const provider = await resolveActiveProvider();
+  const remote =
+    provider === 'gitlab'
+      ? await fetchGitLabDefaultBranch(repoPath)
+      : await fetchGitHubDefaultBranch(repoPath);
   if (remote) {
     sessionCache.set(repoPath, remote);
     return remote;
@@ -94,11 +110,22 @@ export async function fetchGitLabDefaultBranch(repoPath: string): Promise<string
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
+    let token: string | null = null;
+    try {
+      const host = await getActiveGitHost();
+      if (host && host.provider === 'gitlab') token = host.token;
+    } catch {
+      // fall through to unauthenticated request for public repos
+    }
     const storedBase = await AsyncStorage.getItem('@gitnotes:gitlab_base_url');
     const baseUrl = (storedBase || GITLAB_API_BASE).replace(/\/+$/, '');
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    if (token) {
+      headers['PRIVATE-TOKEN'] = token;
+    }
     const response = await fetch(
       `${baseUrl}/projects/${encodeURIComponent(`${info.owner}/${info.repo}`)}`,
-      { signal: controller.signal },
+      { headers, signal: controller.signal },
     );
     if (!response.ok) {
       clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary

Round 4 of the loop, focused on git flows as requested. Full suite: **2894 passed, 7 skipped, 0 failed**; tsc clean; eslint clean.

## Fixes

1. **`writeAndCommit` surfaces unknown pull failure in push-rejected recovery** — when a clone-mode write push was rejected non-fast-forward, the recovery handled corruption (re-clone + replay) and diverged (conflict UX), but an *unknown* failure (transient network, packfile error) fell through to an unconditional retry push against the stale branch. `deleteAndCommit` already threw for this case; write now matches, so callers see the root cause instead of a second guaranteed-rejected push.
2. **Provider-aware branch resolution + authenticated GitLab lookups** — `resolveBranch` always hit api.github.com for the remote default branch: GitLab repos with no hint and no local clone got 404 → silent `'main'` fallback → broken clone sync on repos whose default is `trunk`/`master`. Now routes by active host provider and sends `PRIVATE-TOKEN` on GitLab lookups (private/self-hosted repos previously 401'd into the same wrong fallback).

## Test plan
- New: `__tests__/services/git/localGitWriter.recovery.test.ts` (2), `__tests__/services/git/branchResolver.provider.test.ts` (3).
- Existing localGitWriter (7) + branchResolver (4) suites unchanged and green.

🤖 Generated with [opencode](https://opencode.ai)