### PR TITLE
docs: sync README and wiki with current codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,16 +92,22 @@ Example: `feat: add dark mode support for canvas editor`
 ```
 src/
 ├── components/     # Reusable UI components
-├── contexts/       # React contexts
+├── contexts/       # React contexts (Accounts, Auth, Note, Repo, Theme, ...)
+├── data/           # Static data (philosopher quotes dataset)
 ├── hooks/          # Custom React hooks
-├── i18n/           # Internationalization
-├── models/         # Data models
+├── i18n/           # Internationalization (en, es, fr, de, ja, ko)
+├── lib/            # Shared utilities (cn helper, etc.)
+├── models/         # TypeScript interfaces (Note, Todo, Canvas, AIProvider, ...)
 ├── navigation/     # Navigation configuration
-├── screens/        # App screens
+├── screens/        # App screens (Notes, Canvas, Chat, Settings, ...)
 ├── services/       # Business logic services
+│   ├── ai/         # AI provider factory, model limits, anthropic defaults
+│   ├── canvas/     # Sparse-tile canvas persistence + vision helpers
+│   ├── conflict/   # 3-way merge + AI conflict resolver
+│   └── git/        # Clone/push/pull, staging, sync gate, host factory
 ├── stores/         # Zustand stores
-├── theme/          # Theme configuration
-├── types/          # TypeScript type definitions
+├── theme/          # NativeWind theme configuration
+├── types/          # Shared type definitions (RenderStyle, SortTypes)
 └── utils/          # Utility functions
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@
 - **Files, not a database.** Every note is a real file in your Git repo — nothing locks you in.
 - **Versioned by default.** Edit, branch, diff, and rebase your notes the same way you do code.
 - **Works offline.** Edits queue locally and sync when you're back online.
-- **Open formats.** Markdown, Neorg, Org, JSON, PDF — pick what fits.
+- **Open formats.** Markdown, Neorg, Org, JSON — pick what fits.
 - **Open source.** MPL-2.0; contributions and forks welcome.
 
 ## Highlights
 
 - Notes, todos, journals, and Excalidraw-style canvases — all backed by Git
 - Folders, tags, colors, pins, wiki-links, backlinks, custom templates
-- Multiple GitHub accounts; per-repo API or full-clone sync modes
-- Deprecated importers (Google Keep, Apple Notes) are documented in the [wiki: importers](https://github.com/gedwolmen/gitnotes/wiki/importers)
+- Multi-provider sync (GitHub, GitLab, Gitea-like); per-repo API or full-clone sync modes
+- Optional Pro tier with Neumorphic "Fancy UI", advanced AI, multi-host paywall, and trial/lifetime via StoreKit 2 (RevenueCat) — see the [wiki: Pro Paywall](https://github.com/gedwolmen/gitnotes/wiki/paywall-pro)
 - Optional AI chat layer (Anthropic, OpenAI-compatible providers, Apple Intelligence, on-device Llama)
 - Biometric lock, multilingual UI (EN, ES, FR, DE, JA, KO), light / dark / system themes
 
 ## Stack
 
-Expo SDK 56 · React Native 0.85 · TypeScript 5.7 · isomorphic-git · React Navigation v7 · TanStack Query · Zustand · Vercel AI SDK v6 · Reanimated · FlashList.
+Expo SDK 56 · React Native 0.85 · TypeScript 6 · isomorphic-git · React Navigation v7 · TanStack Query · Zustand · Vercel AI SDK v6 · Reanimated · FlashList · NativeWind v5.
 
 ## Contributing
 

--- a/docs/wiki/ai-integration.md
+++ b/docs/wiki/ai-integration.md
@@ -23,9 +23,11 @@ See [AI Providers](./ai-providers.md) for detailed provider documentation.
 ### Provider Types
 
 ```typescript
-type AIProviderType = 
-  | 'openai-compatible'  // OpenAI, OpenRouter, Ollama, etc.
-  | 'anthropic';         // Claude models
+type AIProviderType =
+  | 'apple'               // Apple Intelligence (on-device, iOS 18+)
+  | 'llama'               // On-device Llama via llama.rn
+  | 'openai-compatible'   // OpenAI, OpenRouter, Ollama, etc.
+  | 'anthropic';          // Claude models
 ```
 
 ### Provider Configuration
@@ -91,6 +93,8 @@ async function generate(prompt: string, provider: AIProviderConfig) {
 ```typescript
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { createAnthropic } from '@ai-sdk/anthropic';
+// Apple Intelligence and on-device Llama bypass the Vercel AI SDK and
+// stream via @react-native-ai/apple / llama.rn directly (see providerFactory.ts).
 
 function createModel(provider: AIProviderConfig) {
   if (provider.type === 'anthropic') {
@@ -100,13 +104,19 @@ function createModel(provider: AIProviderConfig) {
     });
     return anthropic('claude-sonnet-4-20250514');
   }
