### PR TITLE
fix(a11y): drop accessibilityViewIsModal from IconButton wrappers

### DIFF
--- a/__tests__/header-blur.test.tsx
+++ b/__tests__/header-blur.test.tsx
@@ -209,6 +209,11 @@ jest.mock('../src/stores/todoStore', () => ({
     selector({ deleteTodo: jest.fn() }),
 }));
 
+jest.mock('../src/hooks/useGitHostQueries', () => ({
+  useGitHostPullRequests: () => ({ data: [], isLoading: false, isError: false, isSuccess: true, refetch: jest.fn() }),
+  useGitHostIssues: () => ({ data: [], isLoading: false, isError: false, isSuccess: true, refetch: jest.fn() }),
+}));
+
 jest.mock('../src/hooks/useEntityFilter', () => ({
   useEntityFilter: () => ({
     applyFilters: (items: unknown[]) => items,

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -57,7 +57,7 @@ export function IconButton(props: IconButtonProps) {
 
   if (variant === 'ghost') {
     return (
-      <Animated.View accessibilityViewIsModal accessibilityRole="button" style={[{ opacity: disabled ? 0.5 : 1 }, animatedStyle]}>
+      <Animated.View accessibilityRole="button" style={[{ opacity: disabled ? 0.5 : 1 }, animatedStyle]}>
         <Pressable
           testID={testID}
           accessibilityLabel={accessibilityLabel}
@@ -87,7 +87,7 @@ export function IconButton(props: IconButtonProps) {
   const elevation = variant === 'primary' ? 'raised' : 'raised';
 
   return (
-    <Animated.View accessibilityViewIsModal style={[{ opacity: disabled ? 0.5 : 1 }, animatedStyle]}>
+    <Animated.View style={[{ opacity: disabled ? 0.5 : 1 }, animatedStyle]}>
       <Pressable
         testID={testID}
         accessibilityLabel={accessibilityLabel}


### PR DESCRIPTION
The prop marks the wrapper as an accessibility modal, which hides all
sibling content (header titles, actions) from screen readers and from
testing-library queries. The Pressable inside already carries the
accessibilityRole/label, so the wrapper never needed it (#1132's
GenericElement concern does not require modal semantics).
