### PR TITLE
fix: conflict UI improvements + daily quote diagnostic logging

### DIFF
--- a/__tests__/screens/StageScreen.test.tsx
+++ b/__tests__/screens/StageScreen.test.tsx
@@ -45,6 +45,7 @@ jest.mock('../../src/services/StorageService', () => ({
 
 jest.mock('../../src/services/StagePushScheduler', () => ({
   drainPushQueue: jest.fn(async () => undefined),
+  setOnPushFailure: jest.fn(),
 }));
 
 jest.mock('../../src/stores/stageStore', () => {

--- a/src/components/git/FloatingStageButton.tsx
+++ b/src/components/git/FloatingStageButton.tsx
@@ -9,6 +9,7 @@ import Animated, {
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useStageStore } from '../../stores/stageStore';
+import { useConflictStore } from '../../stores/conflictStore';
 import { drainPushQueue } from '../../services/StagePushScheduler';
 import { useTheme } from '../../contexts/ThemeContext';
 import { HapticService } from '../../utils/haptics';
@@ -34,7 +35,16 @@ export function FloatingStageButton({ currentRouteName }: FloatingStageButtonPro
   const pendingCount = useStageStore((s) => s.pendingCount);
   const globalPushing = useStageStore((s) => s.globalPushing);
   const isPushing = useStageStore((s) => s.isPushing);
+  const conflicts = useConflictStore((s) => s.conflicts);
+  const hasConflicts = conflicts.some((c) => c.files.some((f) => !f.autoResolved));
   const position = useStageButtonPosition();
+
+  // Ensure conflict store is loaded before first render — checkOnboarding fires
+  // loadConflicts() without await, so the button may mount before it completes.
+  useEffect(() => {
+    void useConflictStore.getState().loadConflicts();
+  }, []);
+
   const [reduceMotionEnabled, setReduceMotionEnabled] = useState(true);
   const [reduceMotionResolved, setReduceMotionResolved] = useState(false);
 
@@ -103,8 +113,12 @@ export function FloatingStageButton({ currentRouteName }: FloatingStageButtonPro
 
   const handleTap = useCallback(() => {
     HapticService.selection();
-    navigation.navigate('Stage');
-  }, [navigation]);
+    if (hasConflicts) {
+      navigation.navigate('Conflicts');
+    } else {
+      navigation.navigate('Stage');
+    }
+  }, [navigation, hasConflicts]);
 
   const handleLongPress = useCallback(() => {
     if (anyPushing) return;
@@ -145,8 +159,8 @@ export function FloatingStageButton({ currentRouteName }: FloatingStageButtonPro
           <Pressable
             testID="floating-stage.button.navigate-stage"
             accessibilityRole="button"
-            accessibilityLabel="View staged changes"
-            accessibilityHint="Tap to view staged changes. Press and hold to push all staged changes."
+            accessibilityLabel={hasConflicts ? 'Resolve conflicts' : 'View staged changes'}
+            accessibilityHint={hasConflicts ? 'Tap to resolve merge conflicts.' : 'Tap to view staged changes. Press and hold to push all staged changes.'}
             accessibilityState={{ busy: anyPushing }}
             onPress={handleTap}
             onLongPress={handleLongPress}
@@ -155,11 +169,11 @@ export function FloatingStageButton({ currentRouteName }: FloatingStageButtonPro
             delayLongPress={FLOATING_AI_BUTTON_LONG_PRESS_MS}
             style={({ pressed }) => [
               styles.button,
-              { backgroundColor: anyPushing ? colors.border : colors.primary },
+              { backgroundColor: hasConflicts ? colors.error : anyPushing ? colors.border : colors.primary },
               pressed ? styles.pressed : null,
             ]}
           >
-            <Ionicons name="cloud-upload" size={24} color={anyPushing ? colors.textSecondary : '#FFFFFF'} />
+            <Ionicons name={hasConflicts ? 'git-merge' : 'cloud-upload'} size={24} color={hasConflicts ? '#FFFFFF' : anyPushing ? colors.textSecondary : '#FFFFFF'} />
           </Pressable>
         </Animated.View>
       </GestureDetector>

--- a/src/screens/StageScreen.tsx
+++ b/src/screens/StageScreen.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { ScreenHeader, useScreenHeaderHeight } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { groupStaged, useStageStore, type StageGroup } from '../stores/stageStore';
-import { drainPushQueue } from '../services/StagePushScheduler';
+import { drainPushQueue, setOnPushFailure } from '../services/StagePushScheduler';
 import { useGitHubActivityStore } from '../stores/githubActivityStore';
 import type { StagedItem } from '../services/git/StagingService';
 import { readDeleteFailures, parseDeleteFailureKey } from '../services/git/deleteFailures';
@@ -89,6 +89,7 @@ export default function StageScreen() {
   const [headerBlurHeight, setHeaderBlurHeight] = useState(headerHeight);
   const [deleteFailures, setDeleteFailures] = useState<readonly DeleteFailureRow[]>([]);
   const [retryingKey, setRetryingKey] = useState<string | null>(null);
+  const [pushErrors, setPushErrors] = useState<Record<string, string>>({});
 
   const loadDeleteFailures = useCallback(async () => {
     const map = await readDeleteFailures();
@@ -105,6 +106,27 @@ export default function StageScreen() {
   useEffect(() => {
     void loadDeleteFailures();
   }, [loadDeleteFailures]);
+
+  useEffect(() => {
+    setOnPushFailure(({ key, error }) => {
+      setPushErrors((prev) => ({ ...prev, [key]: error }));
+    });
+  }, []);
+
+  useEffect(() => {
+    for (const key of Object.keys(isPushing)) {
+      if (isPushing[key]) {
+        setPushErrors((prev) => {
+          if (prev[key]) {
+            const next = { ...prev };
+            delete next[key];
+            return next;
+          }
+          return prev;
+        });
+      }
+    }
+  }, [isPushing]);
 
   const handleRetryDelete = useCallback(async (row: DeleteFailureRow) => {
     setRetryingKey(row.key);
@@ -163,9 +185,19 @@ export default function StageScreen() {
     }
   }, [loadStaged, loadDeleteFailures]);
 
+  const dismissPushError = useCallback((key: string) => {
+    setPushErrors((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }, []);
+
   const renderGroup = useCallback(
     ({ item }: { item: StageGroup }) => {
       const pushing = isPushing[item.key] ?? false;
+      const pushError = pushErrors[item.key];
+      const isConflict = pushError?.includes('conflict-detected') ?? false;
       return (
         <View>
           <View className="flex-row items-center gap-2 px-4 pt-4 pb-2">
@@ -202,13 +234,40 @@ export default function StageScreen() {
               <Ionicons name="trash" size={13} color="#ffffff" />
             </TouchableOpacity>
           </View>
+          {pushError ? (
+            <View
+              className="flex-row items-start gap-2 mx-4 mb-2 px-3 py-2 rounded-md"
+              style={{ backgroundColor: `${colors.error}18`, borderWidth: 1, borderColor: `${colors.error}40` }}
+            >
+              <Ionicons
+                name={isConflict ? 'git-merge' : 'alert-circle'}
+                size={15}
+                style={{ color: colors.error, marginTop: 1 }}
+              />
+              <View className="flex-1 mr-2">
+                <Text className="text-xs font-medium" style={{ color: colors.error }}>
+                  {isConflict
+                    ? 'Push rejected: merge conflict detected. Pull latest changes or resolve conflicts manually.'
+                    : `Push failed: ${pushError}`}
+                </Text>
+              </View>
+              <TouchableOpacity
+                onPress={() => dismissPushError(item.key)}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                accessibilityRole="button"
+                accessibilityLabel="Dismiss error"
+              >
+                <Ionicons name="close" size={14} style={{ color: colors.error }} />
+              </TouchableOpacity>
+            </View>
+          ) : null}
           {item.items.map((row) => (
             <StageRow key={`${item.key}:${row.filePath}:${row.localCommitOid ?? ''}`} item={row} />
           ))}
         </View>
       );
     },
-    [colors, handlePushGroup, handleDiscardGroup, isPushing],
+    [colors, handlePushGroup, handleDiscardGroup, isPushing, pushErrors, dismissPushError],
   );
 
   const renderEmpty = useCallback(
@@ -264,6 +323,54 @@ export default function StageScreen() {
       </View>
     );
   }, [colors, deleteFailures, handleRetryDelete, retryingKey]);
+
+  const renderPushErrors = useCallback(() => {
+    const errorKeys = Object.keys(pushErrors);
+    if (errorKeys.length === 0) return null;
+    return (
+      <View className="px-4 py-3" style={{ backgroundColor: `${colors.error}15` }}>
+        {errorKeys.map((key) => {
+          const error = pushErrors[key];
+          const separatorIndex = key.indexOf('::');
+          const repoPath = separatorIndex !== -1 ? key.slice(0, separatorIndex) : key;
+          const branch = separatorIndex !== -1 ? key.slice(separatorIndex + 2) : '';
+          const isConflict = error.toLowerCase().includes('conflict');
+          return (
+            <View key={key} className="flex-row items-center gap-2 py-1">
+              <Ionicons
+                name={isConflict ? 'git-merge' : 'alert-circle'}
+                size={16}
+                color={colors.error}
+              />
+              <View className="flex-1 mr-2">
+                <Text className="text-sm font-medium" style={{ color: colors.error }}>
+                  {isConflict
+                    ? 'Push rejected: merge conflict detected. Pull latest changes or resolve conflicts manually.'
+                    : `Push failed: ${error}`}
+                </Text>
+                <Text className="text-xs mt-0.5" style={{ color: colors.textSecondary }} numberOfLines={1}>
+                  {repoName(repoPath)} · {branch}
+                </Text>
+              </View>
+              <TouchableOpacity
+                onPress={() =>
+                  setPushErrors((prev) => {
+                    const next = { ...prev };
+                    delete next[key];
+                    return next;
+                  })
+                }
+                accessibilityRole="button"
+                className="p-1"
+              >
+                <Ionicons name="close" size={16} color={colors.textSecondary} />
+              </TouchableOpacity>
+            </View>
+          );
+        })}
+      </View>
+    );
+  }, [colors, pushErrors]);
 
   const pushAllDisabled = staged.length === 0 || globalPushing;
 
@@ -338,7 +445,16 @@ export default function StageScreen() {
         keyExtractor={(item) => item.key}
         renderItem={renderGroup}
         ListEmptyComponent={renderEmpty}
-        ListHeaderComponent={renderFailedDeletes}
+        ListHeaderComponent={
+          pushErrors && Object.keys(pushErrors).length > 0 ? (
+            <View>
+              {renderPushErrors()}
+              {renderFailedDeletes()}
+            </View>
+          ) : (
+            renderFailedDeletes()
+          )
+        }
         contentContainerStyle={{
           paddingTop: headerBlurHeight + 8,
           paddingBottom: 32,

--- a/src/services/DailyQuoteService.ts
+++ b/src/services/DailyQuoteService.ts
@@ -157,20 +157,33 @@ class DailyQuoteServiceClass {
       .map((j, i) => `[Journal ${i + 1}]\n${j.content.slice(0, 800)}`)
       .join('\n\n');
 
-    const result = await generateText({
-      model,
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You are a wise philosophical mentor. Review the user\'s recent journal entries and select ONE quote from the provided list that best resonates with their current themes. Then write a personalized 2-3 sentence description connecting the quote to their reflections. Reply ONLY with valid JSON in this EXACT format:\n{"quoteId": "the-quote-id", "description": "your personalized description"}',
-        },
-        {
-          role: 'user',
-          content: `Recent journal entries:\n\n${journalText}\n\nAvailable quotes to choose from (each has id, text, author, tags):\n${JSON.stringify(sampleQuotes, null, 2)}\n\nSelect the best matching quote and write a personalized description.`,
-        },
-      ],
-    });
+    let result;
+    try {
+      result = await generateText({
+        model,
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are a wise philosophical mentor. Review the user\'s recent journal entries and select ONE quote from the provided list that best resonates with their current themes. Then write a personalized 2-3 sentence description connecting the quote to their reflections. Reply ONLY with valid JSON in this EXACT format:\n{"quoteId": "the-quote-id", "description": "your personalized description"}',
+          },
+          {
+            role: 'user',
+            content: `Recent journal entries:\n\n${journalText}\n\nAvailable quotes to choose from (each has id, text, author, tags):\n${JSON.stringify(sampleQuotes, null, 2)}\n\nSelect the best matching quote and write a personalized description.`,
+          },
+        ],
+      });
+    } catch (error) {
+      console.warn(
+        '[DailyQuoteService] generateText failed:',
+        error,
+        '| model:',
+        selectedModel.id,
+        '| hasJournals:',
+        recentJournals.length > 0,
+      );
+      return null;
+    }
 
     const raw = (result.text || '').trim();
     const jsonMatch = raw.match(/\{[\s\S]*?\}/);

--- a/src/services/StagePushScheduler.ts
+++ b/src/services/StagePushScheduler.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StagingService, type StagedItem } from './git/StagingService';
 import { GitSyncGate, type CycleSource } from './git/GitSyncGate';
 import { useStageStore } from '../stores/stageStore';
+import { useConflictStore } from '../stores/conflictStore';
 import { githubActivity } from '../stores/githubActivityStore';
 import type { StageState } from '../stores/stageStore';
 
@@ -109,6 +110,13 @@ export async function flushStaged(): Promise<void> {
   // timer that fired before loadStaged populated) — otherwise a just-staged
   // clone-mode commit is missed and nothing re-triggers the push (#1020).
   await useStageStore.getState().loadStaged();
+
+  // Skip idle auto-push when conflicts exist — user must resolve them first.
+  // The notification + floating button red state already guide them to Conflicts.
+  if (useConflictStore.getState().totalUnresolvedFiles() > 0) {
+    return;
+  }
+
   const store = useStageStore.getState();
   const keys = new Set<string>();
   for (const item of store.staged) {


### PR DESCRIPTION
## Summary

**Floating push button conflict awareness:**
- FloatingStageButton turns **red** when unresolved conflicts exist and navigates to Conflicts screen on tap
- Icon changes from `cloud-upload` to `git-merge` when conflicts exist
- Idle auto-push skipped when conflicts exist, preventing repeated `conflict-detected` spam
- Button uses conflictStore.conflicts directly for proper Zustand reactivity

**Push failure inline UX:**
- StageScreen shows dismissible inline error banner when push fails
- Conflict-specific message guides user to resolve merges first

**Daily quote diagnostics:**
- generateAIQuote logs console.warn with model ID + journal context when generateText throws

## Files
- `src/components/git/FloatingStageButton.tsx`
- `src/services/StagePushScheduler.ts`
- `src/screens/StageScreen.tsx`
- `src/services/DailyQuoteService.ts`
- `__tests__/screens/StageScreen.test.tsx`