### PR TITLE
feat(eas): add EAS cloud build pipeline for Rust GitEngine

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "icons:regenerate": "node scripts/regenerate-assets.js",
     "branding": "node scripts/generate-branding.js",
     "branding:check": "node scripts/generate-branding.js --check",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "eas-build-pre-install": "bash scripts/eas/pre-install.sh",
+    "eas-build-post-install": "bash scripts/eas/post-install.sh"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.38",

--- a/scripts/build-rust.sh
+++ b/scripts/build-rust.sh
@@ -1,5 +1,179 @@
 #!/usr/bin/env bash
-# No-op stub: Rust git2 is built separately in the feature branch worktree.
-# This script exists only to satisfy Xcode build phase checks in main.
-echo "[build-rust.sh] No-op stub — Rust build handled in feature branch worktree"
-exit 0
+# Builds the gitnotes_git2 Rust crate for the mobile targets and copies the
+# artifacts into the GitEngine Expo module. Also regenerates the UniFFI
+# Swift/Kotlin bindings from the host-built cdylib.
+#
+# Usage:
+#   scripts/build-rust.sh                 # simulator lib (default local dev)
+#   scripts/build-rust.sh --ios           # simulator + device staticlibs
+#   scripts/build-rust.sh --android       # cargo-ndk shared libs (all ABIs)
+#   scripts/build-rust.sh --bindings      # regenerate Swift/Kotlin bindings
+#   scripts/build-rust.sh --all           # everything above
+#   scripts/build-rust.sh --xcode         # Xcode build-phase mode: build only
+#                                         # the target selected by the current
+#                                         # platform/arch/configuration
+#
+# Environment:
+#   RUST_PROFILE=debug|release (default: debug)
+
+set -euo pipefail
+
+# Xcode build phases run with a minimal PATH; make rustup/cargo visible.
+export PATH="$HOME/.cargo/bin:$PATH"
+if ! command -v cargo >/dev/null 2>&1 && [ -f "$HOME/.cargo/env" ]; then
+  . "$HOME/.cargo/env"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+RUST_DIR="$ROOT_DIR/rust"
+MODULE_DIR="$ROOT_DIR/modules/GitEngine"
+IOS_LIB_DIR="$MODULE_DIR/ios/rust"
+JNI_DIR="$MODULE_DIR/android/src/main/jniLibs"
+SWIFT_GEN_DIR="$MODULE_DIR/ios/generated"
+KOTLIN_GEN_DIR="$MODULE_DIR/android/src/main/java"
+
+PROFILE="${RUST_PROFILE:-debug}"
+PROFILE_FLAGS=()
+if [ "$PROFILE" = "release" ]; then
+  PROFILE_FLAGS=(--release)
+fi
+
+log() { echo "[build-rust] $*"; }
+
+cargo_build() {
+  local target="$1"
+  log "cargo build --target $target ($PROFILE)"
+  (cd "$RUST_DIR" && cargo build --target "$target" "${PROFILE_FLAGS[@]}")
+}
+
+copy_ios_lib() {
+  local target="$1"
+  mkdir -p "$IOS_LIB_DIR"
+  cp "$RUST_DIR/target/$target/$PROFILE/libgitnotes_git2.a" "$IOS_LIB_DIR/libgitnotes_git2.a"
+  log "copied $target staticlib -> $IOS_LIB_DIR/libgitnotes_git2.a"
+}
+
+build_ios_sim() {
+  if [ "${1:-}" = "arm64" ] || [ "$(uname -m)" = "arm64" ]; then
+    cargo_build "aarch64-apple-ios-sim"
+    copy_ios_lib "aarch64-apple-ios-sim"
+  else
+    cargo_build "x86_64-apple-ios"
+    copy_ios_lib "x86_64-apple-ios"
+  fi
+}
+
+build_ios() {
+  cargo_build "aarch64-apple-ios-sim"
+  copy_ios_lib "aarch64-apple-ios-sim"
+  cargo_build "aarch64-apple-ios"
+  log "device staticlib at $RUST_DIR/target/aarch64-apple-ios/$PROFILE/libgitnotes_git2.a"
+}
+
+build_android() {
+  if ! command -v cargo-ndk >/dev/null 2>&1; then
+    log "cargo-ndk not found; installing"
+    cargo install cargo-ndk
+  fi
+  local targets=(
+    "aarch64-linux-android:arm64-v8a"
+    "armv7-linux-androideabi:armeabi-v7a"
+    "x86_64-linux-android:x86_64"
+    "i686-linux-android:x86"
+  )
+  for entry in "${targets[@]}"; do
+    local target="${entry%%:*}"
+    local abi="${entry##*:}"
+    log "cargo ndk build --target $target ($PROFILE)"
+    (cd "$RUST_DIR" && cargo ndk --target "$target" --platform 24 build "${PROFILE_FLAGS[@]}")
+    mkdir -p "$JNI_DIR/$abi"
+    cp "$RUST_DIR/target/$target/$PROFILE/libgitnotes_git2.so" "$JNI_DIR/$abi/"
+    log "copied $target -> $JNI_DIR/$abi/libgitnotes_git2.so"
+  done
+}
+
+generate_bindings() {
+  local host
+  host="$(rustc -vV | grep '^host:' | cut -d' ' -f2)"
+  log "building host cdylib for bindgen ($host)"
+  (cd "$RUST_DIR" && cargo build "${PROFILE_FLAGS[@]}")
+
+  local dylib="$RUST_DIR/target/$PROFILE/libgitnotes_git2.dylib"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  log "generating Swift bindings"
+  (cd "$RUST_DIR" && cargo run --features uniffi-cli --bin uniffi-bindgen -- generate \
+    --library "$dylib" --language swift --out-dir "$tmp/swift")
+  mkdir -p "$SWIFT_GEN_DIR/GitNotesGit2FFI"
+  cp "$tmp/swift/GitNotesGit2.swift" "$SWIFT_GEN_DIR/GitNotesGit2.swift"
+  cp "$tmp/swift/GitNotesGit2FFI.h" "$SWIFT_GEN_DIR/GitNotesGit2FFI/GitNotesGit2FFI.h"
+  cp "$tmp/swift/GitNotesGit2FFI.modulemap" "$SWIFT_GEN_DIR/GitNotesGit2FFI/module.modulemap"
+
+  log "generating Kotlin bindings"
+  (cd "$RUST_DIR" && cargo run --features uniffi-cli --bin uniffi-bindgen -- generate \
+    --library "$dylib" --language kotlin --out-dir "$tmp/kotlin" --no-format)
+  mkdir -p "$KOTLIN_GEN_DIR/uniffi/gitnotes_git2"
+  cp "$tmp/kotlin/uniffi/gitnotes_git2/gitnotes_git2.kt" \
+    "$KOTLIN_GEN_DIR/uniffi/gitnotes_git2/gitnotes_git2.kt"
+
+  rm -rf "$tmp"
+  log "bindings regenerated into $MODULE_DIR"
+}
+
+build_for_xcode() {
+  local platform="${PLATFORM_NAME:-iphonesimulator}"
+  local archs="${ARCHS:-arm64}"
+  local arch
+  arch="$(echo "$archs" | awk '{print $1}')"
+  local config="${CONFIGURATION:-Debug}"
+  if [ "$config" = "Release" ]; then
+    PROFILE="release"
+    PROFILE_FLAGS=(--release)
+  fi
+
+  local target
+  case "$platform:$arch" in
+    iphonesimulator:arm64) target="aarch64-apple-ios-sim" ;;
+    iphonesimulator:x86_64) target="x86_64-apple-ios" ;;
+    iphoneos:arm64) target="aarch64-apple-ios" ;;
+    *)
+      log "unknown PLATFORM_NAME/ARCHS: $platform/$arch"
+      exit 1
+      ;;
+  esac
+
+  cargo_build "$target"
+  copy_ios_lib "$target"
+}
+
+DO_IOS_SIM=0
+DO_IOS=0
+DO_ANDROID=0
+DO_BINDINGS=0
+DO_XCODE=0
+
+if [ "$#" -eq 0 ]; then
+  DO_IOS_SIM=1
+fi
+for arg in "$@"; do
+  case "$arg" in
+    --ios) DO_IOS=1 ;;
+    --ios-sim) DO_IOS_SIM=1 ;;
+    --android) DO_ANDROID=1 ;;
+    --bindings) DO_BINDINGS=1 ;;
+    --xcode) DO_XCODE=1 ;;
+    --all) DO_IOS=1; DO_ANDROID=1; DO_BINDINGS=1 ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$DO_XCODE" -eq 1 ]; then build_for_xcode; fi
+if [ "$DO_BINDINGS" -eq 1 ]; then generate_bindings; fi
+if [ "$DO_IOS_SIM" -eq 1 ]; then build_ios_sim; fi
+if [ "$DO_IOS" -eq 1 ]; then build_ios; fi
+if [ "$DO_ANDROID" -eq 1 ]; then build_android; fi

