### PR TITLE
fix(ui): unify pending-work indicator into single floating push button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-08-26
 
+### Unify pending-work indicator into a single floating push button
+
+**fix(ui)** — `FloatingPushButton` is now the only surface for "unpushed work" pending notification. In **clone mode** it counts unpushed git commits (`UnpushedCommitsService.count`); in **API mode** it counts pending sync-queue items for the active repo+branch (`NoteSyncQueueService.getAll`, filtered). Each mode refreshes on its own trigger (commit revision + 30s poll for clone; queue subscription for API). The long-press action is also mode-aware: clone mode pushes unpushed commits as before; API mode drains the queue then pulls. The duplicate top-right `UnpushedQueueBadge` rendered inside `NotesListScreen` is removed — it tracked a different counter and caused two push indicators to appear at once.
+
 ### Immediate floating push-button refresh (#1287)
 
 **fix(git)** — Clone-mode writes and deletes performed through `LocalGitWriter` now increment the Git activity revision immediately after their local commit succeeds. The floating push button refreshes its unpushed-commit count at once rather than waiting for its 30-second polling interval.

--- a/__tests__/git-state-ui.test.tsx
+++ b/__tests__/git-state-ui.test.tsx
@@ -318,18 +318,15 @@ describe('git-state surfaces', () => {
     GitSyncGate.__resetForTest();
   });
 
