### PR TITLE
fix(sync): repair HEAD on pull path, classify pull failures, dedup canvas warnings (#1191 #1192)

### DIFF
--- a/__tests__/services/RepoPullService.canvas-pull.test.ts
+++ b/__tests__/services/RepoPullService.canvas-pull.test.ts
@@ -32,7 +32,7 @@ jest.mock('../../src/services/GitService', () => ({
   },
 }));
 
-import { pullFromSingleRepo } from '../../src/services/RepoPullService';
+import { __resetCanvasParseLogForTests, pullFromSingleRepo } from '../../src/services/RepoPullService';
 import { GitHubService } from '../../src/services/GitHubService';
 import { StorageService } from '../../src/services/StorageService';
 
@@ -58,6 +58,7 @@ describe('RepoPullService canvas pull + reconcile', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockLocalCanvases.length = 0;
+    __resetCanvasParseLogForTests();
     (GitHubService.isAuthenticated as jest.Mock).mockReturnValue(true);
     (StorageService.getSavedRepositories as jest.Mock).mockResolvedValue([
       { path: 'org/repo', branch: 'main' },
@@ -105,6 +106,31 @@ describe('RepoPullService canvas pull + reconcile', () => {
     );
     expect(parseWarning).toBeTruthy();
     expect(parseWarning).toContain('canvases/broken.json');
+    warnSpy.mockRestore();
+  });
+
+  // Bug #1191: a malformed remote canvas re-warned on every pull; it should
+  // warn once per session and stay quiet until it parses cleanly again.
+  it('warns a malformed canvas only once across repeat pulls', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const seedBroken = () => {
+      (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
+        { type: 'blob', path: 'canvases/broken.json', sha: 'a' },
+      ]);
+      (GitHubService.getFileContent as jest.Mock).mockImplementation(
+        async (_owner: string, _repo: string, path: string) =>
+          path === 'canvases/broken.json' ? '{ truncated' : null,
+      );
+    };
+    seedBroken();
+
+    await pullFromSingleRepo('org/repo');
+    await pullFromSingleRepo('org/repo');
+
+    const warns = warnSpy.mock.calls.filter(([msg]) =>
+      String(msg).includes('Failed to parse canvas JSON'),
+    );
+    expect(warns).toHaveLength(1);
     warnSpy.mockRestore();
   });
 

--- a/__tests__/services/git/gitFsService.test.ts
+++ b/__tests__/services/git/gitFsService.test.ts
@@ -75,6 +75,11 @@ jest.mock('expo-file-system/legacy', () => {
       if (!e || e.type !== 'file') throw new Error('File not found');
       return e.content ?? '';
     },
+    async writeAsStringAsync(uri: string, data?: string) {
+      const e = fsStore.get(uri);
+      if (e && e.type === 'file') e.content = String(data ?? '');
+      else fsStore.set(uri, { type: 'file', content: String(data ?? '') });
+    },
   };
 });
 
@@ -268,16 +273,38 @@ describe('GitFsService', () => {
     }
   });
 
