### PR TITLE
fix(git): pre-pull origin into local before attempting push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-08-26
 
+### Push pre-pulls origin into local before attempting the push
+
+**fix(git)** — `LocalGitWriter.push` now runs `GitFsService.pullWithFastForward` *before* the push attempt (it was previously only run on push-rejection as a retry). When origin has diverged from local, the conflict is detected and surfaced via `ConflictBanner` / Conflicts screen **before** the push has even been tried — instead of after the push has failed and forced a retry. The post-rejection pull fallback is kept for the rare case where origin moves during the in-flight push. Cost in the common path (local is ahead of origin): one extra `fetch` + resolveRef call; `git.fastForward` no-ops when local is already ahead.
+
 ### Push-timeout alert offers a Pull action
 
 **fix(ui)** — When `LocalGitWriter.push` times out after 60s, the alert now offers a real **Pull** button instead of telling the user to "Pull and try again" without a way to do so. Tapping it runs `pullFromSingleRepo(repoPath)` for the active repo. Applied to both the `FloatingPushButton` long-press flow and the `PushScreen.handlePushAll` flow.

--- a/__tests__/services/git/localGitWriter.test.ts
+++ b/__tests__/services/git/localGitWriter.test.ts
@@ -366,6 +366,6 @@ describe('push shallow handling (#1196)', () => {
     const result = await LocalGitWriter.push({ repoPath: 'me/repo', branch: 'main' });
 
     expect(result.success).toBe(true);
-    expect(order).toEqual(['push']);
+    expect(order).toEqual(['fetch', 'push']);
   });
 });


### PR DESCRIPTION
## Problem

When origin had diverged from local (someone else pushed first, or the same repo was edited on another device), the push attempt would fail with non-fast-forward, then the post-failure retry path would pull and surface the conflict — meaning the user saw a "push failed" message *before* they ever got the chance to deal with the conflict.

## Fix

Move the pull BEFORE the push in `LocalGitWriter.push`:

```
ensureOnBranch → ensureNotShallow → pullWithFastForward → push
```

If the pre-pull surfaces a conflict (`reason === 'diverged'`), `surfaceConflictsOnDiverged` is called and `push` returns `{success: false, error: 'conflict-detected'}` — the same shape the callers already handle, and `ConflictBanner` / Conflicts screen takes over before the push was ever attempted.

The post-rejection pull fallback is **kept** (in the `catch` block) for the rare case where origin moves during the in-flight push.

## Cost

Common path (local ahead of origin): one extra `fetch` + `resolveRef` call. `git.fastForward` is documented to be a no-op when local is already ahead, so the only added work is the fetch.

## Verification

- `yarn ts:check` — clean
- `yarn jest` — 2875 passed (1 existing test updated: the `#1196` shallow-handling test now expects `['fetch', 'push']` instead of `['push']` because every push now does a pre-fetch)
- 0 new lint warnings
- Worktree-only changes; main untouched

## Diff vs main

```
 CHANGELOG.md                                  |  4 ++++
 __tests__/services/git/localGitWriter.test.ts |  2 +-
 src/services/git/LocalGitWriter.ts            | 11 +++++++++++
 3 files changed, 16 insertions(+), 1 deletion(-)
```