### PR TITLE
fix(sync/git): drain Promise.allSettled, account-key grouping, discardStaged placeholder, recovery preserves writes

### DIFF
--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -518,11 +518,14 @@ class NoteSyncQueueServiceClass {
       // Process all (repo, branch) groups in parallel — they're
       // independent of each other. Within a single group the processing
       // stays serial so write ordering against the same repo is
-      // preserved (issue #565 phase B.3).
+      // preserved (issue #565 phase B.3). Promise.allSettled is used so
+      // that all groups complete even if one rejects — no group's backoff
+      // state is lost (issue #1205).
       const totalDue = due.length;
       let completed = 0;
-      const perGroupOutcomes = await Promise.all(
-        Array.from(groups.entries()).map(([key, items]) =>
+      const groupEntries = Array.from(groups.entries());
+      const groupResults = await Promise.allSettled(
+        groupEntries.map(([key, items]) =>
           this.drainGroup(key, items, now).then((outcome) => {
             completed += items.length;
             if (onProgress) {
@@ -531,6 +534,45 @@ class NoteSyncQueueServiceClass {
             return outcome;
           }),
         ),
+      );
+
+      // Process each settled result. For rejected groups, re-process to
+      // apply backoff rather than silently losing retry state (issue #1205).
+      const perGroupOutcomes = await Promise.all(
+        groupResults.map(async (result, index) => {
+          if (result.status === 'fulfilled') {
+            return result.value;
+          }
+          const [key, items] = groupEntries[index];
+          console.warn('[NoteSyncQueue] drainGroup rejected, re-processing for backoff:', result.reason);
+          const sep = key.indexOf('\n');
+          const repoPath = key.slice(0, sep);
+          const branch = key.slice(sep + 1);
+          GitSyncGate.markPushActive(repoPath, branch);
+          try {
+            const groupOutcome = await this.processDrainGroup(repoPath, branch, items, now);
+            // Merge: count the group's failed items and apply backoff entries
+            // for any item not already in updatedById or droppedIds.
+            const merged: typeof groupOutcome = {
+              ...groupOutcome,
+              updatedById: new Map(groupOutcome.updatedById),
+            };
+            for (const item of items) {
+              if (!merged.updatedById.has(item.id) && !merged.droppedIds.has(item.id)) {
+                merged.updatedById.set(item.id, {
+                  ...item,
+                  attempts: item.attempts + 1,
+                  lastError: result.reason?.message ?? String(result.reason),
+                  nextRetryAt: now + backoffMsForAttempts(item.attempts + 1),
+                });
+                merged.failed++;
+              }
+            }
+            return merged;
+          } finally {
+            GitSyncGate.clearPushActive(repoPath, branch);
+          }
+        }),
       );
 
       const updatedById = new Map<string, QueuedMutation>();
@@ -653,7 +695,7 @@ class NoteSyncQueueServiceClass {
         if (repoInfo) {
           const subgroups = new Map<string, (QueuedMutation & { type: 'note.delete' })[]>();
           for (const item of dueDeletes) {
-            const key = item.params.accountId ?? '';
+            const key = item.params.accountId !== undefined ? item.params.accountId : '__default__';
             const arr = subgroups.get(key) ?? [];
             arr.push(item);
             subgroups.set(key, arr);
@@ -722,7 +764,7 @@ class NoteSyncQueueServiceClass {
         if (repoInfo) {
           const subgroups = new Map<string, BatchEligibleUpsert[]>();
           for (const item of dueUpserts) {
-            const key = item.params.accountId ?? '';
+            const key = item.params.accountId !== undefined ? item.params.accountId : '__default__';
             const arr = subgroups.get(key) ?? [];
             arr.push(item);
             subgroups.set(key, arr);
@@ -846,7 +888,7 @@ class NoteSyncQueueServiceClass {
     if (isClone && pendingFlush.length > 0) {
       const byAccount = new Map<string, typeof pendingFlush>();
       for (const entry of pendingFlush) {
-        const key = entry.item.params.accountId ?? '__default__';
+        const key = entry.item.params.accountId !== undefined ? entry.item.params.accountId : '__default__';
         const arr = byAccount.get(key) ?? [];
         arr.push(entry);
         byAccount.set(key, arr);

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -92,6 +92,7 @@ async function handleCorruptionAndRetry<T>(
   repoPath: string,
   branch: string,
   token: string | undefined,
+  filePathForRecoveryCheck: string | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {
   try {
@@ -99,6 +100,33 @@ async function handleCorruptionAndRetry<T>(
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     if (!isCorruptionError(errorMsg)) throw error;
+
+    // Before attempting recovery, check if there are uncommitted working tree
+    // changes that would be lost. If so, skip recovery to preserve user data.
+    if (filePathForRecoveryCheck !== undefined) {
+      const info = parseRepoPath(repoPath);
+      if (info) {
+        const dir = repoDirVirtual(info.owner, info.repo);
+        const fs = makeRepoFs();
+        try {
+          const status = await git.status({ fs, dir, filepath: filePathForRecoveryCheck });
+          if (status !== 'unmodified') {
+            console.warn(
+              `[LocalGitWriter] clone corruption detected with uncommitted changes to '${filePathForRecoveryCheck}' in ${repoPath}@${branch} — skipping recovery to preserve user data`,
+            );
+            throw new Error(
+              `Clone corruption detected with uncommitted changes to '${filePathForRecoveryCheck}' in ${repoPath}@${branch}. ` +
+              `Please commit your changes before continuing.`,
+            );
+          }
+        } catch (statusCheckError) {
+          // If status check itself failed (e.g., repo already corrupt), be
+          // conservative and propagate the original corruption error
+          if (statusCheckError !== error) throw error;
+        }
+      }
+    }
+
     console.warn(`[LocalGitWriter] clone corruption detected, attempting recovery...`);
     const hasLocalCommits = await hasUnpushedLocalCommits(repoPath, branch);
     if (hasLocalCommits) {
@@ -151,6 +179,20 @@ export async function hasUnpushedLocalCommits(repoPath: string, branch: string):
     return true;
   } catch {
     return false;
+  }
+}
+
+async function getUncommittedWorkingChanges(
+  fs: ReturnType<typeof makeRepoFs>,
+  dir: string,
+): Promise<string[]> {
+  try {
+    const matrix = await git.statusMatrix({ fs, dir });
+    return matrix
+      .filter(([, head, workdir]) => head !== workdir)
+      .map(([filepath]) => filepath);
+  } catch {
+    return [];
   }
 }
 
@@ -287,7 +329,7 @@ static async writeAndCommit(opts: WriteOpts): Promise<LocalGitWriterResult> {
     const filePath = toRepoRelativePath(opts.filePath);
 
     try {
-      return await handleCorruptionAndRetry(opts.repoPath, opts.branch, opts.token, async () => {
+      return await handleCorruptionAndRetry(opts.repoPath, opts.branch, opts.token, filePath, async () => {
         const dir = repoDirVirtual(info.owner, info.repo);
         const fs = makeRepoFs();
         const fsRoot = clonesRoot();
@@ -408,7 +450,7 @@ static async deleteAndCommit(opts: DeleteOpts): Promise<LocalGitWriterResult> {
     const filePath = toRepoRelativePath(opts.filePath);
 
     try {
-      return await handleCorruptionAndRetry(opts.repoPath, opts.branch, opts.token, async () => {
+      return await handleCorruptionAndRetry(opts.repoPath, opts.branch, opts.token, filePath, async () => {
         const dir = repoDirVirtual(info.owner, info.repo);
         const fs = makeRepoFs();
         const fsRoot = clonesRoot();

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -431,8 +431,11 @@ export class StagingService {
           result.error?.includes('cannot discard without an origin')
         ) {
           const staged = await StagingService.listStaged(repoPath, branch);
-          if (staged.length > 0) {
-            await GitFsService.unstageFiles({ repoPath, files: staged.map((s) => s.filePath) });
+          const realFiles = staged
+            .map((s) => s.filePath)
+            .filter((f) => f !== UNPUSHED_COMMITS_PLACEHOLDER);
+          if (realFiles.length > 0) {
+            await GitFsService.unstageFiles({ repoPath, files: realFiles });
           }
           notifyStagedChanged();
           return { success: true };


### PR DESCRIPTION
## Summary

### fixes #1205 - NoteSyncQueueService.drain Promise.all drops outcomes
Replaced Promise.all with Promise.allSettled so all groups complete even if one rejects. Rejected groups re-process to apply backoff, preventing lost retry state.

### fixes #1208 - batchUpsert subgroups collapses items from different accounts
Changed `accountId ?? ` to `accountId !== undefined ? accountId : __default__` consistently across all subgroup creation points. Items with undefined accountId now use explicit `__default__` key instead of silent `` collapse.

### fixes #1203 - discardStaged passes placeholder to git.resetIndex
Filter UNPUSHED_COMMITS_PLACEHOLDER entries before calling unstageFiles so git.resetIndex gets real file paths, not a no-op placeholder.

### fixes #1204 - LocalGitWriter.writeAndCommit corruption recovery drops writes
handleCorruptionAndRetry now checks for uncommitted working changes before running repo-level recovery. If user data would be lost, recovery is skipped and an error is thrown.

## Testing
- yarn ts:check — clean
- yarn jest __tests__/services/NoteSyncQueueService.test.ts --no-coverage --forceExit