### PR TITLE
fix(conflict): fail-closed conflict gate + atomic addConflict (#1219 #1218)

### DIFF
--- a/__tests__/services/StagePushScheduler.test.ts
+++ b/__tests__/services/StagePushScheduler.test.ts
@@ -42,6 +42,7 @@ jest.mock('../../src/stores/conflictStore', () => ({
     getState: () => ({
       conflicts: (globalThis as any).__mockConflicts ?? [],
       loadConflicts: (globalThis as any).__mockLoadConflicts ?? (async () => undefined),
+      loadError: (globalThis as any).__mockLoadError ?? false,
     }),
   },
 }));
@@ -56,6 +57,7 @@ import {
   __resetForTests,
   drainPushQueue,
   flushStaged,
+  hasUnresolvedConflicts,
   onStagedChanged,
   setOnPushFailure,
   startScheduler,
@@ -661,5 +663,15 @@ describe('StagePushScheduler', () => {
     expect(StagingService.pushStaged).not.toHaveBeenCalled();
     expect(useStageStore.getState().isPushing['a/repo::main']).toBe(false);
     expect(useStageStore.getState().globalPushing).toBe(false);
+  });
+
+  test('hasUnresolvedConflicts returns true when conflict store load fails (#1219)', async () => {
+    (globalThis as any).__mockLoadConflicts = async () => {
+      (globalThis as any).__mockLoadError = true;
+    };
+
+    const result = await hasUnresolvedConflicts('test/repo', 'main');
+
+    expect(result).toBe(true);
   });
 });

--- a/__tests__/stores/conflictStore.test.ts
+++ b/__tests__/stores/conflictStore.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useConflictStore } from '../../src/stores/conflictStore';
+import type { ConflictSet } from '../../src/services/conflict/types';
+
+jest.mock('@react-native-async-storage/async-storage');
+
+function makeConflict(repoPath: string, branch: string, detectedAt: number): ConflictSet {
+  return {
+    repoPath,
+    branch,
+    localRef: `refs/heads/${branch}`,
+    remoteRef: `refs/remotes/origin/${branch}`,
+    mergeBaseRef: 'abc123',
+    files: [],
+    detectedAt,
+  };
+}
+
+describe('useConflictStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useConflictStore.setState({ conflicts: [], isLoading: false, loadError: false });
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('smoke test', () => {
+    expect(true).toBe(true);
+  });
+
+  describe('addConflict', () => {
+    it('adds a new conflict when none exist', async () => {
+      const store = useConflictStore.getState();
+      await store.loadConflicts();
+      const conflict = makeConflict('me/repo', 'main', 1);
+      await store.addConflict(conflict);
+      expect(store.getConflict('me/repo', 'main')).toEqual(conflict);
+    });
+
+    it('replaces existing conflict for same repoPath+branch', async () => {
+      const store = useConflictStore.getState();
+      await store.loadConflicts();
+      const conflict1 = makeConflict('me/repo', 'main', 1);
+      const conflict2 = makeConflict('me/repo', 'main', 2);
+      await store.addConflict(conflict1);
+      await store.addConflict(conflict2);
+      const found = store.getConflict('me/repo', 'main');
+      expect(found?.detectedAt).toBe(2);
+    });
+
+    it('concurrent addConflict calls do not lose entries', async () => {
+      const store = useConflictStore.getState();
+      await store.loadConflicts();
+      const conflicts: ConflictSet[] = [
+        makeConflict('me/repo1', 'main', 1),
+        makeConflict('me/repo2', 'main', 2),
+        makeConflict('me/repo3', 'main', 3),
+        makeConflict('me/repo4', 'main', 4),
+        makeConflict('me/repo5', 'main', 5),
+      ];
+      await Promise.all(conflicts.map((c) => store.addConflict(c)));
+      const state = useConflictStore.getState();
+      expect(state.conflicts).toHaveLength(5);
+      for (const conflict of conflicts) {
+        expect(state.getConflict(conflict.repoPath, conflict.branch)).toEqual(conflict);
+      }
+    });
+
+    it('concurrent addConflict calls with different branches do not lose entries', async () => {
+      const store = useConflictStore.getState();
+      await store.loadConflicts();
+      const conflicts: ConflictSet[] = [
+        makeConflict('me/repo', 'feature-a', 1),
+        makeConflict('me/repo', 'feature-b', 2),
+        makeConflict('me/repo', 'feature-c', 3),
+        makeConflict('me/repo', 'feature-d', 4),
+        makeConflict('me/repo', 'feature-e', 5),
+      ];
+      await Promise.all(conflicts.map((c) => store.addConflict(c)));
+      const state = useConflictStore.getState();
+      expect(state.conflicts).toHaveLength(5);
+      for (const conflict of conflicts) {
+        expect(state.getConflict(conflict.repoPath, conflict.branch)).toEqual(conflict);
+      }
+    });
+  });
+
+  describe('loadError behavior', () => {
+    it('sets loadError: true when AsyncStorage.getItem throws', async () => {
+      useConflictStore.setState({ isLoading: true, loadError: false });
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage unavailable'));
+      await useConflictStore.getState().loadConflicts();
+      expect(useConflictStore.getState().loadError).toBe(true);
+    });
+
+    it('sets loadError: false and populates conflicts on success', async () => {
+      const conflictData = [makeConflict('test/repo', 'main', 1)];
+      useConflictStore.setState({ isLoading: true, loadError: false });
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(conflictData));
+      await useConflictStore.getState().loadConflicts();
+      expect(useConflictStore.getState().loadError).toBe(false);
+      expect(useConflictStore.getState().conflicts).toEqual(conflictData);
+    });
+
+    it('sets loadError: false when AsyncStorage returns null', async () => {
+      useConflictStore.setState({ isLoading: true, loadError: false });
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      await useConflictStore.getState().loadConflicts();
+      expect(useConflictStore.getState().loadError).toBe(false);
+      expect(useConflictStore.getState().conflicts).toEqual([]);
+    });
+  });
+});

