### PR TITLE
fix(a11y): add accessibilityRole='button' to MarkdownToolbar items

### DIFF
--- a/src/components/MarkdownToolbar.tsx
+++ b/src/components/MarkdownToolbar.tsx
@@ -31,6 +31,7 @@ export function MarkdownToolbar({ onFormat, format }: Props) {
             onPress={() => onFormat(action)}
             style={styles.button}
             accessibilityLabel={label}
+            accessibilityRole="button"
           >
             <Text style={styles.buttonText}>{label}</Text>
           </TouchableOpacity>


### PR DESCRIPTION
MarkdownToolbar buttons were missing accessibilityRole='button', causing VoiceOver to announce them as GenericElement instead of Button. Added accessibilityRole='button' to all TouchableOpacity items. Fixes #1121.