### PR TITLE
fix(sync): per-repo conflict isolation in idle auto-push

### DIFF
--- a/src/services/StagePushScheduler.ts
+++ b/src/services/StagePushScheduler.ts
@@ -111,12 +111,6 @@ export async function flushStaged(): Promise<void> {
   // clone-mode commit is missed and nothing re-triggers the push (#1020).
   await useStageStore.getState().loadStaged();
 
-  // Skip idle auto-push when conflicts exist — user must resolve them first.
-  // The notification + floating button red state already guide them to Conflicts.
-  if (useConflictStore.getState().totalUnresolvedFiles() > 0) {
-    return;
-  }
-
   const store = useStageStore.getState();
   const keys = new Set<string>();
   for (const item of store.staged) {
@@ -125,6 +119,16 @@ export async function flushStaged(): Promise<void> {
   for (const key of keys) {
     const parts = keyParts(key);
     if (parts !== null) {
+      const repoConflicts = useConflictStore.getState().conflicts.filter(
+        (c) => c.repoPath === parts.repoPath && c.branch === parts.branch,
+      );
+      const unresolvedCount = repoConflicts.reduce(
+        (sum, c) => sum + c.files.filter((f) => !f.autoResolved).length,
+        0,
+      );
+      if (unresolvedCount > 0) {
+        continue;
+      }
       store.requestPush(parts.repoPath, parts.branch);
     }
   }


### PR DESCRIPTION
flushStaged() previously called totalUnresolvedFiles() which summed
conflicts across ALL repos/branches — a single conflicted repo blocked
idle auto-push for every other repo.

Now checks conflicts per individual (repoPath, branch) inside the
enqueue loop and skips only that specific key, continuing to enqueue
all conflict-free repos. Conflicts on repo-a no longer block pushes
to repo-b.
