### PR TITLE
fix(paywall): guard interstitialEligible with isPro check (#1072)

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -32,7 +32,7 @@ import { RootStackParamList } from './types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAIStore } from '../stores/aiStore';
 import { useAIHubStore } from '../stores/aiHubStore';
-import { useProStore } from '../stores/proStore';
+import { selectIsPro, useProStore } from '../stores/proStore';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -87,16 +87,17 @@ export default function AppNavigator() {
   const openChatRepoPicker = useAIHubStore((state) => state.openChatRepoPicker);
   const closeChatRepoPicker = useAIHubStore((state) => state.closeChatRepoPicker);
   const [currentRouteName, setCurrentRouteName] = useState<string | undefined>(undefined);
+  const isPro = useProStore(selectIsPro);
   const interstitialEligible = useProStore((s) => s.interstitialEligible);
   const markInterstitialShown = useProStore((s) => s.markInterstitialShown);
 
   useEffect(() => {
-    if (!interstitialEligible) return;
+    if (!interstitialEligible || isPro) return;
     markInterstitialShown();
     if (navigationRef.isReady()) {
       navigationRef.navigate('Paywall');
     }
-  }, [interstitialEligible, markInterstitialShown]);
+  }, [interstitialEligible, isPro, markInterstitialShown]);
 
   const baseTheme = isDark ? DarkTheme : DefaultTheme;
   const navigationTheme = {


### PR DESCRIPTION
## Summary

Fixes #1072 - interstitialEligible auto-presents paywall at every launch

### Problem
In AppNavigator.tsx, the useEffect for interstitialEligible would navigate to Paywall without checking if the user already has Pro. If interstitialEligible is stale (user already upgraded but state not yet synced from RevenueCat), they would see the paywall at every single app launch.

### Solution
Added isPro check using selectIsPro from proStore before navigating to Paywall. If the user is already Pro, the interstitial paywall will not be shown even if interstitialEligible is true.

### Testing
- TypeScript compilation passes
- All 2893 existing tests pass
- ESLint passes (only pre-existing warning)