### PR TITLE
fix(ui): add Pull button to push-timeout alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-08-26
 
+### Push-timeout alert offers a Pull action
+
+**fix(ui)** — When `LocalGitWriter.push` times out after 60s, the alert now offers a real **Pull** button instead of telling the user to "Pull and try again" without a way to do so. Tapping it runs `pullFromSingleRepo(repoPath)` for the active repo. Applied to both the `FloatingPushButton` long-press flow and the `PushScreen.handlePushAll` flow.
+
 ### Floating push button shows optimistic count + spinner while commits are in flight
 
 **fix(ui)** — `FloatingPushButton` now reflects an in-flight local commit immediately. `noteStore.createNote` (clone mode) and `noteStore.updateNote` (clone-mode rename) wrap their `CommitService.commit` calls in `gitOperationRegistry.begin({kind:'upsert'|'rename', status:'running'})` and `succeed`/`fail` on completion. The FAB subscribes to `useGitOperationStore` and, in clone mode, adds the count of those running ops to its displayed number — so the button appears the moment the user taps save, before the local git commit completes — and swaps the cloud-upload icon for an `ActivityIndicator` (badge background also swaps to the primary color) so the user sees that work is happening. The display reverts to the real unpushed-commit count once the op succeeds.

--- a/src/components/git/FloatingPushButton.tsx
+++ b/src/components/git/FloatingPushButton.tsx
@@ -347,7 +347,19 @@ export function FloatingPushButton({ currentRouteName }: FloatingPushButtonProps
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       if (message.includes('60s')) {
-        Alert.alert('Push timed out', 'Push timed out after 60s. Pull and try again.');
+        Alert.alert(
+          'Push timed out',
+          'Push timed out after 60s. Pull the latest changes and try again.',
+          [
+            { text: 'OK', style: 'cancel' },
+            {
+              text: 'Pull',
+              onPress: () => {
+                void pullFromSingleRepo(activeRepoPath);
+              },
+            },
+          ],
+        );
       } else {
         Alert.alert('Push failed', message);
       }

--- a/src/screens/PushScreen.tsx
+++ b/src/screens/PushScreen.tsx
@@ -257,7 +257,19 @@ export default function PushScreen() {
       }
     } catch (error) {
       if (error instanceof Error && error.message.includes('60s')) {
-        Alert.alert('Push timed out', 'Push timed out after 60s. Pull and try again.');
+        Alert.alert(
+          'Push timed out',
+          'Push timed out after 60s. Pull the latest changes and try again.',
+          [
+            { text: 'OK', style: 'cancel' },
+            {
+              text: 'Pull',
+              onPress: () => {
+                void pullFromSingleRepo(repoPath);
+              },
+            },
+          ],
+        );
       } else {
         Alert.alert('Push failed', error instanceof Error ? error.message : 'Unknown error');
       }


### PR DESCRIPTION
## Problem

When `LocalGitWriter.push` times out after 60s, the alert reads:

> Push timed out
> Push timed out after 60s. Pull and try again.
> [OK]

But there was no way to actually pull from the alert — the only button was OK. The user had to dismiss the alert and find a Pull action elsewhere (settings, pull-to-refresh on the notes list, etc.).

## Fix

Add a **Pull** button to the timeout alert in both places the 60s timeout fires:

- `FloatingPushButton.handleLongPress` (clone mode push from the FAB)
- `PushScreen.handlePushAll` (push from the Push screen)

The Pull button calls the already-imported `pullFromSingleRepo(repoPath)` for the active repo. The OK button stays as `style: 'cancel'`.

## Verification

- `yarn ts:check` — clean
- `yarn jest` — 2875 passed (no test changes; this is pure alert-button wiring)
- 0 new lint warnings
- Worktree-only changes; main untouched

## Diff vs main

```
 CHANGELOG.md                              |  4 ++++
 src/components/git/FloatingPushButton.tsx | 14 +++++++++++++-
 src/screens/PushScreen.tsx                | 14 +++++++++++++-
 3 files changed, 30 insertions(+), 2 deletions(-)
```