### PR TITLE
fix(ui): add skip option to AI onboarding step (#1069)

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -306,6 +306,14 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
                 label="See Plans"
                 style={{ marginTop: 8 }}
               />
+              <Button
+                variant="ghost"
+                fullWidth
+                testID="onboarding.button.skip-ai"
+                onPress={handleSkipGithubTools}
+                label="Skip for Now"
+                style={{ marginTop: 8 }}
+              />
             </View>
           ) : (
             <Button


### PR DESCRIPTION
## Summary

Fixes #1069 - AI onboarding step has no skip option

### Problem
In OnboardingScreen.tsx, the AI_STEP (Pro upsell step) had no skip option - only "Continue" and "See Plans" buttons. This was inconsistent with every other onboarding step which has a skip option.

### Solution
Added "Skip for Now" button to the AI_STEP, consistent with the TOKEN_STEP and GitHub Tools step pattern.

### Changes
- **OnboardingScreen.tsx**: Added "Skip for Now" ghost button that calls `handleSkipGithubTools` (same handler used by GitHub Tools skip)

### Testing
- TypeScript compilation passes