### PR TITLE
fix(sync): overlay cancel releases push state + fan-out push-failure handlers (#1220 #1217)

### DIFF
--- a/__tests__/screens/StageScreen.test.tsx
+++ b/__tests__/screens/StageScreen.test.tsx
@@ -46,6 +46,7 @@ jest.mock('../../src/services/StorageService', () => ({
 jest.mock('../../src/services/StagePushScheduler', () => ({
   drainPushQueue: jest.fn(async () => undefined),
   setOnPushFailure: jest.fn(),
+  addOnPushFailure: jest.fn(() => jest.fn()),
 }));
 
 jest.mock('../../src/stores/stageStore', () => {

--- a/__tests__/services/PushNotificationService.test.ts
+++ b/__tests__/services/PushNotificationService.test.ts
@@ -16,9 +16,10 @@ jest.mock('../../src/services/NotificationService', () => ({
   },
 }));
 
-const mockSetOnPushFailure = jest.fn();
+const mockAddOnPushFailure = jest.fn(() => jest.fn());
 jest.mock('../../src/services/StagePushScheduler', () => ({
-  setOnPushFailure: mockSetOnPushFailure,
+  setOnPushFailure: jest.fn(),
+  addOnPushFailure: mockAddOnPushFailure,
 }));
 
 const mockSubscribe = jest.fn(() => jest.fn());
@@ -54,7 +55,7 @@ describe('PushNotificationService', () => {
 
   test('failure notification is scheduled with the push-failure payload shape', () => {
     pushService.attachToScheduler();
-    const handler = mockSetOnPushFailure.mock.calls[0][0] as FailureHandler;
+    const handler = mockAddOnPushFailure.mock.calls[0][0] as FailureHandler;
 
     handler({ key: '/repo/path::main', error: 'boom' });
 
@@ -68,7 +69,7 @@ describe('PushNotificationService', () => {
 
   test('conflict-caused failures are flagged conflict: true', () => {
     pushService.attachToScheduler();
-    const handler = mockSetOnPushFailure.mock.calls[0][0] as FailureHandler;
+    const handler = mockAddOnPushFailure.mock.calls[0][0] as FailureHandler;
 
     handler({ key: '/repo/path::main', error: 'conflict-detected' });
     expect(mockSchedulePushFailure).toHaveBeenLastCalledWith(

--- a/src/components/ui/SyncBlockOverlay.tsx
+++ b/src/components/ui/SyncBlockOverlay.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useTheme, useTokens } from '../../contexts/ThemeContext';
 import { useGitOperationStore, GIT_OP_ALL_REPOS } from '../../stores/gitOperationStore';
+import { useStageStore } from '../../stores/stageStore';
 import { GitSyncGate } from '../../services/git/GitSyncGate';
 import { cancelInflightGitHttp } from '../../services/git/gitHttp';
 import { HapticService } from '../../utils/haptics';
@@ -76,6 +77,7 @@ export function SyncBlockOverlay() {
     setCancelling(true);
     void HapticService.error();
     cancelInflightGitHttp();
+    useStageStore.getState().forceUnlockPushState();
   };
 
   // Announce to VoiceOver / TalkBack on visible→true transition only.

--- a/src/screens/StageScreen.tsx
+++ b/src/screens/StageScreen.tsx
@@ -8,7 +8,7 @@ import { ScreenHeader, useScreenHeaderHeight } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { groupStaged, useStageStore, type StageGroup } from '../stores/stageStore';
 import { useConflictStore } from '../stores/conflictStore';
-import { drainPushQueue, setOnPushFailure } from '../services/StagePushScheduler';
+import { drainPushQueue, addOnPushFailure } from '../services/StagePushScheduler';
 import { useGitHubActivityStore } from '../stores/githubActivityStore';
 import type { StagedItem } from '../services/git/StagingService';
 import { readDeleteFailures, parseDeleteFailureKey } from '../services/git/deleteFailures';
@@ -130,9 +130,10 @@ export default function StageScreen() {
   }, [loadDeleteFailures]);
 
   useEffect(() => {
-    setOnPushFailure(({ key, error }) => {
+    const unsub = addOnPushFailure(({ key, error }) => {
       setPushErrors((prev) => ({ ...prev, [key]: error }));
     });
+    return unsub;
   }, []);
 
   useEffect(() => {

--- a/src/services/PushNotificationService.ts
+++ b/src/services/PushNotificationService.ts
@@ -1,5 +1,5 @@
 import { AppState } from 'react-native';
-import { setOnPushFailure } from './StagePushScheduler';
+import { addOnPushFailure } from './StagePushScheduler';
 import { useStageStore } from '../stores/stageStore';
 import { NotificationService } from './NotificationService';
 
@@ -12,6 +12,7 @@ function appIsForegrounded(): boolean {
 
 let lastProgressSentAt = 0;
 let unsubscribeProgress: (() => void) | null = null;
+let unsubscribePushFailure: (() => void) | null = null;
 
 /** Plain push failures open the stage page; conflict-caused ones open the conflicts page
  *  with specific repo/branch if provided. */
@@ -37,7 +38,8 @@ function parsePushKey(key: string): { repoPath: string; branch: string } | null 
 
 /** Route StagePushScheduler push failures into a deep-linkable local notification. */
 export function attachToScheduler(): void {
-  setOnPushFailure(({ key, error }) => {
+  unsubscribePushFailure?.();
+  unsubscribePushFailure = addOnPushFailure(({ key, error }) => {
     const parts = parsePushKey(key);
     if (parts === null) return;
     const { repoPath, branch } = parts;

--- a/src/services/StagePushScheduler.ts
+++ b/src/services/StagePushScheduler.ts
@@ -60,17 +60,29 @@ let idleTimer: ReturnType<typeof setTimeout> | null = null;
 let schedulerRunning = false;
 let draining = false;
 let unsubscribeStaged: (() => void) | null = null;
-let onPushFailure: PushFailureHandler | null = null;
+const pushFailureHandlers = new Set<PushFailureHandler>();
 
-/** Register the push-failure hook (notification wiring lands in todo 9). */
+/**
+ * Add a push-failure handler. Returns an unsubscribe function.
+ * Multiple handlers can coexist — all are called on each push failure (#1217).
+ */
+export function addOnPushFailure(handler: PushFailureHandler): () => void {
+  pushFailureHandlers.add(handler);
+  return () => pushFailureHandlers.delete(handler);
+}
+
+/** @deprecated Use addOnPushFailure instead. Kept for backward compatibility. */
 export function setOnPushFailure(handler: PushFailureHandler | null): void {
-  onPushFailure = handler;
+  if (handler === null) return;
+  pushFailureHandlers.add(handler);
 }
 
 function notifyPushFailure(key: string, error: string): void {
   const formatted = formatSyncError(error);
   console.warn('[StagePushScheduler] push failed:', formatted);
-  onPushFailure?.({ key, error: formatted });
+  for (const handler of [...pushFailureHandlers]) {
+    handler({ key, error: formatted });
+  }
 }
 
 function keyParts(key: string): { repoPath: string; branch: string } | null {
@@ -292,5 +304,5 @@ export function __resetForTests(): void {
   draining = false;
   unsubscribeStaged?.();
   unsubscribeStaged = null;
-  onPushFailure = null;
+  pushFailureHandlers.clear();
 }


### PR DESCRIPTION
## Summary

### #1220 — Overlay Cancel releases gate cycle
SyncBlockOverlay.handleCancel only called cancelInflightGitHttp() but NOT forceUnlockPushState(), leaving the push button stuck in spinner state for up to 10 minutes on hung requests.

Fix: Added useStageStore.getState().forceUnlockPushState() to handleCancel so the push state is cleared immediately when the user taps Cancel.

### #1217 — Fan-out push-failure handlers
setOnPushFailure was a single mutable slot — StageScreen mount overwrote the boot-installed notification handler, silently disabling push-failure notifications for the rest of the session.

Fix: Replaced single-slot with Set<PushFailureHandler> fan-out via addOnPushFailure(handler) that returns an unsubscribe function. Both StageScreen and PushNotificationService can now receive push failures simultaneously.

## Testing
- yarn jest __tests__/components/ui/SyncBlockOverlay.test.tsx — 20/20
- yarn jest __tests__/services/StagePushScheduler.test.ts — 29/29
- yarn jest __tests__/services/PushNotificationService.test.ts — 7/7
- yarn jest __tests__/screens/StageScreen.test.tsx — 8/8
- yarn ts:check — clean