### PR TITLE
fix(ui): floating push button improvements

### DIFF
--- a/src/components/git/FloatingPushButton.tsx
+++ b/src/components/git/FloatingPushButton.tsx
@@ -68,6 +68,12 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
       const repo = repositories.find((r) => r.path === targetPath);
       if (!isMounted) return;
 
+      if (!repo) {
+        setActiveRepoPath(null);
+        setActiveBranch('main');
+        return;
+      }
+
       setActiveRepoPath(targetPath);
       setActiveBranch(repo?.branch ?? 'main');
     };
@@ -76,7 +82,10 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
   }, [repositories]);
 
   useEffect(() => {
-    if (!activeRepoPath) return;
+    if (!activeRepoPath) {
+      setUnpushedCount(0);
+      return;
+    }
     let isMounted = true;
 
     const load = async () => {

--- a/src/components/git/FloatingPushButton.tsx
+++ b/src/components/git/FloatingPushButton.tsx
@@ -22,6 +22,7 @@ import {
   FLOATING_AI_BUTTON_LONG_PRESS_MS,
   useFloatingAIButtonAffordances,
 } from '../ai/useFloatingAIButtonAffordances';
+import { HoldProgressRing } from '../ui/HoldProgressRing';
 import { useTabBarHeight } from '../ui/TabBar';
 import { STAGE_BUTTON_SIZE } from './stageButtonGeometry';
 
@@ -243,6 +244,12 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
 
   return (
     <Animated.View style={[styles.container, animatedStyle]} pointerEvents="box-none">
+      <HoldProgressRing
+        progress={affordances.holdProgress}
+        size={BUTTON_SIZE}
+        color={colors.primary}
+        reduceMotionEnabled={reduceMotionEnabled}
+      />
       <GestureDetector gesture={panGesture}>
         <Animated.View style={triggerAnimatedStyle}>
           <Pressable


### PR DESCRIPTION
## Summary

Two fixes for the floating push button:

### Fix 1: Hold progress ring animation
Add the circular progress ring animation during long press that was present in the original FloatingStageButton but missing from FloatingPushButton.

### Fix 2: Hide button when repo is deleted
When a repo is deleted from the app, the floating push button was not reacting to the change and stayed visible. Now the button verifies the active repo still exists in the repository list and clears itself if the repo is gone.

### Testing
- TypeScript compilation passes
- ESLint passes