### PR TITLE
fix(settings): allow Daily Quote toggle without AI enabled

### DIFF
--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -959,9 +959,8 @@ export function SettingsContent(props: SettingsContentProps) {
               <View className="flex-row items-center gap-2">
                 <Toggle
                   testID="settings.toggle.daily-quote"
-                  value={isAIEnabled ? dailyQuoteEnabled : false}
+                  value={dailyQuoteEnabled}
                   onValueChange={onToggleDailyQuote}
-                  disabled={!isAIEnabled}
                 />
                 <HintIcon hintKey="hints.settings.dailyQuote" testID="hint.daily-quote" />
               </View>


### PR DESCRIPTION
## Summary

Daily Quote is a curated philosophical quote feature (Pro-gated), not an AI feature. Only the **AI Personalization** sub-toggle requires AI to be enabled.

**Bug:** The Daily Quote toggle was incorrectly disabled when AI was off (). This prevented users from seeing Daily Quotes even though the curated fallback works perfectly well without AI — only the personalized description is AI-generated.

**Fix:** Removed  and  from the Daily Quote toggle so it works independently of the AI setting.

**Behavior after fix:**
- Daily Quote toggle → works regardless of AI on/off
- AI Personalization toggle → still requires AI enabled + Daily Quote enabled
- Show Sources toggle → still requires Daily Quote enabled

## Tests
- Full suite: 2889 passing (same pre-existing failures as before: OnboardingScreen Pro gate tests, i18n parity, ConflictResolverScreen)
- : 5/5 passing

## Checklist
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] All tests pass (pre-existing failures noted above)