### PR TITLE
test: add missing repairHeadRef export to GitFsService mock factories

### DIFF
--- a/__tests__/push-rejection-conflicts.test.ts
+++ b/__tests__/push-rejection-conflicts.test.ts
@@ -42,6 +42,7 @@ jest.mock('expo-file-system/legacy', () => {
 });
 
 jest.mock('../src/services/git/GitFsService', () => ({
+  repairHeadRef: jest.fn(async () => undefined),
   GitFsService: {
     pullWithFastForward: jest.fn(),
     findMergeBase: jest.fn(),

--- a/__tests__/screens/SettingsScreen.add-repo-import.test.tsx
+++ b/__tests__/screens/SettingsScreen.add-repo-import.test.tsx
@@ -237,6 +237,7 @@ jest.mock('../../src/services/AuthService', () => {
 });
 
 jest.mock('../../src/services/git/GitFsService', () => ({
+  repairHeadRef: jest.fn(async () => undefined),
    GitFsService: {
      isCloned: jest.fn(async () => false),
      clone: jest.fn(async () => undefined),

--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -215,6 +215,7 @@ jest.mock('../../src/services/SyncEngineService', () => ({
 }));
 
 jest.mock('../../src/services/git/GitFsService', () => ({
+  repairHeadRef: jest.fn(async () => undefined),
   GitFsService: {
     isCloned: jest.fn(async () => false),
     clone: jest.fn(async () => undefined),

--- a/__tests__/services/NoteGitHubSyncService.test.ts
+++ b/__tests__/services/NoteGitHubSyncService.test.ts
@@ -29,6 +29,7 @@ jest.mock('../../src/services/git/LocalGitWriter', () => ({
 }));
 
 jest.mock('../../src/services/git/GitFsService', () => ({
+  repairHeadRef: jest.fn(async () => undefined),
   GitFsService: {
     isCloned: jest.fn(async () => false),
     readFile: jest.fn(async () => null),

--- a/__tests__/services/RepoPullService.data-loss-guard.test.ts
+++ b/__tests__/services/RepoPullService.data-loss-guard.test.ts
@@ -36,6 +36,7 @@ jest.mock('../../src/services/SyncEngineService', () => ({
 }));
 
 jest.mock('../../src/services/git/GitFsService', () => ({
+  repairHeadRef: jest.fn(async () => undefined),
   GitFsService: {
     listTree: jest.fn(async () => []),
     isCloned: jest.fn(async () => true),

--- a/__tests__/services/git/localGitWriter.recovery.test.ts
+++ b/__tests__/services/git/localGitWriter.recovery.test.ts
@@ -37,6 +37,7 @@ jest.mock('expo-file-system/legacy', () => {
 });
 
 jest.mock('../../../src/services/git/GitFsService', () => ({
+  repairHeadRef: jest.fn(async () => undefined),
   GitFsService: {
     pullWithFastForward: jest.fn(async () => ({ ok: true })),
     removeRepo: jest.fn(async () => undefined),

--- a/__tests__/stores/repoStore.test.ts
+++ b/__tests__/stores/repoStore.test.ts
@@ -49,6 +49,7 @@ jest.mock('../../src/services/SyncEngineService', () => ({
 }));
 
 jest.mock('../../src/services/git/GitFsService', () => ({
+  repairHeadRef: jest.fn(async () => undefined),
   GitFsService: {
     removeRepo: jest.fn(),
   },

--- a/__tests__/sync-locking.integration.test.ts
+++ b/__tests__/sync-locking.integration.test.ts
@@ -90,6 +90,7 @@ jest.mock('../src/services/GitService', () => ({
 }));
 
 jest.mock('../src/services/git/GitFsService', () => ({
+  repairHeadRef: jest.fn(async () => undefined),
   GitFsService: {
     getCurrentBranch: jest.fn(async () => null),
     isCloned: jest.fn(async () => false),


### PR DESCRIPTION
PR #1197 moved repairHeadRef into GitFsService; every per-file factory
that stubs that module needs the new named export or LocalGitWriter's
import resolves to undefined.
