### PR TITLE
docs(android): add EAS mapping-file auto-upload wiki page (#1046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable fixes and feature changes to GitNotēs are documented here.
 >
 > **History**: prior fixes (pre-2026-08) lived in single-PR wiki pages. Those pages were retired in [#1047](https://github.com/gedwolmen/gitnotes/pull/1047); their full diagnostic content is preserved in git history via `git log -p -- docs/wiki/<file>.md`.
 
+## 2026-08-24
+
+### Play Console Deobfuscation Warning — EAS Mapping Upload Setup (#1046)
+
+**chore(android)** — Added wiki documentation for EAS mapping-file auto-upload setup. The Play Console warning for version code 10 is resolved by enabling "Auto-upload mapping files" in EAS Project Settings → Submit → Google Play Store. Wiki page added at `docs/wiki/eas-mapping-upload.md`.
+
 ## 2026-08-23
 
 ### Simulator Keychain Entitlement (#1036)

--- a/docs/wiki/eas-mapping-upload.md
+++ b/docs/wiki/eas-mapping-upload.md
@@ -1,0 +1,60 @@
+# EAS Mapping File Auto-Upload Setup
+
+This page documents how to configure EAS Build to automatically upload R8/ProGuard mapping files to Google Play Console, enabling readable crash/ANR stack traces in Play Console.
+
+## Background
+
+When building Android with `eas build --profile production`, R8 runs by default (Expo SDK 50+). R8 emits a `mapping.txt` artifact alongside the AAB. Google Play Console needs this file to deobfuscate crash traces.
+
+Without the mapping file uploaded, crash traces show obfuscated names like `a.b.c.d` instead of readable class/method names.
+
+## Setup
+
+### Enable Auto-Upload in EAS Dashboard
+
+1. Open your EAS project dashboard at https://expo.dev
+2. Navigate to **Project Settings** → **Submit** → **Google Play Store**
+3. Ensure the Play Store integration is linked (service account key configured)
+4. Enable **"Auto-upload mapping files"** (label varies by dashboard version)
+5. Verify the setting is saved
+
+### Verify on Next Build
+
+Run a production build and submit:
+
+```bash
+eas build --profile production --platform android
+eas submit --profile production --platform android
+```
+
+Check the build in Google Play Console → **App Bundle Explorer** → version row. The deobfuscation warning should not appear.
+
+## Manual Upload (Retroactive Fix)
+
+If a version was uploaded without the mapping file:
+
+1. Go to **EAS Build** → **Builds** → find the build for that version
+2. Download `mapping.txt` from the **Artifacts** tab
+3. Go to **Google Play Console** → **Release** → **App Bundle Explorer**
+4. Find the version row → **Upload re-symbolication file**
+5. Upload the `mapping.txt`
+
+## Troubleshooting
+
+### Warning Still Appears After Auto-Upload Enabled
+
+- Check EAS build logs for upload errors
+- Verify the service account has Play Console permissions
+- Check if submission was performed via `eas submit` or manual Play Console upload
+
+### Mapping File Not in Build Artifacts
+
+- Ensure the build completed successfully (R8 must run)
+- Check if `android.buildType` is set to `app-bundle` (not `apk`)
+- Verify `production` profile uses `buildType: "app-bundle"`
+
+## References
+
+- [Expo EAS Build Configuration](https://docs.expo.dev/build/eas-json/)
+- [Google Play Mapping Upload](https://support.google.com/googleplay/android-developer/answer/9859154)
+- [Expo Android Builds](https://docs.expo.dev/build-reference/android-builds/)

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -42,6 +42,7 @@
 | [Pro Dev Override](./pro-dev-override.md) | `__DEV__`-only iOS-simulator override that forces Pro gate for QA — NOT a payment bypass; RevenueCat unchanged; gate triple `__DEV__ && Platform.OS==='ios' && !Device.isDevice` |
 | [Token Removal Repo Cascade](./repo-removal-cascade.md) | removing a token also removes its synced repos, with a confirmation warning |
 | [Report Bugs & Feature Requests](./report-issue-links.md) | Settings About-row + onboarding footer link to `github.com/gedwolmen/gitnotes/issues`, i18n'd across all six locales |
+| [EAS Mapping File Auto-Upload](./eas-mapping-upload.md) | Configure EAS Build to auto-upload R8 mapping files to Google Play Console for deobfuscated crash traces (#1046) |
 
 ### Theming, i18n, quality
 


### PR DESCRIPTION
## Summary

Issue #1046 is a Play Console deobfuscation warning for version code 10. The fix requires enabling "Auto-upload mapping files" in EAS Project Settings → Submit → Google Play Store.

This PR adds wiki documentation at  that:
1. Explains the background (R8 mapping files, Play Console requirements)
2. Documents the EAS dashboard configuration steps
3. Provides manual upload instructions for retroactive fixes
4. Includes troubleshooting guidance

## Changes

- Added  (new wiki page)
- Updated  (added entry to wiki index)
- Updated  (added entry for 2026-08-24)

## Action Required

The EAS dashboard configuration (enabling auto-upload mapping files) must be performed manually at https://expo.dev as it cannot be done via CLI or code changes.