### PR TITLE
fix(pro): cleanup previous RevenueCat listener before registering new one (#1081)

### DIFF
--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -14,6 +14,8 @@ import { resolveGrandfatherStatus } from '../services/GrandfatherService';
 import * as PaywallAnalytics from '../services/PaywallAnalytics';
 
 let _isDevice: boolean | null = null;
+let _customerInfoCleanup: (() => void) | null = null;
+
 function isSimulator(): boolean {
   if (_isDevice === null) {
     try { _isDevice = require('expo-device').isDevice; } catch { _isDevice = true; }
@@ -156,7 +158,8 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
       set({ configured });
       if (configured) {
         customerInfo = await getCustomerInfo();
-        onCustomerInfoUpdate((info) => {
+        _customerInfoCleanup?.();
+        _customerInfoCleanup = onCustomerInfoUpdate((info) => {
           const derived = deriveTrialInfo(info);
           set((state) => ({
             ...derived,


### PR DESCRIPTION
Fixes #1081 - RevenueCat delegate re-registration warning on every app foreground.

The initialize() function was registering a new onCustomerInfoUpdate listener every time it was called without cleaning up the previous one. This caused multiple listeners to accumulate when the app was foregrounded multiple times. Now we store the cleanup function and call it before registering a new listener.