### PR TITLE
fix(sync): hasUnpushedLocalCommits fail-closed + scoped drain (#1209 #1214)

### DIFF
--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -479,6 +479,8 @@ class NoteSyncQueueServiceClass {
   async drain(
     onProgress?: (fraction: number | null) => void,
     source: CycleSource = 'background',
+    repoPath?: string,
+    branch?: string,
   ): Promise<{ succeeded: number; failed: number; remaining: number }> {
     if (this.isDraining) {
       const items = await this.getAll();
@@ -493,7 +495,13 @@ class NoteSyncQueueServiceClass {
     const releaseCycle = GitSyncGate.isCycleHeld() ? null : await GitSyncGate.acquireCycle(source);
 
     try {
-      const initial = await this.getAll();
+      let initial = await this.getAll();
+      if (repoPath !== undefined) {
+        initial = initial.filter((m) => m.params.repo === repoPath);
+        if (branch !== undefined) {
+          initial = initial.filter((m) => (m.params.branch ?? 'main') === branch);
+        }
+      }
       const now = Date.now();
 
       // Group items by (repo, branch). Within a clone-mode group every

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -178,7 +178,7 @@ export async function hasUnpushedLocalCommits(repoPath: string, branch: string):
     if (localOid === mergeBase) return false;
     return true;
   } catch {
-    return false;
+    return true;
   }
 }
 

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -365,7 +365,7 @@ export class StagingService {
       // Always drain: listStaged tags leftover API-mode mutations with the
       // repo's current mode, so a hasApi gate would strand queue items in
       // clone-mode repos forever. drain() handles clone groups internally.
-      await NoteSyncQueueService.drain(onProgress);
+      await NoteSyncQueueService.drain(onProgress, 'manual', repoPath, branch);
 
       if (cloneKeys.size > 0) {
         const token = await AuthService.getToken();


### PR DESCRIPTION
## Summary

### fixes #1209 - hasUnpushedLocalCommits swallows errors
The function now returns `true` (fail-closed) when any error occurs, instead of silently returning `false`. This prevents destructive recovery from proceeding when `getCommitOid` or `findMergeBase` fails transiently.

### fixes #1214 - pushStaged drains entire queue
NoteSyncQueueService.drain now accepts optional `repoPath` and `branch` parameters. When provided, only items matching the scope are drained. `pushStaged(repo, branch)` now passes the scope to `drain`.

## Testing
- yarn ts:check — clean
- yarn jest __tests__/services/NoteSyncQueueService.test.ts --no-coverage --forceExit