### PR TITLE
test(canvas): raise tile-list perf budget to 100ms for CI stability (#1188 follow-up)

### DIFF
--- a/__tests__/services/TilePersistenceService.test.ts
+++ b/__tests__/services/TilePersistenceService.test.ts
@@ -113,12 +113,16 @@ describe('TilePersistenceService', () => {
     }
     await AsyncStorage.multiSet(entries);
 
+    // Perf guard: catches accidental per-tile awaits or O(n^2) scans, which
+    // land in the seconds range. The 100ms budget (vs ~1-5ms typical) leaves
+    // headroom for CPU contention when the whole suite runs in parallel —
+    // a single-shot wall-clock read at 10ms flaked under load.
     const start = Date.now();
     const tiles = await service.listTiles(CANVAS_ID);
     const elapsed = Date.now() - start;
 
     expect(tiles).toHaveLength(500);
-    expect(elapsed).toBeLessThan(10);
+    expect(elapsed).toBeLessThan(100);
   });
 
   it('fires onTileSaved after a successful save', async () => {


### PR DESCRIPTION
The 500-tile list guard asserted a single-shot wall-clock read under
10ms, which flaked at 12ms when the full suite ran in parallel. The
guard's purpose is catching per-tile awaits or quadratic scans (seconds
scale), so a 100ms budget keeps that signal while tolerating scheduler
jitter.
