### PR TITLE
fix(ui): show all iPad Markdown notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ All notable fixes and feature changes to GitNotēs are documented here.
 **fix(i18n)** — Recent PRs added 4 keys to `en.json` (`common.connecting`, `settings.unpushedCommitsTitle`, `settings.unpushedCommitsBody`, `hints.settings.pauseForegroundSync`) without mirroring them in `es/fr/de/ja/ko`. The i18n-key-parity test treated every missing key as a failure and broke CI on every locale. Translations backfilled for all 5 locales.
 
 **test(sync)** — Four test files were left referring to the staging layer deleted by #1249 (`StagingService`, `stageStore`). Updated to assert the new commit-on-save flow: `HomeScreen.color-select` asserts `NoteSyncQueueService.enqueueNoteUpsert`; `todo-delete-sync` and `notes-delete-lock` drop drain-on-save assertions (#927 tracks the API-mode write-through gap); `sync-locking.integration` S2 checks the queue holds the mutation, S3 marked `.skip`. Before: 14 suites / 27 tests failed. After: 9 suites / 13 tests fail (separate categories: Skia mocks, `AccountsProvider` wrap, behavior gaps in `localGitWriter` / `GitSyncGate` / `ForegroundSyncService` / `git-state-ui` / `header-blur` / `CloneProgressModal`).
+### iPad Notes grid shows all Markdown files (#1280)
+
+**fix(ui)** — `SwipeableListItem` now uses `flex: 1` instead of claiming the full row with `width: '100%'`, so every Markdown note remains visible in its assigned iPad multi-column grid slot. The regression test covers four notes in a two-column layout while preserving single- and three-column coverage.
 
 ### Push screen bottom button spacing (#1281)
 

--- a/__tests__/components/list/SwipeableListItem.test.tsx
+++ b/__tests__/components/list/SwipeableListItem.test.tsx
@@ -6,13 +6,13 @@
  *
  * SwipeableListItem is the shared item wrapper for every grid list
  * (TodoListScreen, NotesListScreen, ThoughtDumpScreen). Its root
- * Animated.View must carry an explicit `width: '100%'` so each card
- * stretches to its column slot.
+ * Animated.View must carry `flex: 1` so each card stretches to its column
+ * slot without claiming the entire row.
  *
  * Jest runs no native layout engine, so the tests apply React Native's
- * documented layout contract: a root with `width: '100%'` resolves to the
- * full column slot (containerWidth - gaps) / numColumns, while a root
- * without an explicit width collapses to the card content's intrinsic width.
+ * documented layout contract: a root with `flex: 1` resolves to the full
+ * column slot (containerWidth - gaps) / numColumns, while a root without
+ * an explicit flex value collapses to the card content's intrinsic width.
  */
 import React from 'react';
 import { FlatList, Pressable, StyleSheet, View } from 'react-native';
@@ -70,6 +70,7 @@ const CONTAINER_WIDTH = 1000;
 // Inter-column gap the screens apply via columnWrapperStyle when
 // numColumns > 1.
 const COLUMN_GAP = 8;
+const EXPECTED_TWO_COLUMN_WIDTH = (CONTAINER_WIDTH - COLUMN_GAP) / 2;
 // Intrinsic width of the stub card content. Models the fixed-width TodoCard /
 // NoteCard content that an unpatched wrapper collapses onto (#940 measured
 // 90px, #941 measured 263px on device).
@@ -87,13 +88,13 @@ function flattenedStyle(element: ElementWithStyle): ViewStyle | undefined {
 }
 
 /**
- * Width the item visually occupies in its row. `width: '100%'` fills the
- * column slot the FlatList assigns; without an explicit width the wrapper
+ * Width the item visually occupies in its row. `flex: 1` fills the
+ * column slot the FlatList assigns equally; without flex the wrapper
  * shrinks to the card content's intrinsic width (the #940/#941 collapse).
  */
 function measuredItemWidth(element: ElementWithStyle, numColumns: number): number {
   const style = flattenedStyle(element);
-  if (style?.width === '100%') {
+  if (style?.flex === 1) {
     return (CONTAINER_WIDTH - (numColumns - 1) * COLUMN_GAP) / numColumns;
   }
   return STUB_CONTENT_WIDTH;
@@ -153,11 +154,30 @@ describe('SwipeableListItem', () => {
     }
   });
 
+  it('keeps every note visible inside its assigned iPad grid column (#1280)', () => {
+    const view = render(
+      <GridHarness itemIds={['note-a', 'note-b', 'note-c', 'note-d']} numColumns={2} />,
+    );
+
+    const items = view.getAllByTestId(/^swipeable-/);
+    expect(items).toHaveLength(4);
+
+    for (const item of items) {
+      expect(measuredItemWidth(item, 2)).toBe(EXPECTED_TWO_COLUMN_WIDTH);
+      const style = flattenedStyle(item);
+      expect(style?.flex).toBe(1);
+      expect(style?.width).toBeUndefined();
+    }
+  });
+
   it('fills the full container width in single-column layout', () => {
     const view = render(<GridHarness itemIds={['solo']} numColumns={1} />);
 
     const width = measuredItemWidth(view.getByTestId('swipeable-solo'), 1);
+    const style = flattenedStyle(view.getByTestId('swipeable-solo'));
     expect(width).toBe(CONTAINER_WIDTH);
+    expect(style?.flex).toBe(1);
+    expect(style?.width).toBeUndefined();
   });
 
   it('still fires onToggleSelect when the selection-mode toggle is pressed', () => {
@@ -219,7 +239,7 @@ describe('SwipeableListItem', () => {
     );
 
     const style = flattenedStyle(view.getByTestId('swipeable-sel'));
-    expect(style?.width).toBe('100%');
+    expect(style?.flex).toBe(1);
     expect(style?.shadowColor).toBe('#dc2626');
     expect(style?.elevation).toBe(8);
   });

--- a/src/components/list/SwipeableListItem.tsx
+++ b/src/components/list/SwipeableListItem.tsx
@@ -77,7 +77,7 @@ export function SwipeableListItem({
       testID={`swipeable-${itemId}`}
       className="rounded-sm"
       style={[
-        { width: '100%' },
+        { flex: 1 },
         selected && {
           shadowColor: colors.error,
           shadowOpacity: 0.55,


### PR DESCRIPTION
## Summary
- Replace the shared `SwipeableListItem` root width with `flex: 1` so iPad multi-column Notes cells share their assigned row slots.
- Add #1280 regression coverage for four notes in a two-column grid, including the expected slot width and single-/three-column contracts.
- Document the fix in `CHANGELOG.md`.

Fixes #1280

## Verification
- `yarn jest __tests__/components/list/SwipeableListItem.test.tsx __tests__/screens/NotesListScreen.test.tsx __tests__/screens/TodoListScreen.test.tsx --testPathIgnorePatterns=/node_modules/ --no-coverage --runInBand --forceExit` (3 suites, 26 tests passed)
- `yarn ts:check`
- `yarn eslint src/components/list/SwipeableListItem.tsx __tests__/components/list/SwipeableListItem.test.tsx`
- `git diff --check`

Full Jest was attempted locally but exceeded the 120-second command timeout after many suites passed; the output contained only pre-existing warnings.