### PR TITLE
fix(ui): add bottom margin to PushScreen 'Push N commits' button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable fixes and feature changes to GitNotēs are documented here.
 >
 > **History**: prior fixes (pre-2026-08) lived in single-PR wiki pages. Those pages were retired in [#1047](https://github.com/gedwolmen/gitnotes/pull/1047); their full diagnostic content is preserved in git history via `git log -p -- docs/wiki/<file>.md`.
 
+## 2026-08-26
+
+### Push screen bottom button spacing (#1281)
+
+**fix(ui)** — Added `mb-3` to the "Push N commits" `TouchableOpacity` on `PushScreen` so the button has visible breathing room below it instead of sitting flush against the bottom edge of the screen.
+
 ## 2026-08-25
 
 ### Git Sync: Remove staging, move to commit-based model (#1249)

--- a/src/screens/PushScreen.tsx
+++ b/src/screens/PushScreen.tsx
@@ -365,7 +365,7 @@ export default function PushScreen() {
             accessibilityRole="button"
             accessibilityLabel="Push all commits"
             accessibilityState={{ disabled: pushing }}
-            className="py-3 rounded-[10px] items-center"
+            className="py-3 mb-3 rounded-[10px] items-center"
             style={{ backgroundColor: pushing ? colors.border : colors.primary }}
           >
             {pushing ? (


### PR DESCRIPTION
## Summary

Adds `mb-3` to the bottom action button on the Push screen so the button has visible spacing below it instead of sitting flush against the screen edge.

## Change

```diff
- className="py-3 rounded-[10px] items-center"
+ className="py-3 mb-3 rounded-[10px] items-center"
```

Single-class addition in `src/screens/PushScreen.tsx`. No JS, no tests, no behavior change.