### PR TITLE
fix(conflict): alert user to push after resolving conflicts (#1059)

### DIFF
--- a/src/screens/ConflictResolverScreen.tsx
+++ b/src/screens/ConflictResolverScreen.tsx
@@ -205,7 +205,11 @@ export default function ConflictResolverScreen() {
         }
 
         await removeConflict(repoPath, branch);
-        navigation.goBack();
+        Alert.alert(
+          'Conflicts resolved',
+          'Your changes have been committed locally. Push to sync with GitHub.',
+          [{ text: 'OK', onPress: () => navigation.goBack() }],
+        );
       } catch (e) {
         Alert.alert('Error', e instanceof Error ? e.message : String(e));
       } finally {


### PR DESCRIPTION
Fixes #1059 - Conflict resolution commits locally but never pushes.

Added an alert after successful conflict resolution informing the user that changes have been committed locally and they need to push to sync.