### PR TITLE
fix(ui): prevent notes row clipping

### DIFF
--- a/__tests__/screens/NotesListScreen.test.tsx
+++ b/__tests__/screens/NotesListScreen.test.tsx
@@ -356,6 +356,6 @@ describe('NotesListScreen', () => {
     expect(list.props.initialNumToRender).toBeLessThanOrEqual(10);
     expect(list.props.maxToRenderPerBatch).toBeLessThanOrEqual(6);
     expect(list.props.windowSize).toBeLessThanOrEqual(7);
-    expect(list.props.removeClippedSubviews).toBe(true);
+    expect(list.props.removeClippedSubviews).toBe(false);
   });
 });

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -475,7 +475,7 @@ export default function NotesListScreen() {
           maxToRenderPerBatch={6}
           windowSize={7}
           updateCellsBatchingPeriod={50}
-          removeClippedSubviews={true}
+          removeClippedSubviews={false}
           onScrollToIndexFailed={({ index, highestMeasuredFrameIndex, averageItemLength }) => {
             // Without this, scrollToIndex for a search match beyond the
             // measured window silently fails — search nav appears broken.


### PR DESCRIPTION
## Summary
- disable FlatList clipping for animated note rows
- update the NotesListScreen virtualization regression assertion

## Verification
- `yarn ts:check`
- focused NotesListScreen Jest test passes
- changed-file ESLint reports no errors; existing warnings remain
- full Jest has unrelated baseline failures in staging, Skia, progress animation, and translation parity tests