-  
-  const openai = createOpenAICompatible({
-    name: provider.id,
-    baseURL: provider.baseURL,
-    apiKey: provider.apiKey,
-  });
-  return openai('gpt-4o-mini');
+
+  if (provider.type === 'openai-compatible') {
+    const openai = createOpenAICompatible({
+      name: provider.id,
+      baseURL: provider.baseURL,
+      apiKey: provider.apiKey,
+    });
+    return openai('gpt-4o-mini');
+  }
+
+  // 'apple' and 'llama' are dispatched in providerFactory.ts and use the
+  // native streaming surface — they never reach createModel().
+  throw new Error(`Unsupported provider type: ${provider.type}`);
 }
 ```
 
@@ -118,9 +128,15 @@ function createModel(provider: AIProviderConfig) {
 // src/services/ai/modelLimits.ts
 
 export const MODEL_LIMITS: Record<string, number> = {
+  // Apple Intelligence (on-device) — context window varies by device/memory
+  'apple-on-device': 8192,
+  // On-device Llama — limited by llama.rn KV cache
+  'llama-3.1-8b-instruct': 8192,
+  // OpenAI-compatible
   'gpt-4o-mini': 128000,
   'gpt-4o': 128000,
   'gpt-3.5-turbo': 16385,
+  // Anthropic
   'claude-sonnet-4-20250514': 200000,
   'claude-haiku-3-5-20241022': 200000,
 };

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -26,23 +26,44 @@ GitNotēs is a React Native (Expo) note-taking app with **Git sync** (isomorphic
 
 ### `src/services/`
 
-Business logic layer:
+Business logic layer (top-level + subdirectories):
 
+- `AIService.ts` — Vercel AI SDK integration (`buildProviderInstance`, `initializeModel`)
+- `AuthService.ts` — Git-host token storage + multi-host switching
+- `AccountStorage.ts` — Multi-account persistence
 - `DailyQuoteService.ts` — Philosopher quote generation with AI personalization
-- `AIService.ts` — Vercel AI SDK integration
-- `GitService.ts` — Git clone, commit, push, pull via isomorphic-git
-- `NoteService.ts` — Note CRUD and parsing
-- `JournalService.ts` — Journal entry management
-- `TodoService.ts` — Todo item management
+- `ExportService.ts` — Export notes (Markdown, PDF, share sheet)
+- `RepoImportService.ts`, `RepoPullService.ts` — Import + pull from remote
+- `NoteGitHubSyncService.ts`, `TodoGitHubSyncService.ts`, `CanvasGitHubSyncService.ts`, `TemplateGitHubSyncService.ts` — Per-entity Git sync
+- `NoteSyncQueueService.ts`, `SyncEngineService.ts` — Sync queue + mode registry
+- `BackgroundSyncService.ts`, `ForegroundSyncService.ts` — OS background task + foreground sync loop
+- `StagePushScheduler.ts` — 3-minute idle-push window
+- `LocalGitWriter.ts` (in `git/`) — Clone-mode write/commits/push
+- `StagingService.ts` (in `git/`) — Stage-then-push mutation staging
+- `ConflictResolverService.ts`, `AiConflictResolver.ts` (in `conflict/`) — 3-way merge + AI assist
+- `AtlasComposer.ts`, `AtlasEncoder.ts`, `SparseTileService.ts` (in `canvas/`) — Sparse-tile canvas persistence
+- `providerFactory.ts`, `modelLimits.ts`, `anthropicDefaults.ts` (in `ai/`) — AI provider registry
 
 ### `src/stores/`
 
 Zustand stores:
 
-- `aiStore.ts` — AI settings (providers, personalization toggle)
-- `noteStore.ts` — Active note state
-- `gitStore.ts` — Git repository state
-- `syncStore.ts` — Sync status and queue
+- `noteStore.ts` — Active note state, drafts
+- `todoStore.ts` — Todo items
+- `canvasStore.ts` — Canvas state
+- `chatStore.ts` — AI chat threads/messages
+- `repoStore.ts` — Selected repository + multi-host registry
+- `folderStore.ts` — Folder tree
+- `templateStore.ts` — User-defined note templates
+- `renderStyleStore.ts` — Custom Markdown render styles
+- `draftStore.ts` — Edit drafts
+- `reminderStore.ts` — Note reminders
+- `conflictStore.ts` — Unresolved merge conflicts
+- `stageStore.ts` — Stage-then-push queue + push progress
+- `gitOperationStore.ts` — Per-repo/per-path busy locks
+- `githubActivityStore.ts` — GitHub activity feed
+- `aiStore.ts`, `aiHubStore.ts` — AI providers, model selection
+- `proStore.ts` — Pro tier state (RevenueCat)
 - `themeStore.ts` — Theme mode (light/dark/system)
 
 ### `src/hooks/`
@@ -50,11 +71,18 @@ Zustand stores:
 Custom hooks:
 
 - `useDailyQuote.ts` — Daily quote with cache and refresh
-- `useNote.ts` — Note operations
-- `useAI.ts` — AI chat and generation
-- `useGit.ts` — Git operations wrapper
-- `useSync.ts` — Sync status and progress
-- `useTheme.ts` — Theme access
+- `useEntityList.ts`, `useEntityFilter.ts`, `useNoteTags.ts` — Generic note/todo list filtering
+- `useNetworkStatus.ts` — `NetInfo` wrapper
+- `useBackgroundSync.ts` — Background sync task trigger
+- `useForegroundSyncHealth.ts`, `useForegroundSyncSettings.ts` — Foreground sync introspection
+- `useGitHostQueries.ts`, `useGitHubQueries.ts` — Git host data queries
+- `useProviderAvailability.ts` — AI provider runtime availability
+- `useProGate.ts`, `useProScreenGuard.ts` — Pro tier gate enforcement
+- `useUndoRedo.ts` — Editor undo/redo with concurrent-save guard
+- `useSafeBack.ts` — Header-back with deep-link safety
+- `useResponsive.ts` — Shared `Dimensions` subscription
+- `useRecognitionIndexing.ts`, `useLongPressForVision.ts` — Canvas vision helpers
+- `useHardWrap.ts` — Hard-wrap text editor
 
 ### `src/contexts/`
 
@@ -62,17 +90,37 @@ React contexts:
 
 - `ThemeContext.tsx` — Theme colors, mode, tokens
 - `NoteContext.tsx` — Active note, unsaved changes
-- `SyncContext.tsx` — Sync status provider
+- `TodoContext.tsx` — Active todo
+- `CanvasContext.tsx` — Canvas state
+- `FolderContext.tsx` — Folder navigation
+- `RepoContext.tsx` — Active repository + sync mode
+- `AccountsContext.tsx`, `AuthContext.tsx` — Multi-account/token state
+- `GitHubAuthContext.tsx`, `HostAuthContext.tsx` — Per-host auth
+- `BacklinksContext.tsx` — Wiki-link backlinks
+- `BiometricLockContext.tsx` — Face/Touch ID lock
+- `ViewModeContext.tsx` — List/grid view toggle
 
 ### `src/screens/`
 
 Screen components:
 
-- `HomeScreen.tsx` — Note list with filters and search
-- `NoteEditorScreen.tsx` — Rich text editor
-- `SettingsScreen.tsx` — App settings and AI config
-- `GitSyncScreen.tsx` — Git repository management
-- `AIScreen.tsx` — AI chat interface
+- `HomeScreen.tsx` — Recent + pinned feed
+- `NotesListScreen.tsx`, `NoteEditorScreen.tsx` — Note CRUD
+- `TodoListScreen.tsx` — Todo CRUD
+- `CanvasListScreen.tsx`, `CanvasEditorScreen.tsx` — Canvas CRUD
+- `ChatScreen.tsx`, `ChatThreadListScreen.tsx` — AI chat
+- `SettingsScreen.tsx` — App settings + AI config
+- `StageScreen.tsx` — Staged changes + Push / Push-all
+- `SyncStatusScreen.tsx` — Sync health row
+- `PaywallScreen.tsx` — StoreKit 2 paywall
+- `OnboardingScreen.tsx` — First-run onboarding
+- `ConflictResolverScreen.tsx` — 3-way merge UI
+- `ExploreScreen.tsx` — Repo browse (files, PRs, issues, branches)
+- `GraphViewScreen.tsx` — Backlink graph
+- `TemplateManagerScreen.tsx` — Note template CRUD
+- `RenderStyleSettingsScreen.tsx`, `RenderStyleEditorScreen.tsx` — Render style CRUD
+- `ThoughtDumpScreen.tsx` — Quick capture
+- `FileViewerScreen.tsx`, `ImageViewerScreen.tsx`, `PdfViewerScreen.tsx`, `VideoViewerScreen.tsx` — File viewers
 
 ## Data Flow
 
@@ -80,23 +128,24 @@ Screen components:
 
 ```
 User types in editor
-  → NoteEditorScreen state
-  → NoteContext.updateNote()
-  → NoteService.save() [AsyncStorage]
-  → SyncService.queueChange() [sync queue]
-  → GitService.commit() [isomorphic-git]
-  → GitService.push() [if online]
+  → NoteEditorScreen state (local)
+  → repoStore.saveNote() (AsyncStorage + dirty mark)
+  → Stage-or-queue: clone mode → LocalGitWriter.writeAndCommit
+                   API mode   → NoteSyncQueueService.enqueue
+  → StagePushScheduler drains on the 3-min idle window, on the
+    Stage screen's Push / Push-all, on a long-press of the floating
+    push button, or on the OS background task (≤ 10 files)
 ```
 
 ### AI Chat
 
 ```
 User sends message
-  → AIScreen state
-  → AIService.chat(messages)
-  → Vercel AI SDK (streamText)
+  → ChatScreen state
+  → AIService.chat(messages, provider)
+  → Vercel AI SDK (streamText) via providerFactory
   → Token budget check (modelLimits.ts)
