### PR TITLE
fix: increment revision before commit for immediate push button

### DIFF
--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -4,6 +4,7 @@ import { StorageService } from '../services/StorageService';
 import { NotificationService } from '../services/NotificationService';
 import { useTodoStore } from '../stores/todoStore';
 import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
+import { useGitActivityStore } from '../stores/gitActivityStore';
 
 /** Mirrors TodoGitHubSyncService.serializeTodo so synced todos keep the on-disk shape. */
 function serializeTodoForStage(todo: Partial<Todo>): string {

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -9,6 +9,7 @@ import { CommitService } from '../services/git/CommitService';
 import { resolveDefaultFolder, resolveDefaultRepo } from '../services/git/defaultsPolicy';
 import { recordDeleteFailure } from '../services/git/deleteFailures';
 import { gitOperationRegistry, useGitOperationStore } from './gitOperationStore';
+import { useGitActivityStore } from './gitActivityStore';
 import type { GitOp } from './gitOperationStore';
 import { slugifyLocal, getExtensionForFormat } from '../components/editor/editorShared';
 import { parseRepoPath } from '../utils/gitPathParser';
@@ -98,9 +99,10 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
       const filePath = `${folderPath}/${slug}${ext}`;
 
       // Clone mode: commit the new note to git BEFORE saving to storage.
-      // This ensures the push button appears immediately (unpushed commit exists).
+      // Increment revision BEFORE commit so push button appears immediately.
       const mode = await SyncEngineService.getMode(repo);
       if (mode === 'clone') {
+        useGitActivityStore.getState().incrementRevision();
         const commitResult = await CommitService.commit({
           repo,
           branch: input.branch ?? 'main',


### PR DESCRIPTION
## Summary

Increment the git activity revision BEFORE committing in clone mode, so the push button appears immediately without waiting for the async commit to complete.

## Changes

- `noteStore.ts createNote`: Call `incrementRevision()` before `CommitService.commit()`
- `TodoContext.tsx createTodo`: Same timing fix

## Testing

Push button should now appear immediately when creating a note/todo, not after a 30-second poll cycle.