-  it('shows the persistent cloud-upload badge with the queue count while the pill is hidden', async () => {
+  it('does not render the legacy top-right queue badge (now unified into the FloatingPushButton)', async () => {
     mockPendingCount = 2;
 
-    const { getByTestId, getByText, queryByTestId } = renderWithTheme(<NotesListScreen />);
+    const { queryByTestId, queryByText } = renderWithTheme(<NotesListScreen />);
 
-    await waitFor(() => expect(getByText('2')).toBeTruthy());
-    expect(getByTestId('icon-cloud-upload')).toBeTruthy();
-    // Transient activity affordance is not rendered while the persistent
-    // queue badge is: no HTTP activity means no pill, but pending>0 still
-    // shows the count.
-    expect(queryByTestId('github-activity-indicator')).toBeNull();
-    expect(useGitHubActivityStore.getState().visible).toBe(false);
+    await waitFor(() => {
+      expect(queryByTestId('icon-cloud-upload')).toBeNull();
+      expect(queryByText('2')).toBeNull();
+    });
   });
 
   it.skip('renders a spinner on the cloud icon and no-ops the press while the gate cycle is held', () => {

--- a/src/components/git/FloatingPushButton.tsx
+++ b/src/components/git/FloatingPushButton.tsx
@@ -24,10 +24,12 @@ import type { RootStackParamList } from '../../navigation/types';
 import { useRepoStore } from '../../stores/repoStore';
 import { useGitActivityStore } from '../../stores/gitActivityStore';
 import { LastUsedRepoService } from '../../services/LastUsedRepoService';
+import { SyncEngineService, type SyncEngineMode } from '../../services/SyncEngineService';
 import { UnpushedCommitsService } from '../../services/git/UnpushedCommitsService';
 import { LocalGitWriter } from '../../services/git/LocalGitWriter';
 import { AuthService } from '../../services/AuthService';
 import { pullFromSingleRepo } from '../../services/RepoPullService';
+import { NoteSyncQueueService } from '../../services/NoteSyncQueueService';
 import {
   FLOATING_AI_BUTTON_LONG_PRESS_MS,
   useFloatingAIButtonAffordances,
@@ -62,6 +64,7 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
   const [reduceMotionResolved, setReduceMotionResolved] = useState(false);
   const [activeRepoPath, setActiveRepoPath] = useState<string | null>(null);
   const [activeBranch, setActiveBranch] = useState<string>('main');
+  const [syncMode, setSyncMode] = useState<SyncEngineMode>('clone');
   const [unpushedCount, setUnpushedCount] = useState(0);
   const [isPushing, setIsPushing] = useState(false);
   const commitRevision = useGitActivityStore((s) => s.commitRevision);
@@ -94,6 +97,24 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
 
   useEffect(() => {
     if (!activeRepoPath) {
+      setSyncMode('clone');
+      return;
+    }
+    let isMounted = true;
+    SyncEngineService.getMode(activeRepoPath)
+      .then((mode) => {
+        if (isMounted) setSyncMode(mode);
+      })
+      .catch(() => {
+        if (isMounted) setSyncMode('clone');
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, [activeRepoPath]);
+
+  useEffect(() => {
+    if (!activeRepoPath) {
       setUnpushedCount(0);
       return;
     }
@@ -101,10 +122,20 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
 
     const load = async () => {
       try {
-        const count = await UnpushedCommitsService.count({
-          repo: activeRepoPath,
-          branch: activeBranch,
-        });
+        let count = 0;
+        if (syncMode === 'clone') {
+          count = await UnpushedCommitsService.count({
+            repo: activeRepoPath,
+            branch: activeBranch,
+          });
+        } else {
+          const items = await NoteSyncQueueService.getAll();
+          count = items.filter(
+            (m) =>
+              m.params.repo === activeRepoPath &&
+              (m.params.branch ?? 'main') === activeBranch,
+          ).length;
+        }
         if (isMounted) setUnpushedCount(count);
       } catch {
         if (isMounted) setUnpushedCount(0);
@@ -112,12 +143,20 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
     };
 
     void load();
-    const interval = setInterval(() => void load(), 30_000);
+
+    if (syncMode === 'clone') {
+      const interval = setInterval(() => void load(), 30_000);
+      return () => {
+        isMounted = false;
+        clearInterval(interval);
+      };
+    }
+    const unsubscribe = NoteSyncQueueService.subscribe(load);
     return () => {
       isMounted = false;
-      clearInterval(interval);
+      unsubscribe();
     };
-  }, [activeRepoPath, activeBranch, commitRevision]);
+  }, [activeRepoPath, activeBranch, syncMode, commitRevision]);
 
   const defaultX = viewportWidth - BUTTON_SIZE - insets.right - EDGE_INSET;
   const safeBottom = viewportHeight - Math.max(tabBarHeight, insets.bottom + EDGE_INSET);
@@ -246,6 +285,25 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
     if (isPushing || !activeRepoPath) return;
     setIsPushing(true);
     try {
+      if (syncMode === 'api') {
+        const outcome = await NoteSyncQueueService.drain(
+          undefined,
+          'manual',
+          activeRepoPath,
+          activeBranch,
+        );
+        await pullFromSingleRepo(activeRepoPath);
+        if (outcome.failed > 0) {
+          Alert.alert(
+            'Sync finished with errors',
+            `${outcome.succeeded} pushed, ${outcome.failed} failed.`,
+          );
+        } else if (outcome.succeeded > 0) {
+          Alert.alert('Synced', `${outcome.succeeded} change(s) pushed to GitHub.`);
+        }
+        return;
+      }
+
       const token = (await AuthService.getToken()) ?? undefined;
       const pushPromise = LocalGitWriter.push({
         repoPath: activeRepoPath,
@@ -279,7 +337,7 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
     } finally {
       setIsPushing(false);
     }
-  }, [affordances, isPushing, activeRepoPath, activeBranch, navigation]);
+  }, [affordances, isPushing, activeRepoPath, activeBranch, navigation, syncMode]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -49,33 +49,6 @@ import { useTranslation } from 'react-i18next';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
-function UnpushedQueueBadge() {
-  const [pendingCount, setPendingCount] = useState(0);
-  const visible = useGitHubActivityStore((s) => s.visible);
-
-  useEffect(() => {
-    const refresh = () => {
-      NoteSyncQueueService.pendingCount().then(setPendingCount);
-    };
-    refresh();
-    const unsubscribe = NoteSyncQueueService.subscribe(refresh);
-    return unsubscribe;
-  }, []);
-
-  if (visible || pendingCount === 0) {
-    return null;
-  }
-
-  return (
-    <View testID="icon-cloud-upload" style={{ position: 'absolute', top: 8, right: 12, flexDirection: 'row', alignItems: 'center', gap: 4, zIndex: 999 }}>
-      <Ionicons name="cloud-upload-outline" size={18} color="#2563eb" />
-      <Text style={{ fontSize: 12, fontWeight: '600', color: '#2563eb' }} testID="unpushed-queue-badge.count">
-        {pendingCount}
-      </Text>
-    </View>
-  );
-}
-
 export default function NotesListScreen() {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
@@ -490,7 +463,6 @@ export default function NotesListScreen() {
   return (
     <SafeAreaView edges={[]} className="flex-1" style={{ backgroundColor: colors.background }}>
       {isDeleting ? <GitHubActivityIndicator /> : null}
-      <UnpushedQueueBadge />
 
       <NotesViewModePicker
         visible={showViewModePicker}


### PR DESCRIPTION
FloatingPushButton is now the only surface for 'unpushed work'. It detects the active repo's sync mode via SyncEngineService:

  - clone mode: count = UnpushedCommitsService.count, refreshed on commit revision + 30s poll
  - API mode: count = NoteSyncQueueService.getAll filtered by repo+branch, refreshed via NoteSyncQueueService.subscribe

The long-press action is also mode-aware: clone mode pushes unpushed commits as before; API mode drains the queue then pulls.

The duplicate top-right UnpushedQueueBadge rendered inside NotesListScreen is removed - it tracked a different counter and caused two push indicators to appear at once.

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Add screenshots to help demonstrate your changes for UI-related changes.
