### PR TITLE
fix(paywall): critical regex bypass + Android grandfathering + interstitial navigation + RC mock entitlement (#1227 #1228 #1230 #1231)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -48,6 +48,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { reconcileThoughtDumps } from './src/services/ai/thoughtDumpIndexing';
 import { LastSelectionPreferenceService } from './src/services/LastSelectionPreferenceService';
 import { useProStore } from './src/stores/proStore';
+import { enforceTierLimits } from './src/services/TierLimits';
 import * as PushNotificationService from './src/services/PushNotificationService';
 import * as StagePushScheduler from './src/services/StagePushScheduler';
 import { hideDevMenuFloatingActionButton } from './src/utils/devMenuFab';
@@ -76,7 +77,15 @@ export default function App() {
     void hydrateGitOperationRegistry();
     void useConflictStore.getState().loadConflicts();
     void useRenderStyleStore.getState().hydrate();
-    void useProStore.getState().initialize();
+    // Resolve Pro entitlement before surfacing restored data so the free-tier
+    // repo/account caps can be enforced on data brought back by Android backup
+    // restore (#1233) — before the stores render it, not after.
+    try {
+      await useProStore.getState().initialize();
+      await enforceTierLimits();
+    } catch (error) {
+      console.warn('[App] tier-limit enforcement failed:', error);
+    }
     const completed = await OnboardingService.isOnboardingCompleted();
     setShowOnboarding(!completed);
     await NotificationService.requestPermissions();

--- a/__tests__/services/TierLimits.test.ts
+++ b/__tests__/services/TierLimits.test.ts
@@ -1,0 +1,120 @@
+const mockProState = { status: 'free', entitlementActive: false, isGrandfathered: false };
+jest.mock('../../src/stores/proStore', () => ({
+  __esModule: true,
+  selectIsPro: (state: { entitlementActive?: boolean; isGrandfathered?: boolean }) =>
+    Boolean(state?.entitlementActive || state?.isGrandfathered),
+  useProStore: { getState: () => mockProState },
+}));
+
+jest.mock('../../src/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(async () => []),
+    saveRepositories: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock('../../src/services/AccountStorage', () => ({
+  AccountStorage: {
+    listAccounts: jest.fn(async () => []),
+    removeAccount: jest.fn(async () => undefined),
+  },
+}));
+
+import {
+  enforceTierLimits,
+  FREE_TIER_MAX_REPOS,
+  FREE_TIER_MAX_ACCOUNTS,
+} from '../../src/services/TierLimits';
+import { StorageService } from '../../src/services/StorageService';
+import { AccountStorage } from '../../src/services/AccountStorage';
+import type { GitRepository } from '../../src/services/GitService';
+import type { StoredAccount } from '../../src/services/AccountStorage';
+
+const __setProState = (partial: Record<string, unknown>) => Object.assign(mockProState, partial);
+const getSavedRepositories = StorageService.getSavedRepositories as jest.Mock;
+const saveRepositories = StorageService.saveRepositories as jest.Mock;
+const listAccounts = AccountStorage.listAccounts as jest.Mock;
+const removeAccount = AccountStorage.removeAccount as jest.Mock;
+
+function repo(id: string): GitRepository {
+  return { id, name: id, path: `owner/${id}` };
+}
+
+function account(id: string, addedAt: number): StoredAccount {
+  return { id, login: id, name: id, email: '', avatarUrl: '', addedAt, hostIds: [] };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __setProState({ status: 'free', entitlementActive: false, isGrandfathered: false });
+  getSavedRepositories.mockResolvedValue([]);
+  listAccounts.mockResolvedValue([]);
+  saveRepositories.mockResolvedValue(undefined);
+  removeAccount.mockResolvedValue(undefined);
+});
+
+describe('enforceTierLimits', () => {
+  it('does nothing for Pro users', async () => {
+    __setProState({ status: 'pro', entitlementActive: true, isGrandfathered: false });
+    getSavedRepositories.mockResolvedValue([repo('a'), repo('b')]);
+    listAccounts.mockResolvedValue([account('x', 1), account('y', 2)]);
+
+    await enforceTierLimits();
+
+    expect(saveRepositories).not.toHaveBeenCalled();
+    expect(removeAccount).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for grandfathered users', async () => {
+    __setProState({ status: 'pro', entitlementActive: false, isGrandfathered: true });
+    getSavedRepositories.mockResolvedValue([repo('a'), repo('b')]);
+    listAccounts.mockResolvedValue([account('x', 1), account('y', 2)]);
+
+    await enforceTierLimits();
+
+    expect(saveRepositories).not.toHaveBeenCalled();
+    expect(removeAccount).not.toHaveBeenCalled();
+  });
+
+  it('leaves a free user at or under the cap untouched', async () => {
+    getSavedRepositories.mockResolvedValue([repo('a')]);
+    listAccounts.mockResolvedValue([account('x', 1)]);
+
+    await enforceTierLimits();
+
+    expect(saveRepositories).not.toHaveBeenCalled();
+    expect(removeAccount).not.toHaveBeenCalled();
+  });
+
+  it('truncates restored repos down to the cap, keeping the most recent', async () => {
+    const a = repo('a');
+    const b = repo('b');
+    const c = repo('c');
+    getSavedRepositories.mockResolvedValue([a, b, c]);
+
+    await enforceTierLimits();
+
+    expect(saveRepositories).toHaveBeenCalledTimes(1);
+    expect(saveRepositories).toHaveBeenCalledWith([c]);
+  });
+
+  it('truncates restored accounts down to the cap, removing the extras', async () => {
+    listAccounts.mockResolvedValue([
+      account('oldest', 10),
+      account('middle', 20),
+      account('newest', 30),
+    ]);
+
+    await enforceTierLimits();
+
+    expect(removeAccount).toHaveBeenCalledTimes(2);
+    expect(removeAccount).toHaveBeenCalledWith('oldest');
+    expect(removeAccount).toHaveBeenCalledWith('middle');
+    expect(removeAccount).not.toHaveBeenCalledWith('newest');
+  });
+
+  it('caps are one repo and one account', () => {
+    expect(FREE_TIER_MAX_REPOS).toBe(1);
+    expect(FREE_TIER_MAX_ACCOUNTS).toBe(1);
+  });
+});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -386,7 +386,7 @@ jest.mock('react-native-purchases', () => {
     configure: jest.fn(async () => undefined),
     getOfferings: jest.fn(async () => ({ current: null })),
     purchasePackage: jest.fn(async () => ({
-      customerInfo: { entitlements: { active: { pro: { isActive: true, periodType: 'NORMAL' } } } },
+      customerInfo: { entitlements: { active: { 'GitNotēs Pro': { isActive: true, periodType: 'NORMAL' } } } },
     })),
     restorePurchases: jest.fn(async () => ({ entitlements: { active: {} } })),
     getCustomerInfo: jest.fn(async () => ({

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -10,6 +10,7 @@ import { HintIcon } from '../ui/HintIcon';
 import { aiMemoryIndex } from '../../services/ai/AIMemoryIndexService';
 import { HapticService } from '../../utils/haptics';
 import { promptProUpgrade } from '../../utils/proAlerts';
+import { FREE_TIER_MAX_REPOS } from '../../services/TierLimits';
 import {
   SUPPORTED_LANGUAGES,
   getLanguagePreference,
@@ -638,11 +639,11 @@ export function SettingsContent(props: SettingsContentProps) {
           ))
         )}
         <GroupRow
-          testID={!isPro && repositories.length >= 1 ? 'settings.row.add-repo-locked' : 'settings.button.repo-picker'}
-          onPress={!isPro && repositories.length >= 1 ? () => promptProUpgrade(t, onOpenPaywall) : onOpenRepoPicker}
+          testID={!isPro && repositories.length >= FREE_TIER_MAX_REPOS ? 'settings.row.add-repo-locked' : 'settings.button.repo-picker'}
+          onPress={!isPro && repositories.length >= FREE_TIER_MAX_REPOS ? () => promptProUpgrade(t, onOpenPaywall) : onOpenRepoPicker}
           leading={<Ionicons name="add" size={20} color={colors.primary} />}
           trailing={
-            !isPro && repositories.length >= 1 ? (
+            !isPro && repositories.length >= FREE_TIER_MAX_REPOS ? (
               <Ionicons name="lock-closed" size={18} color={colors.textSecondary} />
             ) : undefined
           }

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -94,17 +94,25 @@ export default function AppNavigator({ showOnboarding, onOnboardingComplete, onO
   const openChatRepoPicker = useAIHubStore((state) => state.openChatRepoPicker);
   const closeChatRepoPicker = useAIHubStore((state) => state.closeChatRepoPicker);
   const [currentRouteName, setCurrentRouteName] = useState<string | undefined>(undefined);
+  const [navigationReady, setNavigationReady] = useState(false);
   const isPro = useProStore(selectIsPro);
   const interstitialEligible = useProStore((s) => s.interstitialEligible);
   const markInterstitialShown = useProStore((s) => s.markInterstitialShown);
 
+  // Deferred interstitial: only consume the one-shot flag after confirming navigation is ready.
+  // navigationReady state variable ensures re-check when onReady fires.
+  const hasNavigatedToInterstitial = React.useRef(false);
   useEffect(() => {
-    if (!interstitialEligible || isPro) return;
+    if (!interstitialEligible || isPro || hasNavigatedToInterstitial.current) return;
+    if (!navigationRef.isReady()) return;
+    hasNavigatedToInterstitial.current = true;
     markInterstitialShown();
-    if (navigationRef.isReady()) {
-      navigationRef.navigate('Paywall');
-    }
-  }, [interstitialEligible, isPro, markInterstitialShown, navigationRef]);
+    navigationRef.navigate('Paywall');
+  }, [interstitialEligible, isPro, markInterstitialShown, navigationRef, navigationReady]);
+
+  const handleOnReady = React.useCallback(() => {
+    setNavigationReady(true);
+  }, []);
 
   useEffect(() => {
     if (showOnboarding) return;
@@ -165,7 +173,10 @@ export default function AppNavigator({ showOnboarding, onOnboardingComplete, onO
         linking={linking}
         theme={navigationTheme}
         ref={navigationRef}
-        onReady={handleStateChange}
+        onReady={() => {
+          handleStateChange();
+          setNavigationReady(true);
+        }}
         onStateChange={handleStateChange}
       >
         <View style={{ flex: 1 }}>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -54,6 +54,7 @@ import { RepoAccessPreflightError } from '../services/git/repoAccessPreflight';
 import { useProStatus } from '../hooks/useProGate';
 import { useProStore } from '../stores/proStore';
 import { promptProUpgrade } from '../utils/proAlerts';
+import { FREE_TIER_MAX_REPOS, FREE_TIER_MAX_ACCOUNTS } from '../services/TierLimits';
 
 // Mirrors GitFsService's MAX_CLONE_RETRIES so a failing repo can't loop the outer flow.
 const MAX_OUTER_CLONE_RETRIES = 1;
@@ -655,7 +656,7 @@ export default function SettingsScreen() {
 
   const handleSelectGithubRepo = useCallback(async (repo: GitHubRepository) => {
     if (isAddingRepoPath !== null) return;
-    if (repositories.length >= 1 && !isPro) {
+    if (repositories.length >= FREE_TIER_MAX_REPOS && !isPro) {
       promptProUpgrade(t, openPaywall);
       return;
     }
@@ -704,7 +705,7 @@ export default function SettingsScreen() {
     if (isAddingRepoPath !== null) return;
     const value = manualRepoInput.trim();
     if (!value) return;
-    if (repositories.length >= 1 && !isPro) {
+    if (repositories.length >= FREE_TIER_MAX_REPOS && !isPro) {
       promptProUpgrade(t, openPaywall);
       return;
     }
@@ -1010,7 +1011,7 @@ export default function SettingsScreen() {
         setStyle={setStyle}
         onOpenConnectToken={() => { setTokenModalMode('connect'); setTokenInput(''); setTokenError(null); setTokenTestResult(null); setTokenVisible(false); setShowTokenModal(true); }}
         onOpenAddAccount={() => {
-          if (accounts.length >= 1 && !isPro) {
+          if (accounts.length >= FREE_TIER_MAX_ACCOUNTS && !isPro) {
             promptProUpgrade(t, openPaywall);
             return;
           }
@@ -1025,7 +1026,7 @@ export default function SettingsScreen() {
           setShowConnectHostModal(true);
         }}
         onAddHostLocked={() => {
-          if (accounts.length >= 1 && !isPro) {
+          if (accounts.length >= FREE_TIER_MAX_ACCOUNTS && !isPro) {
             promptProUpgrade(t, openPaywall);
           } else {
             setConnectHostPreset(undefined);

--- a/src/services/GrandfatherService.ts
+++ b/src/services/GrandfatherService.ts
@@ -15,6 +15,7 @@ export interface GrandfatherResult {
 
 export interface GrandfatherCustomerInfo {
   originalApplicationVersion?: string | null;
+  firstSeenAppVersion?: string | null;
 }
 
 async function getStoredValue(key: string): Promise<string | null> {
@@ -39,10 +40,14 @@ export async function resolveGrandfatherStatus(
   const checked = await getStoredValue(GRANDFATHER_CHECKED_KEY);
   if (checked === 'true') return { isGrandfathered: false, reason: 'checked' };
 
-  // ios-build path: originalApplicationVersion < 9 is a strong anti-bypass signal.
-  const originalVersion = customerInfo?.originalApplicationVersion;
-  if (originalVersion != null) {
-    const parsed = Number.parseInt(originalVersion, 10);
+  // ios-build path: originalApplicationVersion on iOS, firstSeenAppVersion on Android.
+  // Only treat as build number if it is a pure integer — marketing version strings
+  // like '1.0.0' must NOT grant free Pro (parseInt('1.0.0') = 1 < 9 would bypass).
+  const version =
+    customerInfo?.originalApplicationVersion ?? customerInfo?.firstSeenAppVersion;
+  if (version != null) {
+    const isPureBuildNumber = /^\d+$/.test(version);
+    const parsed = isPureBuildNumber ? Number.parseInt(version, 10) : NaN;
     if (Number.isFinite(parsed) && parsed < PRO_PAYWALL_FIRST_BUILD) {
       await markGrandfathered();
       return { isGrandfathered: true, reason: 'ios-build' };

--- a/src/services/TierLimits.ts
+++ b/src/services/TierLimits.ts
@@ -1,0 +1,61 @@
+import { AccountStorage } from './AccountStorage';
+import { StorageService } from './StorageService';
+import { selectIsPro, useProStore } from '../stores/proStore';
+
+/**
+ * Free-tier caps. The UI add-flows (SettingsScreen / SettingsContent) refuse
+ * to add a repo or account beyond these for non-Pro users. Android Auto
+ * Backup restores the AsyncStorage DB directly, which can resurrect an
+ * over-limit set of repos/accounts without ever passing through those flows
+ * (#1233). Enforcing the same caps at load time closes that hole.
+ */
+export const FREE_TIER_MAX_REPOS = 1;
+export const FREE_TIER_MAX_ACCOUNTS = 1;
+
+function isPro(): boolean {
+  return selectIsPro(useProStore.getState());
+}
+
+/**
+ * Enforce the free-tier repo/account caps against data restored from a device
+ * backup. Must run AFTER the Pro entitlement has resolved (see
+ * `useProStore.initialize`) and BEFORE the stores surface restored data, so an
+ * over-limit backup is truncated instead of displayed.
+ *
+ * No-op for Pro / grandfathered users. Truncation is persisted so it survives
+ * a reload.
+ */
+export async function enforceTierLimits(): Promise<void> {
+  if (isPro()) return;
+  await enforceRepoCap();
+  await enforceAccountCap();
+}
+
+async function enforceRepoCap(): Promise<void> {
+  const repos = await StorageService.getSavedRepositories();
+  if (repos.length <= FREE_TIER_MAX_REPOS) return;
+  // Repos are stored in add order (oldest first). Keep the most recently
+  // added, which is the set the user is most likely still using.
+  await StorageService.saveRepositories(repos.slice(repos.length - FREE_TIER_MAX_REPOS));
+}
+
+async function enforceAccountCap(): Promise<void> {
+  const accounts = await AccountStorage.listAccounts();
+  if (accounts.length <= FREE_TIER_MAX_ACCOUNTS) return;
+  // Keep the most recently added account; drop the rest. `removeAccount`
+  // cleans up each account's token and host connections and re-homes the
+  // active pointers, so a restored over-limit set is actually removed rather
+  // than merely hidden.
+  const keepIds = new Set(
+    accounts
+      .slice()
+      .sort((a, b) => (b.addedAt ?? 0) - (a.addedAt ?? 0))
+      .slice(0, FREE_TIER_MAX_ACCOUNTS)
+      .map((a) => a.id),
+  );
+  for (const account of accounts) {
+    if (!keepIds.has(account.id)) {
+      await AccountStorage.removeAccount(account.id);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

### fixes #1227 - CRITICAL parseInt paywall bypass
Marketing version strings like `"1.0.0"` were incorrectly granted free Pro because `parseInt("1.0.0")` = `1` < `9`. Fixed with `/^\d+$/` regex — only pure build numbers grant grandfathering.

### fixes #1228 - Android users never grandfathered
`originalApplicationVersion` is iOS-only. Android users now fall back to `firstSeenAppVersion` for the ios-build grandfathering check.

### fixes #1231 - paywall interstitial flag consumed before navigation ready
The one-shot flag was `markInterstitialShown()` called before `navigationRef.isReady()` was confirmed. Fixed with `navigationReady` state variable — flag consumed only after navigation is confirmed ready.

### fixes #1230 - jest.setup.ts mock entitlement key mismatch
RC mock used `"pro"` but real app uses `"GitNotēs Pro"` (`PRO_ENTITLEMENT_ID`). Corrected.

## New file: TierLimits.ts
Enforces free-tier caps (1 repo, 1 account) at app boot for non-Pro users, so Android backup restore respects limits before data is surfaced.

## Testing
- `yarn ts:check` — clean
- `yarn jest __tests__/services/TierLimits.test.ts` — 6/6 passed
- `yarn jest __tests__/services/GrandfatherService.test.ts` — passed