### PR TITLE
fix(onboarding): show 'Connecting...' text on Continue button while verifying

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -45,6 +45,7 @@
     "reset": "Reset",
     "next": "Next",
     "continue": "Continue",
+    "connecting": "Connecting...",
     "viewMode": "View mode",
     "searchPlaceholder": "Search...",
     "upgrade": "Upgrade"

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -255,7 +255,13 @@ export default function OnboardingScreen({ onComplete, onSkip }: OnboardingScree
               testID="onboarding.button.next"
               onPress={handleNext}
               disabled={isVerifying}
-              label={isVerifying ? '' : isTokenStep ? (token.trim() ? 'Connect' : 'Skip for Now') : 'Next'}
+              label={
+                isVerifying
+                  ? t('common.connecting', { defaultValue: 'Connecting...' })
+                  : isTokenStep
+                    ? (token.trim() ? 'Connect' : 'Skip for Now')
+                    : 'Next'
+              }
               trailingIcon={
                 isVerifying ? (
                   <ActivityIndicator color={colors.accent} />


### PR DESCRIPTION
## Summary

On the Onboarding screen's GitHub token step, tapping **Continue** while the token is being verified used to render the button as an empty-string + spinner. The button is already disabled during verification, but the label was wiped to `''`, leaving the user with just a spinner floating in the button shape and no feedback that anything is happening.

## Change

```diff
- label={isVerifying ? '' : isTokenStep ? (token.trim() ? 'Connect' : 'Skip for Now') : 'Next'}
+ label={
+   isVerifying
+     ? t('common.connecting', { defaultValue: 'Connecting...' })
+     : isTokenStep
+       ? (token.trim() ? 'Connect' : 'Skip for Now')
+       : 'Next'
+ }
```

Plus `common.connecting` added to `src/i18n/en.json`. Other locales fall back to the `defaultValue` at runtime (existing i18n-key-parity allow-list handles this).

The button stays `disabled={isVerifying}` (grayed), the trailing `ActivityIndicator` still renders, and the label is now visible so the user knows the app is working on their request.