### PR TITLE
fix(onboarding): add Configure API Key link from AI onboarding step (#1068)

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -219,6 +219,15 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
             <Text className="text-[13px] text-center leading-[18px] mt-2 opacity-80" style={{ color: colors.textSecondary }}>
               {t('onboarding.pro.reminder', { defaultValue: 'You can upgrade anytime in Settings → GitNotēs Pro.' })}
             </Text>
+            <TouchableOpacity
+              testID="onboarding.button.configure-api-key"
+              onPress={() => navigation.navigate('MainTabs', { screen: 'SettingsTab' })}
+              className="mt-4"
+            >
+              <Text className="text-[13px] font-medium" style={{ color: colors.accent }}>
+                Configure API Key
+              </Text>
+            </TouchableOpacity>
           </View>
         ) : isGithubToolsStep ? (
           <View className="flex-1 px-10 items-center">


### PR DESCRIPTION
Fixes #1068 - BYOK messaging good but no API key path from onboarding.

Added a "Configure API Key" link in the AI onboarding step that navigates directly to Settings so users can add their own API key without having to complete onboarding and navigate there manually.