### PR TITLE
fix(ui): hide FloatingPushButton on the Push screen

### DIFF
--- a/src/components/git/FloatingPushButton.tsx
+++ b/src/components/git/FloatingPushButton.tsx
@@ -293,6 +293,7 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
     || currentRouteName === 'ChatThreadList'
     || currentRouteName === 'ChatScreen'
     || currentRouteName === 'Paywall'
+    || currentRouteName === 'Push'
   ) {
     return null;
   }


### PR DESCRIPTION
## Summary

The Push screen has its own **Push / Push-all** action at the bottom and lists the unpushed commits above it. The floating FAB on top of it duplicates the affordance and visually overlaps the bottom action area. Hiding it on this screen while leaving it everywhere else.

## Change

```diff
   if (
     unpushedCount === 0
     || currentRouteName === 'ChatThreadList'
     || currentRouteName === 'ChatScreen'
     || currentRouteName === 'Paywall'
+    || currentRouteName === 'Push'
   ) {
     return null;
   }
```

The component already short-circuits to `return null` based on the route name passed in from `AppNavigator`. This just extends the existing exclusion list (which already covers `ChatThreadList`, `ChatScreen`, and `Paywall`).

The FAB still appears on every other screen where it serves as the entry point to the push flow.