--- a/scripts/eas/post-install.sh
+++ b/scripts/eas/post-install.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# EAS Build Post-Install Hook
+# Builds Rust native artifacts and generates UniFFI bindings for iOS and Android.
+# Runs during `eas build` after npm install but before native build.
+
+set -euo pipefail
+
+export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+export PATH="$CARGO_HOME/bin:$PATH"
+export RUST_PROFILE="${RUST_PROFILE:-release}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+RUST_DIR="$ROOT_DIR/rust"
+MODULE_DIR="$ROOT_DIR/modules/GitEngine"
+IOS_LIB_DIR="$MODULE_DIR/ios/rust"
+JNI_DIR="$MODULE_DIR/android/src/main/jniLibs"
+SWIFT_GEN_DIR="$MODULE_DIR/ios/generated"
+KOTLIN_GEN_DIR="$MODULE_DIR/android/src/main/java"
+
+PROFILE_FLAGS=()
+if [ "$RUST_PROFILE" = "release" ]; then
+  PROFILE_FLAGS=(--release)
+fi
+
+log() { echo "[eas-post-install] $*"; }
+
+# Source cargo env if needed
+if [ -f "$HOME/.cargo/env" ]; then
+  . "$HOME/.cargo/env"
+fi
+
+log "Building Rust git2 engine for iOS..."
+
+# Ensure iOS directories exist
+mkdir -p "$IOS_LIB_DIR"
+mkdir -p "$SWIFT_GEN_DIR/GitNotesGit2FFI"
+
+# Build iOS simulator (arm64)
+log "Building aarch64-apple-ios-sim..."
+(cd "$RUST_DIR" && cargo build --target aarch64-apple-ios-sim "${PROFILE_FLAGS[@]}")
+cp "$RUST_DIR/target/aarch64-apple-ios-sim/$RUST_PROFILE/libgitnotes_git2.a" "$IOS_LIB_DIR/libgitnotes_git2.a"
+log "iOS simulator staticlib copied"
+
+# Build iOS device
+log "Building aarch64-apple-ios (device)..."
+(cd "$RUST_DIR" && cargo build --target aarch64-apple-ios "${PROFILE_FLAGS[@]}")
+# Device artifact kept in place, Xcode will pick it up during build
+
+# Build Android libs
+log "Building Android libs for all ABIs..."
+ANDROID_TARGETS=(
+  "aarch64-linux-android:arm64-v8a"
+  "armv7-linux-androideabi:armeabi-v7a"
+  "x86_64-linux-android:x86_64"
+  "i686-linux-android:x86"
+)
+
+for entry in "${ANDROID_TARGETS[@]}"; do
+  target="${entry%%:*}"
+  abi="${entry##*:}"
+  log "Building $target -> $abi"
+  mkdir -p "$JNI_DIR/$abi"
+  (cd "$RUST_DIR" && cargo ndk --target "$target" --platform 24 build "${PROFILE_FLAGS[@]}")
+  cp "$RUST_DIR/target/$target/$RUST_PROFILE/libgitnotes_git2.so" "$JNI_DIR/$abi/"
+  log "Copied $abi lib"
+done
+
+log "Generating UniFFI Swift bindings..."
+# Generate Swift bindings from host cdylib
+HOST_TARGET=""
+if [ "$(uname -m)" = "arm64" ]; then
+  HOST_TARGET="aarch64-apple-darwin"
+else
+  HOST_TARGET="x86_64-apple-darwin"
+fi
+
+(cd "$RUST_DIR" && cargo build --target "$HOST_TARGET" "${PROFILE_FLAGS[@]}")
+
+DYLIB="$RUST_DIR/target/$HOST_TARGET/$RUST_PROFILE/libgitnotes_git2.dylib"
+
+TMP_DIR=$(mktemp -d)
+(cd "$RUST_DIR" && cargo run --features uniffi-cli --bin uniffi-bindgen -- generate \
+  --library "$DYLIB" --language swift --out-dir "$TMP_DIR/swift")
+cp "$TMP_DIR/swift/GitNotesGit2.swift" "$SWIFT_GEN_DIR/"
+cp "$TMP_DIR/swift/GitNotesGit2FFI.h" "$SWIFT_GEN_DIR/GitNotesGit2FFI/"
+cp "$TMP_DIR/swift/GitNotesGit2FFI.modulemap" "$SWIFT_GEN_DIR/GitNotesGit2FFI/"
+
+log "Generating UniFFI Kotlin bindings..."
+(cd "$RUST_DIR" && cargo run --features uniffi-cli --bin uniffi-bindgen -- generate \
+  --library "$DYLIB" --language kotlin --out-dir "$TMP_DIR/kotlin" --no-format)
+mkdir -p "$KOTLIN_GEN_DIR/uniffi/gitnotes_git2"
+cp "$TMP_DIR/kotlin/uniffi/gitnotes_git2/gitnotes_git2.kt" "$KOTLIN_GEN_DIR/uniffi/gitnotes_git2/"
+
+rm -rf "$TMP_DIR"
+
+log "All Rust artifacts built and bindings generated successfully."

