### PR TITLE
fix(ui): canvas thumbnail placeholder, modal full-width iPad, template git sync (#1249 bugs #16 #17 #18)

### DIFF
--- a/src/components/CanvasThumbnail.tsx
+++ b/src/components/CanvasThumbnail.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import {
   Canvas as SkiaCanvas,
   Path,
@@ -290,6 +291,14 @@ export default function CanvasThumbnail({ scene, width, height, background }: Ca
 
     return null;
   };
+
+  if (!scene || elements.length === 0) {
+    return (
+      <View style={[styles.wrap, { width, height, backgroundColor: fillColor, justifyContent: 'center', alignItems: 'center' }]} pointerEvents="none">
+        <Ionicons name="easel-outline" size={Math.min(width, height) * 0.4} color="#9CA3AF" />
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.wrap, { width, height }]} pointerEvents="none">

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -114,7 +114,7 @@ export function Modal(props: ModalProps) {
                 }
               : {
                   width: fullWidth ? slotWidth : undefined,
-                  maxWidth: 480,
+                  maxWidth: fullWidth ? undefined : 480,
                   height: slotHeight,
                   alignItems: 'stretch',
                   justifyContent: 'center',

--- a/src/screens/TemplateManagerScreen.tsx
+++ b/src/screens/TemplateManagerScreen.tsx
@@ -18,6 +18,7 @@ import { NoteTemplate, NoteTemplateIcon } from '../services/TemplateService';
 import { HapticService } from '../utils/haptics';
 import { TemplateRepoPreferenceService, TemplateRepoPreference } from '../services/TemplateRepoPreferenceService';
 import { pullTemplatesFromConfiguredRepo } from '../services/RepoPullService';
+import { syncTemplateToGitHub } from '../services/TemplateGitHubSyncService';
 import {
   commitPendingTag,
   parseTagInput,
@@ -166,6 +167,7 @@ export default function TemplateManagerScreen() {
     const finalTags = commitPendingTag(tagDraft, draftTags);
 
     try {
+      let savedTemplate: NoteTemplate | null = null;
       if (editingId) {
         await updateTemplate(editingId, {
           name,
@@ -175,8 +177,9 @@ export default function TemplateManagerScreen() {
           content: draftContent,
           tags: finalTags,
         });
+        savedTemplate = getAllTemplates().find((t) => t.id === editingId) ?? null;
       } else {
-        await createTemplate({
+        savedTemplate = await createTemplate({
           name,
           icon: draftIcon,
           description,
@@ -185,6 +188,15 @@ export default function TemplateManagerScreen() {
           tags: finalTags,
         });
       }
+
+      if (savedTemplate && templatesRepoPref) {
+        await syncTemplateToGitHub({
+          repoPath: templatesRepoPref.repoPath,
+          branch: templatesRepoPref.branch,
+          template: savedTemplate,
+        });
+      }
+
       HapticService.success();
       setShowEditor(false);
     } catch (error) {
@@ -203,6 +215,8 @@ export default function TemplateManagerScreen() {
     editingId,
     createTemplate,
     updateTemplate,
+    templatesRepoPref,
+    getAllTemplates,
     t,
   ]);
 


### PR DESCRIPTION
Fixes issue #1249 bugs #16, #17, #18:

- **#16 Canvas list shows no preview**: CanvasThumbnail now shows a placeholder icon when scene is undefined or has no elements, making canvases distinguishable in the list.
- **#17 New template UI doesn't use full width on iPad**: Modal component now respects fullWidth mode by not applying the hardcoded maxWidth:480 constraint when fullWidth is true.
- **#18 Creating a custom template doesn't show push button**: TemplateManagerScreen now syncs templates to git after creation/update when a templates repo is configured, which creates an unpushed commit and shows the push button.

Note: Bug #19 (sync settings defaults) was already correctly defaulting to OFF.