### PR TITLE
fix(explore): refresh on focus + discard button for changes/staging

### DIFF
--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, RefreshControl, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -61,6 +61,12 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
     if (active) void load();
   }, [active, load, version]);
 
+  useFocusEffect(
+    useCallback(() => {
+      if (active) void load();
+    }, [active, load]),
+  );
+
   const stageFile = useCallback(
     async (path: string) => {
       try {
@@ -86,6 +92,19 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
       setError(caught instanceof Error ? caught.message : String(caught));
     }
   }, [data, repo.localPath, onChanged]);
+
+  const discardFile = useCallback(
+    async (path: string) => {
+      try {
+        await GitEngine.remove(repo.localPath, [path], true);
+        onChanged();
+        setVersion((value) => value + 1);
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : String(caught));
+      }
+    },
+    [repo.localPath, onChanged],
+  );
 
   const renderItem = useCallback(
     ({ item }: { item: FileStatus }) => {
@@ -123,7 +142,10 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
             )}
           </Pressable>
           {!item.staged && (
-            <View className="mt-2 flex-row justify-end">
+            <View className="mt-2 flex-row justify-end gap-2">
+              <Button size="sm" variant="ghost" onPress={() => void discardFile(item.path)}>
+                <ButtonText>Discard</ButtonText>
+              </Button>
               <Button size="sm" variant="outline" onPress={() => void stageFile(item.path)}>
                 <ButtonText>Stage</ButtonText>
               </Button>
@@ -132,7 +154,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
         </View>
       );
     },
-    [data, navigation, repo.id, stageFile],
+    [data, navigation, repo.id, stageFile, discardFile],
   );
 
   if (error) {

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, RefreshControl, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -77,6 +77,12 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
     if (active) void load();
   }, [active, load, version]);
 
+  useFocusEffect(
+    useCallback(() => {
+      if (active) void load();
+    }, [active, load]),
+  );
+
   const unstage = useCallback(
     async (path: string) => {
       setBusyPath(path);
@@ -108,6 +114,22 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
     }
   }, [data, repo.localPath, onChanged]);
 
+  const discardFile = useCallback(
+    async (path: string) => {
+      setBusyPath(path);
+      try {
+        await GitEngine.remove(repo.localPath, [path], false);
+        onChanged();
+        setVersion((value) => value + 1);
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : String(caught));
+      } finally {
+        setBusyPath(null);
+      }
+    },
+    [repo.localPath, onChanged],
+  );
+
   const renderItem = useCallback(
     ({ item }: { item: FileStatus }) => {
       const diff = data?.diffs[item.path];
@@ -138,7 +160,17 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
               </View>
             )}
           </Pressable>
-          <View className="mt-2 flex-row justify-end">
+          <View className="mt-2 flex-row justify-end gap-2">
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={busyPath !== null}
+              onPress={() => void discardFile(item.path)}
+              testID={`explore.discard.${item.path}`}
+            >
+              {busyPath === item.path ? <Text className="text-xs" style={{ color: colors.textSecondary }}>…</Text> : null}
+              <ButtonText>Discard</ButtonText>
+            </Button>
             <Button
               size="sm"
               variant="outline"
@@ -153,7 +185,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
         </View>
       );
     },
-    [colors, data, navigation, repo.id, unstage, busyPath],
+    [colors, data, navigation, repo.id, unstage, discardFile, busyPath],
   );
 
   if (error) {


### PR DESCRIPTION
## Summary

Fix two issues in the Explore tab:

1. **Refresh on focus**: Changes and staging sections now refresh when navigating back to the Explore tab (was requiring tab navigation to see new changes)

2. **Discard button**: Added discard button to both Changes and Staging sections:
   - Changes section: discards working tree changes (keeps staged state)
   - Staging section: unstages AND reverts file to HEAD

## Changes

| File | Change |
|------|--------|
| `ChangesSection.tsx` | Add `useFocusEffect`, add `discardFile` function, add Discard button |
| `StagingSection.tsx` | Add `useFocusEffect`, add `discardFile` function, add Discard button |

## Testing

1. Make changes to a file in a cloned repo
2. Go to Explore > Changes - changes should appear immediately  
3. Navigate away and back - changes should still refresh
4. Click Discard - changes should be removed
5. Stage a file, then click Discard - file should be unstaged and reverted to HEAD