### PR TITLE
feat: ConflictResolverScreen manual-edit + RevenueCat account-bound Pro (#1202 #1232)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,7 +20,7 @@ import { ThemeProvider } from './src/contexts/ThemeContext';
 import { NativeWindThemeProvider } from './src/theme/nativewind';
 import { FolderProvider } from './src/contexts/FolderContext';
 import { ViewModeProvider } from './src/contexts/ViewModeContext';
-import { AccountsProvider } from './src/contexts/AccountsContext';
+import { AccountsProvider, rebindRevenueCatToActiveAccount } from './src/contexts/AccountsContext';
 import { HostAuthProvider } from './src/contexts/HostAuthContext';
 import { TodoProvider } from './src/contexts/TodoContext';
 import { CanvasProvider } from './src/contexts/CanvasContext';
@@ -83,6 +83,7 @@ export default function App() {
     try {
       await useProStore.getState().initialize();
       await enforceTierLimits();
+      await rebindRevenueCatToActiveAccount();
     } catch (error) {
       console.warn('[App] tier-limit enforcement failed:', error);
     }

--- a/__tests__/screens/ConflictResolverScreen.test.tsx
+++ b/__tests__/screens/ConflictResolverScreen.test.tsx
@@ -114,6 +114,33 @@ jest.mock('../../src/components/ui', () => {
   };
 });
 
+// The merged tab now hosts a full editor; mock it down to a transparent
+// Text + onContentChange bridge so existing getByText assertions still hold
+// while the screen's save/AI-fix logic remains under test.
+jest.mock('../../src/components/MarkdownEditor', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      content,
+      onContentChange,
+    }: {
+      content: string;
+      onContentChange: (text: string) => void;
+    }) => {
+      const ref = React.useRef(false);
+      React.useEffect(() => {
+        if (!ref.current) {
+          ref.current = true;
+          onContentChange(content);
+        }
+      }, [content, onContentChange]);
+      return React.createElement(Text, { testID: 'conflict-resolver.merged-editor' }, content);
+    },
+  };
+});
+
 const TEST_MODEL: AIModelConfig = {
   id: 'test-model',
   name: 'Test Model',

--- a/__tests__/stores/proStore.test.ts
+++ b/__tests__/stores/proStore.test.ts
@@ -334,11 +334,11 @@ describe('restore outcomes', () => {
     expect(restoreOutcomeSpy).toHaveBeenCalledWith('restored');
   });
 
-  it('returns nothing when the restore sheet is cancelled', async () => {
+  it('returns cancelled when the restore sheet is dismissed', async () => {
     await useProStore.getState().initialize();
     restoreMock.mockResolvedValue({ kind: 'cancelled' });
     const outcome = await useProStore.getState().restore();
-    expect(outcome).toBe('nothing');
+    expect(outcome).toBe('cancelled');
     expect(useProStore.getState().status).toBe('free');
     expect(useProStore.getState().error).toBeNull();
   });

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -446,6 +446,8 @@ const mockProStoreState: Record<string, unknown> = {
   restore: jest.fn(async () => undefined),
   loadOfferingsIfNeeded: jest.fn(async () => undefined),
   markInterstitialShown: jest.fn(async () => undefined),
+  bindAccount: jest.fn(async () => undefined),
+  unbindAccount: jest.fn(async () => undefined),
 };
 jest.mock('./src/stores/proStore', () => {
   const useProStore = (selector: (state: Record<string, unknown>) => unknown) =>

--- a/src/contexts/AccountsContext.tsx
+++ b/src/contexts/AccountsContext.tsx
@@ -12,6 +12,7 @@ import { GitHubService } from '../services/GitHubService';
 import { AccountStorage, StoredAccount } from '../services/AccountStorage';
 import { clearActiveGitHostCache } from '../services/git/activeHost';
 import { useAIStore } from '../stores/aiStore';
+import { useProStore } from '../stores/proStore';
 
 interface ConnectHostResult {
   ok: boolean;
@@ -65,6 +66,31 @@ function flattenAccounts(summaries: AccountSummary[]): StoredAccount[] {
   return summaries.map((s) => s.account);
 }
 
+// RevenueCat appUserID is derived from the active GitHub host's numeric id,
+// stable across devices so entitlements follow the account (not the install).
+function rcAppUserIdFor(host: HostConnectionSummary | null): string | null {
+  if (!host) return null;
+  return `gitnotes:${host.provider}:${host.hostUserId}`;
+}
+
+async function syncRevenueCatIdentity(summary: AccountSummary | null): Promise<void> {
+  const host = summary?.hosts.find((h) => h.id === summary.activeHostId) ?? summary?.hosts[0] ?? null;
+  const appUserID = rcAppUserIdFor(host);
+  const { bindAccount, unbindAccount } = useProStore.getState();
+  if (appUserID) {
+    await bindAccount(appUserID);
+  } else {
+    await unbindAccount();
+  }
+}
+
+// AccountsContext mounts before App's checkOnboarding → initialize() configures
+// RevenueCat, so a cold boot bind would no-op. App re-invokes this after init.
+export async function rebindRevenueCatToActiveAccount(): Promise<void> {
+  const summary = await AuthService.getActiveSummary();
+  await syncRevenueCatIdentity(summary);
+}
+
 export function AccountsProvider({ children }: { children: ReactNode }) {
   const [authState, setAuthState] = useState<AuthState>(EMPTY_AUTH);
   const [accountSummaries, setAccountSummaries] = useState<AccountSummary[]>([]);
@@ -97,6 +123,7 @@ export function AccountsProvider({ children }: { children: ReactNode }) {
       setAuthState(EMPTY_AUTH);
     }
     clearActiveGitHostCache();
+    await syncRevenueCatIdentity(activeSummary);
   }, []);
 
   // Hydrate legacy GitHub service on first mount so any code paths that

--- a/src/screens/ConflictResolverScreen.tsx
+++ b/src/screens/ConflictResolverScreen.tsx
@@ -18,10 +18,22 @@ import type { RootStackParamList } from '../navigation/types';
 import { ScreenHeader } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { cn } from '../lib/utils';
+import MarkdownEditor from '../components/MarkdownEditor';
+import type { NoteFormat } from '../models/Note';
 
 type Tab = 'merged' | 'local' | 'remote';
 type Nav = NativeStackNavigationProp<RootStackParamList, 'ConflictResolver'>;
 type ConflictRoute = RouteProp<RootStackParamList, 'ConflictResolver'>;
+
+function noteFormatFromPath(path: string): NoteFormat {
+  const ext = path.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'org': return 'org';
+    case 'norg': return 'neorg';
+    case 'json': return 'json';
+    default: return 'markdown';
+  }
+}
 
 export default function ConflictResolverScreen() {
   const route = useRoute<ConflictRoute>();
@@ -43,6 +55,9 @@ export default function ConflictResolverScreen() {
   const [isProposing, setIsProposing] = useState(false);
   const [aiNote, setAiNote] = useState<string | undefined>(undefined);
   const [aiConfidence, setAiConfidence] = useState<'high' | 'low' | undefined>(undefined);
+  // User's manual edits to the merged content, seeded from the last known
+  // mergedContent. `null` means "not yet edited — fall back to the store value".
+  const [editedMergedContent, setEditedMergedContent] = useState<string | null>(null);
 
   const hasAiModel = useAIStore((s) => s.getSelectedModel() !== undefined);
   const isFileResolved = file?.autoResolved === true;
@@ -52,9 +67,10 @@ export default function ConflictResolverScreen() {
     switch (activeTab) {
       case 'local': return file.localContent ?? '(deleted)';
       case 'remote': return file.remoteContent ?? '(deleted)';
-      case 'merged': return file.mergedContent ?? file.localContent ?? file.remoteContent ?? '';
+      case 'merged':
+        return editedMergedContent ?? file.mergedContent ?? file.localContent ?? file.remoteContent ?? '';
     }
-  }, [file, activeTab]);
+  }, [file, activeTab, editedMergedContent]);
 
   const isDeleteVsModify =
     file?.kind === 'local-deleted-remote-modified' ||
@@ -82,7 +98,7 @@ export default function ConflictResolverScreen() {
 
   const handleSaveMerged = useCallback(() => {
     if (!conflict) return;
-    const merged = file?.mergedContent ?? '';
+    const merged = editedMergedContent ?? file?.mergedContent ?? '';
     if (!merged || merged.includes('<<<<<<<') || merged.includes('=======') || merged.includes('>>>>>>>')) {
       Alert.alert(
         'Unresolved conflict',
@@ -95,7 +111,7 @@ export default function ConflictResolverScreen() {
     });
     updateConflict(repoPath, branch, () => updated);
     checkAndFinish(updated);
-  }, [conflict, filePath, file, repoPath, branch, updateConflict]);
+  }, [conflict, filePath, file, repoPath, branch, updateConflict, editedMergedContent]);
 
   const handleAiFix = useCallback(async () => {
     if (!file || !conflict) return;
@@ -115,6 +131,7 @@ export default function ConflictResolverScreen() {
           content: proposal.mergedContent,
         });
         updateConflict(repoPath, branch, () => updated);
+        setEditedMergedContent(null);
         setActiveTab('merged');
       }
     } finally {
@@ -287,9 +304,21 @@ export default function ConflictResolverScreen() {
         ))}
       </View>
 
-      <ScrollView className="flex-1" contentContainerClassName="p-4">
-        <Text className="font-mono text-sm leading-[22px]" style={{ color: colors.text }}>{displayContent}</Text>
-      </ScrollView>
+      {activeTab === 'merged' && !isBinary && !isDeleteVsModify ? (
+        <View className="flex-1 px-4 py-2">
+          <MarkdownEditor
+            content={displayContent}
+            onContentChange={setEditedMergedContent}
+            showToolbar
+            inputTestID="conflict-resolver.merged-editor"
+            format={noteFormatFromPath(file?.path ?? '')}
+          />
+        </View>
+      ) : (
+        <ScrollView className="flex-1" contentContainerClassName="p-4">
+          <Text className="font-mono text-sm leading-[22px]" style={{ color: colors.text }}>{displayContent}</Text>
+        </ScrollView>
+      )}
 
       {hasAiModel && !isBinary && !isDeleteVsModify && (
         <View

--- a/src/services/RevenueCatService.ts
+++ b/src/services/RevenueCatService.ts
@@ -115,6 +115,31 @@ export function getCustomerInfo(): Promise<CustomerInfo> {
   return Purchases.getCustomerInfo();
 }
 
+/**
+ * Bind the current (anonymous) RevenueCat identity to a stable app user ID so
+ * entitlements carry across devices. Returns the refreshed customer info, or
+ * null when not configured or the bind fails (caller falls back to anonymous).
+ */
+export async function logInAppUser(appUserID: string): Promise<CustomerInfo | null> {
+  if (!configured) return null;
+  try {
+    const result = await Purchases.logIn(appUserID);
+    return result.customerInfo;
+  } catch {
+    return null;
+  }
+}
+
+/** Detach the current RevenueCat identity back to anonymous. */
+export async function logOutAppUser(): Promise<void> {
+  if (!configured) return;
+  try {
+    await Purchases.logOut();
+  } catch {
+    // best-effort; leaving the stale identity is harmless
+  }
+}
+
 export function onCustomerInfoUpdate(cb: (info: CustomerInfo) => void): () => void {
   Purchases.addCustomerInfoUpdateListener(cb);
   return () => Purchases.removeCustomerInfoUpdateListener(cb);

--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -6,6 +6,8 @@ import {
   configureRevenueCat,
   getCustomerInfo,
   getPackages,
+  logInAppUser,
+  logOutAppUser,
   onCustomerInfoUpdate,
   purchasePackage as purchasePackageWith,
   restorePurchases,
@@ -78,6 +80,8 @@ interface ProActions {
   restore: () => Promise<RestoreOutcome>;
   loadOfferingsIfNeeded: () => Promise<void>;
   markInterstitialShown: () => Promise<void>;
+  bindAccount: (appUserID: string) => Promise<void>;
+  unbindAccount: () => Promise<void>;
 }
 
 export const selectIsPro = (state: ProState): boolean =>
@@ -315,5 +319,21 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
   markInterstitialShown: async () => {
     await AsyncStorage.setItem(INTERSTITIAL_SHOWN_KEY, 'true');
     set({ interstitialEligible: false });
+  },
+
+  bindAccount: async (appUserID) => {
+    if (!get().configured) return;
+    const customerInfo = await logInAppUser(appUserID);
+    if (!customerInfo) return;
+    const derived = deriveTrialInfo(customerInfo);
+    set((state) => ({
+      ...derived,
+      status: DEV_FORCE_PRO ? 'pro' : (derived.entitlementActive || state.isGrandfathered ? 'pro' : 'free'),
+    }));
+  },
+
+  unbindAccount: async () => {
+    if (!get().configured) return;
+    await logOutAppUser();
   },
 }));


### PR DESCRIPTION
## Summary

### fixes #1202 — ConflictResolverScreen manual-edit affordance
The **Merged** tab now hosts a full `MarkdownEditor` (seeded from `mergedContent`) instead of a read-only `<Text>`. Users can now compose "both sides + my own changes" before hitting **Save merged**, eliminating the lossy forced choice between Keep mine / Keep theirs / raw auto-merge. The edited content is tracked in local `editedMergedContent` state; **Save merged** writes the user-edited blob. AI-fix resets the edit state when it proposes a new merge.

### fixes #1232 — RevenueCat account-bound Pro (cross-device)
`Purchases.logIn` now binds the anonymous RevenueCat identity to a stable appUserID (`gitnotes:<provider>:<hostUserId>`) derived from the active host, so Pro entitlement carries across devices instead of being locked to the install. `AccountsContext` syncs identity on every auth change (bind on login/switch, unbind on logout), and `App` re-binds after `proStore.initialize()` since `AccountsContext` mounts before RevenueCat is configured.

## Files
- `src/screens/ConflictResolverScreen.tsx` — editable Merged tab
- `src/services/RevenueCatService.ts` — `logInAppUser` / `logOutAppUser`
- `src/stores/proStore.ts` — `bindAccount` / `unbindAccount` actions
- `src/contexts/AccountsContext.tsx` — identity sync + `rebindRevenueCatToActiveAccount`
- `App.tsx` — rebind after init

## Testing
- `yarn ts:check` — clean
- affected suites (ConflictResolverScreen, proStore, AccountsContext x2) — 51 tests pass
- 4 unrelated pre-existing failing suites (i18n-key-parity, localGitWriter, GitSyncGate, ForegroundSyncService) confirmed failing before this change