-  test('pullWithFastForward classifies network failure as unknown', async () => {
-    getGitMocks().fetch.mockRejectedValueOnce(new Error('network'));
+  test('pullWithFastForward classifies network failure as network (#1191)', async () => {
+    getGitMocks().fetch.mockRejectedValueOnce(new Error('network request failed'));
     const result = await GitFsService.pullWithFastForward({
       repoPath: 'me/repo',
       branch: 'main',
     });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.reason).toBe('unknown');
+      expect(result.reason).toBe('network');
     }
+  });
+
+  test('pullWithFastForward classifies timeouts as timeout (#1191)', async () => {
+    getGitMocks().fetch.mockRejectedValueOnce(Object.assign(new Error('request timed out'), { code: 'ETIMEDOUT' }));
+    const result = await GitFsService.pullWithFastForward({
+      repoPath: 'me/repo',
+      branch: 'main',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('timeout');
+    }
+  });
+
+  test('pullWithFastForward repairs a nested symbolic HEAD before pulling (#1192)', async () => {
+    const headUri = 'file:///doc/GitNotes/me/repo/.git/HEAD';
+    getFsStore().set(headUri, { type: 'file', content: 'ref: refs/heads/refs/heads/main\n' });
+
+    const result = await GitFsService.pullWithFastForward({ repoPath: 'me/repo', branch: 'main' });
+
+    expect(result.ok).toBe(true);
+    expect(getFsStore().get(headUri)?.content).toBe('ref: refs/heads/main\n');
   });
 
   test('clone failure cleans up partial clone by calling removeRepo', async () => {

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -33,6 +33,16 @@ export function __resetSkippedTodoLogForTests(): void {
   reportedSkippedTodos.clear();
 }
 
+// Session-scoped dedup for canvas JSON parse warnings (#1191): without it a
+// malformed remote canvas re-warns on every pull. Files that later parse
+// cleanly drop out of the set, so a future breakage re-warns again.
+const reportedCanvasParseWarns = new Map<string, Set<string>>();
+
+/** Test-only seam: clear the per-repo canvas parse-warn dedup cache. */
+export function __resetCanvasParseLogForTests(): void {
+  reportedCanvasParseWarns.clear();
+}
+
 async function hasUnpushedCommits(repoPath: string, branch: string): Promise<boolean> {
   try {
     const localRef = `refs/heads/${branch}`;
@@ -157,9 +167,11 @@ const isMissingObject = /Could not find object|not foundobject|NotFoundError|Pac
                       GitFsService.readFile({ repoPath, ref: branch, filepath: path }),
                   };
                 }
+                // Diverged pulls are resolved above (conflict surface), so
+                // everything reaching here is transient — retry beats advice.
+                const detail = result.error ? ` — ${result.error}` : '';
                 throw new Error(
-                  `Local repo ${repoPath}@${branch} pull failed (${result.reason}). ` +
-                    `Push or reset your local commits before the next pull.`,
+                  `Local repo ${repoPath}@${branch} pull failed (${result.reason}${detail}). Will retry automatically.`,
                 );
       }
     }
@@ -567,6 +579,8 @@ async function pullCanvasesFromRepo(
 
   let processed = 0;
   const canvasJsonCount = files.filter((f) => f.path.endsWith('.json')).length;
+  const previouslyWarnedCanvasPaths = reportedCanvasParseWarns.get(repoPath) ?? new Set<string>();
+  const freshBadCanvasPaths: string[] = [];
   try {
     await StorageService.mutateCanvases((allCanvases) => {
       // Upsert: add / update canvases from files that still exist remotely.
@@ -582,7 +596,10 @@ async function pullCanvasesFromRepo(
           try {
             scene = JSON.parse(file.content);
           } catch (error) {
-            console.warn('[RepoPullService] Failed to parse canvas JSON:', file.path, error);
+            freshBadCanvasPaths.push(file.path);
+            if (!previouslyWarnedCanvasPaths.has(file.path)) {
+              console.warn('[RepoPullService] Failed to parse canvas JSON:', file.path, error);
+            }
             continue;
           }
 
@@ -614,6 +631,12 @@ async function pullCanvasesFromRepo(
             );
             pulled++;
           }
+        }
+
+        if (freshBadCanvasPaths.length > 0) {
+          reportedCanvasParseWarns.set(repoPath, new Set(freshBadCanvasPaths));
+        } else {
+          reportedCanvasParseWarns.delete(repoPath);
         }
 
         // Reconcile: drop local canvases whose backing file was deleted remotely.

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -94,6 +94,59 @@ function ensureToken(token: string | undefined) {
   return () => ({ username: 'x-access-token', password: token });
 }
 
+/**
+ * Repair a corrupted .git/HEAD before any ref operation. isomorphic-git's
+ * checkout can write a nested symbolic target (`ref: refs/heads/refs/heads/main`,
+ * #1189), and a dangling symbolic target jams every later git op; both are
+ * rewritten to point at the requested branch.
+ */
+export async function repairHeadRef(
+  fs: ReturnType<typeof makeGitFs>,
+  dir: string,
+  branch: string,
+): Promise<void> {
+  // Best-effort by contract: any failure here must not take down the
+  // surrounding pull/push — an unrepaired HEAD just fails again downstream.
+  try {
+    await repairHeadRefInner(fs, dir, branch);
+  } catch {
+    // ignore — next op will retry
+  }
+}
+
+async function repairHeadRefInner(
+  fs: ReturnType<typeof makeGitFs>,
+  dir: string,
+  branch: string,
+): Promise<void> {
+  const headPath = `${dir}/.git/HEAD`;
+  const healthyHead = `ref: refs/heads/${branch}\n`;
+
+  let raw: string;
+  try {
+    raw = String(await fs.promises.readFile(headPath, 'utf8'));
+  } catch {
+    return;
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed === healthyHead.trim()) return;
+
+  if (trimmed.startsWith('ref: refs/heads/refs/heads/')) {
+    await fs.promises.writeFile(headPath, healthyHead, 'utf8');
+    return;
+  }
+
+  if (trimmed.startsWith('ref: ')) {
+    try {
+      await git.resolveRef({ fs, dir, ref: trimmed.slice(5).trim() });
+      return;
+    } catch {
+      await fs.promises.writeFile(headPath, healthyHead, 'utf8');
+    }
+  }
+}
+
 function authedRemote(owner: string, repo: string): string {
   return `https://github.com/${owner}/${repo}.git`;
 }
@@ -297,12 +350,17 @@ export class GitFsService {
    * UX is a separate, larger product surface.
    */
   static async pullWithFastForward(opts: FetchOpts): Promise<
-    { ok: true } | { ok: false; reason: 'diverged' | 'unknown'; error?: string }
+    { ok: true } | { ok: false; reason: 'diverged' | 'timeout' | 'network' | 'unknown'; error?: string }
   > {
     const info = parseRepoPath(opts.repoPath);
     if (!info) return { ok: false, reason: 'unknown', error: `Invalid repo path: ${opts.repoPath}` };
     const dir = repoDirVirtual(info.owner, info.repo);
     const fs = makeRepoFs();
+
+    // A corrupted HEAD (#1189) makes fast-forward throw for reasons that have
+    // nothing to do with the remote; repair it so the pull below judges the
+    // real divergence state.
+    await repairHeadRef(fs, dir, opts.branch);
 
     try {
       const remoteRef = `refs/remotes/origin/${opts.branch}`;
@@ -355,6 +413,12 @@ export class GitFsService {
         return { ok: false, reason: 'diverged', error: message };
       }
       await cleanCorruptedPackfiles(opts.repoPath);
+      if (/timed?\s*-?out|etimedout/i.test(message)) {
+        return { ok: false, reason: 'timeout', error: message };
+      }
+      if (/network|econn|enotfound|dns|offline|socket/i.test(message)) {
+        return { ok: false, reason: 'network', error: message };
+      }
       return { ok: false, reason: 'unknown', error: message };
     }
   }

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -4,7 +4,7 @@ import { parseRepoPath } from '../../utils/gitPathParser';
 import { makeGitFs as buildGitFs } from './gitFs';
 import { gitHttp } from './gitHttp';
 import { formatSyncError } from './formatSyncError';
-import { GitFsService } from './GitFsService';
+import { GitFsService, repairHeadRef } from './GitFsService';
 import { ConflictResolverService } from '../conflict/ConflictResolverService';
 import { useConflictStore } from '../../stores/conflictStore';
 
@@ -181,45 +181,6 @@ async function ensureParentDirs(rootDir: string, virtualPath: string): Promise<v
  * If the branch ref is missing locally (single-branch clone of a different
  * branch), we fetch it from origin first and then check out.
  */
-/**
- * Repair a corrupted .git/HEAD before any ref operation. isomorphic-git's
- * checkout can write a nested symbolic target (`ref: refs/heads/refs/heads/main`,
- * #1189), and a dangling symbolic target jams every later git op; both are
- * rewritten to point at the requested branch.
- */
-async function repairHeadRef(
-  fs: ReturnType<typeof makeRepoFs>,
-  dir: string,
-  branch: string,
-): Promise<void> {
-  const headPath = `${dir}/.git/HEAD`;
-  const healthyHead = `ref: refs/heads/${branch}\n`;
-
-  let raw: string;
-  try {
-    raw = String(await fs.promises.readFile(headPath, 'utf8'));
-  } catch {
-    return;
-  }
-
-  const trimmed = raw.trim();
-  if (trimmed === healthyHead.trim()) return;
-
-  if (trimmed.startsWith('ref: refs/heads/refs/heads/')) {
-    await fs.promises.writeFile(headPath, healthyHead, 'utf8');
-    return;
-  }
-
-  if (trimmed.startsWith('ref: ')) {
-    try {
-      await git.resolveRef({ fs, dir, ref: trimmed.slice(5).trim() });
-      return;
-    } catch {
-      await fs.promises.writeFile(headPath, healthyHead, 'utf8');
-    }
-  }
-}
-
 async function ensureOnBranch(
   fs: ReturnType<typeof makeRepoFs>,
   dir: string,


### PR DESCRIPTION
- pullWithFastForward now runs repairHeadRef so a corrupted HEAD
  (#1189) no longer jams pulls into silent no-ops; LocalGitWriter's
  private copy moves to GitFsService where both callers share it
- pull failures classify as timeout/network instead of unknown, and
  the surfaced error includes the underlying cause with retry guidance
  instead of telling users to push/reset on transient failures
- malformed canvas JSON warns once per file per session instead of on
  every pull
