### PR TITLE
fix(ui): issues #1249-6-9-10 - folder discovery, hint icon, spinners

### DIFF
--- a/src/components/ai/ChatRepoPickerModal.tsx
+++ b/src/components/ai/ChatRepoPickerModal.tsx
@@ -476,9 +476,10 @@ export const ChatRepoPickerModal: React.FC<ChatRepoPickerModalProps> = ({
             variant="primary"
             onPress={handleConfirm}
             disabled={!selectedRepoPath || isInitializing}
+            leadingIcon={isInitializing ? <ActivityIndicator size="small" color="#fff" /> : undefined}
           >
             {isInitializing
-              ? 'Initializing...'
+              ? 'Initializing'
               : initError
                 ? 'Retry'
                 : 'Confirm Selection'}

--- a/src/components/settings/CloneProgressModal.tsx
+++ b/src/components/settings/CloneProgressModal.tsx
@@ -1,5 +1,5 @@
-import { memo, useEffect, useState } from 'react';
-import { Text, View } from 'react-native';
+import { memo } from 'react';
+import { ActivityIndicator, Text, View } from 'react-native';
 import { Button, Modal } from '../ui';
 import { useTheme, useTokens } from '../../contexts/ThemeContext';
 
@@ -25,23 +25,16 @@ interface CloneProgressModalProps {
  * ("Attempt to present ... which is already presenting"), which silently
  * swallowed the progress UI and left users staring at an endless row spinner.
  */
-function AnimatedProgressDots({ phase }: { phase: string }) {
+function CloneProgressSpinner({ phase }: { phase: string }) {
   const { colors } = useTheme();
   const { spacing, type } = useTokens();
-  const [step, setStep] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => {
-      setStep((s) => (s + 1) % 3);
-    }, 400);
-    return () => clearInterval(id);
-  }, []);
-  useEffect(() => {
-    setStep(0);
-  }, [phase]);
   return (
-    <Text style={{ color: colors.textSecondary, fontSize: type.sm, marginBottom: spacing[4] }}>
-      {phase} {'.'.repeat(step + 1)}
-    </Text>
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[3], marginBottom: spacing[4] }}>
+      <ActivityIndicator size="small" color={colors.primary} />
+      <Text style={{ color: colors.textSecondary, fontSize: type.sm }}>
+        {phase}
+      </Text>
+    </View>
   );
 }
 
@@ -88,7 +81,7 @@ export const CloneProgressContent = memo(function CloneProgressContent({
       ) : (
         <>
           {progress.total === null ? (
-            <AnimatedProgressDots phase={progress.phase} />
+            <CloneProgressSpinner phase={progress.phase} />
           ) : (
             <Text style={{ color: colors.textSecondary, fontSize: type.sm, marginBottom: spacing[4] }}>
               {progress.phase} · {pctLabel}

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -804,11 +804,14 @@ export function SettingsContent(props: SettingsContentProps) {
         </GroupRow>
         <GroupRow
           trailing={
-            <Toggle
-              testID="settings.toggle.pause-sync"
-              value={syncPaused}
-              onValueChange={onToggleSyncPaused}
-            />
+            <View className="flex-row items-center gap-2">
+              <Toggle
+                testID="settings.toggle.pause-sync"
+                value={syncPaused}
+                onValueChange={onToggleSyncPaused}
+              />
+              <HintIcon hintKey="hints.settings.pauseForegroundSync" testID="hint.pause-foreground-sync" />
+            </View>
           }
         >
           <View className="flex-row items-center gap-2">

--- a/src/components/thoughts/ThoughtDumpRepoPickerModal.tsx
+++ b/src/components/thoughts/ThoughtDumpRepoPickerModal.tsx
@@ -471,9 +471,10 @@ export const ThoughtDumpRepoPickerModal: React.FC<ThoughtDumpRepoPickerModalProp
             variant="primary"
             onPress={handleConfirm}
             disabled={!selectedRepoPath || isInitializing}
+            leadingIcon={isInitializing ? <ActivityIndicator size="small" color="#fff" /> : undefined}
           >
             {isInitializing
-              ? 'Saving...'
+              ? 'Saving'
               : initError
                 ? 'Retry'
                 : 'Confirm Selection'}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -853,6 +853,7 @@
       "lockTimeout": "How long after closing the app before the biometric lock activates.",
       "syncFrequently": "Pulls from tracked repositories when the app comes to the foreground, when network reconnects, and on the chosen interval. Recommended for multi-device use.",
       "syncInterval": "How often the app automatically pulls for new changes when sync frequently is enabled.",
+      "pauseForegroundSync": "Stops automatic pulls when the app is in the foreground, allowing local commits to diverge from remote. Useful for multi-device conflict testing.",
       "backgroundSync": "Background sync runs even when the app is not active, ensuring your notes stay up to date.",
       "cloneMode": "Clone mode syncs through a local git working tree. Requires more storage but works fully offline with LFS support.",
       "apiMode": "API mode uses the GitHub Contents API for per-file operations. Faster initially but requires network and lacks offline support.",

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -645,7 +645,16 @@ class GitHubServiceClass {
     );
 
     const subEntries = subTreeResults.flatMap((r) => r ?? []);
-    return [...blobItems, ...subEntries];
+
+    // Include dirItems as 'tree' type entries so getRepositoryFolders can
+    // discover folders. Without this, truncated repos have no folder entries.
+    const dirEntries = dirItems.map((item) => ({
+      path: item.path,
+      type: 'tree' as const,
+      sha: item.sha,
+    }));
+
+    return [...blobItems, ...dirEntries, ...subEntries];
   }
 
   async getFileContent(


### PR DESCRIPTION
## Summary

Fixes 3 issues from #1249:

### Issue 6: Folder selector does not reflect existing repo folders
**Root cause:** `GitHubService._getTreeRecursiveImpl` was not including directory entries when fetching truncated trees. The `getRepositoryFolders` method filters for `type === tree` entries, but when GitHub returns `truncated: true` and we recursively fetch subtrees, we were only returning blob items (files) and their nested contents - not the directory entries themselves.

**Fix:** Include `dirItems` as tree type entries in the return value so `getRepositoryFolders` can discover folders.

### Issue 9: "Pause foreground sync" needs inline explanation
**Fix:** Added `HintIcon` component next to the toggle with explanation text for what the setting does.

### Issue 10: Replace "..." loading text with spinners
**Fix:** Replaced animated dots ("...") with `ActivityIndicator` spinners in:
- `CloneProgressModal.tsx` - renamed `AnimatedProgressDots` to `CloneProgressSpinner`
- `ChatRepoPickerModal.tsx` - replaced "Initializing..." text with spinner  
- `ThoughtDumpRepoPickerModal.tsx` - replaced "Saving..." text with spinner

## Testing
- TypeScript compilation passes
- ESLint passes with no new warnings