### PR TITLE
fix(editor): expose .json format in format picker (#1076)

### DIFF
--- a/src/components/editor/editorShared.ts
+++ b/src/components/editor/editorShared.ts
@@ -13,6 +13,7 @@ export const FORMAT_OPTIONS: { label: string; value: NoteFormat }[] = [
   { label: '.md', value: 'markdown' },
   { label: '.norg', value: 'neorg' },
   { label: '.org', value: 'org' },
+  { label: '.json', value: 'json' },
 ];
 
 export function normalizeNotePathForLookup(path: string): string {


### PR DESCRIPTION
Fixes #1076 - JSON format is a valid NoteFormat but not exposed in the format picker.

The FORMAT_OPTIONS array now includes .json alongside .md, .norg, and .org to match the NoteFormat type definition and README promise.