### PR TITLE
fix(navigation): pass repoPath/branch in conflicts deep link (#1067)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -87,7 +87,11 @@ export default function App() {
       const data = response.notification.request.content.data;
       if (data?.kind === 'push-failure') {
         await Linking.openURL(
-          PushNotificationService.resolvePushFailureRoute(data.conflict === true),
+          PushNotificationService.resolvePushFailureRoute(
+            data.conflict === true,
+            data.repoPath ? String(data.repoPath) : undefined,
+            data.branch ? String(data.branch) : undefined,
+          ),
         );
         return;
       }

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -61,7 +61,7 @@ const getLinkingConfig = (): LinkingOptions<RootStackParamList> => {
         ChatScreen: 'chat/:threadId',
         ThoughtDump: 'thought-dump',
         Stage: 'stage',
-        Conflicts: 'conflicts',
+        Conflicts: 'conflicts/:repoPath/:branch',
       },
     },
   };

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -17,7 +17,7 @@ type ProductionStackParamList = {
   TemplateManager: undefined;
   SyncStatus: undefined;
   Stage: undefined;
-  Conflicts: { mode?: 'manage' } | undefined;
+  Conflicts: { mode?: 'manage'; repoPath?: string; branch?: string } | undefined;
   ConflictResolver: { repoPath: string; branch: string; filePath: string };
   AddReminder: undefined;
   ThoughtDump: { openVoiceOnMount?: boolean } | undefined;

--- a/src/screens/SyncStatusScreen.tsx
+++ b/src/screens/SyncStatusScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { View, Text, FlatList, TouchableOpacity, Alert } from 'react-native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RouteProp } from '@react-navigation/native';
@@ -83,6 +83,17 @@ export default function SyncStatusScreen({ onAiFixRemaining }: SyncStatusScreenP
     }
     return Array.from(byKey.values());
   }, [conflicts]);
+
+  useEffect(() => {
+    const { repoPath, branch } = route.params ?? {};
+    if (repoPath && branch) {
+      const group = groups.find((g) => g.repoPath === repoPath && g.branch === branch);
+      const firstFile = group?.files[0];
+      if (firstFile) {
+        navigation.navigate('ConflictResolver', { repoPath, branch, filePath: firstFile.path });
+      }
+    }
+  }, [route.params, groups, navigation]);
 
   const rows = useMemo<Row[]>(() => {
     const out: Row[] = [];

--- a/src/services/PushNotificationService.ts
+++ b/src/services/PushNotificationService.ts
@@ -13,8 +13,16 @@ function appIsForegrounded(): boolean {
 let lastProgressSentAt = 0;
 let unsubscribeProgress: (() => void) | null = null;
 
-/** Plain push failures open the stage page; conflict-caused ones open the conflicts page. */
-export function resolvePushFailureRoute(conflict: boolean): string {
+/** Plain push failures open the stage page; conflict-caused ones open the conflicts page
+ *  with specific repo/branch if provided. */
+export function resolvePushFailureRoute(
+  conflict: boolean,
+  repoPath?: string,
+  branch?: string,
+): string {
+  if (conflict && repoPath && branch) {
+    return `gitnotes://conflicts/${encodeURIComponent(repoPath)}/${encodeURIComponent(branch)}`;
+  }
   return conflict ? 'gitnotes://conflicts' : 'gitnotes://stage';
 }
 


### PR DESCRIPTION
Fixes #1067 - deep link routes to wrong screen.

When a push notification fails with a conflict, the notification now includes repoPath and branch in the deep link URL. The Conflicts screen navigates directly to ConflictResolver for that specific repo/branch.

### Changes
- `PushNotificationService.resolvePushFailureRoute`: Accept optional repoPath/branch params
- `App.tsx`: Pass repoPath/branch from notification data to deep link URL
- `AppNavigator.tsx`: Update deep link path to `conflicts/:repoPath/:branch`
- `SyncStatusScreen.tsx`: Navigate to ConflictResolver when opened with repoPath/branch params
- `types.ts`: Update Conflicts param type to include optional repoPath/branch