### PR TITLE
fix(git): detect divergence when local branch is ahead of remote

### DIFF
--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -384,6 +384,20 @@ export class GitFsService {
         singleBranch: true,
         onAuth: ensureToken(opts.token),
       });
+      // git.fastForward is a no-op when the local branch is already ahead of
+      // the remote (e.g. a freshly-created local commit) — it doesn't throw,
+      // it just returns silently. The push retry that follows would then fail
+      // with the same non-fast-forward rejection. Detect this explicitly and
+      // surface divergence so the caller can handle it instead of pushing
+      // a divergent branch.
+      const localOid = await git.resolveRef({ fs, dir, ref: `refs/heads/${opts.branch}` }).catch(() => null);
+      const remoteOid = await git.resolveRef({ fs, dir, ref: remoteRef }).catch(() => null);
+      if (localOid && remoteOid && localOid !== remoteOid) {
+        const localHasRemote = await git.isDescendent({ fs, dir, oid: remoteOid, ancestor: localOid }).catch(() => false);
+        if (!localHasRemote) {
+          return { ok: false, reason: 'diverged', error: 'Local branch has unpushed commits that diverged from remote' };
+        }
+      }
       // The LFS pointer walk is the most expensive step after a fetch. Skip it
       // when the remote ref did not move — no new objects arrived, so no new
       // placeholders can exist. This makes idle pulls (nothing changed on the


### PR DESCRIPTION
## Summary

Fixes push failure when the local branch has unpushed commits that diverged from the remote.

## Bug

`git.fastForward` in isomorphic-git is a no-op when the local branch is already ahead of the remote. It returns silently without throwing, so the push retry in `LocalGitWriter.push` would fail with the same non-fast-forward rejection.

## Flow that caused the bug

1. User creates a note → local commit (e.g. C1)
2. Remote has commits the local doesn't have (from another device)
3. Push fails: non-fast-forward
4. `pullWithFastForward` is called
5. Fetch gets remote changes
6. `git.fastForward` sees local is ahead → returns silently (no-op)
7. Pull returns `{ ok: true }` (incorrectly)
8. Retry push at line 760 fails with the same error
9. User sees "remote rejected non-fast-forward"

## Fix

After the fast-forward, explicitly check if the local ref has the remote as an ancestor. If not, return `{ ok: false, reason: 'diverged' }` so the caller surfaces the conflict instead of pushing a divergent branch.