### PR TITLE
fix(a11y): set NoteCard TouchableOpacity accessibilityLabel to title only

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -52,9 +52,22 @@ function NoteCardImpl({
 
   const { allTags: mergedTags } = useNoteTags(note.tags ?? [], note.content ?? '');
 
+  const title = note.title || 'Untitled Note';
+  const formattedDate = format(new Date(note.updatedAt), showCompact ? 'MMM d' : 'MMM d, yyyy');
+  const noteFormat = (() => {
+    const f = note.format ?? 'markdown';
+    if (f === 'neorg') return '.norg';
+    if (f === 'org') return '.org';
+    if (f === 'pdf') return '.pdf';
+    if (f === 'json') return '.json';
+    return '.md';
+  })();
+
   return (
     <TouchableOpacity
       testID={`note-card-${note.id}`}
+      accessibilityLabel={`${title}, ${formattedDate}, ${noteFormat}`}
+      accessibilityRole="button"
       style={[
         styles.card,
         {


### PR DESCRIPTION
NoteCard TouchableOpacity was missing accessibilityLabel, causing VoiceOver to read all child text (title + content + date + format) as separate accessible elements. Now sets accessibilityLabel to title, date, and format only - excludes full content. Also adds accessibilityRole='button'. Fixes #1120.