### PR TITLE
fix: commit notes, todos, canvases to git in clone mode

### DIFF
--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -64,6 +64,21 @@ export function useTodos(): TodoContextValue {
       console.warn('[TodoContext] Notification schedule failed:', err);
     }
 
+    if (finalTodo.repo) {
+      const syncResult = await syncTodoToGitHub({
+        repo: finalTodo.repo,
+        branch: finalTodo.branch,
+        filePath: finalTodo.filePath,
+        text: finalTodo.text,
+        todo: finalTodo,
+      });
+      if (!syncResult.success) {
+        console.warn('[TodoContext] GitHub sync failed:', syncResult.error);
+      } else if (syncResult.filePath && !finalTodo.filePath) {
+        finalTodo = (await StorageService.updateTodo({ id: finalTodo.id, filePath: syncResult.filePath })) ?? finalTodo;
+      }
+    }
+
     useTodoStore.setState((s) => ({ todos: [finalTodo, ...s.todos] }));
     return finalTodo;
   }, []);
@@ -98,6 +113,20 @@ export function useTodos(): TodoContextValue {
     try {
       const todo = useTodoStore.getState().todos.find((t) => t.id === id);
       if (todo) await NotificationService.cancelAllForTodo(todo);
+
+      if (todo?.repo && todo?.filePath) {
+        const syncResult = await syncTodoToGitHub({
+          repo: todo.repo,
+          branch: todo.branch,
+          filePath: todo.filePath,
+          text: todo.text,
+          todo,
+        });
+        if (!syncResult.success) {
+          console.warn('[TodoContext] GitHub delete sync failed:', syncResult.error);
+        }
+      }
+
       const ok = await StorageService.deleteTodo(id);
       if (ok) useTodoStore.setState((s) => ({ todos: s.todos.filter((t) => t.id !== id) }));
       return ok;

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -1,10 +1,13 @@
 import { create } from 'zustand';
-import { Canvas, CanvasCreateInput, CanvasUpdateInput, sortCanvasesByUpdated } from '../models/Canvas';
+import { Canvas, CanvasCreateInput, CanvasUpdateInput, sortCanvasesByUpdated, slugifyCanvasTitle } from '../models/Canvas';
 import { StorageService } from '../services/StorageService';
 import { GitHubService } from '../services/GitHubService';
 import { formatSyncError } from '../services/git/formatSyncError';
 import { deleteCanvasFromGitHub } from '../services/CanvasGitHubSyncService';
 import { gitOperationRegistry } from './gitOperationStore';
+import { SyncEngineService } from '../services/SyncEngineService';
+import { CommitService } from '../services/git/CommitService';
+import { resolveDefaultFolder } from '../services/git/defaultsPolicy';
 
 interface CanvasState {
   canvases: Canvas[];
@@ -40,6 +43,27 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()((set, get) =
   createCanvas: async (input) => {
     try {
       set({ error: null });
+
+      const slug = input.title ? slugifyCanvasTitle(input.title) : `canvas-${Date.now()}`;
+      const filePath = `${resolveDefaultFolder('canvas')}${slug}.json`;
+
+      const mode = await SyncEngineService.getMode(input.repo ?? '');
+      if (mode === 'clone' && input.repo) {
+        const scene = input.scene ?? { elements: [], viewportX: 0, viewportY: 0, viewportWidth: 0, viewportHeight: 0 };
+        const content = JSON.stringify(scene, null, 2);
+        const commitResult = await CommitService.commit({
+          repo: input.repo,
+          branch: input.branch ?? 'main',
+          filePath,
+          content,
+          message: `Create canvas: ${input.title || filePath}`,
+        });
+        if (!commitResult.success) {
+          set({ error: commitResult.error ?? 'Failed to create canvas' });
+          return null;
+        }
+      }
+
       const newCanvas = await StorageService.createCanvas(input);
       set((state) => ({ canvases: sortCanvasesByUpdated([...state.canvases, newCanvas]) }));
       return newCanvas;

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -88,6 +88,32 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
     }
     try {
       set({ error: null });
+
+      // Derive filePath for clone-mode commit (same logic as deriveDefaultNotePath
+      // but computed from input fields since the Note object doesn't exist yet)
+      const title = (input.title ?? '').trim();
+      const slug = title ? slugifyLocal(title) : `note-${Date.now()}`;
+      const ext = getExtensionForFormat(input.format ?? 'markdown');
+      const folderPath = input.folderPath ?? resolveDefaultFolder('note');
+      const filePath = `${folderPath}/${slug}${ext}`;
+
+      // Clone mode: commit the new note to git BEFORE saving to storage.
+      // This ensures the push button appears immediately (unpushed commit exists).
+      const mode = await SyncEngineService.getMode(repo);
+      if (mode === 'clone') {
+        const commitResult = await CommitService.commit({
+          repo,
+          branch: input.branch ?? 'main',
+          filePath,
+          content: input.content ?? '',
+          message: `Create note: ${title || filePath}`,
+        });
+        if (!commitResult.success) {
+          set({ error: commitResult.error ?? 'Failed to create note' });
+          return null;
+        }
+      }
+
       const newNote = await StorageService.createNote({ ...input, repo });
       set((state) => ({ notes: sortNotesWithPinnedFirst([...state.notes, newNote]) }));
       return newNote;


### PR DESCRIPTION
## Summary

Fixes a bug where the push button didn't appear after creating notes, todos, or canvases in clone mode.

## Bug

In clone mode (commit-on-save + explicit push), entity creation was saving to local storage but never committing to git. This meant:
- Push button never appeared (no unpushed commits detected)
- Changes couldn't be pushed to GitHub
- Data was lost on app restart since it wasn't in the git history

## Root Cause

The sync architecture requires ALL changes to be committed locally via `CommitService.commit()` in clone mode. While `deleteNote` had this logic, `createNote` did not - and the same bug existed for todos and canvases.

## Changes

### noteStore.ts
- `createNote`: Now calls `CommitService.commit()` before saving to storage in clone mode

### TodoContext.tsx  
- `createTodo`: Now calls `syncTodoToGitHub` after creating
- `deleteTodo`: Now calls `syncTodoToGitHub` for repo-backed todos

### canvasStore.ts
- `createCanvas`: Now calls `CommitService.commit()` in clone mode

## Testing

- TypeScript compiles clean
- All existing noteStore tests pass