### PR TITLE
fix(git): FAB invalidation on commit/push (#1249 bugs #2 #15 #18 #4)

### DIFF
--- a/src/components/git/FloatingPushButton.tsx
+++ b/src/components/git/FloatingPushButton.tsx
@@ -15,6 +15,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import { HapticService } from '../../utils/haptics';
 import type { RootStackParamList } from '../../navigation/types';
 import { useRepoStore } from '../../stores/repoStore';
+import { useGitActivityStore } from '../../stores/gitActivityStore';
 import { LastUsedRepoService } from '../../services/LastUsedRepoService';
 import { UnpushedCommitsService } from '../../services/git/UnpushedCommitsService';
 import {
@@ -51,6 +52,7 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
   const [activeRepoPath, setActiveRepoPath] = useState<string | null>(null);
   const [activeBranch, setActiveBranch] = useState<string>('main');
   const [unpushedCount, setUnpushedCount] = useState(0);
+  const commitRevision = useGitActivityStore((s) => s.commitRevision);
 
   useEffect(() => {
     let isMounted = true;
@@ -94,7 +96,7 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
       isMounted = false;
       clearInterval(interval);
     };
-  }, [activeRepoPath, activeBranch]);
+  }, [activeRepoPath, activeBranch, commitRevision]);
 
   const defaultX = viewportWidth - BUTTON_SIZE - insets.right - EDGE_INSET;
   const safeBottom = viewportHeight - Math.max(tabBarHeight, insets.bottom + EDGE_INSET);

--- a/src/screens/PushScreen.tsx
+++ b/src/screens/PushScreen.tsx
@@ -21,6 +21,7 @@ import { LocalGitWriter } from '../services/git/LocalGitWriter';
 import { AuthService } from '../services/AuthService';
 import { pullFromSingleRepo } from '../services/RepoPullService';
 import { useSafeBack } from '../hooks/useSafeBack';
+import { useGitActivityStore } from '../stores/gitActivityStore';
 import type { RootStackParamList } from '../navigation/types';
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'Push'>;
@@ -242,6 +243,7 @@ export default function PushScreen() {
       const result = await Promise.race([pushPromise, timeoutPromise]);
       if (result.success) {
         await pullFromSingleRepo(repoPath);
+        useGitActivityStore.getState().incrementRevision();
         Alert.alert('Pushed', 'All commits have been pushed to GitHub.', [
           { text: 'OK', onPress: () => navigation.goBack() },
         ]);

--- a/src/services/git/CommitService.ts
+++ b/src/services/git/CommitService.ts
@@ -8,6 +8,7 @@ import { LocalGitWriter } from './LocalGitWriter';
 import { getGitHostService } from './gitHostFactory';
 import type { GitHostUser } from './GitHost';
 import { repairHeadRef } from './GitFsService';
+import { useGitActivityStore } from '../../stores/gitActivityStore';
 
 const CLONES_SUBDIR = 'GitNotes/';
 
@@ -117,6 +118,7 @@ export class CommitService {
         push: false,
       });
       if (!result.success) return { success: false, error: result.error };
+      useGitActivityStore.getState().incrementRevision();
       return { success: true };
     }
 
@@ -148,6 +150,7 @@ export class CommitService {
       push: false,
     });
     if (!result.success) return { success: false, error: result.error };
+    useGitActivityStore.getState().incrementRevision();
     return { success: true };
   }
 
@@ -205,6 +208,7 @@ export class CommitService {
         author: { name: opts.author.name, email: opts.author.email },
       });
 
+      useGitActivityStore.getState().incrementRevision();
       return { success: true, oid: sha };
     } catch (e) {
       const raw = e instanceof Error ? e.message : String(e);

--- a/src/stores/gitActivityStore.ts
+++ b/src/stores/gitActivityStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface GitActivityState {
+  commitRevision: number;
+  incrementRevision: () => void;
+}
+
+export const useGitActivityStore = create<GitActivityState>((set) => ({
+  commitRevision: 0,
+  incrementRevision: () => set((s) => ({ commitRevision: s.commitRevision + 1 })),
+}));


### PR DESCRIPTION
Fixes bugs where FloatingPushButton didn't appear after note/canvas/todo/template changes and didn't disappear after push. Added commitRevision counter in gitActivityStore; CommitService increments after commit, PushScreen increments after push, FAB re-polls immediately.