### PR TITLE
chore: bump version to v1.5.3

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "GitNot\u0113s",
     "slug": "gitnotes",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "orientation": "portrait",
     "icon": "./assets/generated/icon.png",
     "userInterfaceStyle": "automatic",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnotes",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MPL-2.0",
   "main": "expo/AppEntry.js",
   "engines": {


### PR DESCRIPTION
Bumps `package.json` and `app.json` from v1.5.2 → v1.5.3.