### PR TITLE
fix(git): repair corrupted symbolic HEAD and use full refs in ensureOnBranch (#1189)

### DIFF
--- a/__tests__/services/git/localGitWriter.test.ts
+++ b/__tests__/services/git/localGitWriter.test.ts
@@ -11,6 +11,7 @@ jest.mock('isomorphic-git', () => {
     // B.1) doesn't short-circuit the existing tests. Tests that exercise
     // the unmodified path can override per-call.
     status: jest.fn(async (..._a: any[]) => 'modified'),
+    resolveRef: jest.fn(async (..._a: any[]) => 'resolved-sha'),
   };
   (globalThis as any).__lgwGitMocks = mocks;
   return {
@@ -21,20 +22,31 @@ jest.mock('isomorphic-git', () => {
 
 jest.mock('expo-file-system/legacy', () => {
   const fsStore = new Map<string, { type: 'file' | 'dir' }>();
+  const contentStore = new Map<string, string>();
   (globalThis as any).__lgwFsStore = fsStore;
+  (globalThis as any).__lgwFsContent = contentStore;
   return {
     __esModule: true,
     documentDirectory: 'file:///doc/',
     EncodingType: { Base64: 'base64', UTF8: 'utf8' },
     async getInfoAsync(uri: string) {
       const e = fsStore.get(uri);
-      return e ? { exists: true, uri, isDirectory: e.type === 'dir' } : { exists: false, uri };
+      if (e) return { exists: true, uri, isDirectory: e.type === 'dir' };
+      if (contentStore.has(uri)) return { exists: true, uri, isDirectory: false };
+      return { exists: false, uri };
     },
-    async writeAsStringAsync(uri: string) {
+    readAsStringAsync: jest.fn(async (uri: string) => {
+      const c = contentStore.get(uri);
+      if (c === undefined) throw new Error(`ENOENT: ${uri}`);
+      return c;
+    }),
+    writeAsStringAsync: jest.fn(async (uri: string, data?: string) => {
       fsStore.set(uri, { type: 'file' });
-    },
+      if (typeof data === 'string') contentStore.set(uri, data);
+    }),
     async deleteAsync(uri: string) {
       fsStore.delete(uri);
+      contentStore.delete(uri);
     },
     async makeDirectoryAsync(uri: string) {
       fsStore.set(uri, { type: 'dir' });
@@ -55,6 +67,20 @@ function getGitMocks() {
     fetch: jest.Mock;
     status: jest.Mock;
   };
+}
+
+function getFsContent() {
+  return (globalThis as any).__lgwFsContent as Map<string, string>;
+}
+
+const HEAD_URI = 'file:///doc/GitNotes/owner/repo/.git/HEAD';
+
+function getHeadContent(): string | undefined {
+  return getFsContent().get(HEAD_URI);
+}
+
+function getGitMocksExtra() {
+  return (globalThis as any).__lgwGitMocks as { resolveRef: jest.Mock };
 }
 
 function getFsStore() {
@@ -192,5 +218,69 @@ describe('LocalGitWriter', () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/Invalid repo path/);
     expect(getGitMocks().add).not.toHaveBeenCalled();
+  });
+});
+
+describe('HEAD ref repair (#1189)', () => {
+  const REPO = 'owner/repo';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getFsContent().delete(HEAD_URI);
+    getGitMocks().currentBranch.mockResolvedValue('main');
+    getGitMocksExtra().resolveRef.mockResolvedValue('resolved-sha');
+  });
+
+  test('rewrites a nested refs/heads prefix to the healthy symbolic ref', async () => {
+    getFsContent().set(HEAD_URI, 'ref: refs/heads/refs/heads/main\n');
+    const fsmod = jest.requireMock('expo-file-system/legacy');
+    // eslint-disable-next-line no-console
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await LocalGitWriter.resetToRemote({ repoPath: REPO, branch: 'main' });
+
+    // eslint-disable-next-line no-console
+    console.log('PROBE reads:', (fsmod.readAsStringAsync as jest.Mock).mock.calls.filter(([u]) => String(u).includes('.git/HEAD')).length,
+      'writes:', (fsmod.writeAsStringAsync as jest.Mock).mock.calls.filter(([u]) => String(u).includes('.git/HEAD')).length,
+      'content now:', JSON.stringify(getHeadContent()));
+    spy.mockRestore();
+    expect(getHeadContent()).toBe('ref: refs/heads/main\n');
+  });
+
+  test('rewrites a dangling symbolic HEAD and checks out the full ref', async () => {
+    getFsContent().set(HEAD_URI, 'ref: refs/heads/gone\n');
+    const git = getGitMocks();
+    getGitMocksExtra().resolveRef.mockRejectedValueOnce(new Error('does not exist upstream'));
+    git.currentBranch.mockResolvedValue('dev');
+
+    await LocalGitWriter.resetToRemote({ repoPath: REPO, branch: 'main' });
+
+    expect(getHeadContent()).toBe('ref: refs/heads/main\n');
+    expect(git.checkout).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: 'refs/heads/main' }),
+    );
+  });
+
+  test('leaves a healthy HEAD untouched', async () => {
+    getFsContent().set(HEAD_URI, 'ref: refs/heads/main\n');
+    const writeMock = jest.requireMock('expo-file-system/legacy').writeAsStringAsync;
+    writeMock.mockClear();
+
+    await LocalGitWriter.resetToRemote({ repoPath: REPO, branch: 'main' });
+
+    expect(getHeadContent()).toBe('ref: refs/heads/main\n');
+    const headWrites = writeMock.mock.calls.filter(([uri]) => uri === HEAD_URI);
+    expect(headWrites).toHaveLength(0);
+  });
+
+  test('survives a missing HEAD file (fresh init)', async () => {
+    const git = getGitMocks();
+    git.currentBranch.mockResolvedValue('dev');
+
+    await LocalGitWriter.resetToRemote({ repoPath: REPO, branch: 'main' });
+
+    expect(git.checkout).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: 'refs/heads/main' }),
+    );
   });
 });

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -181,17 +181,58 @@ async function ensureParentDirs(rootDir: string, virtualPath: string): Promise<v
  * If the branch ref is missing locally (single-branch clone of a different
  * branch), we fetch it from origin first and then check out.
  */
