### PR TITLE
fix(conflict): push after resolving conflicts in API mode

### DIFF
--- a/__tests__/screens/ConflictResolverScreen.test.tsx
+++ b/__tests__/screens/ConflictResolverScreen.test.tsx
@@ -27,6 +27,8 @@ const mockDeleteAndCommit = jest.fn(async () => undefined);
 const mockMergeCommit = jest.fn(async () => ({}));
 const mockGetToken = jest.fn(async () => null);
 const mockGetUser = jest.fn();
+const mockGetMode = jest.fn(async () => 'api');
+const mockLocalGitWriterPush = jest.fn(async () => ({ success: true }));
 
 let alertSpy: jest.SpyInstance;
 let alertButtons: { text: string; onPress?: () => void; style?: string }[] = [];
@@ -67,6 +69,13 @@ jest.mock('../../src/services/git/LocalGitWriter', () => ({
   LocalGitWriter: {
     writeAndCommit: (...args: unknown[]) => mockWriteAndCommit(...args),
     deleteAndCommit: (...args: unknown[]) => mockDeleteAndCommit(...args),
+    push: (...args: unknown[]) => mockLocalGitWriterPush(...args),
+  },
+}));
+
+jest.mock('../../src/services/SyncEngineService', () => ({
+  SyncEngineService: {
+    getMode: (...args: unknown[]) => mockGetMode(...args),
   },
 }));
 
@@ -247,6 +256,10 @@ describe('ConflictResolverScreen AI-fix flow', () => {
     });
 
     expect(mockRemoveConflict).toHaveBeenCalledWith('owner/repo', 'main');
+    expect(mockGetMode).toHaveBeenCalledWith('owner/repo');
+    expect(mockLocalGitWriterPush).toHaveBeenCalled();
+    expect(mockGoBack).not.toHaveBeenCalled();
+    alertButtons[0]?.onPress?.();
     expect(mockGoBack).toHaveBeenCalled();
   });
 

--- a/src/screens/ConflictResolverScreen.tsx
+++ b/src/screens/ConflictResolverScreen.tsx
@@ -10,6 +10,7 @@ import { ConflictResolverService } from '../services/conflict/ConflictResolverSe
 import { proposeMerge } from '../services/conflict/AiConflictResolver';
 import { GitFsService } from '../services/git/GitFsService';
 import { LocalGitWriter } from '../services/git/LocalGitWriter';
+import { SyncEngineService } from '../services/SyncEngineService';
 import { AuthService } from '../services/AuthService';
 import type { FileConflict } from '../services/conflict/types';
 import type { RootStackParamList } from '../navigation/types';
@@ -205,11 +206,26 @@ export default function ConflictResolverScreen() {
         }
 
         await removeConflict(repoPath, branch);
-        Alert.alert(
-          'Conflicts resolved',
-          'Your changes have been committed locally. Push to sync with GitHub.',
-          [{ text: 'OK', onPress: () => navigation.goBack() }],
-        );
+
+        const isApiMode = (await SyncEngineService.getMode(repoPath)) === 'api';
+        if (isApiMode) {
+          const pushResult = await LocalGitWriter.push({ repoPath, branch, token });
+          if (!pushResult.success) {
+            Alert.alert('Push failed', pushResult.error ?? 'Unknown error', [
+              { text: 'OK', onPress: () => navigation.goBack() },
+            ]);
+            return;
+          }
+          Alert.alert('Conflicts resolved', 'Your changes have been pushed to GitHub.', [
+            { text: 'OK', onPress: () => navigation.goBack() },
+          ]);
+        } else {
+          Alert.alert(
+            'Conflicts resolved',
+            'Your changes have been committed locally. Use the push button to sync with GitHub.',
+            [{ text: 'OK', onPress: () => navigation.goBack() }],
+          );
+        }
       } catch (e) {
         Alert.alert('Error', e instanceof Error ? e.message : String(e));
       } finally {


### PR DESCRIPTION
## Summary

Fixes #1059 - Conflict resolution commits locally but never pushes.

### Problem
When resolving conflicts, the code was committing with `push: false` and showing an alert "Push to sync with GitHub" but never actually pushing. This left users thinking their conflicts were resolved when they were only saved locally.

### Solution
- In **API mode**: After committing conflict resolutions, actually push to GitHub
- In **clone mode**: Show a more informative message telling users to use the push button

### Changes
- `src/screens/ConflictResolverScreen.tsx`:
  - Added `SyncEngineService` import
  - Check sync mode after committing
  - In API mode: call `LocalGitWriter.push()` after commit
  - Show appropriate success/failure message based on mode

### Testing
- TypeScript compilation passes