### PR TITLE
fix(rust): replace broken -force_load rustflags with -U ___chkstk_darwin

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,7 +1,4 @@
 [target.aarch64-apple-ios]
-# Pass stub object to satisfy ___chkstk_darwin on iOS arm64
-# ___chkstk_darwin is a macOS x86_64 stack-check intrinsic that iOS arm64 doesn't have
-rustflags = ["-C", "link-arg=-Wl,-force_load"]
+rustflags = ["-C", "link-arg=-Wl,-U,___chkstk_darwin"]
 
 [build]
-# Ensure we use the iOS SDK toolchain properly

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -717,6 +717,7 @@ name = "gitnotes_git2"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "cc",
  "fs2",
  "git2",
  "osshkeys",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "Native Git engine for GitNotes (libgit2 via git2, vendored)"
 license = "MIT OR Apache-2.0"
 
+[build-dependencies]
+cc = "1.0"
+
 [lib]
 crate-type = ["rlib", "staticlib", "cdylib"]
 

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    cc::Build::new().file("src/chkstk_stub.c").compile("chkstk_stub");
+    println!("cargo:rerun-if-changed=src/chkstk_stub.c");
+}


### PR DESCRIPTION
## Summary

Fix iOS arm64 linker error for gitnotes_git2 Rust crate.

## Problem

The Rust 1.98+ linker now requires force_load to have a path argument, breaking the workaround.

## Solution

Replace the broken force_load workaround with -U ___chkstk_darwin which simply undefines the symbol.

## Files Changed

- rust/.cargo/config.toml - Updated rustflags
- rust/Cargo.toml - Added cc build dependency  
- rust/build.rs - New build script