-  → Provider selection (AIProviderType)
+  → Provider selection (AIProviderType: apple | llama | openai-compatible | anthropic)
   → Stream response to UI
 ```
 
@@ -108,7 +157,7 @@ HomeScreen mounts
   → Check cache (cacheKey + Date.now())
   → If stale: DailyQuoteService.fetchQuote()
     → Check aiPersonalizationEnabled
-    → If disabled: return generic quote
+    → If disabled: return generic quote from src/data/philosopher_quotes.json
     → If enabled: generate with AI (journals context)
   → Update cache (AsyncStorage)
   → Render DailyQuoteCard
@@ -118,17 +167,29 @@ HomeScreen mounts
 
 | Store | Purpose | Persistence |
 |-------|---------|-------------|
-| `aiStore` | AI settings | AsyncStorage + SecureStore (API keys) |
-| `noteStore` | Active note | AsyncStorage |
-| `gitStore` | Git repo state | AsyncStorage |
-| `syncStore` | Sync queue | AsyncStorage |
+| `aiStore`, `aiHubStore` | AI settings | AsyncStorage + SecureStore (API keys) |
+| `noteStore` | Active note + drafts | AsyncStorage |
+| `todoStore` | Todo items | AsyncStorage |
+| `canvasStore` | Canvas state | AsyncStorage |
+| `chatStore` | AI chat threads | AsyncStorage |
+| `repoStore` | Multi-host repo registry + sync mode | AsyncStorage + SecureStore |
+| `folderStore` | Folder tree | AsyncStorage |
+| `templateStore` | Note templates | AsyncStorage |
+| `renderStyleStore` | Markdown render styles | AsyncStorage |
+| `draftStore` | Unsaved drafts | AsyncStorage |
+| `reminderStore` | Note reminders | AsyncStorage + Notifications |
+| `conflictStore` | Unresolved merge conflicts | AsyncStorage |
+| `stageStore` | Stage-then-push queue + push progress | AsyncStorage |
+| `gitOperationStore` | Per-repo/per-path busy locks | in-memory |
+| `githubActivityStore` | GitHub activity feed | AsyncStorage |
+| `proStore` | Pro tier state | SecureStore + RevenueCat |
 | `themeStore` | Theme mode | AsyncStorage |
-| `settingsStore` | App settings | AsyncStorage |
 
 ## Offline Strategy
 
 1. **Write to AsyncStorage first** (fast, reliable)
-2. **Queue changes in syncStore** (change type + data)
-3. **Git commit locally** (isomorphic-git on device)
-4. **Push when online** (syncService checks NetInfo)
-5. **Pull on app focus** (fetch remote changes)
+2. **Queue changes in `stageStore` / `NoteSyncQueueService`** (clone vs API branch)
+3. **Clone mode: local commit via `LocalGitWriter.writeAndCommit`** (isomorphic-git on device, `push: false`)
+4. **Push when online** — clone mode drains via `StagePushScheduler` / Stage screen / floating-button long-press / OS background task; API mode pushes immediately on save
+5. **Pull on app focus** — `ForegroundSyncService.runPull` checks `NetInfo`, app state, and pull intervals
+6. **Resolve conflicts** — `ConflictResolverService` (3-way merge) with optional AI assist via `AiConflictResolver`

--- a/docs/wiki/development-guide.md
+++ b/docs/wiki/development-guide.md
@@ -20,9 +20,6 @@ cd gitnotes
 # Install dependencies
 yarn install
 
-# Install iOS pods (macOS only)
-cd ios && pod install && cd ..
-
 # Start Metro bundler
 yarn start
 
@@ -33,7 +30,7 @@ yarn ios
 yarn android
 
 # Run on web
-yarn dev
+yarn web
 ```
 
 ## Environment Variables
@@ -54,35 +51,26 @@ GITHUB_TOKEN=ghp_...
 yarn start                  # Start Metro
 yarn ios                    # Run on iOS
 yarn android                # Run on Android
-yarn dev                    # Run on web (Expo)
-yarn clean                  # CleanMetro cache
-yarn reset                  # Reset all caches
+yarn web                    # Run on web (Expo)
 ```
 
 ### Testing
 
 ```bash
-yarn jest                   # Run all tests
-yarn jest --watch           # Watch mode
-yarn jest --coverage        # Coverage report
-yarn jest path/to/test.ts   # Specific file
-yarn ts:check               # Type check (tsc --noEmit)
+yarn jest                       # Run all tests
+yarn jest --watch               # Watch mode
+yarn jest --coverage            # Coverage report
+yarn jest path/to/test.ts       # Specific file
+yarn ts:check                   # Type check (tsc --noEmit)
 ```
 
 ### Linting & Formatting
 
 ```bash
-yarn eslint . --ext .ts,.tsx    # Lint
-yarn eslint . --ext .ts,.tsx --fix  # Auto-fix
-yarn prettier --write .         # Format all
-yarn lint                       # eslint + prettier
-```
-
-### Git
-
-```bash
-yarn commit                 # Interactive commit (commitizen)
-yarn release                # Semantic release (bump version)
+yarn lint                       # ESLint (flat config)
+yarn lint:fix                   # ESLint --fix
+yarn format                     # Prettier --write
+yarn format:check               # Prettier --check
 ```
 
 ## Build & Deploy
@@ -128,9 +116,6 @@ yarn ios
 ### Type errors
 
 ```bash
-# Regenerate types
-yarn generate-types
-
 # Check all
 yarn ts:check
 ```
@@ -141,22 +126,30 @@ yarn ts:check
 gitnotes/
 ├── src/
 │   ├── components/     # UI components
-│   ├── contexts/       # React contexts
+│   ├── contexts/       # React contexts (Accounts, Auth, Note, Repo, Theme, ...)
+│   ├── data/           # Static data (philosopher quotes)
 │   ├── hooks/          # Custom hooks
-│   ├── i18n/           # Localization
+│   ├── i18n/           # Localization (en/es/fr/de/ja/ko)
+│   ├── lib/            # Shared utilities (cn helper, ...)
 │   ├── models/         # TypeScript interfaces
 │   ├── navigation/     # Nav config
 │   ├── screens/        # Screen components
 │   ├── services/       # Business logic
+│   │   ├── ai/         # AI provider factory + model limits
+│   │   ├── canvas/     # Sparse-tile canvas persistence
+│   │   ├── conflict/   # 3-way merge + AI conflict resolver
+│   │   └── git/        # Clone/push/pull + sync gate + host factory
 │   ├── stores/         # Zustand stores
-│   ├── theme/          # NativeWind theme
-│   └── types/          # Shared types
+│   ├── theme/          # NativeWind theme tokens
+│   └── types/          # Shared types (RenderStyle, SortTypes)
 ├── __tests__/          # Jest tests
-├── docs/               # Documentation
+├── docs/               # Documentation + wiki source
 ├── ios/                # Native iOS code
 ├── android/            # Native Android code
 ├── assets/             # Images, fonts
 ├── AGENTS.md           # AI agent rules
+├── CHANGELOG.md        # Single-PR fixes, grouped by date
+├── CONTRIBUTING.md     # Contributor guide
 └── package.json        # Dependencies
 ```
 
@@ -165,7 +158,7 @@ gitnotes/
 1. Fork the repo
 2. Create a feature branch (`feature/my-feature`)
 3. Make changes, add tests
-4. Run `yarn lint` and `yarn jest`
+4. Run `yarn lint`, `yarn ts:check`, and `yarn jest`
 5. Commit with descriptive message
 6. Push and open a PR
 

