### PR TITLE
fix(sync): preserve folderPath when syncing notes in API mode

### DIFF
--- a/src/services/NoteSyncQueueService.ts
+++ b/src/services/NoteSyncQueueService.ts
@@ -43,6 +43,7 @@ export interface NoteUpsertParams {
   tags?: string[];
   color?: NoteColor | null;
   knownSha?: string;
+  folderPath?: string;
 }
 
 export interface NoteDeleteParams {
@@ -937,6 +938,9 @@ class NoteSyncQueueServiceClass {
         filePath: result.filePath,
         ...(result.finalContent != null && result.finalContent !== item.params.content
           ? { content: result.finalContent }
+          : {}),
+        ...(item.params.folderPath !== undefined
+          ? { folderPath: item.params.folderPath }
           : {}),
       });
     } catch (error) {

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -1,7 +1,7 @@
 import { GitHubService } from './GitHubService';
 import { GitService } from './GitService';
 import { StorageService } from './StorageService';
-import { createNote, isNoteColor, NoteColor } from '../models/Note';
+import { createNote, deriveFolderPath, isNoteColor, NoteColor } from '../models/Note';
 import { createCanvas, updateCanvas, CanvasScene } from '../models/Canvas';
 import { createTodoItem, applyTodoUpdate, reorderTodos } from '../models/Todo';
 import { parseRepoPath } from '../utils/gitPathParser';
@@ -475,6 +475,7 @@ async function pullNotesFromRepo(
             repo: repoPath,
             branch,
             filePath: item.path,
+            folderPath: deriveFolderPath(item.path),
             format,
             tags,
             color,

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -267,6 +267,7 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
       format: input.format,
       tags: input.tags,
       color: input.color,
+      folderPath: input.folderPath,
     });
     const updatedNote = await StorageService.updateNote(input);
     if (updatedNote) {


### PR DESCRIPTION
## Bug

Notes inside a folder show 'No folder' in the editor despite being placed in a folder. The issue occurs in **API mode** sync.

## Root Cause

 was silently dropped at three points in the API sync path:

1. ** missing ** — the sync queue had no field for it, so it was dropped when  called .
2. ** didn't pass  to the queue** — even if the field existed, the caller wasn't providing it.
3. ** only synced +** — after a successful push,  was never written back to storage.
4. ** didn't derive ** — when re-importing notes from GitHub,  was set to  instead of being derived from .

## Fix

| File | Change |
|------|--------|
|  | Added  to  interface |
|  | Passed  to  in API mode |
|  | Updated  to sync  back to storage after API push |
|  | Added  when creating pulled notes |

TypeScript clean. Pre-existing 5 test failures in clone-mode mock tests are unrelated (identical failures before this change).