### PR TITLE
fix(staging): add push-failure console.warn and filter .tmp files from stage view (#1139)

### DIFF
--- a/src/services/StagePushScheduler.ts
+++ b/src/services/StagePushScheduler.ts
@@ -66,6 +66,7 @@ export function setOnPushFailure(handler: PushFailureHandler | null): void {
 }
 
 function notifyPushFailure(key: string, error: string): void {
+  console.warn('[StagePushScheduler] Push failed:', key, error);
   onPushFailure?.({ key, error });
 }
 

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -301,6 +301,7 @@ export class StagingService {
         });
       } else {
         for (const filePath of changedFiles) {
+          if (filePath.endsWith('.tmp')) continue;
           items.push({
             repoPath: repo.path,
             branch: repoBranch,


### PR DESCRIPTION
## Summary

- **Issue #1139 fix 1**: Added console.warn to notifyPushFailure in StagePushScheduler.ts
- **Issue #1139 fix 2**: Filter .tmp files from staged files view in StagingService.ts

## Changes

- src/services/StagePushScheduler.ts: Added console.warn to notifyPushFailure
- src/services/git/StagingService.ts: Filter .tmp files from stage view