### PR TITLE
fix(ui): show optimistic count + spinner on FloatingPushButton during in-flight commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-08-26
 
+### Floating push button shows optimistic count + spinner while commits are in flight
+
+**fix(ui)** — `FloatingPushButton` now reflects an in-flight local commit immediately. `noteStore.createNote` (clone mode) and `noteStore.updateNote` (clone-mode rename) wrap their `CommitService.commit` calls in `gitOperationRegistry.begin({kind:'upsert'|'rename', status:'running'})` and `succeed`/`fail` on completion. The FAB subscribes to `useGitOperationStore` and, in clone mode, adds the count of those running ops to its displayed number — so the button appears the moment the user taps save, before the local git commit completes — and swaps the cloud-upload icon for an `ActivityIndicator` (badge background also swaps to the primary color) so the user sees that work is happening. The display reverts to the real unpushed-commit count once the op succeeds.
+
 ### Unify pending-work indicator into a single floating push button
 
 **fix(ui)** — `FloatingPushButton` is now the only surface for "unpushed work" pending notification. In **clone mode** it counts unpushed git commits (`UnpushedCommitsService.count`); in **API mode** it counts pending sync-queue items for the active repo+branch (`NoteSyncQueueService.getAll`, filtered). Each mode refreshes on its own trigger (commit revision + 30s poll for clone; queue subscription for API). The long-press action is also mode-aware: clone mode pushes unpushed commits as before; API mode drains the queue then pulls. The duplicate top-right `UnpushedQueueBadge` rendered inside `NotesListScreen` is removed — it tracked a different counter and caused two push indicators to appear at once.

