### PR TITLE
fix(clone-mode): checkout ref path + stranded commits registry + docs sync (#1201 #1210 #1234)

### DIFF
--- a/docs/wiki/paywall-pro.md
+++ b/docs/wiki/paywall-pro.md
@@ -161,11 +161,11 @@ The Pro upgrade page uses a bento-grid tile layout rather than full-width cards:
 
 ## RevenueCat configuration
 
-- Entitlement: `pro` (both products grant it)
+- Entitlement: `GitNotēs Pro` (both products grant it)
 - Offering: `default` with packages `monthly` + `yearly` (optional) + `lifetime`
 - Product identifiers (must match the stores exactly):
   - iOS: `com.xaventra.gitnotes.monthly`, `com.xaventra.gitnotes.yearly`, `com.xaventra.gitnotes.lifetime`
-  - Android: `gitnotes_monthly`, `gitnotes_yearly`, `gitnotes_lifetime`
+  - Android: `com.xaventra.gitnotes.monthly:monthly-base`, `com.xaventra.gitnotes.yearly:yearly-base`, `com.xaventra.gitnotes.lifetime`
 
 ## Environment variables
 

--- a/src/screens/StageScreen.tsx
+++ b/src/screens/StageScreen.tsx
@@ -13,6 +13,9 @@ import { useGitHubActivityStore } from '../stores/githubActivityStore';
 import type { StagedItem } from '../services/git/StagingService';
 import { readDeleteFailures, parseDeleteFailureKey } from '../services/git/deleteFailures';
 import { retryDeleteFailure } from '../services/git/retryDeleteFailure';
+import { readStrandedCommits, clearStrandedCommit, type StrandedCommitEntry } from '../services/git/strandedCommits';
+import { AuthService } from '../services/AuthService';
+import { LocalGitWriter } from '../services/git/LocalGitWriter';
 import { useSafeBack } from '../hooks/useSafeBack';
 import type { RootStackParamList } from '../navigation/types';
 import { pullFromSingleRepo } from '../services/RepoPullService';
@@ -106,6 +109,8 @@ export default function StageScreen() {
   const [deleteFailures, setDeleteFailures] = useState<readonly DeleteFailureRow[]>([]);
   const [retryingKey, setRetryingKey] = useState<string | null>(null);
   const [pushErrors, setPushErrors] = useState<Record<string, string>>({});
+  const [strandedCommits, setStrandedCommits] = useState<readonly StrandedCommitEntry[]>([]);
+  const [strandedActionInProgress, setStrandedActionInProgress] = useState<string | null>(null);
 
   // Load conflicts proactively when StageScreen mounts so per-group conflict status
   // is available immediately without requiring a push attempt first.
@@ -125,9 +130,19 @@ export default function StageScreen() {
     setDeleteFailures(rows);
   }, []);
 
+  const loadStrandedCommits = useCallback(async () => {
+    const map = await readStrandedCommits();
+    const rows: StrandedCommitEntry[] = Object.values(map);
+    setStrandedCommits(rows);
+  }, []);
+
   useEffect(() => {
     void loadDeleteFailures();
   }, [loadDeleteFailures]);
+
+  useEffect(() => {
+    void loadStrandedCommits();
+  }, [loadStrandedCommits]);
 
   useEffect(() => {
     const unsub = addOnPushFailure(({ key, error }) => {
@@ -160,6 +175,59 @@ export default function StageScreen() {
     }
     void loadDeleteFailures();
   }, [loadDeleteFailures]);
+
+  const handlePushStranded = useCallback(async (entry: StrandedCommitEntry) => {
+    setStrandedActionInProgress(entry.oid);
+    try {
+      const token = await AuthService.getToken();
+      const result = await LocalGitWriter.push({
+        repoPath: entry.repo,
+        branch: entry.branch,
+        token: token ?? undefined,
+      });
+      if (result.success) {
+        await clearStrandedCommit(entry.repo, entry.branch, entry.oid);
+        void loadStrandedCommits();
+      } else {
+        Alert.alert('Push failed', result.error ?? 'Unknown error');
+      }
+    } finally {
+      setStrandedActionInProgress(null);
+    }
+  }, [loadStrandedCommits]);
+
+  const handleDiscardStranded = useCallback(async (entry: StrandedCommitEntry) => {
+    Alert.alert(
+      'Discard Stranded Commit',
+      `Discard the stranded commit "${entry.message}"? This cannot be undone.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Discard',
+          style: 'destructive',
+          onPress: async () => {
+            setStrandedActionInProgress(entry.oid);
+            try {
+              const token = await AuthService.getToken();
+              const result = await LocalGitWriter.resetToRemote({
+                repoPath: entry.repo,
+                branch: entry.branch,
+                token: token ?? undefined,
+              });
+              if (result.success) {
+                await clearStrandedCommit(entry.repo, entry.branch, entry.oid);
+                void loadStrandedCommits();
+              } else {
+                Alert.alert('Discard failed', result.error ?? 'Unknown error');
+              }
+            } finally {
+              setStrandedActionInProgress(null);
+            }
+          },
+        },
+      ],
+    );
+  }, [loadStrandedCommits]);
 
   const groups = groupStaged(staged);
 
@@ -425,6 +493,69 @@ export default function StageScreen() {
     );
   }, [colors, deleteFailures, handleRetryDelete, retryingKey]);
 
+  const renderStrandedCommits = useCallback(() => {
+    if (strandedCommits.length === 0) return null;
+    return (
+      <View className="px-4 pb-2">
+        <Text className="text-sm font-bold pt-4 pb-2" style={{ color: colors.text }}>
+          Stranded commits
+        </Text>
+        {strandedCommits.map((entry) => (
+          <View
+            key={entry.oid}
+            className="flex-row items-center justify-between py-2 border-b"
+            style={{ borderBottomWidth: 0.5, borderBottomColor: colors.border }}
+          >
+            <View className="flex-1 mr-3">
+              <View className="flex-row items-center gap-2">
+                <Text className="text-[15px] font-medium" style={{ color: colors.text }} numberOfLines={1}>
+                  {entry.sha}
+                </Text>
+                <Text className="text-xs" style={{ color: colors.textSecondary }} numberOfLines={1}>
+                  {entry.repo} · {entry.branch}
+                </Text>
+              </View>
+              <Text className="text-xs mt-0.5" style={{ color: colors.textSecondary }} numberOfLines={1}>
+                {entry.message}
+              </Text>
+              <Text className="text-xs mt-0.5" style={{ color: colors.error }} numberOfLines={1}>
+                {entry.error}
+              </Text>
+            </View>
+            <View className="flex-row items-center gap-2">
+              <TouchableOpacity
+                testID={`stage.push-stranded.${entry.oid}`}
+                onPress={() => handlePushStranded(entry)}
+                disabled={strandedActionInProgress === entry.oid}
+                accessibilityRole="button"
+                accessibilityState={{ disabled: strandedActionInProgress === entry.oid }}
+                className="px-3 py-1.5 rounded-md"
+                style={{ backgroundColor: strandedActionInProgress === entry.oid ? colors.border : colors.primary }}
+              >
+                <Text className="text-xs font-bold" style={{ color: '#ffffff' }}>
+                  Push
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                testID={`stage.discard-stranded.${entry.oid}`}
+                onPress={() => handleDiscardStranded(entry)}
+                disabled={strandedActionInProgress === entry.oid}
+                accessibilityRole="button"
+                accessibilityState={{ disabled: strandedActionInProgress === entry.oid }}
+                className="px-3 py-1.5 rounded-md"
+                style={{ backgroundColor: strandedActionInProgress === entry.oid ? colors.border : colors.error }}
+              >
+                <Text className="text-xs font-bold" style={{ color: '#ffffff' }}>
+                  Discard
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ))}
+      </View>
+    );
+  }, [colors, strandedCommits, handlePushStranded, handleDiscardStranded, strandedActionInProgress]);
+
   const renderPushErrors = useCallback(() => {
     const errorKeys = Object.keys(pushErrors);
     if (errorKeys.length === 0) return null;
@@ -556,9 +687,13 @@ export default function StageScreen() {
             <View>
               {renderPushErrors()}
               {renderFailedDeletes()}
+              {renderStrandedCommits()}
             </View>
           ) : (
-            renderFailedDeletes()
+            <View>
+              {renderFailedDeletes()}
+              {renderStrandedCommits()}
+            </View>
           )
         }
         contentContainerStyle={{

--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -11,6 +11,7 @@ import { LocalGitWriter } from './git/LocalGitWriter';
 import { classifyGitHubSyncError, isRetryableFailure, syncStatusForError } from './git/syncFailure';
 import { resolveBranch } from './git/resolveBranch';
 import { clearDeleteFailure, clearDeleteFailuresForRepo, readDeleteFailures, recordDeleteFailure, DELETE_FAILURES_STORAGE_KEY } from './git/deleteFailures';
+import { recordStrandedCommit, getStrandedCommitOid } from './git/strandedCommits';
 import { GitSyncGate, type CycleSource } from './git/GitSyncGate';
 import { batchDeleteFiles, batchUpsertFiles } from './git/BatchGitOperations';
 import type { BatchDeleteFilesResult, BatchUpsertFilesResult } from './git/BatchGitOperations';
@@ -676,6 +677,12 @@ class NoteSyncQueueServiceClass {
             kind: 'exhausted',
             at: Date.now(),
           });
+        }
+        if (isClone) {
+          const stranded = await getStrandedCommitOid(repoPath, branch);
+          if (stranded) {
+            await recordStrandedCommit(repoPath, branch, stranded.oid, stranded.message, error || 'push failed after max retries');
+          }
         }
       } else {
         updatedById.set(item.id, {

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -235,7 +235,7 @@ async function ensureOnBranch(
   if (current === branch) return;
 
   try {
-    await git.checkout({ fs, dir, ref: `refs/heads/${branch}` });
+    await git.checkout({ fs, dir, ref: branch });
     return;
   } catch {
     // local branch ref is missing - fetch then retry checkout below.
@@ -251,7 +251,7 @@ async function ensureOnBranch(
     tags: false,
     onAuth: tokenAuth(token),
   });
-  await git.checkout({ fs, dir, ref: `refs/heads/${branch}` });
+  await git.checkout({ fs, dir, ref: branch });
 }
 
 /**

--- a/src/services/git/strandedCommits.ts
+++ b/src/services/git/strandedCommits.ts
@@ -1,0 +1,149 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import git from 'isomorphic-git';
+import { parseRepoPath } from '../../utils/gitPathParser';
+import { makeGitFs } from './gitFs';
+
+const CLONES_SUBDIR = 'GitNotes/';
+
+function clonesRoot(): string {
+  const docDir = require('expo-file-system').documentDirectory;
+  if (!docDir) {
+    throw new Error('expo-file-system documentDirectory is not available');
+  }
+  return docDir.endsWith('/') ? docDir + CLONES_SUBDIR : docDir + '/' + CLONES_SUBDIR;
+}
+
+function makeRepoFs() {
+  return makeGitFs(clonesRoot());
+}
+
+function repoDirVirtual(owner: string, repo: string): string {
+  return '/' + owner + '/' + repo;
+}
+
+/**
+ * Durable record of stranded local commits that failed to push after
+ * MAX_ATTEMPTS retries in clone mode.
+ */
+export const STRANDED_COMMITS_STORAGE_KEY = '@gitnotes:stranded_commits_v1';
+
+export interface StrandedCommitEntry {
+  key: string;
+  sha: string;
+  oid: string;
+  message: string;
+  strandedAt: number;
+  repo: string;
+  branch: string;
+  error: string;
+}
+
+export type StrandedCommitMap = Record<string, StrandedCommitEntry>;
+
+export function strandedCommitKey(
+  repo: string,
+  branch: string,
+  oid: string,
+): string {
+  return repo + '::' + branch + '::' + oid;
+}
+
+export async function getStrandedCommitOid(
+  repoPath: string,
+  branch: string,
+): Promise<{ oid: string; message: string } | null> {
+  const info = parseRepoPath(repoPath);
+  if (!info) return null;
+
+  const localRef = 'refs/heads/' + branch;
+  const remoteRef = 'refs/remotes/origin/' + branch;
+  const dir = repoDirVirtual(info.owner, info.repo);
+  const fs = makeRepoFs();
+
+  try {
+    const localOid = await git.resolveRef({ fs, dir, ref: localRef });
+    const remoteOid = await git.resolveRef({ fs, dir, ref: remoteRef }).catch(() => null);
+
+    if (remoteOid === null) return null;
+    if (localOid === remoteOid) return null;
+
+    const commits = await git.log({ fs, dir, ref: localRef, depth: 100 });
+    for (const commit of commits) {
+      if (commit.oid === remoteOid) break;
+      if (commit.oid !== remoteOid) {
+        const message = commit.commit.message.split('\n')[0] ?? '';
+        return { oid: commit.oid, message };
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readStrandedCommits(): Promise<StrandedCommitMap> {
+  try {
+    const raw = await AsyncStorage.getItem(STRANDED_COMMITS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return parsed as StrandedCommitMap;
+  } catch {
+    return {};
+  }
+}
+
+export async function recordStrandedCommit(
+  repo: string,
+  branch: string,
+  oid: string,
+  message: string,
+  error: string,
+): Promise<void> {
+  try {
+    const map = await readStrandedCommits();
+    const key = strandedCommitKey(repo, branch, oid);
+    map[key] = {
+      key,
+      sha: oid.slice(0, 7),
+      oid,
+      message,
+      strandedAt: Date.now(),
+      repo,
+      branch,
+      error,
+    };
+    await AsyncStorage.setItem(STRANDED_COMMITS_STORAGE_KEY, JSON.stringify(map));
+  } catch { /* best-effort */ }
+}
+
+export async function clearStrandedCommit(
+  repo: string,
+  branch: string,
+  oid: string,
+): Promise<void> {
+  try {
+    const map = await readStrandedCommits();
+    const key = strandedCommitKey(repo, branch, oid);
+    if (!(key in map)) return;
+    delete map[key];
+    await AsyncStorage.setItem(STRANDED_COMMITS_STORAGE_KEY, JSON.stringify(map));
+  } catch { /* best-effort */ }
+}
+
+export async function clearStrandedCommitsForRepo(repoPath: string): Promise<void> {
+  try {
+    const map = await readStrandedCommits();
+    const prefix = repoPath + '::';
+    let changed = false;
+    for (const key of Object.keys(map)) {
+      if (key.startsWith(prefix)) {
+        delete map[key];
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    await AsyncStorage.setItem(STRANDED_COMMITS_STORAGE_KEY, JSON.stringify(map));
+  } catch { /* best-effort */ }
+}


### PR DESCRIPTION
## Summary

### fixes #1201 - Pull/Discard silent no-ops on iPhone
LocalGitWriter.checkout was passing full ref path `refs/heads/${branch}` to git.checkout, but isomorphic-git automatically prepends `refs/heads/` — creating nested refs like `refs/heads/refs/heads/main`. This caused Pull and Discard to silently fail. Fixed by passing bare branch name.

### fixes #1210 - Clone-mode push stranding
When processDrainGroup exhausts MAX_ATTEMPTS=8 retries, local commits were orphaned (left on refs/heads/<branch>) with no recovery path. New `strandedCommits.ts` registry tracks them; StageScreen shows "Stranded commits" section with per-entry Push/Discard actions.

### fixes #1234 - docs/wiki paywall-pro.md out of sync
Entitlement corrected from `pro` to `GitNotēs Pro`; Android product IDs updated with base-plan suffixes (`:monthly-base`, `:yearly-base`).

## Testing
- `yarn ts:check` — clean