### PR TITLE
fix(nav): add zIndex:10000 to TabBar above floating buttons

### DIFF
--- a/src/components/ui/TabBar.tsx
+++ b/src/components/ui/TabBar.tsx
@@ -50,6 +50,7 @@ export function TabBar({ state, navigation }: BottomTabBarProps) {
           paddingBottom: insets.bottom + spacing[3],
           paddingTop: spacing[4],
           backgroundColor: 'transparent',
+          zIndex: 10000,
         }}
       >
         <View
@@ -123,6 +124,7 @@ export function TabBar({ state, navigation }: BottomTabBarProps) {
         paddingBottom: insets.bottom + spacing[3],
         paddingTop: spacing[4],
         backgroundColor: 'transparent',
+        zIndex: 10000,
       }}
     >
       <BlurView


### PR DESCRIPTION
TabBar was missing z-index while FloatingAIButton and FloatingStageButton have zIndex:9999. On React Native, native stack navigator siblings render without guaranteed z-ordering, so the TabBar could be visually below floating buttons. Setting zIndex:10000 ensures TabBar always renders above floating buttons, fixing tap interception on tab bar buttons. Fixes #1122.