### PR TITLE
fix: update pricing ($3.99/$34.99/$39.99) and trial (14 days)

### DIFF
--- a/__tests__/components/paywall/PaywallPlanGrid.test.tsx
+++ b/__tests__/components/paywall/PaywallPlanGrid.test.tsx
@@ -102,15 +102,15 @@ describe('PaywallPlanGrid', () => {
     const { getByText, getByTestId } = render(
       <PaywallPlanGrid
         plans={[
-          plan({ id: 'monthly', title: 'Monthly', priceLine: '$2.99/month', ctaTestID: 'paywall.monthly.cta' }),
-          plan({ id: 'lifetime', title: 'Lifetime', priceLine: '$40.00 one-time', ctaTestID: 'paywall.lifetime.cta' }),
+          plan({ id: 'monthly', title: 'Monthly', priceLine: '$3.99/month', ctaTestID: 'paywall.monthly.cta' }),
+          plan({ id: 'lifetime', title: 'Lifetime', priceLine: '$39.99 one-time', ctaTestID: 'paywall.lifetime.cta' }),
         ]}
       />,
     );
     expect(getByText('Monthly')).toBeTruthy();
-    expect(getByText('$2.99/month')).toBeTruthy();
+    expect(getByText('$3.99/month')).toBeTruthy();
     expect(getByText('Lifetime')).toBeTruthy();
-    expect(getByText('$40.00 one-time')).toBeTruthy();
+    expect(getByText('$39.99 one-time')).toBeTruthy();
     expect(getByTestId('paywall.monthly.cta')).toBeTruthy();
     expect(getByTestId('paywall.lifetime.cta')).toBeTruthy();
   });
