### PR TITLE
fix(ui): gray out push button while processing instead of spinner

### DIFF
--- a/src/components/git/FloatingPushButton.tsx
+++ b/src/components/git/FloatingPushButton.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AccessibilityInfo,
-  ActivityIndicator,
   Alert,
   Pressable,
   StyleSheet,
@@ -322,15 +321,11 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
             disabled={isPushing}
             style={({ pressed }) => [
               styles.button,
-              { backgroundColor: colors.primary },
-              pressed ? styles.pressed : null,
+              { backgroundColor: isPushing ? colors.border : colors.primary },
+              pressed && !isPushing ? styles.pressed : null,
             ]}
           >
-            {isPushing ? (
-              <ActivityIndicator size="small" color="#FFFFFF" />
-            ) : (
-              <Ionicons name="cloud-upload" size={24} color="#FFFFFF" />
-            )}
+            <Ionicons name="cloud-upload" size={24} color="#FFFFFF" />
           </Pressable>
           {unpushedCount > 0 ? (
             <View style={[styles.badge, { backgroundColor: colors.error }]}>


### PR DESCRIPTION
## Summary

The previous fix (#1271) added a spinner when the push button is processing, but the user prefers the button to just gray out. This PR replaces the spinner with a grayed-out background.

### Changes
- Removed `ActivityIndicator` import
- Background color changes to `colors.border` (gray) when `isPushing` is true
- Cloud-upload icon stays visible (no spinner)
- Press effect is suppressed when isPushing is true

### Testing
- TypeScript compilation passes
- ESLint passes (only pre-existing warnings)