### PR TITLE
fix(settings): add accessibilityRole to account row and guard remove-connection button (#1127, #1124)

### DIFF
--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -266,6 +266,10 @@ export function SettingsContent(props: SettingsContentProps) {
       }),
     [providers],
   );
+  const totalHosts = useMemo(
+    () => accountSummaries.reduce((sum, s) => sum + s.hosts.length, 0),
+    [accountSummaries],
+  );
   const providerAvailability = useProvidersAvailability(visibleProviders);
   const intervalLabel =
     SYNC_INTERVAL_OPTIONS.find((opt) => opt.value === syncIntervalSeconds)?.label ?? t('settings.everyMinute');
@@ -467,6 +471,7 @@ export function SettingsContent(props: SettingsContentProps) {
                 <React.Fragment key={summary.accountId}>
                   <GroupRow
                     testID="settings.row.account"
+                    accessibilityRole="button"
                     leading={summary.account.avatarUrl ? <Image source={{ uri: summary.account.avatarUrl }} style={styles.avatar} /> : null}
                   >
                     <Text style={[styles.settingLabel, { color: colors.text }]}>
@@ -583,7 +588,7 @@ export function SettingsContent(props: SettingsContentProps) {
               </Text>
             </GroupRow>
 
-            {accountSummaries.length < 2 ? (
+            {totalHosts > 1 ? (
               <GroupRow testID="settings.button.remove-token" onPress={onRemoveToken}>
                 <Text style={[styles.settingLabel, { color: colors.error }]}>
                   {t('accounts.removeActiveConnection')}

--- a/src/components/ui/Group.tsx
+++ b/src/components/ui/Group.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, ReactNode } from 'react';
-import { Pressable, StyleProp, Text, View, ViewStyle, StyleSheet } from 'react-native';
+import { Pressable, StyleProp, Text, View, ViewStyle, StyleSheet, AccessibilityRole } from 'react-native';
 import { Surface } from './Surface';
 import { useTheme, useTokens } from '../../contexts/ThemeContext';
 
@@ -85,10 +85,11 @@ export interface GroupRowProps {
   style?: StyleProp<ViewStyle>;
   children?: ReactNode;
   testID?: string;
+  accessibilityRole?: AccessibilityRole;
 }
 
 export function GroupRow(props: GroupRowProps) {
-  const { onPress, onLongPress, disabled, leading, trailing, style, children, testID } = props;
+  const { onPress, onLongPress, disabled, leading, trailing, style, children, testID, accessibilityRole } = props;
   const { colors, spacing } = useTokens();
 
   const content = (
@@ -115,6 +116,7 @@ export function GroupRow(props: GroupRowProps) {
   return (
     <Pressable
       testID={testID}
+      accessibilityRole={accessibilityRole}
       onPress={disabled ? undefined : onPress}
       onLongPress={disabled ? undefined : onLongPress}
       disabled={disabled}


### PR DESCRIPTION
Fixes two accessibility issues in SettingsContent.tsx:

1. **Issue #1127**: Added accessibilityRole="button" to the GroupRow that wraps the account/account summary row (avatar, name, login).

2. **Issue #1124**: Fixed the guard for "Remove Active Connection" button. Changed from checking `accountSummaries.length < 2` to `totalHosts > 1`, correctly guarding against the case where there is only 1 host total (regardless of account count).