### PR TITLE
fix(i18n): remove Optional from API key placeholder since it's required for Test Connection (#1077)

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -769,7 +769,7 @@
     },
     "namePlaceholder": "Name (z. B. Mein Ollama, OpenAI)",
     "baseUrlPlaceholder": "Basis-URL (z. B. http://localhost:11434/v1)",
-    "apiKeyPlaceholder": "API-Schlüssel (Optional)",
+    "apiKeyPlaceholder": "API-Schlüssel",
     "appleDescription": "Verwendet Apple Foundation Models — keine Konfiguration erforderlich.",
     "llamaDescription": "Läuft lokal auf deinem Gerät — lade das Modell über die Modellauswahl herunter.",
     "testConnection": "Verbindung testen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -729,7 +729,7 @@
     },
     "namePlaceholder": "Name (e.g., My Ollama, OpenAI)",
     "baseUrlPlaceholder": "Base URL (e.g., http://localhost:11434/v1)",
-    "apiKeyPlaceholder": "API Key (Optional)",
+    "apiKeyPlaceholder": "API Key",
     "appleDescription": "Uses Apple Foundation Models — no configuration needed.",
     "llamaDescription": "Runs locally on your device — download model from the model selector.",
     "testConnection": "Test Connection",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -769,7 +769,7 @@
     },
     "namePlaceholder": "Name (e.g., My Ollama, OpenAI)",
     "baseUrlPlaceholder": "Base URL (e.g., http://localhost:11434/v1)",
-    "apiKeyPlaceholder": "API Key (Optional)",
+    "apiKeyPlaceholder": "API Key",
     "appleDescription": "Uses Apple Foundation Models — no configuration needed.",
     "llamaDescription": "Runs locally on your device — download model from the model selector.",
     "testConnection": "Test Connection",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -769,7 +769,7 @@
     },
     "namePlaceholder": "Name (e.g., My Ollama, OpenAI)",
     "baseUrlPlaceholder": "Base URL (e.g., http://localhost:11434/v1)",
-    "apiKeyPlaceholder": "API Key (Optional)",
+    "apiKeyPlaceholder": "API Key",
     "appleDescription": "Uses Apple Foundation Models — no configuration needed.",
     "llamaDescription": "Runs locally on your device — download model from the model selector.",
     "testConnection": "Test Connection",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -769,7 +769,7 @@
     },
     "namePlaceholder": "Name (e.g., My Ollama, OpenAI)",
     "baseUrlPlaceholder": "Base URL (e.g., http://localhost:11434/v1)",
-    "apiKeyPlaceholder": "API Key (Optional)",
+    "apiKeyPlaceholder": "API Key",
     "appleDescription": "Uses Apple Foundation Models — no configuration needed.",
     "llamaDescription": "Runs locally on your device — download model from the model selector.",
     "testConnection": "Test Connection",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -769,7 +769,7 @@
     },
     "namePlaceholder": "Name (e.g., My Ollama, OpenAI)",
     "baseUrlPlaceholder": "Base URL (e.g., http://localhost:11434/v1)",
-    "apiKeyPlaceholder": "API Key (Optional)",
+    "apiKeyPlaceholder": "API Key",
     "appleDescription": "Uses Apple Foundation Models — no configuration needed.",
     "llamaDescription": "Runs locally on your device — download model from the model selector.",
     "testConnection": "Test Connection",


### PR DESCRIPTION
Fixes #1077 - API key labeled Optional but required for Test Connection.

The placeholder was misleading - Test Connection requires an API key for Anthropic and other providers, so "(Optional)" was removed from all 6 locales (EN, ES, FR, DE, JA, KO).