### PR TITLE
fix(explore): fix Issues/PR Open settings navigation and loading spacing

### DIFF
--- a/src/components/explore/IssuesSection.tsx
+++ b/src/components/explore/IssuesSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ActivityIndicator, Pressable, RefreshControl, View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -139,7 +139,7 @@ export function IssuesSection({ repo, active, chromeTopInset = 0 }: SectionProps
             <Button
               variant="ghost"
               size="sm"
-              onPress={() => navigation.navigate('Repos' as any)}
+              onPress={() => navigation.navigate('MainTabs', { screen: 'SettingsTab' })}
               testID="explore.issue.open-settings"
             >
               <ButtonText>Open settings</ButtonText>
@@ -150,13 +150,22 @@ export function IssuesSection({ repo, active, chromeTopInset = 0 }: SectionProps
     );
   }
 
+  const listContentContainerStyle = useMemo(
+    () => ({
+      paddingTop: issues !== null ? chromeTopInset : 0,
+      paddingBottom: 96,
+      flexGrow: 1,
+    }),
+    [issues, chromeTopInset],
+  );
+
   return (
     <FlatList<GitHostIssue>
       className="flex-1"
       data={issues ?? []}
       keyExtractor={(item) => item.id}
       renderItem={renderItem}
-       contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 96, flexGrow: 1 }}
+      contentContainerStyle={listContentContainerStyle}
       refreshControl={
         <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
       }

--- a/src/components/explore/PullRequestsSection.tsx
+++ b/src/components/explore/PullRequestsSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ActivityIndicator, Pressable, RefreshControl, View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -124,7 +124,7 @@ export function PullRequestsSection({ repo, active, chromeTopInset = 0 }: Sectio
             <Button
               variant="ghost"
               size="sm"
-              onPress={() => navigation.navigate('Repos' as any)}
+              onPress={() => navigation.navigate('MainTabs', { screen: 'SettingsTab' })}
               testID="explore.pr.open-settings"
             >
               <ButtonText>Open settings</ButtonText>
@@ -135,13 +135,22 @@ export function PullRequestsSection({ repo, active, chromeTopInset = 0 }: Sectio
     );
   }
 
+  const listContentContainerStyle = useMemo(
+    () => ({
+      paddingTop: prs !== null ? chromeTopInset : 0,
+      paddingBottom: 96,
+      flexGrow: 1,
+    }),
+    [prs, chromeTopInset],
+  );
+
   return (
     <FlatList<PullRequest>
       className="flex-1"
       data={prs ?? []}
       keyExtractor={(item) => item.id}
       renderItem={renderItem}
-       contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 96, flexGrow: 1 }}
+      contentContainerStyle={listContentContainerStyle}
       refreshControl={
         <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
       }


### PR DESCRIPTION
## Summary

Fixed two issues in IssuesSection and PullRequestsSection:

1. **Navigation error**: 'Repos' screen doesn't exist - changed to MainTabs/SettingsTab
2. **Loading spacing**: paddingTop was applied unconditionally - now only applied when data exists

## Files changed
- src/components/explore/IssuesSection.tsx
- src/components/explore/PullRequestsSection.tsx