### PR TITLE
fix(sync): format push errors with formatSyncError before surfacing

### DIFF
--- a/src/services/StagePushScheduler.ts
+++ b/src/services/StagePushScheduler.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StagingService, type StagedItem } from './git/StagingService';
 import { GitSyncGate, type CycleSource } from './git/GitSyncGate';
+import { formatSyncError } from './git/formatSyncError';
 import { useStageStore } from '../stores/stageStore';
 import { useConflictStore } from '../stores/conflictStore';
 import { githubActivity } from '../stores/githubActivityStore';
@@ -67,8 +68,9 @@ export function setOnPushFailure(handler: PushFailureHandler | null): void {
 }
 
 function notifyPushFailure(key: string, error: string): void {
-  console.warn('[StagePushScheduler] push failed:', error);
-  onPushFailure?.({ key, error });
+  const formatted = formatSyncError(error);
+  console.warn('[StagePushScheduler] push failed:', formatted);
+  onPushFailure?.({ key, error: formatted });
 }
 
 function keyParts(key: string): { repoPath: string; branch: string } | null {

--- a/src/services/git/formatSyncError.ts
+++ b/src/services/git/formatSyncError.ts
@@ -67,6 +67,14 @@ const MATCHERS: Matcher[] = [
     needles: ['internal error caused this command to fail', 'isomorphic-git'],
     message: 'Sync failed. Pull to retry.',
   },
+  {
+    needles: ['could not generate', 'PushRejectedError', 'branch has diverged'],
+    message: 'Push rejected — your branch has diverged from remote. Pull remote changes first.',
+  },
+  {
+    needles: ['could not find', 'not found', 'no remote ref found', 'cannot discard without an origin'],
+    message: 'Push rejected — branch may not exist on remote or remote ref is missing. Push a commit first.',
+  },
 ];
 
 function fallbackFor(op?: SyncOp): string {


### PR DESCRIPTION
notifyPushFailure() was passing raw error strings directly to the
onPushFailure callback and console.warn. Now calls formatSyncError()
first so the user sees actionable messages like 'Push rejected —
your branch has diverged from remote. Pull remote changes first.'
instead of opaque isomorphic-git errors.

Also add missing MATCHERS for 'could not generate' /
'PushRejectedError' / 'branch has diverged' and 'could not find' /
'no remote ref found' so these fall through with helpful messages
rather than the generic 'Sync to GitHub failed'.
