### PR TITLE
fix tests: update step indices, mock push, add es i18n keys

### DIFF
--- a/__tests__/screens/OnboardingScreen.pro-gate.test.tsx
+++ b/__tests__/screens/OnboardingScreen.pro-gate.test.tsx
@@ -78,9 +78,9 @@ jest.mock('../../src/stores/aiStore', () => {
   };
 });
 
-const TOKEN_STEP_INDEX = 6; // 6 INFO_STEPS
-const AI_STEP_INDEX = 7;
-const GITHUB_TOOLS_STEP_INDEX = 8;
+const TOKEN_STEP_INDEX = 5; // 5 INFO_STEPS (removed Scheduled Learning in #1104)
+const AI_STEP_INDEX = 6;
+const GITHUB_TOOLS_STEP_INDEX = 7;
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/__tests__/staging-delete-rewire.test.ts
+++ b/__tests__/staging-delete-rewire.test.ts
@@ -53,6 +53,7 @@ jest.mock('../src/services/git/LocalGitWriter', () => ({
   LocalGitWriter: {
     writeAndCommit: jest.fn(async () => ({ success: true })),
     deleteAndCommit: jest.fn(async () => ({ success: true })),
+    push: jest.fn(async () => ({ success: true })),
   },
 }));
 
@@ -204,6 +205,17 @@ async function pressCommitAndPushButton(): Promise<void> {
   const commit = buttons.find((b) => b.text === 'Commit & Push');
   await act(async () => {
     await commit?.onPress?.();
+  });
+  // Wait for the async commitAndPush to show its alert, then press OK
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 50));
+  });
+  const newCalls = (Alert.alert as jest.Mock).mock.calls;
+  const lastAlert = newCalls[newCalls.length - 1];
+  const alertButtons = lastAlert[2] as Array<{ text?: string; onPress?: () => void | Promise<void> }>;
+  const okButton = alertButtons.find((b) => b.text === 'OK');
+  await act(async () => {
+    await okButton?.onPress?.();
   });
 }
 

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -634,6 +634,8 @@
       "foldersDescription": "Create folders to organize your notes by project or topic.",
       "productiveTitle": "Stay Productive",
       "productiveDescription": "Pin important notes, use checklists, and track your progress.",
+      "dumpTitle": "Dump Your Thoughts",
+      "dumpDescription": "Thought Dump lets you capture fleeting ideas, half-formed questions, and stream-of-consciousness reflections as Markdown files in your repo. They're indexed for smart search and feed context into your AI chats.",
       "thoughtDumpTitle": "Dump Your Thoughts",
       "thoughtDumpDescription": "Thought Dump lets you capture fleeting ideas, half-formed questions, and stream-of-consciousness reflections as Markdown files in your repo. They're indexed for smart search and feed context into your AI chats.",
       "scheduledTitle": "Scheduled Learning",


### PR DESCRIPTION
## Summary

Fixes 3 failing test files:

1. **OnboardingScreen.pro-gate.test.tsx** - Step indices were off by one after #1104 removed the Scheduled Learning step. Updated indices from 6/7/8 to 5/6/7.

2. **staging-delete-rewire.test.ts** - Missing  mock in LocalGitWriter mock after #1103 added push after conflict resolution. Also updated  helper to handle the async alert flow.

3. **es.json** - Missing  and  keys that were added in #1101 for the onboarding dump step.

Note:  has pre-existing failures unrelated to this PR (error message format changed, test not updated).

## Changes

- : Fix step indices
- : Add push mock, update alert handler  
- : Add dumpTitle/dumpDescription keys