### PR TITLE
fix: preserve note formats and journal filtering

### DIFF
--- a/__tests__/hooks/useDailyQuote.test.tsx
+++ b/__tests__/hooks/useDailyQuote.test.tsx
@@ -17,7 +17,7 @@ const mockNotes: Note[] = [
   makeNote({
     id: 'journal-1',
     title: 'Journal 2026-08-20',
-    tags: ['journal'],
+    filePath: 'journals/2026-08-20.md',
     content: 'Reflecting on patience.',
   }),
   makeNote({ id: 'plain-1', title: 'Shopping', tags: ['errands'] }),

--- a/__tests__/notes-pull-reconcile.test.ts
+++ b/__tests__/notes-pull-reconcile.test.ts
@@ -102,6 +102,30 @@ describe('RepoPullService notes reconciliation', () => {
     expect(saved.map((n: any) => n.id).sort()).toEqual(['keep']);
   });
 
+  it('imports markdown, neorg, and org files as notes', async () => {
+    (GitHubService.getTreeRecursiveOrThrow as jest.Mock).mockResolvedValue([
+      { type: 'blob', path: 'notes/markdown.md', sha: 'md' },
+      { type: 'blob', path: 'notes/neorg.norg', sha: 'norg' },
+      { type: 'blob', path: 'notes/org.org', sha: 'org' },
+    ]);
+    (GitHubService.getFileContent as jest.Mock).mockImplementation(
+      async (_owner: string, _repo: string, path: string) => `# ${path}`,
+    );
+    (StorageService.getAllNotes as jest.Mock).mockResolvedValue([]);
+
+    await pullFromSingleRepo('org/repo');
+
+    const saved = (StorageService.saveAllNotes as jest.Mock).mock.calls[0][0] as Array<{
+      filePath: string;
+      format: string;
+    }>;
+    expect(saved.map((note) => [note.filePath, note.format])).toEqual([
+      ['notes/markdown.md', 'markdown'],
+      ['notes/neorg.norg', 'neorg'],
+      ['notes/org.org', 'org'],
+    ]);
+  });
+
   // Pending uploads have no filePath until NoteSyncQueueService writes one
   // back after a successful push. They must survive reconciliation regardless
   // of the remote state, otherwise a pull racing a queued upload would erase

--- a/__tests__/screens/NotesListScreen.test.tsx
+++ b/__tests__/screens/NotesListScreen.test.tsx
@@ -9,6 +9,7 @@ let mockNotesSeed: Note[] = [];
 let mockSearchQuery = '';
 let mockIsLoading = false;
 let mockError: string | null = null;
+let mockViewMode: 'list' | 'journal' = 'list';
 
 const mockSetSearchQuery = jest.fn();
 const mockDeleteNote = jest.fn(async () => true);
@@ -64,7 +65,7 @@ jest.mock('../../src/contexts/RepoContext', () => ({
 }));
 
 jest.mock('../../src/contexts/ViewModeContext', () => ({
-  useViewMode: () => ({ viewMode: 'list' as const, setViewMode: jest.fn() }),
+  useViewMode: () => ({ viewMode: mockViewMode, setViewMode: jest.fn() }),
 }));
 
 jest.mock('../../src/contexts/NoteContext', () => ({
@@ -268,6 +269,7 @@ describe('NotesListScreen', () => {
     mockSearchQuery = '';
     mockIsLoading = false;
     mockError = null;
+    mockViewMode = 'list';
     mockNavigate.mockClear();
     mockSetSearchQuery.mockClear();
     mockDeleteNote.mockClear();
@@ -312,9 +314,9 @@ describe('NotesListScreen', () => {
 
   it('renders a list of notes', () => {
     mockNotesSeed = [
-      createNote({ id: 'n1', title: 'First Note' }),
-      createNote({ id: 'n2', title: 'Second Note' }),
-      createNote({ id: 'n3', title: 'Third Note' }),
+      createNote({ id: 'n1', title: 'First Note', format: 'markdown', filePath: 'notes/first.md' }),
+      createNote({ id: 'n2', title: 'Second Note', format: 'org', filePath: 'notes/second.org' }),
+      createNote({ id: 'n3', title: 'Third Note', format: 'neorg', filePath: 'notes/third.norg' }),
     ];
 
     const { getByText, getByTestId } = render(<NotesListScreen />);
@@ -322,6 +324,21 @@ describe('NotesListScreen', () => {
     expect(getByText('First Note')).toBeTruthy();
     expect(getByText('Second Note')).toBeTruthy();
     expect(getByText('Third Note')).toBeTruthy();
+  });
+
+  it('shows only notes under journals/ in journal view', () => {
+    mockViewMode = 'journal';
+    mockNotesSeed = [
+      createNote({ id: 'journal', title: 'Journal entry', folderPath: 'journals', filePath: 'journals/2026-08-26.md' }),
+      createNote({ id: 'markdown', title: 'Markdown note', folderPath: 'notes', filePath: 'notes/readme.md' }),
+      createNote({ id: 'org', title: 'Org note', format: 'org', filePath: 'org-note.org' }),
+    ];
+
+    const { getByText, queryByText } = render(<NotesListScreen />);
+
+    expect(getByText('Journal entry')).toBeTruthy();
+    expect(queryByText('Markdown note')).toBeNull();
+    expect(queryByText('Org note')).toBeNull();
   });
 
   it('passes search query changes to setSearchQuery', () => {

--- a/__tests__/services/JournalService.test.ts
+++ b/__tests__/services/JournalService.test.ts
@@ -34,23 +34,28 @@ describe('journalNoteTitle', () => {
 });
 
 describe('isJournalEntry', () => {
-  test('returns true for notes with journal tag', () => {
-    const note = baseNote({ tags: ['journal'] });
+  test('returns true for notes under the journals folder', () => {
+    const note = baseNote({ filePath: 'journals/2026-05-05.md' });
     expect(isJournalEntry(note)).toBe(true);
   });
 
-  test('returns true for notes with journal among other tags', () => {
-    const note = baseNote({ tags: ['personal', 'journal', 'daily'] });
+  test('returns true for a new journal with a journals folderPath', () => {
+    const note = baseNote({ folderPath: 'journals' });
     expect(isJournalEntry(note)).toBe(true);
   });
 
-  test('returns false for notes without journal tag', () => {
-    const note = baseNote({ tags: ['personal'] });
+  test('keeps legacy Journal folder entries discoverable', () => {
+    const note = baseNote({ filePath: 'Journal/2026-05-05.md' });
+    expect(isJournalEntry(note)).toBe(true);
+  });
+
+  test('returns false for a tagged note outside the journals folder', () => {
+    const note = baseNote({ tags: ['journal'], filePath: 'notes/meeting.md' });
     expect(isJournalEntry(note)).toBe(false);
   });
 
-  test('returns false for notes with no tags', () => {
-    const note = baseNote({ tags: [] });
+  test('returns false for an untagged note outside the journals folder', () => {
+    const note = baseNote({ tags: [], filePath: 'notes/meeting.md' });
     expect(isJournalEntry(note)).toBe(false);
   });
 });
@@ -78,6 +83,7 @@ describe('findJournalEntry', () => {
     const note = baseNote({
       title: 'Journal 2026-05-05',
       tags: ['journal'],
+      filePath: 'journals/2026-05-05.md',
       createdAt: new Date(2026, 4, 5).getTime(),
     });
     const result = findJournalEntry([note], new Date(2026, 4, 5));
@@ -88,6 +94,7 @@ describe('findJournalEntry', () => {
     const note = baseNote({
       title: 'Journal 2026-05-04',
       tags: ['journal'],
+      filePath: 'journals/2026-05-04.md',
     });
     const result = findJournalEntry([note], new Date(2026, 4, 5));
     expect(result).toBeUndefined();
@@ -97,6 +104,7 @@ describe('findJournalEntry', () => {
     const note = baseNote({
       title: 'Journal 2026-05-05',
       tags: ['personal'],
+      filePath: 'notes/Journal 2026-05-05.md',
     });
     const result = findJournalEntry([note], new Date(2026, 4, 5));
     expect(result).toBeUndefined();
@@ -109,18 +117,21 @@ describe('getJournalEntries', () => {
       id: 'may3',
       title: 'Journal 2026-05-03',
       tags: ['journal'],
+      filePath: 'journals/2026-05-03.md',
       createdAt: new Date(2026, 4, 3).getTime(),
     });
     const may5 = baseNote({
       id: 'may5',
       title: 'Journal 2026-05-05',
       tags: ['journal'],
+      filePath: 'journals/2026-05-05.md',
       createdAt: new Date(2026, 4, 5).getTime(),
     });
     const may10 = baseNote({
       id: 'may10',
       title: 'Journal 2026-05-10',
       tags: ['journal'],
+      filePath: 'journals/2026-05-10.md',
       createdAt: new Date(2026, 4, 10).getTime(),
     });
     const nonJournal = baseNote({
@@ -142,6 +153,7 @@ describe('getJournalEntries', () => {
     const note = baseNote({
       title: 'Journal 2026-01-01',
       tags: ['journal'],
+      filePath: 'journals/2026-01-01.md',
       createdAt: new Date(2026, 0, 1).getTime(),
     });
     const result = getJournalEntries([note], new Date(2026, 4, 1), new Date(2026, 4, 7));
@@ -155,7 +167,7 @@ describe('buildJournalNoteInput', () => {
     const input = buildJournalNoteInput(date);
     expect(input.title).toBe('Journal 2026-05-05');
     expect(input.tags).toEqual(['journal']);
-    expect(input.folderPath).toBe('Journal');
+    expect(input.folderPath).toBe('journals');
     expect(input.format).toBe('markdown');
     expect(input.content).toBe('');
   });

--- a/src/hooks/useDailyQuote.ts
+++ b/src/hooks/useDailyQuote.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNotes } from '../contexts/NoteContext';
 import { dailyQuoteService, type DailyQuote } from '../services/DailyQuoteService';
+import { isJournalEntry } from '../services/JournalService';
 import { useAIStore } from '../stores/aiStore';
 
 interface UseDailyQuoteReturn {
@@ -34,7 +35,7 @@ export function useDailyQuote(): UseDailyQuoteReturn {
       setIsLoading(true);
       setError(null);
       const currentNotes = notesRef.current;
-      const journals = currentNotes.filter((n) => n.tags.includes('journal'));
+      const journals = currentNotes.filter(isJournalEntry);
       const result = await dailyQuoteService.getDailyQuote(journals, currentNotes);
       setQuote(result);
     } catch (err) {
@@ -56,7 +57,7 @@ export function useDailyQuote(): UseDailyQuoteReturn {
       setIsLoading(true);
       setError(null);
       const currentNotes = notesRef.current;
-      const journals = currentNotes.filter((n) => n.tags.includes('journal'));
+      const journals = currentNotes.filter(isJournalEntry);
       const result = await dailyQuoteService.regenerate(journals, currentNotes);
       setQuote(result);
     } catch (err) {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -20,6 +20,7 @@ import { NoteFormatPreferenceService } from '../services/NoteFormatPreferenceSer
 import {
   buildJournalEditorParams,
   findJournalEntry,
+  isJournalEntry,
   journalNoteTitle,
 } from '../services/JournalService';
 import { useResponsive } from '../hooks/useResponsive';
@@ -136,7 +137,9 @@ export default function HomeScreen() {
   }, [navigation, notes, repositories.length, openSettings]);
 
   const todaysJournalTitle = journalNoteTitle(new Date());
-  const hasTodaysJournal = notes.some((n) => n.title === todaysJournalTitle);
+  const hasTodaysJournal = notes.some(
+    (note) => isJournalEntry(note) && note.title === todaysJournalTitle,
+  );
 
   const handleTemplateSelect = useCallback((template: NoteTemplate) => {
     setShowTemplateSelector(false);

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -30,7 +30,7 @@ import { useNetworkStatus } from '../hooks/useNetworkStatus';
 import { useProGate } from '../hooks/useProGate';
 import { GitHubActivityIndicator } from '../components/GitHubActivityIndicator';
 import { ViewMode, VIEW_MODE_ICONS } from '../utils/viewModes';
-import { formatJournalDate } from '../services/JournalService';
+import { formatJournalDate, isJournalEntry } from '../services/JournalService';
 import { NoteCard as NotesListCard } from '../components/notes/NoteCard';
 import { NotesListHeader } from '../components/notes/NotesListHeader';
 import { NotesViewModePicker } from '../components/notes/NotesViewModePicker';
@@ -96,6 +96,15 @@ export default function NotesListScreen() {
   const isFocused = useIsFocused();
   const { inflight } = useGitHubActivityStore();
 
+  const viewScopedNotes = useMemo(
+    () => (viewMode === 'journal' ? notes.filter(isJournalEntry) : notes),
+    [notes, viewMode],
+  );
+  const viewScopedFilteredNotes = useMemo(
+    () => (viewMode === 'journal' ? filteredNotes.filter(isJournalEntry) : filteredNotes),
+    [filteredNotes, viewMode],
+  );
+
   // GitSyncGate publishes registry ops for the held cycle (kind 'pull')
   // and push markers (kind 'push'); the registry is the reactive busy source.
   const gateBusy = useGitOperationStore((s) =>
@@ -148,7 +157,12 @@ export default function NotesListScreen() {
     handleSelectFolder,
     handleToggleTag,
     handleToggleColor,
-  } = useNotesListFilters({ notes, filteredNotes, searchQuery, persistenceKey: '@gitnotes:filters:notes-list' });
+  } = useNotesListFilters({
+    notes: viewScopedNotes,
+    filteredNotes: viewScopedFilteredNotes,
+    searchQuery,
+    persistenceKey: '@gitnotes:filters:notes-list',
+  });
 
   // Consume pending reminder filter pushed by App.tsx on notification tap.
   const consumePendingFilter = useReminderStore((s) => s.consumePendingFilter);

--- a/src/services/JournalService.ts
+++ b/src/services/JournalService.ts
@@ -2,8 +2,20 @@ import { format, startOfDay, endOfDay, isWithinInterval, parseISO } from 'date-f
 import { Note, NoteCreateInput } from '../models/Note';
 
 const JOURNAL_TAG = 'journal';
-const JOURNAL_FOLDER = 'Journal';
+const JOURNAL_FOLDER = 'journals';
+const LEGACY_JOURNAL_FOLDER = 'journal';
 const JOURNAL_TITLE_PREFIX = 'Journal ';
+
+function isUnderJournalFolder(path: string | undefined): boolean {
+  if (!path) return false;
+  const normalized = path.trim().replace(/^\/+|\/+$/g, '').toLowerCase();
+  return (
+    normalized === JOURNAL_FOLDER ||
+    normalized.startsWith(`${JOURNAL_FOLDER}/`) ||
+    normalized === LEGACY_JOURNAL_FOLDER ||
+    normalized.startsWith(`${LEGACY_JOURNAL_FOLDER}/`)
+  );
+}
 
 export function formatJournalDate(date: Date): string {
   return format(date, 'yyyy-MM-dd');
@@ -14,7 +26,7 @@ export function journalNoteTitle(date: Date): string {
 }
 
 export function isJournalEntry(note: Note): boolean {
-  return note.tags.includes(JOURNAL_TAG);
+  return isUnderJournalFolder(note.filePath) || isUnderJournalFolder(note.folderPath);
 }
 
 export function getJournalEntries(notes: Note[], startDate: Date, endDate: Date): Note[] {


### PR DESCRIPTION
## Summary
- preserve Markdown, Neorg, and Org note discovery
- scope Journal view and journal consumers by journal paths
- keep legacy `Journal/` entries discoverable

## Verification
- Focused suites: 4 passed, 39 tests passed
- `yarn ts:check`: passed
- `yarn eslint . --ext .ts,.tsx`: passed with existing warnings
- Full suite: 297 passed, 2 skipped; 20 unrelated baseline/native-environment suites failed
- `git diff --check`: passed