### PR TITLE
fix(paywall): extract hardcoded legal URLs to constants (#1071)

### DIFF
--- a/src/screens/PaywallScreen.tsx
+++ b/src/screens/PaywallScreen.tsx
@@ -20,6 +20,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { useProStore } from '../stores/proStore';
 import { getIntroEligibilities, trackPaywallImpression } from '../services/RevenueCatService';
 import * as PaywallAnalytics from '../services/PaywallAnalytics';
+import { LEGAL_URLS } from '../utils/constants';
 
 export default function PaywallScreen() {
   const { t } = useTranslation();
@@ -297,7 +298,7 @@ export default function PaywallScreen() {
                 testID="paywall.terms-link"
                 role="link"
                 accessibilityRole="link"
-                onPress={() => void Linking.openURL('https://www.gitnotes.org/terms')}
+                onPress={() => void Linking.openURL(LEGAL_URLS.terms)}
               >
                 <Text className="text-xs font-medium" style={{ color: colors.accent }}>
                   {t('paywall.footer.terms')}
@@ -307,7 +308,7 @@ export default function PaywallScreen() {
                 testID="paywall.privacy-link"
                 role="link"
                 accessibilityRole="link"
-                onPress={() => void Linking.openURL('https://www.gitnotes.org/privacy')}
+                onPress={() => void Linking.openURL(LEGAL_URLS.privacy)}
               >
                 <Text className="text-xs font-medium" style={{ color: colors.accent }}>
                   {t('paywall.footer.privacy')}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -52,3 +52,8 @@ export const NOTE_COLORS = {
   purple: '#AF52DE',
   pink: '#FF2D55',
 } as const;
+
+export const LEGAL_URLS = {
+  terms: 'https://www.gitnotes.org/terms',
+  privacy: 'https://www.gitnotes.org/privacy',
+} as const;


### PR DESCRIPTION
Fixes #1071 - PaywallScreen hardcoded legal URLs with no config.

Legal URLs now defined in constants.ts (LEGAL_URLS.terms, LEGAL_URLS.privacy) and imported in PaywallScreen instead of inline strings.