--- a/src/services/StagePushScheduler.ts
+++ b/src/services/StagePushScheduler.ts
@@ -82,9 +82,11 @@ function keyParts(key: string): { repoPath: string; branch: string } | null {
   };
 }
 
-async function hasUnresolvedConflicts(repoPath: string, branch: string): Promise<boolean> {
+export async function hasUnresolvedConflicts(repoPath: string, branch: string): Promise<boolean> {
   await useConflictStore.getState().loadConflicts();
-  const repoConflicts = useConflictStore.getState().conflicts.filter(
+  const state = useConflictStore.getState();
+  if (state.loadError) return true;
+  const repoConflicts = state.conflicts.filter(
     (c) => c.repoPath === repoPath && c.branch === branch,
   );
   return repoConflicts.some((c) => c.files.some((f) => !f.autoResolved));

--- a/src/stores/conflictStore.ts
+++ b/src/stores/conflictStore.ts
@@ -7,11 +7,12 @@ const STORAGE_KEY = 'gitnotes_conflicts';
 interface ConflictState {
   conflicts: ConflictSet[];
   isLoading: boolean;
+  loadError: boolean;
 }
 
 interface ConflictActions {
   loadConflicts: () => Promise<void>;
-  addConflict: (conflict: ConflictSet) => Promise<void>;
+  addConflict: (conflict: ConflictSet) => void;
   updateConflict: (repoPath: string, branch: string, updater: (c: ConflictSet) => ConflictSet) => Promise<void>;
   removeConflict: (repoPath: string, branch: string) => Promise<void>;
   getConflict: (repoPath: string, branch: string) => ConflictSet | undefined;
@@ -29,24 +30,27 @@ async function persist(conflicts: ConflictSet[]): Promise<void> {
 export const useConflictStore = create<ConflictState & ConflictActions>()((set, get) => ({
   conflicts: [],
   isLoading: true,
+  loadError: false,
 
   loadConflicts: async () => {
     try {
       const raw = await AsyncStorage.getItem(STORAGE_KEY);
       const conflicts: ConflictSet[] = raw ? JSON.parse(raw) : [];
-      set({ conflicts, isLoading: false });
+      set({ conflicts, isLoading: false, loadError: false });
     } catch {
-      set({ isLoading: false });
+      set({ isLoading: false, loadError: true });
     }
   },
 
-  addConflict: async (conflict) => {
-    const filtered = get().conflicts.filter(
-      (c) => !(c.repoPath === conflict.repoPath && c.branch === conflict.branch),
-    );
-    const next = [...filtered, conflict];
-    set({ conflicts: next });
-    await persist(next);
+  addConflict: (conflict) => {
+    set((state) => {
+      const filtered = state.conflicts.filter(
+        (c) => !(c.repoPath === conflict.repoPath && c.branch === conflict.branch),
+      );
+      const next = [...filtered, conflict];
+      void persist(next);
+      return { conflicts: next };
+    });
   },
 
   updateConflict: async (repoPath, branch, updater) => {


### PR DESCRIPTION
## Summary

Two conflict integrity fixes:

### #1219 — Fail-closed conflict gate
hasUnresolvedConflicts was swallowing loadConflicts errors — on AsyncStorage failure, conflicts stayed at its previous (usually empty) value, causing the gate to return false and allow pushes into diverged branches.

Fix: conflictStore.loadConflicts now surfaces errors via loadError flag. hasUnresolvedConflicts returns true (block push) when loadError is set.

### #1218 — Atomic addConflict
addConflict used non-atomic read-modify-write: two parallel callers could both read the same snapshot, both write their own next, and one would silently drop.

Fix: Use Zustand functional set((state) => ...) form which serializes concurrent updates through the store internal batching.

## Testing
- yarn jest __tests__/stores/conflictStore.test.ts — 8/8 (new loadError + concurrent tests)
- yarn jest __tests__/services/StagePushScheduler.test.ts — 29/29 (including #1219 fail-closed test)
- yarn ts:check — clean