### PR TITLE
test: align locales, snapshots, and gate mock with #1174/#1183 changes

### DIFF
--- a/__tests__/__snapshots__/theme-parity.test.tsx.snap
+++ b/__tests__/__snapshots__/theme-parity.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`NativeWind theme parity matches the pre-migration key-kit snapshots in 
     }
   >
     <View
+      accessibilityRole="button"
       accessibilityState={
         {
           "busy": undefined,
@@ -274,6 +275,7 @@ exports[`NativeWind theme parity matches the pre-migration key-kit snapshots in 
     }
   >
     <View
+      accessibilityRole="button"
       accessibilityState={
         {
           "busy": undefined,

--- a/__tests__/services/git/GitSyncGate.test.tsx
+++ b/__tests__/services/git/GitSyncGate.test.tsx
@@ -19,6 +19,7 @@ jest.mock('../../../src/stores/todoStore', () => ({
 // test asserts the cycle source through the actual syncNow chain).
 jest.mock('../../../src/services/ForegroundSyncService', () => ({
   isForegroundSyncInFlight: jest.fn(() => false),
+  isForegroundSyncPaused: jest.fn(() => false),
   subscribeForegroundSync: jest.fn(() => jest.fn()),
   acquireExternalSync: jest.fn(() => jest.fn()),
 }));

--- a/__tests__/ui/__snapshots__/Button.test.tsx.snap
+++ b/__tests__/ui/__snapshots__/Button.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`Button snapshots primary in light + dark: primary-dark 1`] = `
   }
 >
   <View
+    accessibilityRole="button"
     accessibilityState={
       {
         "busy": undefined,
@@ -147,6 +148,7 @@ exports[`Button snapshots primary in light + dark: primary-light 1`] = `
   }
 >
   <View
+    accessibilityRole="button"
     accessibilityState={
       {
         "busy": undefined,

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -264,6 +264,8 @@
     "download": "Herunterladen",
     "syncFrequently": "Häufig synchronisieren",
     "syncFrequentlySub": "Empfohlen für mehrere Geräte",
+    "pauseForegroundSync": "Vordergrund-Sync pausieren",
+    "pauseForegroundSyncSub": "Debug: stoppt automatische Pulls, damit lokale Commits abweichen können (#1174)",
     "syncInterval": "Synchronisierungsintervall",
     "backgroundSync": "Hintergrundsynchronisierung",
     "syncUpToDate": "Synchronisierung auf dem neuesten Stand",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -264,6 +264,8 @@
     "download": "Descargar",
     "syncFrequently": "Sincronizar con frecuencia",
     "syncFrequentlySub": "Recomendado para varios dispositivos",
+    "pauseForegroundSync": "Pausar sincronización en primer plano",
+    "pauseForegroundSyncSub": "Depuración: detiene las descargas automáticas para que los commits locales diverjan (#1174)",
     "syncInterval": "Intervalo de sincronización",
     "backgroundSync": "Sincronización en segundo plano",
     "syncUpToDate": "Sincronización al día",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -264,6 +264,8 @@
     "download": "Télécharger",
     "syncFrequently": "Synchroniser fréquemment",
     "syncFrequentlySub": "Recommandé pour plusieurs appareils",
+    "pauseForegroundSync": "Suspendre la synchro au premier plan",
+    "pauseForegroundSyncSub": "Débogage : arrête les pulls automatiques pour permettre la divergence locale (#1174)",
     "syncInterval": "Intervalle de synchronisation",
     "backgroundSync": "Synchronisation en arrière-plan",
     "syncUpToDate": "Synchronisation à jour",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -264,6 +264,8 @@
     "download": "ダウンロード",
     "syncFrequently": "頻繁に同期",
     "syncFrequentlySub": "複数デバイスで推奨",
+    "pauseForegroundSync": "フォアグラウンド同期を一時停止",
+    "pauseForegroundSyncSub": "デバッグ：自動pullを停止し、ローカルコミットの分岐を許可 (#1174)",
     "syncInterval": "同期間隔",
     "backgroundSync": "バックグラウンド同期",
     "syncUpToDate": "同期済み",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -264,6 +264,8 @@
     "download": "다운로드",
     "syncFrequently": "자주 동기화",
     "syncFrequentlySub": "여러 기기에서 권장",
+    "pauseForegroundSync": "포그라운드 동기화 일시중지",
+    "pauseForegroundSyncSub": "디버그: 자동 pull을 중지하여 로컬 커밋 분기 허용 (#1174)",
     "syncInterval": "동기화 간격",
     "backgroundSync": "백그라운드 동기화",
     "syncUpToDate": "동기화 완료",


### PR DESCRIPTION
- five locale files gain the pauseForegroundSync keys for i18n parity
- Button/theme snapshots pick up the intentional accessibilityRole
- GitSyncGate test's ForegroundSyncService mock gains the new export
