### PR TITLE
fix(ui): add accessibilityViewIsModal to IconButton Animated.View wrappers

### DIFF
--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -57,7 +57,7 @@ export function IconButton(props: IconButtonProps) {
 
   if (variant === 'ghost') {
     return (
-      <Animated.View style={[{ opacity: disabled ? 0.5 : 1 }, animatedStyle]}>
+      <Animated.View accessibilityViewIsModal style={[{ opacity: disabled ? 0.5 : 1 }, animatedStyle]}>
         <Pressable
           testID={testID}
           accessibilityLabel={accessibilityLabel}
@@ -87,7 +87,7 @@ export function IconButton(props: IconButtonProps) {
   const elevation = variant === 'primary' ? 'raised' : 'raised';
 
   return (
-    <Animated.View style={[{ opacity: disabled ? 0.5 : 1 }, animatedStyle]}>
+    <Animated.View accessibilityViewIsModal style={[{ opacity: disabled ? 0.5 : 1 }, animatedStyle]}>
       <Pressable
         testID={testID}
         accessibilityLabel={accessibilityLabel}


### PR DESCRIPTION
Adding accessibilityViewIsModal to the Animated.View wrappers in IconButton ensures VoiceOver treats the button as a single modal unit rather than traversing into intermediate animated containers. Fixes #1132.