### PR TITLE
fix(git): commit merge after git.merge to advance branch ref

### DIFF
--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -470,6 +470,7 @@ export class GitFsService {
     const { fs, dir, branch, remoteOid } = opts;
     try {
       const author = await readCommitAuthor(fs, dir, `refs/heads/${branch}`);
+      const mergeMessage = `Merge remote-tracking branch 'origin/${branch}' into ${branch}`;
 
       await git.merge({
         fs,
@@ -477,13 +478,29 @@ export class GitFsService {
         ours: branch,
         theirs: remoteOid,
         author,
-        message: `Merge remote-tracking branch 'origin/${branch}' into ${branch}`,
+        message: mergeMessage,
       });
 
       const conflicted = await listConflictedFiles(fs, dir);
       if (conflicted.length > 0) {
         return { ok: false, reason: 'conflict', error: `Merge produced file conflicts in: ${conflicted.join(', ')}` };
       }
+
+      // git.merge stages the merge changes but does NOT create the merge
+      // commit or update the branch ref. The local branch still points to
+      // the pre-merge commit, so the subsequent push would still be
+      // rejected as non-fast-forward. Commit the staged merge explicitly
+      // with both parents so the local branch advances past the remote.
+      const parents = [opts.localOid, remoteOid];
+      const mergeCommitOid = await git.commit({
+        fs,
+        dir,
+        message: mergeMessage,
+        author,
+        parent: parents,
+      });
+      await git.writeRef({ fs, dir, ref: `refs/heads/${branch}`, value: mergeCommitOid, force: true });
+
       return { ok: true };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
## Summary

Fixes push still failing with non-fast-forward after the merge step. `git.merge` in isomorphic-git stages the merge changes but does NOT create the merge commit or update the branch ref.

## Fix

After `git.merge`:
1. Check for file conflicts (abort if any)
2. Create the merge commit explicitly via `git.commit` with both parents (local + remote)
3. Update `refs/heads/<branch>` to the new merge commit via `git.writeRef`

Now the local branch is ahead of the remote with a proper merge commit, and the push can succeed.