--- a/docs/wiki/i18n.md
+++ b/docs/wiki/i18n.md
@@ -12,9 +12,9 @@ GitNotēs uses **i18next** for internationalization with **6 languages**: Englis
 
 ```json
 {
-  "i18next": "^23.11.5",
-  "react-i18next": "^14.1.2",
-  "expo-localization": "~15.0.3"
+  "i18next": "^26.2.0",
+  "react-i18next": "^17.0.8",
+  "expo-localization": "~56.0.2"
 }
 ```
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -70,12 +70,13 @@ yarn install
 # Run
 yarn ios          # iOS
 yarn android      # Android
-yarn dev          # Web
+yarn web          # Web
 
 # Test
-yarn ts:check     # Type check
-yarn jest         # Run tests
-yarn eslint . --ext .ts,.tsx  # Lint
+yarn ts:check         # Type check
+yarn jest             # Run tests
+yarn lint             # ESLint
+yarn format:check     # Prettier check
 ```
 
 ## Project Structure
@@ -83,16 +84,22 @@ yarn eslint . --ext .ts,.tsx  # Lint
 ```
 src/
 ├── components/       # Reusable UI components
-├── contexts/         # React contexts (ThemeContext, NoteContext)
+├── contexts/         # React contexts (Accounts, Auth, Canvas, Note, Repo, Theme, Todo, ...)
+├── data/             # Static data (philosopher quotes dataset)
 ├── hooks/            # Custom React hooks
 ├── i18n/             # Localization (en/es/fr/de/ja/ko)
-├── models/           # TypeScript interfaces
+├── lib/              # Shared utilities (cn helper, etc.)
+├── models/           # TypeScript interfaces (Note, Todo, Canvas, AIProvider, ...)
 ├── navigation/       # Navigation configuration
-├── screens/          # Screen components
-├── services/         # Business logic (AI, Git, quotes, etc.)
+├── screens/          # Screen components (Notes, Canvas, Chat, Settings, ...)
+├── services/         # Business logic (AI, Git, quotes, sync, paywall, ...)
+│   ├── ai/           # AI provider factory, model limits, anthropic defaults
+│   ├── canvas/       # Sparse-tile canvas persistence + vision helpers
+│   ├── conflict/     # 3-way merge + AI conflict resolver
+│   └── git/          # Clone/push/pull, staging, sync gate, host factory
 ├── stores/           # Zustand stores
 ├── theme/            # NativeWind theme configuration
-└── types/            # Shared type definitions
+└── types/            # Shared type definitions (RenderStyle, SortTypes)
 ```
 
 ## Key Files
@@ -102,6 +109,9 @@ src/
 | `AGENTS.md` | Rules for AI coding agents |
 | `CHANGELOG.md` | Single-PR fixes and narrow bug-fix entries, grouped by date descending |
 | `package.json` | Dependencies and scripts |
-| `tsconfig.json` | TypeScript configuration |
+| `tsconfig.json` | TypeScript configuration (strict mode, path aliases) |
 | `jest.config.js` | Jest configuration |
-| `babel.config.cjs` | Babel configuration |
+| `babel.config.js` | Babel configuration (`babel-preset-expo` + `react-native-worklets/plugin`) |
+| `eslint.config.js` | Flat ESLint config (TS + React hooks + Prettier) |
+| `global.css` | NativeWind v4 `@theme` tokens (light + dark) |
+| `metro.config.js` | Metro bundler config |

--- a/docs/wiki/services.md
+++ b/docs/wiki/services.md
@@ -12,40 +12,120 @@ Services encapsulate business logic. They're React-independent, testable with Je
 
 | Service | Responsibility | Persistence |
 |---------|---------------|-------------|
-| `NoteService.ts` | CRUD operations on notes | AsyncStorage |
-| `JournalService.ts` | Journal entry management | AsyncStorage |
-| `TodoService.ts` | Todo item management | AsyncStorage |
-| `TemplateService.ts` | Note template handling | AsyncStorage |
 | `StorageService.ts` | Low-level storage abstraction | AsyncStorage |
+| `StorageBootstrap.ts` | One-time store bootstrapping | AsyncStorage |
+| `TemplateService.ts` | Note template CRUD | AsyncStorage |
+| `TemplateMarkdownService.ts` | Template Markdown rendering | n/a |
+| `TemplateRepoPreferenceService.ts` | Per-repo template selection | AsyncStorage |
+| `RenderStyleService.ts` | Markdown render-style registry | AsyncStorage |
+| `LastUsedRepoService.ts`, `LastSelectionPreferenceService.ts` | Recents / selections | AsyncStorage |
+| `NoteFormatPreferenceService.ts` | Default note format per repo | AsyncStorage |
+| `PositionMemoryService.ts` | Scroll-position memory | AsyncStorage |
+| `BacklinksService.ts` | Wiki-link backlink index | in-memory + AsyncStorage |
+| `JournalService.ts` | Journal entry management | AsyncStorage |
+| `ContextService.ts` | Cross-entity context building | AsyncStorage |
+| `OnboardingService.ts` | First-run onboarding state | AsyncStorage |
+| `AccountStorage.ts` | Multi-account persistence | AsyncStorage |
+| `ThoughtDumpService.ts` | Thought-dump persistence | AsyncStorage |
+| `ThoughtDumpRepoPreferenceService.ts` | Per-repo thought-dump target | AsyncStorage |
+| `ReminderService.ts` | Note reminders + notifications | AsyncStorage + Notifications |
+
+### Sync & Git Services
+
+| Service | Responsibility | Key Dependencies |
+|---------|---------------|------------------|
+| `SyncEngineService.ts` | Sync mode registry (`clone` / `api`) per repo | AsyncStorage |
+| `NoteSyncQueueService.ts` | FIFO mutation queue with exponential backoff | AsyncStorage |
+| `BackgroundSyncService.ts` | OS background-task entry point | `expo-background-task`, `expo-task-manager` |
+| `ForegroundSyncService.ts` | App-focus / interval pull loop | `NetInfo`, `AppState` |
+| `StagePushScheduler.ts` | 3-min idle-push window + explicit drain | AsyncStorage |
+| `GitService.ts` | Clone-mode core (isomorphic-git facade) | `isomorphic-git` |
+| `NoteGitHubSyncService.ts`, `TodoGitHubSyncService.ts`, `CanvasGitHubSyncService.ts`, `TemplateGitHubSyncService.ts` | Per-entity Git sync | Axios, Git |
+| `RepoImportService.ts`, `RepoPullService.ts` | Import + pull from remote | `isomorphic-git` |
+| `GitHubService.ts` | GitHub REST API client | Axios |
+| `AuthService.ts` | Git-host token storage + multi-host switching | SecureStore |
+
+### Git Subdirectory (`src/services/git/`)
+
+| Service | Responsibility |
+|---------|---------------|
+| `LocalGitWriter.ts` | Clone-mode write/commit/push (`writeAndCommit`, `deleteAndCommit`) |
+| `StagingService.ts` | Stage-then-push mutation staging (`stageUpdate`, `stageDelete`, `pushStaged`) |
+| `GitFsService.ts`, `gitFs.ts` | Filesystem facade for isomorphic-git |
+| `gitHttp.ts`, `http.ts` | Streaming `git-upload-pack` / `git-receive-pack` with cancel |
+| `gitHostFactory.ts`, `GitHost.ts`, `activeHost.ts`, `branchResolver.ts`, `resolveBranch.ts` | Multi-host routing |
+| `GitHubHostService.ts`, `GitLabService.ts`, `GiteaLikeHostService.ts` | Per-host implementations |
+| `CloneMigrationService.ts` | One-time clone migration |
+| `GitSyncGate.ts` | Sync-gate overlay coordination |
+| `BatchGitOperations.ts` | Batched read/write helpers |
+| `lfs.ts` | LFS pointer scan + smudge |
+| `manualSync.ts` | Pull-to-refresh entry point |
+| `repoAccessPreflight.ts` | Token / repo preflight |
+| `repoRemovalCascade.ts` | Token-removal repo cascade |
+| `formatSyncError.ts`, `syncFailure.ts` | Error normalization |
+| `syncTiming.ts` | Timing instrumentation seam |
+| `deleteFailures.ts`, `retryDeleteFailure.ts` | Durable delete-failure map |
+| `featureFlags.ts` | Per-build feature flags |
 
 ### AI Services
 
 | Service | Responsibility | Key Dependencies |
 |---------|---------------|------------------|
-| `AIService.ts` | Vercel AI SDK integration | `ai` SDK, `@ai-sdk/anthropic` |
+| `AIService.ts` | Vercel AI SDK integration (`buildProviderInstance`, `initializeModel`) | `ai` SDK, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible` |
 | `DailyQuoteService.ts` | Philosopher quote generation | `AIService`, AsyncStorage |
