### PR TITLE
fix(stage): surface discard errors to UI and handle no-remote-ref gracefully

### DIFF
--- a/src/screens/StageScreen.tsx
+++ b/src/screens/StageScreen.tsx
@@ -203,7 +203,12 @@ export default function StageScreen() {
           {
             text: 'Discard',
             style: 'destructive',
-            onPress: () => void discardStaged(group.repoPath, group.branch),
+            onPress: async () => {
+              const error = await discardStaged(group.repoPath, group.branch);
+              if (error) {
+                Alert.alert('Discard Failed', error);
+              }
+            },
           },
         ],
       );
@@ -472,11 +477,16 @@ export default function StageScreen() {
                     {
                       text: 'Discard All',
                       style: 'destructive',
-                      onPress: async () => {
-                        for (const group of groups) {
-                          await discardStaged(group.repoPath, group.branch);
-                        }
-                      },
+              onPress: async () => {
+                const errors: string[] = [];
+                for (const group of groups) {
+                  const error = await discardStaged(group.repoPath, group.branch);
+                  if (error) errors.push(error);
+                }
+                if (errors.length > 0) {
+                  Alert.alert('Discard Failed', errors.join('\n'));
+                }
+              },
                     },
                   ],
                 );

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -612,4 +612,14 @@ export class GitFsService {
       return null;
     }
   }
+
+  static async unstageFiles(opts: { repoPath: string; files: string[] }): Promise<void> {
+    const info = parseRepoPath(opts.repoPath);
+    if (!info) return;
+    const dir = repoDirVirtual(info.owner, info.repo);
+    const fs = makeRepoFs();
+    for (const file of opts.files) {
+      await git.resetIndex({ fs, dir, ref: 'HEAD', filepath: file });
+    }
+  }
 }

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -404,7 +404,20 @@ export class StagingService {
         branch,
         token: token ?? undefined,
       });
-      if (!result.success) return { success: false, error: result.error };
+      if (!result.success) {
+        if (
+          result.error?.includes('No remote ref found') ||
+          result.error?.includes('cannot discard without an origin')
+        ) {
+          const staged = await StagingService.listStaged(repoPath, branch);
+          if (staged.length > 0) {
+            await GitFsService.unstageFiles({ repoPath, files: staged.map((s) => s.filePath) });
+          }
+          notifyStagedChanged();
+          return { success: true };
+        }
+        return { success: false, error: result.error };
+      }
 
       notifyStagedChanged();
       return { success: true };

--- a/src/stores/stageStore.ts
+++ b/src/stores/stageStore.ts
@@ -33,7 +33,7 @@ interface StageActions {
   setGlobalPushing: (bool: boolean) => void;
   setPushProgress: (fraction: number | null) => void;
   pushAll: () => void;
-  discardStaged: (repoPath: string, branch: string) => Promise<void>;
+  discardStaged: (repoPath: string, branch: string) => Promise<string | null>;
   dequeueNext: () => string | null;
   shiftQueue: () => void;
   registerQueueSubscription: () => void;
@@ -146,8 +146,11 @@ export const useStageStore = create<StageState & StageActions>()((set, get) => (
     const result = await StagingService.discardStaged(repoPath, branch);
     if (!result.success) {
       console.warn('[stageStore] discardStaged failed:', result.error);
+      void get().loadStaged();
+      return result.error ?? 'Discard failed';
     }
     void get().loadStaged();
+    return null;
   },
 
   dequeueNext: () => get().pushQueue[0] ?? null,


### PR DESCRIPTION
- stageStore.discardStaged now returns error string on failure so UI
  can surface it instead of silently swallowing it
- handleDiscardGroup (per-group) shows Alert with error message on
  failure
- handleDiscardAll (header) collects all failures and shows them in one
  Alert
- StagingService.discardStaged falls back to git resetIndex --head
  for each staged file when resetToRemote fails with 'No remote ref
  found' — handles freshly-cloned repos that have no origin to reset to
- Add GitFsService.unstageFiles using isomorphic-git resetIndex
