### PR TITLE
fix: replace deprecated InteractionManager with setTimeout

### DIFF
--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import { Alert, View, Text, ActivityIndicator, RefreshControl, FlatList, TouchableOpacity, InteractionManager, LayoutChangeEvent } from 'react-native';
+import { Alert, View, Text, ActivityIndicator, RefreshControl, FlatList, TouchableOpacity, LayoutChangeEvent } from 'react-native';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
@@ -165,23 +165,21 @@ export default function NotesListScreen() {
   const consumePendingFilter = useReminderStore((s) => s.consumePendingFilter);
   useEffect(() => {
     if (!isFocused) return;
-    InteractionManager.runAfterInteractions(() => {
-      const pending = consumePendingFilter();
-      if (!pending) return;
-      handleClearFilters();
-      if (pending.kind === 'repo' && pending.repoPath) {
+    const pending = consumePendingFilter();
+    if (!pending) return;
+    handleClearFilters();
+    if (pending.kind === 'repo' && pending.repoPath) {
+      const repo = repositories.find((r) => r.path === pending.repoPath) ?? null;
+      if (repo) handleSelectRepo(repo);
+    } else if (pending.kind === 'folder') {
+      if (pending.repoPath) {
         const repo = repositories.find((r) => r.path === pending.repoPath) ?? null;
         if (repo) handleSelectRepo(repo);
-      } else if (pending.kind === 'folder') {
-        if (pending.repoPath) {
-          const repo = repositories.find((r) => r.path === pending.repoPath) ?? null;
-          if (repo) handleSelectRepo(repo);
-        }
-        if (pending.folderPath) handleSelectFolder(pending.folderPath);
-      } else if (pending.kind === 'tag' && pending.tag) {
-        handleToggleTag(pending.tag);
       }
-    });
+      if (pending.folderPath) handleSelectFolder(pending.folderPath);
+    } else if (pending.kind === 'tag' && pending.tag) {
+      handleToggleTag(pending.tag);
+    }
   }, [isFocused, consumePendingFilter, handleClearFilters, handleSelectRepo, handleSelectFolder, handleToggleTag, repositories]);
 
   const activeFilterChips: FilterChip[] = useMemo(() => {

--- a/src/services/ai/thoughtDumpIndexing.ts
+++ b/src/services/ai/thoughtDumpIndexing.ts
@@ -1,4 +1,4 @@
-import { InteractionManager } from 'react-native';
+
 import * as FileSystem from 'expo-file-system/legacy';
 import { aiMemoryIndex } from './AIMemoryIndexService';
 import { ThoughtDumpService } from '../ThoughtDumpService';
@@ -57,11 +57,11 @@ async function ensureEmbedderResolved(): Promise<void> {
 }
 
 function runIdle(fn: () => Promise<void>): void {
-  InteractionManager.runAfterInteractions(() => {
+  setTimeout(() => {
     fn().catch((err) => {
       if (__DEV__) console.warn('[ThoughtDumpIndexing] idle task failed:', err);
     });
-  });
+  }, 0);
 }
 
 export function indexDump(dump: ThoughtDump): void {


### PR DESCRIPTION
## Summary

Replace deprecated `InteractionManager` usage with `setTimeout(fn, 0)`.

### Why

`InteractionManager` has been deprecated in React Native and will be removed in a future release. The warning recommends using `requestIdleCallback` instead, but in React Native `setTimeout(fn, 0)` is the idiomatic replacement for deferred task execution.

### Changes

| File | Change |
|------|--------|
| `NotesListScreen.tsx` | Remove `InteractionManager` import, remove `runAfterInteractions` wrapper |
| `thoughtDumpIndexing.ts` | Replace `InteractionManager.runAfterInteractions` with `setTimeout(fn, 0)` |