### PR TITLE
fix(sync): deepen shallow clones before push and surface shallow errors (#1196)

### DIFF
--- a/__tests__/services/git/formatSyncError.test.ts
+++ b/__tests__/services/git/formatSyncError.test.ts
@@ -28,6 +28,8 @@ describe('formatSyncError', () => {
   test.each([
     ['push rejected', 'Someone else changed this on GitHub. Pull and try again.'],
     ['GitHub API error: 401', "GitHub rejected the token. Check you copied the full token (starts with ghp_ or github_pat_) — and that it wasn't expired or revoked."],
+    ['fatal: shallow update not allowed', 'Local clone history is incomplete. Pull to refresh it, then Push again.'],
+    ['remote rejected: fetch first', 'Someone else changed this on GitHub. Pull and try again.'],
     ['GitHub API error: 409', 'This file changed on GitHub. Pull and try again.'],
     ['GitHub API error: 422', 'GitHub rejected the change. Try again.'],
     ['GitHub API error: 503', 'GitHub is having trouble — will retry.'],

--- a/__tests__/services/git/localGitWriter.test.ts
+++ b/__tests__/services/git/localGitWriter.test.ts
@@ -284,3 +284,57 @@ describe('HEAD ref repair (#1189)', () => {
     );
   });
 });
+
+describe('push shallow handling (#1196)', () => {
+  const SHALLOW_URI = 'file:///doc/GitNotes/me/repo/.git/shallow';
+
+  beforeEach(() => {
+    getFsStore().delete(SHALLOW_URI);
+    getFsContent().delete(SHALLOW_URI);
+    getFsContent().delete('file:///doc/GitNotes/me/repo/.git/HEAD');
+    getGitMocks().currentBranch.mockResolvedValue('main');
+  });
+
+  afterEach(() => {
+    getFsStore().delete(SHALLOW_URI);
+    getFsContent().delete(SHALLOW_URI);
+  });
+
+  test('deepens a shallow clone before pushing (#1196)', async () => {
+    // Existence is judged by fsStore; content lives in the separate map the
+    // harness readAsStringAsync reads from — both must be seeded.
+    getFsStore().set(SHALLOW_URI, { type: 'file' });
+    getFsContent().set(SHALLOW_URI, 'oid-shallow-base\n');
+    const order: string[] = [];
+    getGitMocks().fetch.mockImplementationOnce(async () => {
+      order.push('fetch');
+    });
+    getGitMocks().push.mockImplementationOnce(async () => {
+      order.push('push');
+      return { ok: true };
+    });
+
+    const result = await LocalGitWriter.push({ repoPath: 'me/repo', branch: 'main' });
+
+    expect(result.success).toBe(true);
+    expect(order).toEqual(['fetch', 'push']);
+    expect(getFsStore().has(SHALLOW_URI)).toBe(false);
+  });
+
+  test('skips deepening when the clone is not shallow (#1196)', async () => {
+    const order: string[] = [];
+    getGitMocks().fetch.mockImplementation(async () => {
+      order.push('fetch');
+      return undefined;
+    });
+    getGitMocks().push.mockImplementationOnce(async () => {
+      order.push('push');
+      return { ok: true };
+    });
+
+    const result = await LocalGitWriter.push({ repoPath: 'me/repo', branch: 'main' });
+
+    expect(result.success).toBe(true);
+    expect(order).toEqual(['push']);
+  });
+});

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -213,6 +213,37 @@ async function ensureOnBranch(
 }
 
 /**
+ * Shallow clones (depth-limited clone/fetch) can miss parent objects needed
+ * to build a valid push pack (#1196): isomorphic-git then fails with errors
+ * that surface as generic sync failures. Detect the shallow marker and deepen
+ * with one full fetch; foreground pulls may re-mark shallowness afterwards,
+ * so this intentionally re-runs on every push.
+ */
+async function ensureNotShallow(
+  fs: ReturnType<typeof makeRepoFs>,
+  dir: string,
+  branch: string,
+  token: string | undefined,
+): Promise<void> {
+  const shallowPath = `${dir}/.git/shallow`;
+  try {
+    await fs.promises.readFile(shallowPath, 'utf8');
+  } catch {
+    return;
+  }
+  await git.fetch({
+    fs,
+    http: gitHttp,
+    dir,
+    ref: branch,
+    singleBranch: true,
+    tags: false,
+    onAuth: tokenAuth(token),
+  });
+  await fs.promises.unlink(shallowPath).catch(() => undefined);
+}
+
+/**
  * Backwards-compatible thin re-export of the shared sanitizer. New
  * callers should use `formatSyncError` directly from
  * `services/git/formatSyncError`; this wrapper keeps the existing import
@@ -555,6 +586,7 @@ static async deleteAndCommit(opts: DeleteOpts): Promise<LocalGitWriterResult> {
     const fs = makeRepoFs();
     try {
       await ensureOnBranch(fs, dir, opts.branch, opts.token);
+      await ensureNotShallow(fs, dir, opts.branch, opts.token);
       await git.push({
         fs,
         dir,

--- a/src/services/git/formatSyncError.ts
+++ b/src/services/git/formatSyncError.ts
@@ -20,8 +20,12 @@ interface Matcher {
 
 const MATCHERS: Matcher[] = [
   {
-    needles: ['push rejected', 'not a simple fast-forward', 'non-fast-forward', 'one or more branches were not updated'],
+    needles: ['push rejected', 'not a simple fast-forward', 'non-fast-forward', 'one or more branches were not updated', 'fetch first'],
     message: 'Someone else changed this on GitHub. Pull and try again.',
+  },
+  {
+    needles: ['shallow', 'unshallow', 'shallow update not allowed'],
+    message: 'Local clone history is incomplete. Pull to refresh it, then Push again.',
   },
   {
     needles: ['cannot lock ref'],


### PR DESCRIPTION
- LocalGitWriter.push detects .git/shallow and runs one full fetch
  before pushing, so depth-limited pulls can't leave the clone without
  the parent objects a push pack needs
- formatSyncError gains shallow/unshallow and fetch-first matchers so
  these failures stop collapsing into the generic fallback
