### PR TITLE
fix(git): provide valid author for merge commits

### DIFF
--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -469,14 +469,14 @@ export class GitFsService {
   }): Promise<{ ok: true } | { ok: false; reason: 'conflict' | 'unknown'; error?: string }> {
     const { fs, dir, branch, remoteOid } = opts;
     try {
-      const author = await readCommitAuthor(fs, dir, `refs/heads/${branch}`).catch(() => null);
+      const author = await readCommitAuthor(fs, dir, `refs/heads/${branch}`);
 
       await git.merge({
         fs,
         dir,
         ours: branch,
         theirs: remoteOid,
-        ...(author ? { author } : {}),
+        author,
         message: `Merge remote-tracking branch 'origin/${branch}' into ${branch}`,
       });
 
@@ -775,14 +775,17 @@ async function readCommitAuthor(
   fs: ReturnType<typeof makeGitFs>,
   dir: string,
   ref: string,
-): Promise<{ name: string; email: string } | null> {
+): Promise<{ name: string; email: string }> {
+  const fallback = { name: 'gitnotes', email: 'gitnotes@users.noreply.gitnotes' };
   try {
-    const commit = await git.readCommit({ fs, dir, oid: ref });
+    const oid = await git.resolveRef({ fs, dir, ref }).catch(() => null);
+    if (!oid) return fallback;
+    const commit = await git.readCommit({ fs, dir, oid });
     const author = commit.commit.author;
-    if (!author?.name || !author?.email) return null;
+    if (!author?.name || !author?.email) return fallback;
     return { name: author.name, email: author.email };
   } catch {
-    return null;
+    return fallback;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes 'No name was provided for author' error when the merge commit is created during push retry.

## Bug

The previous PR (#1274) added a merge step to handle divergent branches, but the merge failed because:

1. `git.readCommit` takes `oid` not `ref` — passing a ref string silently failed
2. `readCommitAuthor` returned `null` when the read failed
3. `git.merge` requires a valid author — without it, throws

## Fix

- Resolve the ref to an OID before reading the commit
- Always return a valid author (use the existing commit's author or fall back to a default 'gitnotes' author)
- Always pass the author to `git.merge`