### PR TITLE
fix(notif): dedup push-failure notifications within 2-minute window

### DIFF
--- a/__tests__/services/PushNotificationService.test.ts
+++ b/__tests__/services/PushNotificationService.test.ts
@@ -77,13 +77,38 @@ describe('PushNotificationService', () => {
       expect.any(String),
       { kind: 'push-failure', repoPath: '/repo/path', branch: 'main', conflict: true },
     );
+  });
 
-    handler({ key: '/repo/path::main', error: 'remote branch has conflicting changes' });
-    expect(mockSchedulePushFailure).toHaveBeenLastCalledWith(
-      'Push failed',
-      expect.any(String),
-      { kind: 'push-failure', repoPath: '/repo/path', branch: 'main', conflict: true },
-    );
+  test('repeated push failures for the same (repo, branch) within the dedup window are suppressed', () => {
+    pushService.attachToScheduler();
+    const handler = mockAddOnPushFailure.mock.calls[0][0] as FailureHandler;
+
+    handler({ key: '/repo/path::main', error: 'boom' });
+    expect(mockSchedulePushFailure).toHaveBeenCalledTimes(1);
+
+    jest.setSystemTime(5000 + 30 * 1000);
+    handler({ key: '/repo/path::main', error: 'still failing' });
+    expect(mockSchedulePushFailure).toHaveBeenCalledTimes(1);
+  });
+
+  test('push failures for different (repo, branch) are not deduped against each other', () => {
+    pushService.attachToScheduler();
+    const handler = mockAddOnPushFailure.mock.calls[0][0] as FailureHandler;
+
+    handler({ key: '/repo/a::main', error: 'boom' });
+    handler({ key: '/repo/b::main', error: 'boom' });
+    expect(mockSchedulePushFailure).toHaveBeenCalledTimes(2);
+  });
+
+  test('push failures for the same (repo, branch) past the dedup window are notified again', () => {
+    pushService.attachToScheduler();
+    const handler = mockAddOnPushFailure.mock.calls[0][0] as FailureHandler;
+
+    handler({ key: '/repo/path::main', error: 'boom' });
+    expect(mockSchedulePushFailure).toHaveBeenCalledTimes(1);
+    jest.setSystemTime(5000 + 3 * 60 * 1000);
+    handler({ key: '/repo/path::main', error: 'boom' });
+    expect(mockSchedulePushFailure).toHaveBeenCalledTimes(2);
   });
 
   test('start notification fires via dismissAndReschedule with body-text file count', () => {

--- a/src/services/PushNotificationService.ts
+++ b/src/services/PushNotificationService.ts
@@ -5,6 +5,11 @@ import { NotificationService } from './NotificationService';
 
 const PROGRESS_THROTTLE_MS = 1000;
 
+/** Dedup window for push-failure notifications: a stuck push that retries
+ * every interval cycle otherwise spams the user with identical alerts. */
+const PUSH_FAILURE_DEDUP_WINDOW_MS = 2 * 60 * 1000;
+const lastFailureNotifiedAt = new Map<string, number>();
+
 /** Foregrounded app shows progress in-UI (ring + activity banner) — no banner needed. */
 function appIsForegrounded(): boolean {
   return AppState.currentState === 'active';
@@ -43,6 +48,10 @@ export function attachToScheduler(): void {
     const parts = parsePushKey(key);
     if (parts === null) return;
     const { repoPath, branch } = parts;
+    const dedupKey = `${repoPath}::${branch}`;
+    const last = lastFailureNotifiedAt.get(dedupKey);
+    if (last !== undefined && Date.now() - last < PUSH_FAILURE_DEDUP_WINDOW_MS) return;
+    lastFailureNotifiedAt.set(dedupKey, Date.now());
     const conflict = error.toLowerCase().includes('conflict');
     void NotificationService.schedulePushFailure(
       'Push failed',


### PR DESCRIPTION
## Summary
A stuck push that retries on every foreground interval cycle spams the user
with identical "Push failed" local notifications. Suppress repeats for the
same (repoPath, branch) within 2 minutes.

## Test plan
- New unit tests in `PushNotificationService.test.ts`:
  - single failure → notified once
  - second failure for same (repo, branch) within window → suppressed
  - failure for different (repo, branch) → not deduped (separate)
  - failure past the dedup window → notified again
- Existing payload-shape and conflict tests still pass (one assertion each,
no double-fire within window)

## Verification
- `yarn ts:check` clean
- `yarn eslint` clean
- `yarn jest PushNotificationService` 10/10 pass
- `yarn jest PushNotificationService StagePushScheduler StagingService gitFs` 88/88 pass
- Full suite: 0 new failures (pre-existing flakes in i18n/GitSyncGate/ForegroundSync
  exist on clean branch tip, unrelated to this change)