### PR TITLE
fix(GitEngine): fix Podfile insertion to use correct line

### DIFF
--- a/modules/GitEngine/plugin/withGitEngineRust.js
+++ b/modules/GitEngine/plugin/withGitEngineRust.js
@@ -14,13 +14,13 @@ function withGitEngineRustPodfile(config) {
     let contents = podConfig.modResults.contents;
 
     const gitEnginePod = "pod 'GitEngine', :path => '../modules/GitEngine/ios-local'";
-    const useExpoModules = 'use_expo_modules!';
-    if (!contents.includes(gitEnginePod) && contents.includes(useExpoModules)) {
-      const nativeModulesLine = 'config = use_native_modules!';
-      const afterNativeModules = contents.indexOf(nativeModulesLine) !== -1
-        ? contents.indexOf(nativeModulesLine) + nativeModulesLine.length
-        : contents.indexOf(useExpoModules);
-      contents = contents.slice(0, afterNativeModules) + '\n  ' + gitEnginePod + '\n' + contents.slice(afterNativeModules);
+    if (!contents.includes(gitEnginePod)) {
+      const nativeModulesCall = 'config = use_native_modules!(config_command)';
+      const insertionPoint = contents.indexOf(nativeModulesCall);
+      if (insertionPoint !== -1) {
+        const afterCall = insertionPoint + nativeModulesCall.length;
+        contents = contents.slice(0, afterCall) + '\n  ' + gitEnginePod + '\n' + contents.slice(afterCall);
+      }
     }
 
     const marker = 'post_install do |installer|';


### PR DESCRIPTION
The previous PR #1343 had a bug in the Podfile plugin insertion logic.

**Problem**: The plugin was inserting the GitEngine pod after `config = use_native_modules!` but before the `(config_command)` argument, breaking Podfile syntax.

**Fix**: Changed the insertion point to use the complete `config = use_native_modules!(config_command)` line.