+/**
+ * Repair a corrupted .git/HEAD before any ref operation. isomorphic-git's
+ * checkout can write a nested symbolic target (`ref: refs/heads/refs/heads/main`,
+ * #1189), and a dangling symbolic target jams every later git op; both are
+ * rewritten to point at the requested branch.
+ */
+async function repairHeadRef(
+  fs: ReturnType<typeof makeRepoFs>,
+  dir: string,
+  branch: string,
+): Promise<void> {
+  const headPath = `${dir}/.git/HEAD`;
+  const healthyHead = `ref: refs/heads/${branch}\n`;
+
+  let raw: string;
+  try {
+    raw = String(await fs.promises.readFile(headPath, 'utf8'));
+  } catch {
+    return;
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed === healthyHead.trim()) return;
+
+  if (trimmed.startsWith('ref: refs/heads/refs/heads/')) {
+    await fs.promises.writeFile(headPath, healthyHead, 'utf8');
+    return;
+  }
+
+  if (trimmed.startsWith('ref: ')) {
+    try {
+      await git.resolveRef({ fs, dir, ref: trimmed.slice(5).trim() });
+      return;
+    } catch {
+      await fs.promises.writeFile(headPath, healthyHead, 'utf8');
+    }
+  }
+}
+
 async function ensureOnBranch(
   fs: ReturnType<typeof makeRepoFs>,
   dir: string,
   branch: string,
   token: string | undefined,
 ): Promise<void> {
+  await repairHeadRef(fs, dir, branch);
+
   const current = await git.currentBranch({ fs, dir, fullname: false }).catch(() => null);
   if (current === branch) return;
 
   try {
-    await git.checkout({ fs, dir, ref: branch });
+    await git.checkout({ fs, dir, ref: `refs/heads/${branch}` });
     return;
   } catch {
     // local branch ref is missing - fetch then retry checkout below.
@@ -207,7 +248,7 @@ async function ensureOnBranch(
     tags: false,
     onAuth: tokenAuth(token),
   });
-  await git.checkout({ fs, dir, ref: branch });
+  await git.checkout({ fs, dir, ref: `refs/heads/${branch}` });
 }
 
 /**


### PR DESCRIPTION
isomorphic-git checkout can persist a nested symbolic target
(refs/heads/refs/heads/<branch>), which jams every later git op:
pushes fail generically (#1187), staging never converges (#1185),
and discard silently no-ops. repairHeadRef now rewrites nested or
dangling HEAD targets to the requested branch before every write
path, and checkouts address the branch by its full ref.
