### PR TITLE
fix(explore): add discardFiles to restore files to HEAD instead of git rm

### DIFF
--- a/rust/src/api/bridge.rs
+++ b/rust/src/api/bridge.rs
@@ -207,7 +207,12 @@ pub fn unstage_paths(path: String, paths: Vec<String>) -> Result<(), BridgeError
     Ok(())
 }
 
-/// Remove the given paths from the index (+ worktree unless `keep_worktree`).
+#[uniffi::export]
+pub fn discard_files(path: String, paths: Vec<String>) -> Result<(), BridgeError> {
+    engine::ops::discard_files(std::path::Path::new(&path), &paths)?;
+    Ok(())
+}
+
 #[uniffi::export]
 pub fn remove_paths(
     path: String,

--- a/rust/src/engine/ops.rs
+++ b/rust/src/engine/ops.rs
@@ -175,6 +175,28 @@ pub fn remove_paths(path: &Path, paths: &[String], keep_worktree: bool) -> Resul
     })
 }
 
+/// Discard working tree changes for the given paths: restore them to HEAD state.
+/// This is `git checkout HEAD -- <paths>`.
+pub fn discard_files(path: &Path, paths: &[String]) -> Result<()> {
+    run_with_lock(path, || {
+        let repo = open_repo(path)?;
+        let head = repo.head()?;
+        let commit = head.peel_to_commit()?;
+        let tree = commit.tree()?;
+        for p in paths {
+            let entry = tree.get_path(Path::new(p)).map_err(|e| EngineError::Git(e))?;
+            let blob = repo.find_blob(entry.id()).map_err(|e| EngineError::Git(e))?;
+            let worktree_path = path.join(p);
+            if let Some(parent) = worktree_path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| EngineError::Io(e))?;
+            }
+            std::fs::write(&worktree_path, blob.content())
+                .map_err(|e| EngineError::Io(e))?;
+        }
+        Ok(())
+    })
+}
+
 /// LINE-LEVEL PARTIAL STAGING. Stages only the selected diff lines of
 /// `file_path`, leaving the rest unstaged. Ported from GitSync
 /// `stage_file_lines` (git_manager.rs:1718).

--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -96,7 +96,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
   const discardFile = useCallback(
     async (path: string) => {
       try {
-        await GitEngine.remove(repo.localPath, [path], true);
+        await GitEngine.discardFiles(repo.localPath, [path]);
         onChanged();
         setVersion((value) => value + 1);
       } catch (caught) {

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -118,7 +118,8 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
     async (path: string) => {
       setBusyPath(path);
       try {
-        await GitEngine.remove(repo.localPath, [path], false);
+        await GitEngine.unstage(repo.localPath, [path]);
+        await GitEngine.discardFiles(repo.localPath, [path]);
         onChanged();
         setVersion((value) => value + 1);
       } catch (caught) {

--- a/src/services/git/engine/GitEngine.ts
+++ b/src/services/git/engine/GitEngine.ts
@@ -33,6 +33,7 @@ let GitEngineModule: {
   stagePaths(path: string, paths: string[]): Promise<void>;
   unstagePaths(path: string, paths: string[]): Promise<void>;
   removePaths(path: string, paths: string[], keepWorktree: boolean): Promise<void>;
+  discardFiles(path: string, paths: string[]): Promise<void>;
   stageFileLines(path: string, filePath: string, hunks: HunkSelection[]): Promise<void>;
   commit(path: string, message: string, authorName: string, authorEmail: string): Promise<CommitInfo>;
   recentCommits(path: string, limit: number): Promise<CommitInfo[]>;
@@ -326,6 +327,11 @@ export async function unstage(repoPath: string, paths: string[]): Promise<void> 
 export async function remove(repoPath: string, paths: string[], keepWorktree = false): Promise<void> {
   if (!GitEngineModule) return;
   return run(() => GitEngineModule!.removePaths(repoPath, paths, keepWorktree), undefined);
+}
+
+export async function discardFiles(repoPath: string, paths: string[]): Promise<void> {
+  if (!GitEngineModule) return;
+  return run(() => GitEngineModule!.discardFiles(repoPath, paths), undefined);
 }
 
 /** LINE-LEVEL PARTIAL STAGING: stage only the selected diff lines. */


### PR DESCRIPTION
## Summary

Fix discard button in Explore tab to properly restore files to HEAD state instead of deleting them.

### Problem

`GitEngine.remove()` implements `git rm` semantics (deletes files from worktree). The discard button was calling this, which would **delete** the file instead of **restoring** it to the HEAD state.

### Solution

1. **Rust `ops.rs`**: Added `discard_files()` function that reads the file blob from HEAD and writes it to the worktree (`git checkout HEAD -- <paths>`)

2. **Rust `bridge.rs`**: Exported `discard_files` via UniFFI

3. **TypeScript `GitEngine.ts`**: Added `discardFiles()` JS facade

4. **ChangesSection**: Calls `discardFiles()` to restore working tree changes to HEAD

5. **StagingSection**: Calls `unstage()` then `discardFiles()` to unstage AND revert file to HEAD

### Testing

1. Make changes to a file
2. Click Discard - file should be restored to HEAD (not deleted)
3. Stage a file, then click Discard - file should be unstaged AND restored to HEAD