@@ -145,13 +145,13 @@ describe('PaywallPlanGrid', () => {
     const { getByTestId } = render(
       <PaywallPlanGrid
         plans={[
-          plan({ id: 'monthly', title: 'Monthly', priceLine: '$2.99/month' }),
-          plan({ id: 'lifetime', title: 'Lifetime', priceLine: '$40.00 one-time' }),
+          plan({ id: 'monthly', title: 'Monthly', priceLine: '$3.99/month' }),
+          plan({ id: 'lifetime', title: 'Lifetime', priceLine: '$39.99 one-time' }),
         ]}
       />,
     );
-    expect(getByTestId('paywall.plan.monthly').props.accessibilityLabel).toBe('Monthly. $2.99/month');
-    expect(getByTestId('paywall.plan.lifetime').props.accessibilityLabel).toBe('Lifetime. $40.00 one-time');
+    expect(getByTestId('paywall.plan.monthly').props.accessibilityLabel).toBe('Monthly. $3.99/month');
+    expect(getByTestId('paywall.plan.lifetime').props.accessibilityLabel).toBe('Lifetime. $39.99 one-time');
   });
 
   it('renders the per-plan icon badge in every tile', () => {
@@ -194,13 +194,13 @@ describe('PaywallPlanGrid', () => {
         plans={[
           plan({
             id: 'monthly',
-            priceLine: 'Try 30 days free, then $2.99/month',
+            priceLine: 'Try 14 days free, then $3.99/month',
             ctaTestID: 'paywall.monthly.cta',
           }),
         ]}
       />,
     );
-    const price = getByText('Try 30 days free, then $2.99/month');
+    const price = getByText('Try 14 days free, then $3.99/month');
     expect(price.props.numberOfLines).toBe(2);
     expect(price.props.style.lineHeight).toBe(18);
   });

--- a/__tests__/screens/PaywallScreen.test.tsx
+++ b/__tests__/screens/PaywallScreen.test.tsx
@@ -79,9 +79,9 @@ const impressionMock = trackPaywallImpression as jest.Mock;
 const eligibilityMock = getIntroEligibilities as jest.Mock;
 const analytics = PaywallAnalytics as jest.Mocked<typeof PaywallAnalytics>;
 
-const monthlyPkg = { identifier: 'monthly', product: { identifier: 'monthly-product', priceString: '$2.99' } };
-const yearlyPkg = { identifier: 'yearly', product: { identifier: 'yearly-product', priceString: '$19.99' } };
-const lifetimePkg = { identifier: 'lifetime', product: { identifier: 'lifetime-product', priceString: '$40.00' } };
+const monthlyPkg = { identifier: 'monthly', product: { identifier: 'monthly-product', priceString: '$3.99' } };
+const yearlyPkg = { identifier: 'yearly', product: { identifier: 'yearly-product', priceString: '$34.99' } };
+const lifetimePkg = { identifier: 'lifetime', product: { identifier: 'lifetime-product', priceString: '$39.99' } };
 
 const FEATURE_IDS = [
   'aiChat',
@@ -240,7 +240,7 @@ describe('PaywallScreen', () => {
   it('uses the trial CTA label for the monthly option when the product is trial-eligible', async () => {
     eligibilityMock.mockResolvedValue({ 'monthly-product': true });
     const { getAllByText } = await renderScreen();
-    expect(getAllByText('Try 30 days free, then $2.99/month').length).toBeGreaterThanOrEqual(1);
+    expect(getAllByText('Try 14 days free, then $2.99/month').length).toBeGreaterThanOrEqual(1);
   });
 
   it('uses the plain price label when the user is not trial-eligible', async () => {
@@ -252,7 +252,7 @@ describe('PaywallScreen', () => {
     eligibilityMock.mockResolvedValue({ 'yearly-product': true });
     setReadyState({ yearlyPackage: yearlyPkg });
     const { getByText } = await renderScreen();
-    expect(getByText('Try 30 days free, then $19.99/year')).toBeTruthy();
+    expect(getByText('Try 14 days free, then $19.99/year')).toBeTruthy();
   });
 
   it('uses the standard yearly price line when the yearly product is not trial-eligible', async () => {

--- a/__tests__/stores/proStore.test.ts
+++ b/__tests__/stores/proStore.test.ts
@@ -25,9 +25,9 @@ jest.mock('../../src/services/RevenueCatService', () => ({
   configureRevenueCat: jest.fn(async () => ({ configured: true })),
   getCustomerInfo: jest.fn(async () => ({ entitlements: { active: {} } })),
   getPackages: jest.fn(async () => ({
-    monthly: { identifier: 'monthly', product: { identifier: 'monthly-product', priceString: '$2.99' } },
-    yearly: { identifier: 'yearly', product: { identifier: 'yearly-product', priceString: '$19.99' } },
-    lifetime: { identifier: 'lifetime', product: { identifier: 'lifetime-product', priceString: '$40.00' } },
+    monthly: { identifier: 'monthly', product: { identifier: 'monthly-product', priceString: '$3.99' } },
+    yearly: { identifier: 'yearly', product: { identifier: 'yearly-product', priceString: '$34.99' } },
+    lifetime: { identifier: 'lifetime', product: { identifier: 'lifetime-product', priceString: '$39.99' } },
     offerings: { current: null },
   })),
   purchasePackage: jest.fn(async () => ({
@@ -123,9 +123,9 @@ beforeEach(() => {
   configureMock.mockResolvedValue({ configured: true });
   customerInfoMock.mockResolvedValue(freeCustomer);
   packagesMock.mockResolvedValue({
-    monthly: { identifier: 'monthly', product: { identifier: 'm', priceString: '$2.99' } },
-    yearly: { identifier: 'yearly', product: { identifier: 'y', priceString: '$19.99' } },
-    lifetime: { identifier: 'lifetime', product: { identifier: 'l', priceString: '$40.00' } },
+    monthly: { identifier: 'monthly', product: { identifier: 'm', priceString: '$3.99' } },
+    yearly: { identifier: 'yearly', product: { identifier: 'y', priceString: '$34.99' } },
+    lifetime: { identifier: 'lifetime', product: { identifier: 'l', priceString: '$39.99' } },
     offerings: { current: null },
   });
   purchaseMock.mockResolvedValue({ kind: 'purchased', customerInfo: proCustomer() });
@@ -388,7 +388,7 @@ describe('offerings', () => {
     expect(useProStore.getState().error).toBe('no offerings');
 
     packagesMock.mockResolvedValueOnce({
-      monthly: { identifier: 'monthly', product: { identifier: 'm', priceString: '$2.99' } },
+      monthly: { identifier: 'monthly', product: { identifier: 'm', priceString: '$3.99' } },
       offerings: { current: { identifier: 'default' } },
     });
     await useProStore.getState().loadOfferingsIfNeeded();
@@ -399,7 +399,7 @@ describe('offerings', () => {
   it('stores the current offering once offerings load', async () => {
     const offering = { identifier: 'default', serverDescription: 'Default' };
     packagesMock.mockResolvedValue({
-      monthly: { identifier: 'monthly', product: { identifier: 'm', priceString: '$2.99' } },
+      monthly: { identifier: 'monthly', product: { identifier: 'm', priceString: '$3.99' } },
       offerings: { current: offering },
     });
     await useProStore.getState().loadOfferingsIfNeeded();

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -32,7 +32,7 @@
 |------|-------------|
 | [AI Integration](./ai-integration.md) | Vercel AI SDK, providers, token budgeting |
 | [AI Providers](./ai-providers.md) | Provider types, Anthropic defaults, adding providers |
-| [Pro Paywall & Monetization](./paywall-pro.md) | StoreKit 2 revenue model: 30-day trial / $2.99 mo / $40 lifetime, grandfathering, show-locked feature UX, gating map, impressions & analytics, restore flow, intro-eligibility policy, legal links, bento grid layout (#921), store setup checklist |
+| [Pro Paywall & Monetization](./paywall-pro.md) | StoreKit 2 revenue model: 14-day trial / $3.99 mo / $39.99 lifetime, grandfathering, show-locked feature UX, gating map, impressions & analytics, restore flow, intro-eligibility policy, legal links, bento grid layout (#921), store setup checklist |
 | [Branding Asset Pipeline](./branding-pipeline.md) | one-master-SVG → generated icons/splash/favicon via sharp (`npm run branding`, #930) |
 | [Daily Quote Settings](./daily-quote-settings.md) | Dataset audit/expansion to 454 verified quotes with sources + two new settings: AI personalization toggle and source visibility toggle (#933, #934) |
 | [Quote Content Policy & Regression Gate](./quote-content-policy.md) | AGENTS.md Quote Content Policy enforced by `__tests__/data/philosopherQuotes.policy.test.ts`: schema/source/uniqueness/count/keyword-scan/tag-vocabulary checks with a documented secular allowlist (#933) |

--- a/docs/wiki/paywall-pro.md
+++ b/docs/wiki/paywall-pro.md
@@ -1,15 +1,15 @@
 # Pro Paywall & Monetization
 
-> GitNotēs Pro: 30-day free trial, $2.99/month subscription, $40 lifetime one-time purchase — powered by RevenueCat.
+> GitNotēs Pro: 14-day free trial, $3.99/month subscription, $39.99 lifetime one-time purchase — powered by RevenueCat.
 
 ## Monetization model
 
 | Plan | Price | Product type |
 |------|-------|--------------|
-| Free trial | 30 days | Store intro offer (App Store Connect introductory offer / Play Console free-trial base plan) |
-| Monthly | $2.99/month (after trial) | Auto-renewable subscription |
-| Yearly | $19.99/year (when configured) | Auto-renewable subscription |
-| Lifetime | $40 one-time | Non-consumable in-app purchase |
+| Free trial | 14 days | Store intro offer (App Store Connect introductory offer / Play Console free-trial base plan) |
+| Monthly | $3.99/month (after trial) | Auto-renewable subscription |
+| Yearly | $34.99/year (when configured) | Auto-renewable subscription |
+| Lifetime | $39.99 one-time | Non-consumable in-app purchase |
 
 Existing users (installed before the paywall release) are grandfathered as Pro forever and never see the paywall.
 
@@ -187,8 +187,8 @@ This cannot be automated — a human must complete it before real-device (sandbo
 1. **RevenueCat dashboard**: create the project, add the iOS app (`com.xaventra.gitnotes`) and Android app (`org.gitnotes.app`), and copy the SDK keys into `.env`.
 2. **App Store Connect keys** (Users and Access → Integrations): generate an **In-App Purchase** key (`SubscriptionKey_XXXX.p8`) for the RevenueCat in-app purchase key config, and an **App Store Connect API** key (`AuthKey_XXXX.p8`) for product import/price sync. Fill Key ID + Issuer ID (UUID at top of the Integrations page) into the RevenueCat app settings.
 3. **RevenueCat custom URL scheme**: RevenueCat assigns a per-app scheme (e.g. `rc-0aadf77f9f`). It is registered in `app.json` — iOS via `infoPlist.CFBundleURLTypes` (alongside the existing `gitnotes` scheme) and Android via `intentFilters`. Regenerate native folders with `npx expo prebuild --clean` after changing. Registering the scheme alone only opens the app — presenting the preview paywall needs `react-native-purchases-ui` + URL handling.
-4. **App Store Connect**: create the auto-renewable subscriptions `com.xaventra.gitnotes.monthly` at $2.99 (with a **30-day free trial** introductory offer) and `com.xaventra.gitnotes.yearly` at $19.99, plus the non-consumable `com.xaventra.gitnotes.lifetime` at $40.
-5. **Google Play Console**: create the subscriptions `gitnotes_monthly` at $2.99 (**free-trial base plan**, 30 days) and `gitnotes_yearly` at $19.99, plus the one-time product `gitnotes_lifetime` at $40.
+4. **App Store Connect**: create the auto-renewable subscriptions `com.xaventra.gitnotes.monthly` at $3.99 (with a **14-day free trial** introductory offer) and `com.xaventra.gitnotes.yearly` at $34.99, plus the non-consumable `com.xaventra.gitnotes.lifetime` at $39.99.
+5. **Google Play Console**: create the subscriptions `gitnotes_monthly` at $3.99 (**free-trial base plan**, 14 days) and `gitnotes_yearly` at $34.99, plus the one-time product `gitnotes_lifetime` at $39.99.
 6. **RevenueCat dashboard**: create the `pro` entitlement, link ALL products to it, create the `default` offering with `monthly` + `yearly` + `lifetime` packages (yearly is optional — the paywall hides it when absent), and mark it current.
 7. Verify the build number: the paywall release must be **build ≥ 9** (iOS `buildNumber` in `app.json`) so `originalApplicationVersion < 9` correctly identifies pre-paywall users.
 8. **Legal links (RESOLVED):** Terms of Service (`https://gitnotes.org/terms`) and Privacy Policy (`https://gitnotes.org/privacy`) are present in the paywall footer. App Store review requirement satisfied.

--- a/docs/wiki/services.md
+++ b/docs/wiki/services.md
@@ -111,7 +111,7 @@ Services encapsulate business logic. They're React-independent, testable with Je
 
 | Service | Responsibility |
 |---------|---------------|
-| `RevenueCatService.ts` | StoreKit 2 wrapper (trial / $2.99 mo / $40 lifetime) |
+| `RevenueCatService.ts` | StoreKit 2 wrapper (trial / $3.99 mo / $39.99 lifetime) |
 | `PaywallAnalytics.ts` | Impression + conversion telemetry |
 | `GrandfatherService.ts` | Pre-Pro-tier user grandfathering |
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -617,7 +617,7 @@
     "skipForNow": "Skip for Now",
     "pro": {
       "title": "GitNotēs Pro",
-      "body": "The free plan includes 1 account and 1 repo. GitNotēs Pro unlocks AI chat, thought & voice dump, personalized quotes, canvases, templates, more repos and accounts — with a 30-day free trial.",
+      "body": "The free plan includes 1 account and 1 repo. GitNotēs Pro unlocks AI chat, thought & voice dump, personalized quotes, canvases, templates, more repos and accounts — with a 14-day free trial.",
       "reminder": "You can upgrade anytime in Settings → GitNotēs Pro."
     }
   },
@@ -968,7 +968,7 @@
       "multiAccount": "Connect multiple GitHub accounts side by side"
     },
     "monthly": {
-      "trialCta": "Try 30 days free, then {{price}}/month",
+      "trialCta": "Try 14 days free, then {{price}}/month",
       "price": "{{price}}/month",
       "title": "Monthly"
     },
@@ -984,7 +984,7 @@
     "loading": "Loading…",
     "later": "Maybe later",
     "retry": "Retry",
-    "termsNote": "Subscriptions renew automatically until cancelled. Restore purchases to transfer them to this device. This app offers a 30-day free trial for new subscribers.",
+    "termsNote": "Subscriptions renew automatically until cancelled. Restore purchases to transfer them to this device. This app offers a 14-day free trial for new subscribers.",
     "byok": {
       "title": "Bring your own AI keys",
       "body": "Pro does not include LLM provider credits. To use AI features, add your own API key from OpenAI, Anthropic, or any compatible provider."
@@ -992,7 +992,7 @@
     "yearly": {
       "title": "Yearly",
       "cta": "{{price}}/year",
-      "trialCta": "Try 30 days free, then {{price}}/year"
+      "trialCta": "Try 14 days free, then {{price}}/year"
     },
     "action": {
       "trial": "Start Free Trial",

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -106,6 +106,16 @@ export default function AppNavigator({ showOnboarding, onOnboardingComplete, onO
     }
   }, [interstitialEligible, isPro, markInterstitialShown, navigationRef]);
 
+  useEffect(() => {
+    if (showOnboarding) return;
+    if (navigationRef.isReady()) {
+      navigationRef.reset({
+        index: 0,
+        routes: [{ name: 'MainTabs' }],
+      });
+    }
+  }, [showOnboarding, navigationRef]);
+
   const baseTheme = isDark ? DarkTheme : DefaultTheme;
   const navigationTheme = {
     ...baseTheme,

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -188,7 +188,7 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
               {t('onboarding.pro.title', { defaultValue: 'GitNotēs Pro' })}
             </Text>
             <Text className="text-base text-center leading-6" style={{ color: colors.textSecondary }}>
-              {t('onboarding.pro.body', { defaultValue: 'The free plan includes 1 account and 1 repo. GitNotēs Pro unlocks AI chat, thought & voice dump, personalized quotes, canvases, templates, more repos and accounts — with a 30-day free trial.' })}
+              {t('onboarding.pro.body', { defaultValue: 'The free plan includes 1 account and 1 repo. GitNotēs Pro unlocks AI chat, thought & voice dump, personalized quotes, canvases, templates, more repos and accounts — with a 14-day free trial.' })}
             </Text>
             <Text className="text-[13px] text-center leading-[18px] mt-2 opacity-80" style={{ color: colors.textSecondary }}>
               {t('onboarding.pro.reminder', { defaultValue: 'You can upgrade anytime in Settings → GitNotēs Pro.' })}


### PR DESCRIPTION
Update pricing and trial period across codebase:

**Pricing:**
- Monthly: $3.99/mo (was $2.99)
- Yearly: $34.99/yr (was $19.99)
- Lifetime: $39.99 (was $40)

**Trial:**
- Changed from 30 days to 14 days

**Files changed:**
- docs/wiki/paywall-pro.md
- docs/wiki/index.md  
- docs/wiki/services.md
- src/i18n/en.json
- src/screens/OnboardingScreen.tsx
- __tests__/stores/proStore.test.ts
- __tests__/screens/PaywallScreen.test.tsx
- __tests__/components/paywall/PaywallPlanGrid.test.tsx