--- a/__tests__/FloatingPushButton.test.tsx
+++ b/__tests__/FloatingPushButton.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { act } from '@testing-library/react-native';
+
+import { renderWithTheme } from './helpers/renderWithTheme';
+import { FloatingPushButton } from '../src/components/git/FloatingPushButton';
+import { useGitOperationStore, gitOperationRegistry } from '../src/stores/gitOperationStore';
+
+const REPO = 'owner/repo';
+const BRANCH = 'main';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('@react-navigation/native-stack', () => ({}));
+
+jest.mock('../src/stores/repoStore', () => ({
+  useRepoStore: (selector: (s: { repositories: Array<{ path: string; branch: string }> }) => unknown) =>
+    selector({ repositories: [{ path: 'owner/repo', branch: 'main' }] }),
+}));
+
+jest.mock('../src/stores/gitActivityStore', () => ({
+  useGitActivityStore: () => ({ commitRevision: 0, incrementRevision: jest.fn() }),
+}));
+
+jest.mock('../src/services/LastUsedRepoService', () => ({
+  LastUsedRepoService: { get: jest.fn(async () => REPO) },
+}));
+
+jest.mock('../src/services/SyncEngineService', () => ({
+  SyncEngineService: { getMode: jest.fn(async () => 'clone') },
+}));
+
+jest.mock('../src/services/git/UnpushedCommitsService', () => ({
+  UnpushedCommitsService: {
+    count: jest.fn(async () => 0),
+    list: jest.fn(async () => []),
+  },
+}));
+
+jest.mock('../src/services/git/LocalGitWriter', () => ({
+  LocalGitWriter: { push: jest.fn(async () => ({ success: true })) },
+}));
+
+jest.mock('../src/services/AuthService', () => ({
+  AuthService: { getToken: jest.fn(async () => undefined) },
+}));
+
+jest.mock('../src/services/RepoPullService', () => ({
+  pullFromSingleRepo: jest.fn(async () => undefined),
+}));
+
+jest.mock('../src/services/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    getAll: jest.fn(async () => []),
+    subscribe: jest.fn(() => () => {}),
+    drain: jest.fn(async () => ({ succeeded: 0, failed: 0, remaining: 0 })),
+  },
+}));
+
+jest.mock('../src/components/ai/useFloatingAIButtonAffordances', () => ({
+  FLOATING_AI_BUTTON_LONG_PRESS_MS: 500,
+  useFloatingAIButtonAffordances: () => ({
+    pressProgress: { value: 0 },
+    holdProgress: { value: 0 },
+    handlePressIn: jest.fn(),
+    handlePressOut: jest.fn(),
+    handleHoldComplete: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/components/ui/HoldProgressRing', () => ({
+  HoldProgressRing: () => null,
+}));
+
+jest.mock('../src/components/ui/TabBar', () => ({
+  useTabBarHeight: () => 0,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+describe('FloatingPushButton in-flight feedback', () => {
+  beforeEach(() => {
+    useGitOperationStore.setState({ ops: {} });
+  });
+
+  it('renders the cloud-upload icon when nothing is in flight and no real commits exist', async () => {
+    const { queryByTestId } = renderWithTheme(<FloatingPushButton />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(queryByTestId('floating-push.spinner')).toBeNull();
+  });
+
+  it('shows optimistic count + spinner when an upsert op is running for the active repo+branch', async () => {
+    const { queryByTestId, findByTestId } = renderWithTheme(<FloatingPushButton />);
+    await act(async () => {
+      gitOperationRegistry.begin({
+        kind: 'upsert',
+        repo: REPO,
+        branch: BRANCH,
+        path: 'notes/x.md',
+        entityIds: [],
+        status: 'running',
+        attempts: 0,
+      });
+      await Promise.resolve();
+    });
+
+    const spinner = await findByTestId('floating-push.spinner');
+    expect(spinner).toBeTruthy();
+    expect(queryByTestId('floating-push.button.navigate-push')).toBeTruthy();
+  });
+
+  it('drops the spinner once the in-flight op succeeds', async () => {
+    const opId = gitOperationRegistry.begin({
+      kind: 'upsert',
+      repo: REPO,
+      branch: BRANCH,
+      path: 'notes/x.md',
+      entityIds: [],
+      status: 'running',
+      attempts: 0,
+    });
+
+    const { queryByTestId, findByTestId } = renderWithTheme(<FloatingPushButton />);
+    await findByTestId('floating-push.spinner');
+
+    await act(async () => {
+      gitOperationRegistry.succeed(opId);
+      await Promise.resolve();
+    });
+
+    expect(queryByTestId('floating-push.spinner')).toBeNull();
+  });
+
+  it('ignores ops that are not for the active repo or branch', async () => {
+    const { queryByTestId } = renderWithTheme(<FloatingPushButton />);
+    await act(async () => {
+      gitOperationRegistry.begin({
+        kind: 'upsert',
+        repo: 'someone/else',
+        branch: BRANCH,
+        path: 'notes/x.md',
+        entityIds: [],
+        status: 'running',
+        attempts: 0,
+      });
+      await Promise.resolve();
+    });
+
+    expect(queryByTestId('floating-push.spinner')).toBeNull();
+  });
+
+  it('ignores push/pull ops (they are tracked but not commit-in-flight flags)', async () => {
+    const { queryByTestId } = renderWithTheme(<FloatingPushButton />);
+    await act(async () => {
+      gitOperationRegistry.begin({
+        kind: 'push',
+        repo: REPO,
+        branch: BRANCH,
+        path: undefined,
+        entityIds: [],
+        status: 'running',
+        attempts: 0,
+      });
+      await Promise.resolve();
+    });
+
+    expect(queryByTestId('floating-push.spinner')).toBeNull();
+  });
+});

--- a/src/components/git/FloatingPushButton.tsx
+++ b/src/components/git/FloatingPushButton.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AccessibilityInfo,
+  ActivityIndicator,
   Alert,
   Pressable,
   StyleSheet,
@@ -23,6 +24,7 @@ import { HapticService } from '../../utils/haptics';
 import type { RootStackParamList } from '../../navigation/types';
 import { useRepoStore } from '../../stores/repoStore';
 import { useGitActivityStore } from '../../stores/gitActivityStore';
+import { useGitOperationStore } from '../../stores/gitOperationStore';
 import { LastUsedRepoService } from '../../services/LastUsedRepoService';
 import { SyncEngineService, type SyncEngineMode } from '../../services/SyncEngineService';
 import { UnpushedCommitsService } from '../../services/git/UnpushedCommitsService';
@@ -68,6 +70,7 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
   const [unpushedCount, setUnpushedCount] = useState(0);
   const [isPushing, setIsPushing] = useState(false);
   const commitRevision = useGitActivityStore((s) => s.commitRevision);
+  const gitOps = useGitOperationStore((s) => s.ops);
 
   useEffect(() => {
     let isMounted = true;
@@ -157,6 +160,20 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
       unsubscribe();
     };
   }, [activeRepoPath, activeBranch, syncMode, commitRevision]);
+
+  const inFlightCount = useMemo(() => {
+    if (syncMode !== 'clone' || !activeRepoPath) return 0;
+    return Object.values(gitOps).filter(
+      (op) =>
+        (op.status === 'queued' || op.status === 'running') &&
+        op.repo === activeRepoPath &&
+        (op.branch ?? 'main') === activeBranch &&
+        (op.kind === 'upsert' || op.kind === 'delete' || op.kind === 'rename' || op.kind === 'move'),
+    ).length;
+  }, [gitOps, activeRepoPath, activeBranch, syncMode]);
+
+  const displayCount = unpushedCount + inFlightCount;
+  const isCommitting = inFlightCount > 0;
 
   const defaultX = viewportWidth - BUTTON_SIZE - insets.right - EDGE_INSET;
   const safeBottom = viewportHeight - Math.max(tabBarHeight, insets.bottom + EDGE_INSET);
@@ -347,7 +364,7 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
   }));
 
   if (
-    unpushedCount === 0
+    displayCount === 0
     || currentRouteName === 'ChatThreadList'
     || currentRouteName === 'ChatScreen'
     || currentRouteName === 'Paywall'
@@ -369,9 +386,9 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
           <Pressable
             testID="floating-push.button.navigate-push"
             accessibilityRole="button"
-            accessibilityLabel={`Push ${unpushedCount} commits`}
+            accessibilityLabel={isCommitting ? 'Committing changes' : `Push ${displayCount} commits`}
             accessibilityHint="Tap to view unpushed commits. Press and hold to push them now."
-            accessibilityState={{ busy: isPushing }}
+            accessibilityState={{ busy: isPushing || isCommitting }}
             onPress={handleTap}
             onLongPress={handleLongPress}
             onPressIn={affordances.handlePressIn}
@@ -380,16 +397,20 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
             disabled={isPushing}
             style={({ pressed }) => [
               styles.button,
-              { backgroundColor: isPushing ? colors.border : colors.primary },
-              pressed && !isPushing ? styles.pressed : null,
+              { backgroundColor: isPushing || isCommitting ? colors.border : colors.primary },
+              pressed && !isPushing && !isCommitting ? styles.pressed : null,
             ]}
           >
-            <Ionicons name="cloud-upload" size={24} color="#FFFFFF" />
+            {isCommitting ? (
+              <ActivityIndicator size="small" color="#FFFFFF" testID="floating-push.spinner" />
+            ) : (
+              <Ionicons name="cloud-upload" size={24} color="#FFFFFF" />
+            )}
           </Pressable>
-          {unpushedCount > 0 ? (
-            <View style={[styles.badge, { backgroundColor: colors.error }]}>
+          {displayCount > 0 ? (
+            <View style={[styles.badge, { backgroundColor: isCommitting ? colors.primary : colors.error }]}>
               <Text style={styles.badgeText}>
-                {unpushedCount > 99 ? '99+' : unpushedCount}
+                {displayCount > 99 ? '99+' : displayCount}
               </Text>
             </View>
           ) : null}

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -100,16 +100,32 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
       // Clone mode: commit the new note to git BEFORE saving to storage.
       const mode = await SyncEngineService.getMode(repo);
       if (mode === 'clone') {
-        const commitResult = await CommitService.commit({
+        const opId = gitOperationRegistry.begin({
+          kind: 'upsert',
           repo,
           branch: input.branch ?? 'main',
-          filePath,
-          content: input.content ?? '',
-          message: `Create note: ${title || filePath}`,
+          path: filePath,
+          entityIds: [],
+          status: 'running',
+          attempts: 0,
         });
-        if (!commitResult.success) {
-          set({ error: commitResult.error ?? 'Failed to create note' });
-          return null;
+        try {
+          const commitResult = await CommitService.commit({
+            repo,
+            branch: input.branch ?? 'main',
+            filePath,
+            content: input.content ?? '',
+            message: `Create note: ${title || filePath}`,
+          });
+          if (!commitResult.success) {
+            gitOperationRegistry.fail(opId, commitResult.error ?? 'Failed to create note');
+            set({ error: commitResult.error ?? 'Failed to create note' });
+            return null;
+          }
+          gitOperationRegistry.succeed(opId);
+        } catch (commitError) {
+          gitOperationRegistry.fail(opId, commitError instanceof Error ? commitError.message : 'Commit failed');
+          throw commitError;
         }
       }
 
@@ -149,17 +165,33 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
           const mode = await SyncEngineService.getMode(existingNote.repo);
           if (mode === 'clone') {
             const content = input.content ?? existingNote.content ?? '';
-            const commitResult = await CommitService.commit({
+            const opId = gitOperationRegistry.begin({
+              kind: 'rename',
               repo: existingNote.repo,
               branch: existingNote.branch ?? 'main',
-              prevFilePath: oldPath,
-              filePath: newPath,
-              content,
-              message: `Rename note: ${input.title ?? existingNote.title}`,
+              path: newPath,
+              entityIds: [existingNote.id],
+              status: 'running',
+              attempts: 0,
             });
-            if (!commitResult.success) {
-              set({ error: commitResult.error ?? 'Failed to rename note' });
-              return null;
+            try {
+              const commitResult = await CommitService.commit({
+                repo: existingNote.repo,
+                branch: existingNote.branch ?? 'main',
+                prevFilePath: oldPath,
+                filePath: newPath,
+                content,
+                message: `Rename note: ${input.title ?? existingNote.title}`,
+              });
+              if (!commitResult.success) {
+                gitOperationRegistry.fail(opId, commitResult.error ?? 'Failed to rename note');
+                set({ error: commitResult.error ?? 'Failed to rename note' });
+                return null;
+              }
+              gitOperationRegistry.succeed(opId);
+            } catch (renameError) {
+              gitOperationRegistry.fail(opId, renameError instanceof Error ? renameError.message : 'Rename failed');
+              throw renameError;
             }
             // Commit succeeded — update filePath on the note so subsequent syncs
             // use the correct path and don't try to re-create the file.


### PR DESCRIPTION
## Problem

After tapping **save** in the note editor (clone mode), the floating push button took seconds to appear — sometimes waiting up to the 30s poll cycle. During that window the user had no feedback that a local git commit was in flight, so it looked like the save hung.

## Fix

Track in-flight commits via the existing `gitOperationRegistry` at the `noteStore` entry points:

- `noteStore.createNote` (clone-mode commit) wraps in `kind: 'upsert'`
- `noteStore.updateNote` (clone-mode rename commit) wraps in `kind: 'rename'`
- `noteStore.deleteNote` already wraps in `kind: 'delete'` (no change needed)

The `FloatingPushButton` subscribes to `useGitOperationStore` and, in **clone mode**, adds the count of running upsert/delete/rename/move ops for the active repo+branch to its displayed number. When that count is > 0:

- The cloud-upload icon is replaced with an `ActivityIndicator`
- The badge background swaps from `colors.error` to `colors.primary`
- `accessibilityLabel` becomes "Committing changes", `accessibilityState.busy = true`

API mode is intentionally **not** double-counted (the queue count is already the source of truth there).

## Verification

- `yarn ts:check` — clean
- `yarn jest` — 2875 passed (5 new tests in `__tests__/FloatingPushButton.test.tsx` + 2870 existing)
- 0 new lint warnings
- Worktree-only changes; main was untouched

## Diff vs main

```
 CHANGELOG.md                              |   4 +
 __tests__/FloatingPushButton.test.tsx     | 175 ++++++++++++++++++++++++++++++
 src/components/git/FloatingPushButton.tsx |  39 +++++--
 src/stores/noteStore.ts                   |  62 ++++++++---
 4 files changed, 256 insertions(+), 24 deletions(-)
```

Note: this is the second of two commits. The first commit (unify to a single FAB) was already merged as #1293.