### PR TITLE
fix(onboarding): reset navigation to MainTabs when showOnboarding becomes false

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -106,6 +106,16 @@ export default function AppNavigator({ showOnboarding, onOnboardingComplete, onO
     }
   }, [interstitialEligible, isPro, markInterstitialShown, navigationRef]);
 
+  useEffect(() => {
+    if (showOnboarding) return;
+    if (navigationRef.isReady()) {
+      navigationRef.reset({
+        index: 0,
+        routes: [{ name: 'MainTabs' }],
+      });
+    }
+  }, [showOnboarding, navigationRef]);
+
   const baseTheme = isDark ? DarkTheme : DefaultTheme;
   const navigationTheme = {
     ...baseTheme,


### PR DESCRIPTION
Skip button and Continue on last step were not exiting onboarding because NavigationContainer cached initialRouteName on mount. When showOnboarding changed to false, Stack.Navigator still had Onboarding as active route. Add useEffect in AppNavigator that watches showOnboarding and calls navigationRef.reset() when showOnboarding becomes false.