### PR TITLE
fix(ui): clarify SyncBlockOverlay label when push is active (#1066)

### DIFF
--- a/src/components/ui/SyncBlockOverlay.tsx
+++ b/src/components/ui/SyncBlockOverlay.tsx
@@ -43,9 +43,12 @@ export function SyncBlockOverlay() {
   const [cancelArmed, setCancelArmed] = useState(false);
   const [cancelling, setCancelling] = useState(false);
 
-  // Pick label: "pushing" when push markers are active, else "syncing".
+  // Always show "Syncing" as the main label. When push markers are active
+  // (background push queued), add a subtitle so the user understands why
+  // they see "Syncing" even when they didn't initiate a push (#1066).
   const hasPushMarkers = GitSyncGate.isPushActive();
-  const label = hasPushMarkers ? t('sync.overlay.pushing') : t('sync.overlay.syncing');
+  const label = t('sync.overlay.syncing');
+  const subtitle = hasPushMarkers ? t('sync.overlay.includingPush') : undefined;
 
   useEffect(() => {
     Animated.timing(opacity, {
@@ -100,6 +103,11 @@ export function SyncBlockOverlay() {
         <Text style={{ color: colors.text, fontSize: type.sm, fontWeight: '600' }} numberOfLines={1}>
           {label}
         </Text>
+        {subtitle && (
+          <Text style={{ color: colors.textSecondary, fontSize: type.xs }} numberOfLines={1}>
+            {subtitle}
+          </Text>
+        )}
         {cancelArmed && (
           <Pressable
             testID="sync-block-overlay.cancel"

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -620,7 +620,8 @@
       "pushing": "Hochladen…",
       "pulling": "Herunterladen…",
       "cancel": "Abbrechen",
-      "cancelling": "Wird abgebrochen…"
+      "cancelling": "Wird abgebrochen…",
+      "includingPush": "inkl. Push"
     }
   },
   "onboarding": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -580,7 +580,8 @@
       "pushing": "Pushing…",
       "pulling": "Pulling…",
       "cancel": "Cancel",
-      "cancelling": "Cancelling…"
+      "cancelling": "Cancelling…",
+      "includingPush": "including push"
     }
   },
   "onboarding": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -620,7 +620,8 @@
       "pushing": "Enviando…",
       "pulling": "Descargando…",
       "cancel": "Cancelar",
-      "cancelling": "Cancelando…"
+      "cancelling": "Cancelando…",
+      "includingPush": "incl. push"
     }
   },
   "onboarding": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -620,7 +620,8 @@
       "pushing": "Envoi…",
       "pulling": "Réception…",
       "cancel": "Annuler",
-      "cancelling": "Annulation…"
+      "cancelling": "Annulation…",
+      "includingPush": "incl. push"
     }
   },
   "onboarding": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -620,7 +620,8 @@
       "pushing": "送信中…",
       "pulling": "受信中…",
       "cancel": "キャンセル",
-      "cancelling": "キャンセル中…"
+      "cancelling": "キャンセル中…",
+      "includingPush": "Pushを含む"
     }
   },
   "onboarding": {

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -620,7 +620,8 @@
       "pushing": "전송 중…",
       "pulling": "수신 중…",
       "cancel": "취소",
-      "cancelling": "취소 중…"
+      "cancelling": "취소 중…",
+      "includingPush": "Push 포함"
     }
   },
   "onboarding": {


### PR DESCRIPTION
## Summary

Fixes #1066 - SyncBlockOverlay label switches based on invisible internal state

### Problem
The SyncBlockOverlay showed different labels ("Pushing" vs "Syncing") based on `hasPushMarkers` - an internal boolean driven by invisible push queue state. Users saw "Pushing" even when they did not initiate a push, which was confusing.

### Solution
Always show "Syncing" as the main label. When push markers are active (background push queued), show a subtitle "including push" so users understand why syncing is happening even though they did not initiate a push.

### Changes
- **SyncBlockOverlay.tsx**: Changed to always show "Syncing" with a conditional subtitle
- **en.json**: Added new i18n key `sync.overlay.includingPush`

### Testing
- TypeScript compilation passes
- ESLint passes