### PR TITLE
fix(onboarding): remove GitHub Tools step entirely

### DIFF
--- a/__tests__/screens/OnboardingScreen.pro-gate.test.tsx
+++ b/__tests__/screens/OnboardingScreen.pro-gate.test.tsx
@@ -11,7 +11,6 @@ import { Linking } from 'react-native';
 import OnboardingScreen from '../../src/screens/OnboardingScreen';
 import { __setProState } from '../../src/stores/proStore';
 import { OnboardingService } from '../../src/services/OnboardingService';
-import { useAIStore } from '../../src/stores/aiStore';
 
 jest.mock('../../src/contexts/ThemeContext', () => ({
   useTheme: () => ({
@@ -65,22 +64,8 @@ jest.mock('../../src/services/GitHubService', () => ({
   },
 }));
 
-jest.mock('../../src/stores/aiStore', () => {
-  const state = {
-    githubToolsEnabled: false,
-    toggleGithubTools: jest.fn(async () => undefined),
-  };
-  return {
-    useAIStore: Object.assign(
-      jest.fn((selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state)),
-      { getState: () => state }
-    ),
-  };
-});
-
-const TOKEN_STEP_INDEX = 5; // 5 INFO_STEPS (removed Scheduled Learning in #1104)
+const TOKEN_STEP_INDEX = 5;
 const AI_STEP_INDEX = 6;
-const GITHUB_TOOLS_STEP_INDEX = 7;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -95,7 +80,6 @@ async function advanceToAIStep(getByTestId: ReturnType<typeof render>['getByTest
   for (let i = 0; i < TOKEN_STEP_INDEX; i++) {
     fireEvent.press(getByTestId('onboarding.button.next'));
   }
-  // Token step: skip token, just press Connect-or-Skip
   fireEvent.press(getByTestId('onboarding.button.next'));
 }
 
@@ -112,16 +96,14 @@ describe('OnboardingScreen — GitHub Tools Pro gate', () => {
     expect(openUrlSpy).toHaveBeenCalledWith('https://github.com/gedwolmen/gitnotes/issues');
   });
 
-  it('skips the GitHub Tools step and completes onboarding for non-Pro users', async () => {
+  it('completes onboarding for non-Pro users on AI step', async () => {
     const { getByTestId, queryByTestId } = render(
       <OnboardingScreen onComplete={mockOnComplete} onSkip={mockOnSkip} />
     );
 
     await advanceToAIStep(getByTestId);
 
-    // Sanity: we are on the AI step.
     expect(getByTestId('onboarding.button.pro-continue')).toBeTruthy();
-
     fireEvent.press(getByTestId('onboarding.button.pro-continue'));
 
     await waitFor(() => {
@@ -129,38 +111,14 @@ describe('OnboardingScreen — GitHub Tools Pro gate', () => {
       expect(mockOnComplete).toHaveBeenCalledTimes(1);
     });
 
-    // The GitHub Tools "Enable" button must never have been rendered.
     expect(queryByTestId('onboarding.button.enable-github-tools')).toBeNull();
     expect(queryByTestId('onboarding.button.skip-github-tools')).toBeNull();
-
-    // Toggle must never have been invoked.
-    expect(useAIStore.getState().toggleGithubTools).not.toHaveBeenCalled();
   });
 
-  it('does not advance to the GitHub Tools step index for non-Pro users', async () => {
-    const { getByTestId } = render(
-      <OnboardingScreen onComplete={mockOnComplete} onSkip={mockOnSkip} />
-    );
-
-    await advanceToAIStep(getByTestId);
-    fireEvent.press(getByTestId('onboarding.button.pro-continue'));
-
-    await waitFor(() => {
-      expect(mockOnComplete).toHaveBeenCalledTimes(1);
-    });
-
-    // AI step is the last step non-Pro users can be on before finish() runs.
-    // GITHUB_TOOLS_STEP_INDEX must not be reachable; we verify by ensuring
-    // the GitHub Tools enable button (only rendered at that index) never appeared.
-    expect(() => getByTestId('onboarding.button.enable-github-tools')).toThrow();
-    // Reference the index so the test fails loudly if the constant shifts in src.
-    expect(GITHUB_TOOLS_STEP_INDEX).toBeGreaterThan(AI_STEP_INDEX);
-  });
-
-  it('shows the GitHub Tools step for Pro users and lets them enable the toggle', async () => {
+  it('completes onboarding for Pro users on AI step', async () => {
     __setProState({ status: 'pro', entitlementActive: true, isGrandfathered: false });
 
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <OnboardingScreen onComplete={mockOnComplete} onSkip={mockOnSkip} />
     );
 
@@ -168,19 +126,15 @@ describe('OnboardingScreen — GitHub Tools Pro gate', () => {
     fireEvent.press(getByTestId('onboarding.button.pro-continue'));
 
     await waitFor(() => {
-      expect(getByTestId('onboarding.button.enable-github-tools')).toBeTruthy();
-    });
-
-    fireEvent.press(getByTestId('onboarding.button.enable-github-tools'));
-
-    await waitFor(() => {
-      expect(useAIStore.getState().toggleGithubTools).toHaveBeenCalledTimes(1);
       expect(OnboardingService.completeOnboarding).toHaveBeenCalledTimes(1);
       expect(mockOnComplete).toHaveBeenCalledTimes(1);
     });
+
+    expect(queryByTestId('onboarding.button.enable-github-tools')).toBeNull();
+    expect(queryByTestId('onboarding.button.skip-github-tools')).toBeNull();
   });
 
-  it('shows the GitHub Tools step for grandfathered users (treated as Pro)', async () => {
+  it('completes onboarding for grandfathered users on AI step', async () => {
     __setProState({ status: 'pro', entitlementActive: false, isGrandfathered: true });
 
     const { getByTestId } = render(
@@ -191,28 +145,6 @@ describe('OnboardingScreen — GitHub Tools Pro gate', () => {
     fireEvent.press(getByTestId('onboarding.button.pro-continue'));
 
     await waitFor(() => {
-      expect(getByTestId('onboarding.button.enable-github-tools')).toBeTruthy();
-    });
-  });
-
-  it('lets Pro users skip the GitHub Tools step without enabling the toggle', async () => {
-    __setProState({ status: 'pro', entitlementActive: true, isGrandfathered: false });
-
-    const { getByTestId } = render(
-      <OnboardingScreen onComplete={mockOnComplete} onSkip={mockOnSkip} />
-    );
-
-    await advanceToAIStep(getByTestId);
-    fireEvent.press(getByTestId('onboarding.button.pro-continue'));
-
-    await waitFor(() => {
-      expect(getByTestId('onboarding.button.skip-github-tools')).toBeTruthy();
-    });
-
-    fireEvent.press(getByTestId('onboarding.button.skip-github-tools'));
-
-    await waitFor(() => {
-      expect(useAIStore.getState().toggleGithubTools).not.toHaveBeenCalled();
       expect(OnboardingService.completeOnboarding).toHaveBeenCalledTimes(1);
       expect(mockOnComplete).toHaveBeenCalledTimes(1);
     });

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -18,8 +18,6 @@ import { useTheme } from '../contexts/ThemeContext';
 import { OnboardingService } from '../services/OnboardingService';
 import { AuthService } from '../services/AuthService';
 import { GitHubService } from '../services/GitHubService';
-import { useAIStore } from '../stores/aiStore';
-import { useProGate } from '../hooks/useProGate';
 import { Button, Input, Surface } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import type { RootStackParamList } from '../navigation/types';
@@ -70,10 +68,8 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
 
   const TOKEN_STEP = INFO_STEPS.length;
   const AI_STEP = TOKEN_STEP + 1;
-  const GITHUB_TOOLS_STEP = AI_STEP + 1;
-  const TOTAL_STEPS = INFO_STEPS.length + 3;
+  const TOTAL_STEPS = INFO_STEPS.length + 2;
   const { colors } = useTheme();
-  const { isPro } = useProGate();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const [currentStep, setCurrentStep] = useState(0);
   const [token, setToken] = useState('');
@@ -105,33 +101,9 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
         setCurrentStep(AI_STEP);
       }
     } else if (currentStep === AI_STEP) {
-      setCurrentStep(GITHUB_TOOLS_STEP);
-    } else if (currentStep === GITHUB_TOOLS_STEP) {
       await finish();
     }
   }, [currentStep, token, finish]);
-
-  const handleEnableGithubTools = useCallback(async () => {
-    await useAIStore.getState().toggleGithubTools();
-    await finish();
-  }, [finish]);
-
-  const handleSkipGithubTools = useCallback(async () => {
-    // Skipping leaves githubToolsEnabled at its default (false), so no toggle call
-    await finish();
-  }, [finish]);
-
-  const handleProContinue = useCallback(() => {
-    if (isPro) {
-      setCurrentStep(GITHUB_TOOLS_STEP);
-    } else {
-      void finish();
-    }
-  }, [isPro, finish]);
-
-  const handleSeePlans = useCallback(() => {
-    navigation.navigate('Paywall');
-  }, [navigation]);
 
   const handleSkip = useCallback(async () => {
     await OnboardingService.completeOnboarding();
@@ -140,7 +112,6 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
 
   const isTokenStep = currentStep === TOKEN_STEP;
   const isAIStep = currentStep === AI_STEP;
-  const isGithubToolsStep = currentStep === GITHUB_TOOLS_STEP;
 
   return (
     <SafeAreaView className="flex-1" style={{ backgroundColor: colors.background }} edges={['top', 'bottom']}>
@@ -232,25 +203,6 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
               </Text>
             </TouchableOpacity>
           </View>
-        ) : isGithubToolsStep ? (
-          <ScrollView
-            className="flex-1 px-10"
-            contentContainerStyle={{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', gap: 16 }}
-            showsVerticalScrollIndicator={false}
-          >
-            <Surface elevation="raised" radius="pill" className="w-[140px] h-[140px] items-center justify-center">
-              <Ionicons name="git-branch-outline" size={72} color={colors.accent} />
-            </Surface>
-            <Text className="text-[28px] font-bold text-center" style={{ color: colors.text }}>
-              {t('onboarding.githubTools.title', { defaultValue: 'GitHub Agent Tools' })}
-            </Text>
-            <Text className="text-base text-center leading-6" style={{ color: colors.textSecondary }}>
-              {t('onboarding.githubTools.body', { defaultValue: 'Your AI can now list repos, create issues, open pull requests, review changes, and post PR reviews using your connected GitHub account. All write operations respect your Action Mode setting.' })}
-            </Text>
-            <Text className="text-[13px] text-center leading-[18px] opacity-80" style={{ color: colors.textSecondary }}>
-              {t('onboarding.githubTools.bodyReminder', { defaultValue: 'You can turn this on or off anytime in Settings → AI → GitHub Tools.' })}
-            </Text>
-          </ScrollView>
         ) : (
           <View className="flex-1 px-10 items-center">
             <Surface elevation="raised" radius="pill" className="w-[140px] h-[140px] items-center justify-center mb-6">
@@ -283,34 +235,14 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
             ))}
           </View>
 
-          {isGithubToolsStep ? (
-            <View className="w-full">
-              <Button
-                variant="primary"
-                fullWidth
-                testID="onboarding.button.enable-github-tools"
-                onPress={handleEnableGithubTools}
-                label={t('onboarding.githubTools.enable', { defaultValue: 'Enable GitHub Tools' })}
-                trailingIcon={<Ionicons name="git-branch-outline" size={20} color={colors.accent} />}
-                iconAlign="edge"
-              />
-              <Button
-                variant="ghost"
-                fullWidth
-                testID="onboarding.button.skip-github-tools"
-                onPress={handleSkipGithubTools}
-                label="Skip for Now"
-                style={{ marginTop: 8 }}
-              />
-            </View>
-          ) : isAIStep ? (
+          {isAIStep ? (
             <Button
               variant="primary"
               fullWidth
               testID="onboarding.button.pro-continue"
-              onPress={handleProContinue}
+              onPress={handleNext}
               label={t('common.continue', { defaultValue: 'Continue' })}
-              trailingIcon={<Ionicons name="arrow-forward" size={20} color={colors.accent} />}
+              trailingIcon={<Ionicons name="checkmark" size={20} color={colors.accent} />}
               iconAlign="edge"
             />
           ) : (


### PR DESCRIPTION
Remove the GitHub Tools onboarding step. GitHub Tools is now disabled by default - users can enable it in Settings → AI if needed. Onboarding flow: 5 info steps → Token step → AI step → Done. Tests updated to reflect new flow.