### PR TITLE
fix(filters): show branch selector when repo is selected

### DIFF
--- a/src/components/EntityFilterModal.tsx
+++ b/src/components/EntityFilterModal.tsx
@@ -311,7 +311,7 @@ export function EntityFilterModal<T extends FilterableItem>(props: Props<T>) {
             }}
           />
 
-          {selectedRepo && allBranches.length > 0 && (
+          {selectedRepo && (
             <>
               <Text style={[styles.label, { color: colors.textSecondary }]}>Branch</Text>
               {renderChipRow(allBranches, selectedBranch, setSelectedBranch, 'git-branch-outline')}

--- a/src/components/notes/NotesFilterModal.tsx
+++ b/src/components/notes/NotesFilterModal.tsx
@@ -172,7 +172,7 @@ export function NotesFilterModal({
               )}
             </View>
 
-            {selectedRepo && allBranches.length > 0 ? (
+            {selectedRepo ? (
               <>
                 <Text style={[styles.label, { color: colors.textSecondary }]}>{t('notesFilter.branch')}</Text>
                 <View style={styles.chipWrap}>


### PR DESCRIPTION
## Summary

Remove the `allBranches.length > 0` guard that was hiding the branch selector when a repo had no items with branches yet. Now the branch selector always appears when a repo is selected, with 'All' as the default option.

## Changes

- **EntityFilterModal.tsx**: Changed `selectedRepo && allBranches.length > 0` → `selectedRepo`
- **NotesFilterModal.tsx**: Changed `selectedRepo && allBranches.length > 0` → `selectedRepo`

## Before

When filtering notes/todos/canvases, selecting a repo would not show the branch selector if that repo had no items with branches yet.

## After

The branch selector always appears when a repo is selected, allowing users to filter by branch even if no items exist on that branch yet.

## Testing

- TypeScript compilation: ✓
- ESLint (no new errors): ✓