-| `AIMemoryService.ts` | AI context memory (thought dumps) | AsyncStorage |
-| `modelLimits.ts` | Token budget per provider | Provider metadata |
-| `anthropicDefaults.ts` | Anthropic constants | `@ai-sdk/anthropic` |
+| `ai/providerFactory.ts` | Provider registry and factory | `ai` SDK |
+| `ai/providerAvailability.ts`, `ai/providerAvailabilityCopy.ts` | Runtime availability checks | per-provider |
+| `ai/providerQuirks.ts` | Provider-specific workarounds | per-provider |
+| `ai/modelLimits.ts` | Context window limits per provider | Provider metadata |
+| `ai/anthropicDefaults.ts` | Anthropic constants + default models | `@ai-sdk/anthropic` |
+| `ai/modelDiscoveryService.ts` | Lazy model discovery with caching | `@ai-sdk/anthropic` |
+| `ai/AIMemoryIndexService.ts`, `ai/thoughtDumpIndexing.ts` | Thought-dump indexing | AsyncStorage |
+| `ai/systemPrompt.ts` | Shared system prompts | n/a |
+| `ai/tools.ts`, `ai/actionExecutor.ts` | AI tool-call surface | `ai` SDK |
+| `ai/openrouterPreflight.ts` | OpenRouter preflight checks | `@ai-sdk/openai-compatible` |
+| `ai/aiServiceErrors.ts` | Typed AI errors | n/a |
+| `ai/config.ts` | AI feature flags / config | n/a |
 
-### Git Services
+### Canvas Services (`src/services/canvas/`)
 
-| Service | Responsibility | Key Dependencies |
-|---------|---------------|------------------|
-| `GitService.ts` | Clone, commit, push, pull | `isomorphic-git` |
-| `NoteGitHubSyncService.ts` | Note sync to GitHub API | Axios, Git |
-| `RepoPullService.ts` | Pull repo from remote | `isomorphic-git` |
-| `SyncEngineService.ts` | Sync queue management | AsyncStorage |
-| `ConflictResolverService.ts` | 3-way merge | `isomorphic-git` |
+| Service | Responsibility |
+|---------|---------------|
+| `AtlasComposer.ts`, `AtlasEncoder.ts` | Sparse-tile canvas atlas encode/decode |
+| `SparseTileService.ts` | Tile persistence + retrieval |
+| `TilePersistenceService.ts` | Tile flush chain |
+| `RecognizedTextService.ts`, `CanvasVisionService.ts` | Vision pipeline |
+| `VisionCapabilityChecker.ts` | Capability detection |
+| `VisionResponseParser.ts` | Vision response parsing |
+| `HotspotGrid.ts` | Hotspot layout |
 
-### Utility Services
+### Conflict Services (`src/services/conflict/`)
+
+| Service | Responsibility |
+|---------|---------------|
+| `ConflictResolverService.ts` | 3-way merge orchestrator |
+| `AiConflictResolver.ts` | AI-assisted merge suggestions |
+| `threeWayMerge.ts` | Pure merge primitives |
+| `types.ts` | Conflict types |
+
+### Auth / Paywall / Monetization
+
+| Service | Responsibility |
+|---------|---------------|
+| `RevenueCatService.ts` | StoreKit 2 wrapper (trial / $2.99 mo / $40 lifetime) |
+| `PaywallAnalytics.ts` | Impression + conversion telemetry |
+| `GrandfatherService.ts` | Pre-Pro-tier user grandfathering |
+
+### Utility / Export / Notifications
 
 | Service | Responsibility | Dependencies |
 |---------|---------------|--------------|
-| `NetworkService.ts` | Online/offline detection | `NetInfo` |
-| `SecureStorageService.ts` | Encrypted storage | `expo-secure-store` |
-| `ExportService.ts` | Export notes (MD, PDF) | `expo-sharing` |
-| `ImportService.ts` | Import from files | `expo-document-picker` |
+| `ExportService.ts` | Export notes (MD, PDF, share sheet) | `expo-sharing`, `expo-print` |
+| `ShareService.ts` | OS share sheet | `expo-sharing` |
+| `NotificationService.ts` | Local notifications | `expo-notifications` |
+| `PushNotificationService.ts` | Push token registration | `expo-notifications` |
+| `ChatStorageService.ts` | AI chat thread persistence | AsyncStorage |
+
+> Online/offline detection lives in the `useNetworkStatus` hook (`@react-native-community/netinfo`), not in a dedicated service class.
 
 ## Service Patterns
 

--- a/docs/wiki/sync-engine.md
+++ b/docs/wiki/sync-engine.md
@@ -11,24 +11,27 @@ GitNotēs uses **isomorphic-git** for Git operations (clone, commit, push, pull)
 ```
 User edits note
   ↓
-NoteService.save() → AsyncStorage (fast)
+repoStore.saveNote() → AsyncStorage (fast)
   ↓
-SyncEngineService.queueChange()
-  ↓
-GitService.commit() [local]
-  ↓
-NetworkService.isOnline() ?
-  ├─ Yes → GitService.push() [remote]
-  └─ No  → Queue in syncStore (retry later)
+Sync mode (per repo, see SyncEngineService.getMode):
+  ├─ clone → LocalGitWriter.writeAndCommit(..., push: false)
+  │           → Stage screen / floating-button long-press /
+  │             StagePushScheduler (3-min idle) / OS background-task drain
+  │           → LocalGitWriter.push
+  └─ api   → NoteSyncQueueService.enqueue
+             → on push trigger: drainPushQueue → NoteSyncQueueService.drain
 ```
+
+Network state is read from the `useNetworkStatus` hook (NetInfo) — pull and push both gate on `isConnected && isInternetReachable`.
 
 ## Key Services
 
-### GitService
+### GitService (clone-mode facade)
 
