### PR TITLE
fix(sync): replace console.error with console.warn in RepoPullService

### DIFF
--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -706,7 +706,7 @@ async function pullTodosFromRepo(
         } catch (error) {
           skipped++;
           skippedPaths.push(file.path);
-          console.error(
+          console.warn(
             `[RepoPullService] Failed to parse todo JSON in ${file.path} (skipping):`,
             error instanceof Error ? error.message : error,
           );
@@ -751,7 +751,7 @@ async function pullTodosFromRepo(
         }
       }
       if (skipped > 0) {
-        console.error(
+        console.warn(
           `[RepoPullService] Skipped ${skipped} todo file(s) with invalid JSON content: ${skippedPaths.join(', ')}`,
         );
       }


### PR DESCRIPTION
Two console.error calls in pullTodosFromRepo were surfacing as React Native console overlays in production, blocking tab bar navigation. Changed to console.warn to match existing codebase patterns. Fixes #1131, #1134.