### PR TITLE
fix(explore): proper error when native module unavailable and fix FlatList layout

### DIFF
--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -186,7 +186,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
       data={data?.statuses ?? []}
       keyExtractor={(item) => item.path}
       renderItem={renderItem}
-       contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 96, flexGrow: 1 }}
+        contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 96 }}
       refreshControl={
         <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
       }
@@ -207,7 +207,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
       }
         ListEmptyComponent={
           !loading ? (
-            <View className="flex-1 items-center justify-center" style={{ minHeight: 240 }} testID="explore.changes.empty">
+            <View className="items-center justify-center py-16" testID="explore.changes.empty">
               <Ionicons name="checkmark-circle-outline" size={40} color={colors.accent} />
               <Text className="mt-2 text-center text-sm" style={{ color: colors.textSecondary }}>
                 Working tree clean — no changes.

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -220,7 +220,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
         data={data?.staged ?? []}
         keyExtractor={(item) => item.path}
         renderItem={renderItem}
-        contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 16, flexGrow: 1 }}
+        contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 16 }}
         refreshControl={
           <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
         }
@@ -246,7 +246,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
         }
         ListEmptyComponent={
           !loading ? (
-            <View className="flex-1 items-center justify-center" style={{ minHeight: 240 }} testID="explore.staging.empty">
+            <View className="items-center justify-center py-16" testID="explore.staging.empty">
               <Ionicons name="layers-outline" size={40} color={colors.textSecondary} />
               <Text className="mt-2 text-center text-sm" style={{ color: colors.textSecondary }}>
                 Nothing staged. Stage changes from the Changes tab.

--- a/src/services/git/engine/GitEngine.ts
+++ b/src/services/git/engine/GitEngine.ts
@@ -330,7 +330,9 @@ export async function remove(repoPath: string, paths: string[], keepWorktree = f
 }
 
 export async function discardFiles(repoPath: string, paths: string[]): Promise<void> {
-  if (!GitEngineModule) return;
+  if (!GitEngineModule) {
+    throw new Error('GitEngine native module unavailable: cannot discard changes');
+  }
   return run(() => GitEngineModule!.discardFiles(repoPath, paths), undefined);
 }
 


### PR DESCRIPTION
## Summary

Fix two issues:

1. **Proper error when native module unavailable** -  now throws an error instead of silently returning when the native module is unavailable. Previously, the discard would appear to work (item removed from list) but nothing actually happened.

2. **FlatList layout fix** - Remove  from  and fix  to use  instead of  with . This prevents content from going off-screen when the list becomes empty.

### Changes

- GitEngine.ts: discardFiles now throws error when native module unavailable
- ChangesSection.tsx: Remove flexGrow: 1, fix ListEmptyComponent layout
- StagingSection.tsx: Remove flexGrow: 1, fix ListEmptyComponent layout