--- a/scripts/eas/pre-install.sh
+++ b/scripts/eas/pre-install.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# EAS Build Pre-Install Hook
+# Installs Rust toolchain, cross-compilation targets, and cargo-ndk.
+# Runs during `eas build` before npm install.
+
+set -euo pipefail
+
+export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+export PATH="$CARGO_HOME/bin:$PATH"
+
+echo "[eas-pre-install] Checking Rust installation..."
+
+if ! command -v rustup >/dev/null 2>&1; then
+  echo "[eas-pre-install] Installing rustup..."
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "[eas-pre-install] Cargo not found after install, sourcing env..."
+  [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+fi
+
+echo "[eas-pre-install] Rust version: $(rustc --version)"
+echo "[eas-pre-install] Adding iOS cross-compilation targets..."
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+
+echo "[eas-pre-install] Adding Android NDK targets..."
+rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
+
+echo "[eas-pre-install] Installing cargo-ndk for Android builds..."
+cargo install cargo-ndk --version 3.6.1 || cargo install cargo-ndk
+
+echo "[eas-pre-install] Verifying targets..."
+rustup show
+
+echo "[eas-pre-install] Done."


### PR DESCRIPTION
## Summary

Fixes the `GitEngine native module unavailable: cannot clone` error during EAS cloud builds.

### Root Cause
The Rust build infrastructure for EAS was documented but never implemented:
- `scripts/build-rust.sh` was a stub (`exit 0`)
- `scripts/eas/` directory was missing
- npm hooks for EAS lifecycle were missing

### Changes

| File | Change |
|------|--------|
| `scripts/eas/pre-install.sh` | New - installs rustup toolchain, iOS/Android targets, cargo-ndk |
| `scripts/eas/post-install.sh` | New - builds Rust staticlib for iOS, .so for Android, generates UniFFI bindings |
| `scripts/build-rust.sh` | Restored from stub to full implementation |
| `package.json` | Added `eas-build-pre-install` and `eas-build-post-install` npm hooks |

### Testing
After merging, run:
```bash
eas build --platform ios --profile production
```

The build should now successfully compile the Rust git2 engine and generate Swift bindings during the EAS build process.