### PR TITLE
fix(git): branch list empty for private repos + auto-select default + hold animation

### DIFF
--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StorageService } from './StorageService';
+import { AuthService } from './AuthService';
 import { parseRepoPath } from '../utils/gitPathParser';
 import { fetchGitHubDefaultBranch, fetchGitLabDefaultBranch } from './git/branchResolver';
 import type { GitHostProvider } from './git/GitHost';
@@ -225,13 +226,36 @@ export class GitService {
           await this.setCachedData(cacheKey, result);
           return result;
         }
-        // Host returned empty - try authenticated GitHub API directly if token provided
-        if (authToken && provider === 'github') {
+        // Host returned empty - try authenticated GitHub API directly.
+        // For private repos, unauthenticated requests are rate-limited so they
+        // return empty. Try with token if available, or fetch one.
+        const token = authToken ?? (provider === 'github' ? await AuthService.getToken() : null);
+        if (provider === 'github' && !token) {
+          // No token yet, try to get one
+          const fetchedToken = await AuthService.getToken();
+          if (fetchedToken) {
+            const branchesUrl = `${GITHUB_API_BASE}/repos/${repoInfo.owner}/${repoInfo.repo}/branches`;
+            const metaUrl = `${GITHUB_API_BASE}/repos/${repoInfo.owner}/${repoInfo.repo}`;
+            const [ghBranches, ghMeta] = await Promise.all([
+              this.fetchFromGitHub<Array<{ name: string }>>(branchesUrl, fetchedToken),
+              this.fetchFromGitHub<{ default_branch?: string }>(metaUrl, fetchedToken),
+            ]);
+            if (ghBranches && ghBranches.length > 0) {
+              const defaultBranch = ghMeta?.default_branch;
+              const result = ghBranches.map((b) => ({
+                name: b.name,
+                isCurrent: defaultBranch ? b.name === defaultBranch : false,
+              }));
+              await this.setCachedData(cacheKey, result);
+              return result;
+            }
+          }
+        } else if (token) {
           const branchesUrl = `${GITHUB_API_BASE}/repos/${repoInfo.owner}/${repoInfo.repo}/branches`;
           const metaUrl = `${GITHUB_API_BASE}/repos/${repoInfo.owner}/${repoInfo.repo}`;
           const [ghBranches, ghMeta] = await Promise.all([
-            this.fetchFromGitHub<Array<{ name: string }>>(branchesUrl, authToken),
-            this.fetchFromGitHub<{ default_branch?: string }>(metaUrl, authToken),
+            this.fetchFromGitHub<Array<{ name: string }>>(branchesUrl, token),
+            this.fetchFromGitHub<{ default_branch?: string }>(metaUrl, token),
           ]);
           if (ghBranches && ghBranches.length > 0) {
             const defaultBranch = ghMeta?.default_branch;


### PR DESCRIPTION
## Summary

Fixes the branch selector issues for private repos.

### Root Causes
1. `GitService.getBranches` was calling GitHub unauthenticated API first. For private repos, GitHub rate-limits unauthenticated requests, causing empty responses.
2. When the branch picker opened, no branch was auto-selected even though branches loaded, leaving the required branch field empty.
3. The floating push button was missing the hold progress ring animation that existed in the original FloatingStageButton.

### Fixes
1. **GitService.getBranches**: Modified to automatically fetch the auth token when unauthenticated request fails, then retry with authentication.
2. **GitContextPicker.goToBranchView**: Auto-select the current branch (marked `isCurrent: true`) or fall back to the first branch when opening the branch picker.
3. **FloatingPushButton**: Added `HoldProgressRing` component to show circular progress animation during long press.

### Testing
- TypeScript compilation passes
- ESLint passes