-Core Git operations:
+Core clone-mode Git operations live behind `GitService.ts`; low-level write/commit/push is in `src/services/git/LocalGitWriter.ts`.
 
 ```typescript
+// GitService.ts — public surface
 class GitService {
   async cloneRepo(repoUrl: string, branch: string): Promise<void> {
     const fs = this.getFS();
@@ -40,6 +43,7 @@ class GitService {
       ref: branch,
       singleBranch: true,
       depth: 1,
+      noCheckout: true, // batched full checkout via checkout-orphan
     });
   }
 
@@ -81,132 +85,95 @@ class GitService {
 
 ### SyncEngineService
 
-Queue-based sync:
+Per-repo sync-mode registry. `getMode(repoPath)` returns `'clone' | 'api'`; the per-repo override map is persisted under `@gitnotes:sync_engine_modes` (default `'clone'`).
 
 ```typescript
 class SyncEngineService {
-  async queueChange(change: SyncChange): Promise<void> {
-    const queue = await StorageService.get<SyncChange[]>('syncQueue', []);
-    queue.push(change);
-    await StorageService.set('syncQueue', queue);
+  async getMode(repoPath: string): Promise<'clone' | 'api'> {
+    const overrides = await StorageService.get<Record<string, 'clone' | 'api'>>(
+      '@gitnotes:sync_engine_modes',
+      {},
+    );
+    return overrides[repoPath] ?? 'clone';
   }
 
-  async processQueue(): Promise<void> {
-    const queue = await StorageService.get<SyncChange[]>('syncQueue', []);
-    if (queue.length === 0) return;
-
-    const networkStatus = await NetworkService.getStatus();
-    if (!networkStatus.isConnected) return;
-
-    try {
-      // Commit all queued changes
-      const files = queue.map(c => c.filePath);
-      const message = `Sync ${queue.length} change(s)`;
-      await gitService.commit(message, files);
-      
-      // Push to remote
-      await gitService.push(token);
-      
-      // Clear queue on success
-      await StorageService.set('syncQueue', []);
-    } catch (error) {
-      console.error('Sync failed:', error);
-      // Keep queue for retry
-    }
+  async setMode(repoPath: string, mode: 'clone' | 'api'): Promise<void> {
+    // Persist override
   }
 }
 ```
 
-### NetworkService
+The actual mutation queue lives in `NoteSyncQueueService` (API mode) and `StagingService` (clone mode). Pull orchestration lives in `ForegroundSyncService` and the OS background task.
 
-Online/offline detection:
+### Network status (hook, not service)
+
+Online/offline detection is a hook, not a service:
 
 ```typescript
+// src/hooks/useNetworkStatus.ts
 import NetInfo from '@react-native-community/netinfo';
 
-class NetworkService {
-  async getStatus(): Promise<NetworkStatus> {
-    const state = await NetInfo.fetch();
-    return {
-      isConnected: state.isConnected ?? false,
-      isInternetReachable: state.isInternetReachable ?? false,
-      type: state.type,
-    };
-  }
+export function useNetworkStatus() {
+  const [status, setStatus] = useState<NetworkStatus>({
+    isConnected: true,
+    isInternetReachable: true,
+    type: 'unknown',
+  });
 
-  subscribe(callback: (status: NetworkStatus) => void): () => void {
-    return NetInfo.addEventListener(callback);
-  }
+  useEffect(() => {
+    return NetInfo.addEventListener(setStatus);
+  }, []);
+
+  return status;
 }
 ```
 
 ## Sync Flows
 
-### Auto-Sync (on app focus)
+### Foreground pull (app focus, online transitions, interval)
 
 ```typescript
-// App.tsx
-useEffect(() => {
-  const subscription = AppState.addEventListener('change', (state) => {
-    if (state === 'active') {
-      syncEngineService.processQueue();
-    }
-  });
-  return () => subscription.remove();
-}, []);
+// ForegroundSyncService.runPull — called from App.tsx / hook subscriptions
+await foregroundSyncService.runPull({ reason: 'appFocus' | 'onlineTransition' | 'interval' });
 ```
 
-### Manual Sync
+### Manual sync (pull-only)
 
 ```typescript
-// SyncButton.tsx
+// src/services/git/manualSync.ts
+import { runSyncCycle } from '../src/services/git/manualSync';
+
 const handleSync = async () => {
   setLoading(true);
-  await gitService.pull(token);
-  await syncEngineService.processQueue();
+  await runSyncCycle({ reason: 'manual' }); // pull + store refresh, never pushes
   setLoading(false);
 };
 ```
 
-### Periodic Sync (background)
+### Background sync (OS task)
 
-```typescript
-// App.tsx
-useEffect(() => {
-  const interval = setInterval(async () => {
-    const status = await NetworkService.getStatus();
-    if (status.isConnected) {
-      await syncEngineService.processQueue();
-    }
-  }, 5 * 60 * 1000); // 5 minutes
-  return () => clearInterval(interval);
-}, []);
-```
+`BackgroundSyncService` is the entry point registered with `expo-background-task`. It calls `pullAllFromRepos()` and surfaces a single local notification when the pull changed something (sum of `notes + canvases + todos + templates` > 0). Pushes never run from the OS background task except for small sets (≤ 10 files) via the dedicated background-push path.
 
 ## Conflict Resolution
 
 ### 3-Way Merge
 
 ```typescript
+// src/services/conflict/ConflictResolverService.ts
+import { threeWayMerge } from './threeWayMerge';
+
 class ConflictResolverService {
-  async resolve(localContent: string, remoteContent: string, baseContent: string): Promise<string> {
-    // Use isomorphic-git's merge strategy
-    const merged = await git.merge({
-      fs,
-      dir: repoDir,
-      ours: 'HEAD',
-      theirs: 'origin/main',
-    });
-    
-    if (merged.conflicts) {
-      // Manual resolution UI
-      return openConflictResolver(merged.conflicts);
-    }
-    
-    return merged.result;
+  async resolve(
+    localContent: string,
+    remoteContent: string,
+    baseContent: string,
+  ): Promise<{ merged: string; conflicts: ConflictBlock[] }> {
+    return threeWayMerge({ base: baseContent, ours: localContent, theirs: remoteContent });
   }
 }
 ```
+
+`AiConflictResolver.ts` (same folder) layers AI suggestions on top when an AI provider is configured.
 
 ### Conflict UI
 
@@ -229,15 +196,17 @@ const handleResolve = (resolution: 'local' | 'remote' | 'merge') => {
 ### Network Errors
 
 ```typescript
+import { formatSyncError } from '../src/services/git/formatSyncError';
+
 try {
   await gitService.push(token);
 } catch (error) {
-  if (error.message.includes('Network request failed')) {
-    // Queue for retry
-    await syncEngineService.queueChange(change);
-    showToast('Offline — changes queued for sync');
-  } else if (error.message.includes('401')) {
-    // Token expired
+  const msg = formatSyncError(error);
+  if (msg.kind === 'offline') {
+    // Clone mode keeps the commit staged; API mode retries via NoteSyncQueueService backoff
+    showToast('Offline — changes will sync when online');
+  } else if (msg.kind === 'unauthorized') {
+    // Token expired / revoked
     await refreshToken();
     await gitService.push(newToken);
   } else {
@@ -248,47 +217,27 @@ try {
 
 ### Auth Errors
 
-```typescript
-try {
-  await gitService.push(token);
-} catch (error) {
-  if (error.message.includes('403')) {
-    alert('No push access to repository');
-  } else if (error.message.includes('404')) {
-    alert('Repository not found');
-  }
-}
-```
+`formatSyncError` distinguishes rate-limit 403s from permission/scope 403s (the latter includes the exact scopes needed — fine-grained `Contents: Read and write` with the repo selected, or a classic token with the `repo` scope). 404s surface "Repository not found" with a re-auth path.
 
 ### Sync Queue Persistence
 
 ```typescript
-interface SyncChange {
+// NoteSyncQueueService — API mode
+interface PendingMutation {
   id: string;
   type: 'create' | 'update' | 'delete';
   filePath: string;
   content?: string;
-  timestamp: number;
+  attempts: number;
+  nextAttemptAt: number; // epoch ms
 }
 
-// Retry logic
-async function processQueue() {
+// Retry loop with exponential backoff (BACKOFF_BASE_MS = 500, BACKOFF_CAP_MS = 30_000, MAX_ATTEMPTS = 8)
+async function drain(onProgress?: (fraction: number | null) => void) {
   const queue = await getQueue();
-  const networkStatus = await NetworkService.getStatus();
-  
-  if (!networkStatus.isConnected) {
-    return; // Retry later
-  }
-  
-  for (const change of queue) {
-    try {
-      await applyChange(change);
-      await removeFromQueue(change.id);
-    } catch (error) {
-      console.error('Failed to sync change:', change.id, error);
-      // Keep in queue for retry
-    }
-  }
+  const now = Date.now();
+  const due = queue.filter(m => m.nextAttemptAt <= now);
+  // ... group by (repo, branch), Promise.all per group, fire onProgress per resolution
 }
 ```
 

--- a/docs/wiki/testing-guide.md
+++ b/docs/wiki/testing-guide.md
@@ -15,21 +15,39 @@ GitNotēs uses **Jest** with **React Native Testing Library**. Tests run in Node
 ```javascript
 module.exports = {
   preset: '@react-native/jest-preset',
+  transform: {
+    '^.+\\.js$': 'babel-jest',
+    '^.+\\.ts$': 'babel-jest',
+    '^.+\\.tsx$': 'babel-jest',
+  },
+  testEnvironment: 'node',
+  testMatch: [
+    '**/__tests__/**/*.test.{ts,tsx}',
+    '**/?(*.)+(spec|test).{ts,tsx}',
+  ],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '\\.(css)$': '<rootDir>/__mocks__/styleMock.js',
+    '^expo-blur$': '<rootDir>/__mocks__/expo-blur.ts',
+    '^expo-file-system/legacy$': '<rootDir>/__mocks__/expo-file-system-legacy.ts',
+    '^expo-image$': '<rootDir>/__mocks__/expo-image.ts',
+    '^expo-secure-store$': '<rootDir>/__mocks__/expo-secure-store.ts',
+    '^@ai-sdk/anthropic$': '<rootDir>/__mocks__/ai-sdk-anthropic.ts',
+  },
+  setupFiles: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: [
     '/node_modules/',
-    '/.worktrees/',  // Excludes git worktrees
+    '/.worktrees/',
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|expo|...))',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|expo|expo-[^/]+|@expo|react-native-reanimated|@shopify|nativewind|react-native-css|@rn-primitives|class-variance-authority|tailwind-merge|tailwindcss-animate)/)',
   ],
   collectCoverage: true,
   coveragePathIgnorePatterns: [
     '/node_modules/',
+    '/__tests__/',
     '/.worktrees/',
   ],
-  moduleNameMapper: {
-    '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js',
-  },
 };
 ```
 
@@ -268,26 +286,34 @@ jest.mock('@react-native-async-storage/async-storage', () => {
 
 ```yaml
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  test:
+  build-test:
+    name: TypeScript + Jest
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'yarn'
-      
+
       - run: yarn install --frozen-lockfile
       - run: yarn ts:check
+      - run: yarn lint
+      - run: yarn format:check
       - run: yarn jest --coverage
-      - run: yarn eslint . --ext .ts,.tsx
-      
-      - uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 ```
 
 ## Coverage

--- a/docs/wiki/theme-styling.md
+++ b/docs/wiki/theme-styling.md
@@ -31,37 +31,24 @@ Components (className prop)
 
 ```json
 {
-  "nativewind": "^5.0.3",
-  "tailwindcss": "^3.4.1",
-  "react-native-css-interop": "^0.1.3"
+  "nativewind": "^5.0.0-preview.4",
+  "tailwindcss": "^4.3.3",
+  "react-native-css": "^3.0.7",
+  "@tailwindcss/postcss": "^4.3.3"
 }
 ```
 
-### Tailwind Config
+Tailwind v4 uses **CSS-based config** — there is no `tailwind.config.js`. Tokens are declared inside an `@theme { … }` block in `global.css`, and the PostCSS pipeline is wired by `postcss.config.js` (`@tailwindcss/postcss`). NativeWind v5's preset/theme is imported once at the top of `global.css`.
+
+### PostCSS config
 
 ```javascript
-// tailwind.config.js
+// postcss.config.js
 
 module.exports = {
-  content: ['./src/**/*.{js,jsx,ts,tsx}'],
-  presets: [require('nativewind/preset')],
-  theme: {
-    extend: {
-      colors: {
-        // Light theme
-        primary: 'rgb(var(--color-primary) / <alpha-value>)',
-        background: 'rgb(var(--color-background) / <alpha-value>)',
-        card: 'rgb(var(--color-card) / <alpha-value>)',
-        text: 'rgb(var(--color-text) / <alpha-value>)',
-        border: 'rgb(var(--color-border) / <alpha-value>)',
-      },
-      fontFamily: {
-        sans: ['Inter', 'sans-serif'],
-        mono: ['JetBrains Mono', 'monospace'],
-      },
-    },
+  plugins: {
+    '@tailwindcss/postcss': {},
   },
-  plugins: [],
 };
 ```
 
@@ -70,28 +57,69 @@ module.exports = {
 ```css
 /* global.css */
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/preflight.css' layer(base);
+@import 'tailwindcss/utilities.css';
+@import 'nativewind/theme';
 
-@layer base {
-  :root {
-    --color-primary: 59 130 246;      /* blue-500 */
-    --color-background: 255 255 255;  /* white */
-    --color-card: 249 250 251;        /* gray-50 */
-    --color-text: 17 24 39;           /* gray-900 */
-    --color-border: 229 231 235;      /* gray-200 */
-  }
+@theme {
+  --color-bg: #f2f2f2;
+  --color-surface: #ffffff;
+  --color-highlight: #ffffff;
+  --color-shadow: #bfbfbf;
+  --color-text: #1c1c1e;
+  --color-text-secondary: #6e6e73;
+  --color-accent: #7b8cde;
+  --color-accent-muted: #a8b3e5;
+  --color-error: #e07a7a;
 
-  .dark {
-    --color-primary: 96 165 250;      /* blue-400 */
-    --color-background: 17 24 39;     /* gray-900 */
-    --color-card: 31 41 55;           /* gray-800 */
-    --color-text: 243 244 246;        /* gray-100 */
-    --color-border: 55 65 81;         /* gray-700 */
-  }
+  --color-background: #f2f2f2;
+  --color-surface-secondary: #f5f5f5;
+  --color-primary: #7b8cde;
+  --color-border: #d8d8d8;
+  --color-card: #ffffff;
+  --color-elevated: #ffffff;
+  --color-secondary: #f5f5f5;
+  --color-foreground: #1c1c1e;
+  --color-muted: #f5f5f5;
+  --color-muted-foreground: #6e6e73;
+  --color-destructive: #e07a7a;
+
+  --spacing: 4px;
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-8: 32px;
+
+  --radius-sm: 12px;
+  --radius-md: 18px;
+  --radius-lg: 24px;
+  --radius-pill: 999px;
+}
+
+.dark {
+  --color-bg: #1c1c1e;
+  --color-surface: #2c2c2e;
+  --color-highlight: #3a3a3c;
+  --color-shadow: #000000;
+  --color-text: #f2f2f2;
+  --color-text-secondary: #98989d;
+  --color-background: #1c1c1e;
+  --color-surface-secondary: #2c2c2e;
+  --color-card: #2c2c2e;
+  --color-elevated: #3a3a3c;
+  --color-secondary: #2c2c2e;
+  --color-foreground: #f2f2f2;
+  --color-muted: #2c2c2e;
+  --color-muted-foreground: #98989d;
+  --color-border: #3a3a3c;
 }
 ```
+
+See the real `global.css` for the full token list (spacing, radius, typography).
 
 ## Theme Context
 
@@ -193,73 +221,39 @@ function SettingsRow({ label }: { label: string }) {
 
 ## Design Tokens
 
-### Colors
+Tokens live in `global.css` under `@theme { … }` (Tailwind v4 CSS config). NativeWind reads them as Tailwind classes: `bg-primary`, `text-foreground`, `border-border`, `rounded-lg`, etc.
 
-```typescript
-// src/theme/tokens.ts
+### Spacing scale
 
-export const colors = {
-  light: {
-    primary: '#3B82F6',
-    background: '#FFFFFF',
-    card: '#F9FAFB',
-    text: '#111827',
-    border: '#E5E7EB',
-    muted: '#6B7280',
-    accent: '#8B5CF6',
-  },
-  dark: {
-    primary: '#60A5FA',
-    background: '#111827',
-    card: '#1F2937',
-    text: '#F3F4F6',
-    border: '#374151',
-    muted: '#9CA3AF',
-    accent: '#A78BFA',
-  },
-};
+The app uses a 4px-based spacing scale declared in `global.css`:
+
+```css
+@theme {
+  --spacing: 4px;
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-8: 32px;
+}
 ```
 
-### Spacing
+### Radius scale
 
-```typescript
-export const spacing = {
-  1: 4,
-  2: 8,
-  3: 12,
-  4: 16,
-  5: 20,
-  6: 24,
-  8: 32,
-  10: 40,
-  12: 48,
-};
+```css
+@theme {
+  --radius-sm: 12px;
+  --radius-md: 18px;
+  --radius-lg: 24px;
+  --radius-pill: 999px;
+}
 ```
 
-### Typography
+### Color tokens
 
-```typescript
-export const typography = {
-  fontFamily: {
-    sans: 'Inter',
-    mono: 'JetBrains Mono',
-  },
-  fontSize: {
-    xs: 12,
-    sm: 14,
-    base: 16,
-    lg: 18,
-    xl: 20,
-    '2xl': 24,
-  },
-  fontWeight: {
-    normal: '400',
-    medium: '500',
-    semibold: '600',
-    bold: '700',
-  },
-};
-```
+All semantic colors (`primary`, `background`, `card`, `surface`, `border`, `text`, `foreground`, `muted`, `muted-foreground`, `accent`, `destructive`, …) are declared as `--color-*` in `@theme` and overridden under `.dark` for dark mode. See `global.css` for the canonical list — light + dark values live there.
 
 ## Component Examples
 
@@ -390,9 +384,17 @@ yarn install
 
 ### Tailwind classes not recognized
 
+Tailwind v4 uses **CSS-based config** — there is no `tailwind.config.js`. Tokens live in `global.css` under `@theme { … }`. If a class isn't applying:
+
 ```bash
-# Check tailwind.config.js content paths
-# Should include: './src/**/*.{js,jsx,ts,tsx}'
+# Confirm the @tailwindcss/postcss plugin is wired
+cat postcss.config.js    # should list '@tailwindcss/postcss'
+
+# Confirm global.css imports nativewind/theme
+head -5 global.css       # should include @import 'nativewind/theme';
+
+# Reset Metro + transform cache
+yarn start --clear
 ```
 
 ### Button label centering with trailing icons


### PR DESCRIPTION
## Summary

Documentation had drifted from the codebase across multiple files. README and wiki pages referenced old package versions, deprecated commands, fictional services (`NoteService`, `JournalService`, `TodoService`, `NetworkService`), and a Tailwind v3 setup that was already on v4. This PR brings the docs back in line without changing their look or structure.

## Changes by file

- **README.md** — TS `5.7` → `6`; dropped `PDF` from save formats (PDF is a viewer, not a save format); `Multiple GitHub accounts` → `Multi-provider sync (GitHub, GitLab, Gitea-like)`; added Pro tier to Highlights with a wiki link; added NativeWind v5 to Stack
- **CONTRIBUTING.md** — expanded Project Structure with real `src/` subdirs (`data/`, `lib/`, `services/ai`, `services/canvas`, `services/conflict`, `services/git`) and real models
- **docs/wiki/index.md** — `yarn dev` → `yarn web`; replaced `eslint . --ext .ts,.tsx` with the real `yarn lint` / `yarn format:check`; `babel.config.cjs` → `babel.config.js`; expanded Project Structure; added missing key files (`eslint.config.js`, `global.css`, `metro.config.js`)
- **docs/wiki/development-guide.md** — `yarn dev` → `yarn web`; removed fictional commands (`yarn clean`, `yarn reset`, `yarn commit`, `yarn release`, `yarn generate-types`); expanded Project Structure
- **docs/wiki/architecture.md** — rewrote services/hooks/contexts/screens/stores lists to match `src/` reality; updated Tech Stack table and Data Flow diagrams
- **docs/wiki/services.md** — rebuilt service catalog to match `src/services/` + subdirs (`ai/`, `git/`, `canvas/`, `conflict/`); added all real services grouped properly
- **docs/wiki/theme-styling.md** — Tailwind `3.4.1` → `4.3.3`; `react-native-css-interop` → `react-native-css`; replaced `tailwind.config.js` example with `@theme` CSS config (v4 is CSS-based); updated `global.css` example to actual `@theme` syntax; dropped fictional `tokens.ts` reference
- **docs/wiki/i18n.md** — bumped dependencies (`i18next 23 → 26`, `react-i18next 14 → 17`, `expo-localization 15 → 56`)
- **docs/wiki/sync-engine.md** — removed dead `NoteService`/`NetworkService` references; rewrote architecture diagram for clone-mode stage-then-push + API write-through; replaced examples with `repoStore`, `StagingService`, `LocalGitWriter`, `NoteSyncQueueService`, `ForegroundSyncService`, `useNetworkStatus` (hook, not service); kept the accurate recent Push-model section
- **docs/wiki/ai-integration.md** — added `'apple'` and `'llama'` provider types; expanded model limits with Apple Intelligence + on-device Llama
- **docs/wiki/testing-guide.md** — `jest.config.js` example now matches real config (custom `moduleNameMapper` mocks, full `transformIgnorePatterns`); CI workflow example matches current `ci.yml`

## Preserved

Section headings, bullet styles, table formats, code-fence conventions, link patterns, and visual hierarchy are all untouched. Only the content inside the same containers was corrected.

## Checklist

- [x] All section headings and structure preserved
- [x] Markdown re-formatted with `yarn prettier --write`
- [x] No secrets introduced
- [x] Conventional Commits style matching repo history
