### PR TITLE
fix(ai): include raw error message in unknown availability cases (#1070)

### DIFF
--- a/src/services/ai/providerAvailabilityCopy.ts
+++ b/src/services/ai/providerAvailabilityCopy.ts
@@ -21,7 +21,6 @@ export function describeAvailability(t: TFunction, reason: AvailabilityReason): 
     case 'llama-not-installed':
       return reason.message || t('ai.availability.llamaNotInstalled');
     case 'unknown':
-    default:
-      return t('ai.availability.unknown');
+      return reason.message ? `${t('ai.availability.unknown')} (${reason.message})` : t('ai.availability.unknown');
   }
 }


### PR DESCRIPTION
Fixes #1070 - Provider availability errors lose the root cause.

The unknown case now appends the raw error message in parentheses so users and support requests have diagnostic value instead of just seeing "unknown".