### PR TITLE
fix(paywall): show error with retry button when RevenueCat offerings fail to load (#1061)

### DIFF
--- a/src/screens/PaywallScreen.tsx
+++ b/src/screens/PaywallScreen.tsx
@@ -248,7 +248,21 @@ export default function PaywallScreen() {
 
         {!offeringsReady ? (
           <View className="mt-8 items-center" testID="paywall.loading">
-            <ActivityIndicator color={colors.primary} size="large" />
+            {error ? (
+              <View className="items-center gap-4">
+                <Ionicons name="warning-outline" size={48} color={colors.error} />
+                <Text className="text-sm text-center" style={{ color: colors.textSecondary }}>
+                  {error}
+                </Text>
+                <Button
+                  variant="secondary"
+                  onPress={() => void loadOfferingsIfNeeded()}
+                  label="Retry"
+                />
+              </View>
+            ) : (
+              <ActivityIndicator color={colors.primary} size="large" />
+            )}
           </View>
         ) : (
           <>


### PR DESCRIPTION
Fixes #1061 - PaywallScreen infinite spinner when RevenueCat offerings fail to load.

When offeringsReady is false and error is set, show the error message with a retry button instead of an infinite spinner. Users now have a recovery path when RevenueCat fails.