### PR TITLE
fix(app): move OnboardingScreen into AppNavigator NavigationContainer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -29,7 +29,6 @@ import { BiometricLockProvider } from './src/contexts/BiometricLockContext';
 import { BiometricLockScreen } from './src/components/BiometricLockScreen';
 import { BacklinksProvider } from './src/contexts/BacklinksContext';
 import AppNavigator from './src/navigation/AppNavigator';
-import OnboardingScreen from './src/screens/OnboardingScreen';
 import { OnboardingService } from './src/services/OnboardingService';
 import { NotificationService } from './src/services/NotificationService';
 import * as Notifications from 'expo-notifications';
@@ -155,22 +154,6 @@ export default function App() {
     );
   }
 
-  if (showOnboarding) {
-  return (
-    <SafeAreaProvider>
-      <ThemeProvider>
-        <NativeWindThemeProvider>
-          <StatusBar style="auto" />
-          <OnboardingScreen
-            onComplete={handleOnboardingComplete}
-            onSkip={handleOnboardingSkip}
-          />
-        </NativeWindThemeProvider>
-      </ThemeProvider>
-    </SafeAreaProvider>
-  );
-  }
-
   return (
     <QueryClientProvider client={queryClient}>
     <SafeAreaProvider>
@@ -188,7 +171,11 @@ export default function App() {
                           <BiometricLockProvider>
                             <StatusBar style="auto" />
                             <StartupSyncGate>
-                              <AppNavigator />
+                              <AppNavigator
+              showOnboarding={showOnboarding}
+              onOnboardingComplete={handleOnboardingComplete}
+              onOnboardingSkip={handleOnboardingSkip}
+            />
                             </StartupSyncGate>
                             <GitHubActivityIndicator />
                             <SyncBlockOverlay />

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -28,6 +28,7 @@ import { ChatRepoPickerModal } from '../components/ai/ChatRepoPickerModal';
 import { AddReminderScreen } from '../components/settings/AddReminderScreen';
 import ThoughtDumpScreen from '../screens/ThoughtDumpScreen';
 import PaywallScreen from '../screens/PaywallScreen';
+import OnboardingScreen from '../screens/OnboardingScreen';
 import { RootStackParamList } from './types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAIStore } from '../stores/aiStore';
@@ -78,7 +79,13 @@ const getLinkingConfig = (): LinkingOptions<RootStackParamList> => {
 
 const linking = getLinkingConfig();
 
-export default function AppNavigator() {
+interface AppNavigatorProps {
+  showOnboarding?: boolean;
+  onOnboardingComplete?: () => void;
+  onOnboardingSkip?: () => void;
+}
+
+export default function AppNavigator({ showOnboarding, onOnboardingComplete, onOnboardingSkip }: AppNavigatorProps) {
   const { isDark, colors } = useTheme();
   const navigationRef = useNavigationContainerRef<RootStackParamList>();
   const chatRepoOwner = useAIStore((state) => state.chatRepoOwner);
@@ -152,7 +159,13 @@ export default function AppNavigator() {
         onStateChange={handleStateChange}
       >
         <View style={{ flex: 1 }}>
-          <Stack.Navigator initialRouteName="MainTabs">
+          <Stack.Navigator initialRouteName={showOnboarding ? 'Onboarding' : 'MainTabs'}>
+            <Stack.Screen
+              name="Onboarding"
+              options={{ headerShown: false }}
+            >
+              {() => <OnboardingScreen onComplete={onOnboardingComplete!} onSkip={onOnboardingSkip!} />}
+            </Stack.Screen>
             <Stack.Screen 
               name="MainTabs" 
               component={TabNavigator}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -22,6 +22,7 @@ type ProductionStackParamList = {
   AddReminder: undefined;
   ThoughtDump: { openVoiceOnMount?: boolean } | undefined;
   Paywall: undefined;
+  Onboarding: undefined;
 };
 
 type DevOnlyStackParamList = {


### PR DESCRIPTION
OnboardingScreen used useNavigation() but was rendered outside NavigationContainer when showOnboarding was true, causing [Error: Couldn't find a navigation object]. Fix: integrate OnboardingScreen as a route in AppNavigator's stack navigator with conditional initialRouteName. Full suite: 2896 passing, 0 failing.