### PR TITLE
fix(sync): wire formatSyncError into NoteGitHubSyncService error path

### DIFF
--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -11,6 +11,7 @@ import { githubActivity } from '../stores/githubActivityStore';
 import { getGitHostService } from './git/gitHostFactory';
 import { FEATURE_USE_MULTI_HOST_WRITE } from './featureFlags';
 import { classifyGitHubSyncError, extractHttpErrorDetails, syncStatusForError } from './git/syncFailure';
+import { formatSyncError } from './git/formatSyncError';
 import type { GitHostProvider } from './git/GitHost';
 
 async function resolveAuthor(provider: GitHostProvider = 'github'): Promise<{ name: string; email: string }> {
@@ -37,8 +38,9 @@ export interface NoteGitHubSyncResult {
 
 function failedSyncResult(error: unknown): NoteGitHubSyncResult {
   const details = extractHttpErrorDetails(error);
-  const message = details.message || 'Unknown error';
-  const status = details.status ?? syncStatusForError(message);
+  const rawMessage = details.message || 'Unknown error';
+  const status = details.status ?? syncStatusForError(rawMessage);
+  const message = formatSyncError(rawMessage);
   return status === undefined
     ? { success: false, error: message }
     : { success: false, error: message, status };

--- a/src/services/git/formatSyncError.ts
+++ b/src/services/git/formatSyncError.ts
@@ -72,6 +72,10 @@ const MATCHERS: Matcher[] = [
     message: 'Push rejected — your branch has diverged from remote. Pull remote changes first.',
   },
   {
+    needles: ['modified on github since', 'was modified on github since'],
+    message: 'SHA conflict — remote was updated. Pull to merge, then push again.',
+  },
+  {
     needles: ['could not find', 'not found', 'no remote ref found', 'cannot discard without an origin'],
     message: 'Push rejected — branch may not exist on remote or remote ref is missing. Push a commit first.',
   },


### PR DESCRIPTION
failedSyncResult() now passes the raw error through formatSyncError()
before returning it to callers, so all API-mode sync errors shown
in the UI are structured and actionable rather than raw git strings.

Also add missing MATCHERS for 'modified on github since' /
'was modified on github since' with message 'SHA conflict — remote
was updated. Pull to merge, then push again.'
