### PR TITLE
fix(ai): preserve raw error message in unknown availability cases

### DIFF
--- a/src/services/ai/providerAvailabilityCopy.ts
+++ b/src/services/ai/providerAvailabilityCopy.ts
@@ -21,7 +21,9 @@ export function describeAvailability(t: TFunction, reason: AvailabilityReason): 
     case 'llama-not-installed':
       return reason.message || t('ai.availability.llamaNotInstalled');
     case 'unknown':
-    default:
-      return t('ai.availability.unknown');
+    default: {
+      const msg = 'message' in reason && reason.message ? reason.message : null;
+      return msg ? `${t('ai.availability.unknown')} (${msg})` : t('ai.availability.unknown');
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #1070 - Provider availability errors lose the root cause.

When an unknown error occurs, the raw message from the native module is now appended to the i18n translation instead of being discarded.

### Before
```
"Not available on this device"
```

### After
```
"Not available on this device (native error message here)"
```

### Changes
- `src/services/ai/providerAvailabilityCopy.ts`: Append raw message for `unknown` case

### Testing
- TypeScript compilation passes