### PR TITLE
fix(ai): show device-platform-specific unavailable reason in model selector (#1065)

### DIFF
--- a/src/components/ai/ModelSelector.tsx
+++ b/src/components/ai/ModelSelector.tsx
@@ -222,7 +222,7 @@ export function ModelSelector({ visible, onClose }: ModelSelectorProps) {
                             </Text>
                             {isUnavailable && (
                               <Text style={[styles.modelDesc, { color: colors.textSecondary }]}>
-                                {t('ai.availability.unknown')}
+                                {unavailableReason ?? t('ai.availability.unknown')}
                               </Text>
                             )}
                             {needsDownload && !downloading && (


### PR DESCRIPTION
Fixes #1065 - Llama shows generic unknown on iOS instead of Android-only message