### PR TITLE
docs(agents): require worktrees for all agent work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,37 @@
 
 > Rules for AI coding agents working in this repository.
 
+## Worktrees (ALWAYS)
+
+**All agent work — fixes, features, refactors, even small edits — must happen inside a git worktree. Never edit files in the main worktree's working tree directly.**
+
+This repo regularly runs multiple agent sessions concurrently (different branches, different issues in flight). Editing the main worktree's working tree races every other session because they all serve from / commit against the same `main` working tree. The multiple times this session was blocked by "another session's uncommitted changes in main" made this rule non-negotiable.
+
+### Workflow
+
+```bash
+# From the repo root (the main worktree):
+git worktree add -b <type>/<scope>-<slug> .worktrees/<scope>-<slug> main
+# e.g.  git worktree add -b fix/discard-placeholder .worktrees/fix-discard main
+
+# Always create the worktree under .worktrees/ at the repo root — never in
+# /tmp, the home directory, or anywhere outside the repo. .worktrees/ is
+# gitignored so the symlink/node_modules and per-worktree state don't pollute git.
+
+ln -sfn "$(pwd)/node_modules" .worktrees/<scope>-<slug>/node_modules
+# node_modules is a 2.5 GB tree that is symlinked from main into the worktree
+# so Metro (which is rooted at main) and jest (which resolves from the worktree)
+# both work without a duplicate install.
+```
+
+### Rules
+
+- **One worktree per branch.** Never branch from another worktree's branch — always branch from `main` (or the upstream you're targeting). After `git fetch origin` in the main repo, base new worktrees on the updated `origin/main`.
+- **Coordinate before touching shared files.** Before editing `conflictStore.ts`, `StagePushScheduler.ts`, `LocalGitWriter.ts`, or any file another agent's `git status` shows as modified in the main working tree, check `git worktree list` and `git status` in the other worktrees. If another session has uncommitted work on the same files, wait or scope your change to a different file.
+- **Metro serves from main.** The Expo dev-client connects to Metro on the main worktree's port (8081). If you need your branch code to be served by Metro (e.g. for sim surface verification), copy the changed files from your worktree into main's working tree temporarily and revert after verification — Metro cannot serve from a worktree (`.worktrees/` is in `metro.config.js`'s `resolver.blockList`).
+- **Do not commit secrets / tokens / Metro debug output** — review `git diff` before committing. This applies whether you are in a worktree or not.
+- **Clean up** with `git worktree remove <path>` when a branch is merged and the worktree is no longer needed. Branches are cheap to recreate.
+
 ## Testing
 
 All tests must pass before pushing:
@@ -30,7 +61,7 @@ yarn eslint . --ext .ts,.tsx  # Linting
 - Atomic commits with descriptive messages (imperative mood).
 - No `node_modules/`, `.DS_Store`, `.env`, or build artifacts.
 - Branch per feature, rebase before merging.
-- Create git worktrees inside `.worktrees/` at the repository root (e.g. `.worktrees/<branch-name>`), never in random locations such as the home directory or paths outside the repo. `.worktrees/` is already gitignored.
+- Worktrees are required — see the "Worktrees (ALWAYS)" section above. The old note that said "create git worktrees inside `.worktrees/`" was too soft; the requirement is unconditional.
 - `lint-staged` runs on pre-commit (ESLint + Prettier).
 
 ## Sync Architecture (Git Services) — source of truth


### PR DESCRIPTION
## Summary

Promotes the existing worktree note in AGENTS.md to a mandatory rule with its own dedicated section ("Worktrees (ALWAYS)"). All agent work — fixes, features, refactors, even small edits — must now happen inside a git worktree. This prevents the main working-tree race condition that repeatedly blocked this session (uncommitted changes from another agent's session).

The new section covers:
- **Why**: concurrent agent sessions racing the same working tree.
- **How**: concrete commands (`git worktree add`, symlink `node_modules`).
- **Rules**: one worktree per branch, coordinate before touching shared files, Metro serves from main, clean up merged worktrees.

Also updates the "Git Discipline" section to point at the new section instead of the old soft wording.

## Verification
- `yarn ts:check` clean (docs-only change, no type errors)
- Previewed the final file — structure intact, no broken markdown