### PR TITLE
fix(staging): discardStaged clears sync queue so staged items vanish immediately (#1201)

### DIFF
--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -271,6 +271,18 @@ class NoteSyncQueueServiceClass {
     } catch { /* best-effort */ }
   }
 
+  async purgeForRepoAndBranch(repoPath: string, branch: string): Promise<void> {
+    const queue = await this.getAll();
+    const remaining = queue.filter((m) => {
+      if (m.params.repo !== repoPath) return true;
+      const mBranch = m.params.branch || 'main';
+      return mBranch !== branch;
+    });
+    if (remaining.length < queue.length) {
+      await this.saveAll(remaining);
+    }
+  }
+
   async purgeForRepo(repoPath: string): Promise<void> {
     const queue = await this.getAll();
     const remaining = queue.filter((m) => m.params.repo !== repoPath);

--- a/src/services/git/StagingService.ts
+++ b/src/services/git/StagingService.ts
@@ -437,12 +437,14 @@ export class StagingService {
           if (realFiles.length > 0) {
             await GitFsService.unstageFiles({ repoPath, files: realFiles });
           }
+          await NoteSyncQueueService.purgeForRepoAndBranch(repoPath, branch);
           notifyStagedChanged();
           return { success: true };
         }
         return { success: false, error: result.error };
       }
 
+      await NoteSyncQueueService.purgeForRepoAndBranch(repoPath, branch);
       notifyStagedChanged();
       return { success: true };
     } catch (error) {


### PR DESCRIPTION
## Summary

**Root cause**: `StagingService.discardStaged` resets the git branch to origin (via `LocalGitWriter.resetToRemote`), which removes local commits. However, the `NoteSyncQueueService` sync queue was NOT being cleared. After `loadStaged()` re-read the queue, all queued mutations re-appeared as staged items — making the Discard button appear to do nothing.

**Fix**: After a successful git reset in `discardStaged`, call `NoteSyncQueueService.purgeForRepoAndBranch(repoPath, branch)` to clear queued mutations for that specific (repo, branch). Also clears the queue in the fallback path (no remote ref).

Also added `purgeForRepoAndBranch` to `NoteSyncQueueService` (branch-aware variant of existing `purgeForRepo`).

## Files
- `src/services/NoteSyncQueueService.ts` — added `purgeForRepoAndBranch`
- `src/services/git/StagingService.ts` — call `purgeForRepoAndBranch` after successful git reset

## Testing
- `yarn ts:check` — clean
- StagingService + NoteSyncQueueService test suites — 96 tests pass
- stageStore + StageScreen test suites — 20 tests pass
- full suite — 2926 pass, 10 pre-existing failures (unrelated)