### PR TITLE
feat: per-host SSH key authentication for Git operations

### DIFF
--- a/__tests__/services/git/ssh-credential-flow.test.ts
+++ b/__tests__/services/git/ssh-credential-flow.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { remoteUrlForHost } from '../../../src/services/git/GitFsService';
+import { formatSyncError } from '../../../src/services/git/formatSyncError';
+
+jest.mock('../../../src/services/AccountStorage', () => ({
+  AccountStorage: {
+    getSshKey: jest.fn(),
+    setSshKey: jest.fn(),
+    deleteSshKey: jest.fn(),
+    getHostUseSsh: jest.fn(),
+    setHostUseSsh: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/services/git/engine/GitEngine', () => ({
+  generateSshKey: jest.fn(),
+  setCredential: jest.fn(),
+  getCredential: jest.fn(),
+  clearCredential: jest.fn(),
+}));
+
+describe('remoteUrlForHost', () => {
+  test('GitHub HTTPS when useSsh=false', () => {
+    const url = remoteUrlForHost('owner', 'repo', {
+      useSsh: false,
+      provider: 'github',
+      instanceBaseUrl: null,
+    });
+    expect(url).toBe('https://github.com/owner/repo.git');
+  });
+
+  test('GitHub SSH when useSsh=true', () => {
+    const url = remoteUrlForHost('owner', 'repo', {
+      useSsh: true,
+      provider: 'github',
+      instanceBaseUrl: null,
+    });
+    expect(url).toBe('git@github.com:owner/repo.git');
+  });
+
+  test('GitLab SSH when useSsh=true', () => {
+    const url = remoteUrlForHost('owner', 'repo', {
+      useSsh: true,
+      provider: 'gitlab',
+      instanceBaseUrl: null,
+    });
+    expect(url).toBe('git@gitlab.com:owner/repo.git');
+  });
+
+  test('GitLab HTTPS when useSsh=false', () => {
+    const url = remoteUrlForHost('owner', 'repo', {
+      useSsh: false,
+      provider: 'gitlab',
+      instanceBaseUrl: null,
+    });
+    expect(url).toBe('https://gitlab.com/owner/repo.git');
+  });
+
+  test('Gitea SSH with custom instanceBaseUrl', () => {
+    const url = remoteUrlForHost('owner', 'repo', {
+      useSsh: true,
+      provider: 'gitea',
+      instanceBaseUrl: 'https://gitea.example.com',
+    });
+    expect(url).toBe('git@gitea.example.com:owner/repo.git');
+  });
+
+  test('Gitea HTTPS with custom instanceBaseUrl', () => {
+    const url = remoteUrlForHost('owner', 'repo', {
+      useSsh: false,
+      provider: 'gitea',
+      instanceBaseUrl: 'https://gitea.example.com',
+    });
+    expect(url).toBe('https://gitea.example.com/owner/repo.git');
+  });
+
+  test('Forgejo SSH with custom instanceBaseUrl', () => {
+    const url = remoteUrlForHost('owner', 'repo', {
+      useSsh: true,
+      provider: 'forgejo',
+      instanceBaseUrl: 'https://forgejo.example.org',
+    });
+    expect(url).toBe('git@forgejo.example.org:owner/repo.git');
+  });
+
+  test('unknown provider falls back to GitHub HTTPS', () => {
+    const url = remoteUrlForHost('owner', 'repo', {
+      useSsh: false,
+      provider: 'unknown' as any,
+      instanceBaseUrl: null,
+    });
+    expect(url).toBe('https://github.com/owner/repo.git');
+  });
+
+  test('unknown provider with useSsh=true falls back to GitHub SSH', () => {
+    const url = remoteUrlForHost('owner', 'repo', {
+      useSsh: true,
+      provider: 'unknown' as any,
+      instanceBaseUrl: null,
+    });
+    expect(url).toBe('git@github.com:owner/repo.git');
+  });
+
+  test('instanceBaseUrl trailing slash is stripped', () => {
+    const url = remoteUrlForHost('owner', 'repo', {
+      useSsh: true,
+      provider: 'gitea',
+      instanceBaseUrl: 'https://gitea.example.com/',
+    });
+    expect(url).toBe('git@gitea.example.com:owner/repo.git');
+  });
+});
+
+describe('formatSyncError - SSH auth failures', () => {
+  test('Permission denied (publickey) maps to SSH auth message', () => {
+    const message = formatSyncError('Git remote: Permission denied (publickey).');
+    expect(message).toContain('SSH key');
+    expect(message).toContain('not recognized');
+  });
+
+  test('publickey in error maps to SSH auth message', () => {
+    const message = formatSyncError('fatal: Could not read from remote repository. publickey');
+    expect(message).toContain('SSH key');
+  });
+
+  test('ssh auth maps to SSH auth message', () => {
+    const message = formatSyncError('SSH_AUTH error: authentication failed');
+    expect(message).toContain('SSH key');
+  });
+
+  test('authentication failed maps to SSH auth message', () => {
+    const message = formatSyncError('fatal: authentication failed');
+    expect(message).toContain('SSH key');
+  });
+
+  test('git@github.com permission denied maps to SSH auth message', () => {
+    const message = formatSyncError('git@github.com: permission denied (publickey)');
+    expect(message).toContain('SSH key');
+  });
+
+  test('HTTPS 403 still shows HTTPS-specific message not SSH', () => {
+    const message = formatSyncError('GitHub API error: 403');
+    expect(message).toContain('token');
+    expect(message).toContain('Contents: Read and write');
+    expect(message).not.toContain('SSH');
+  });
+
+  test('SSH auth failure is non-retryable', () => {
+    const message = formatSyncError('Permission denied (publickey)');
+    expect(message).not.toContain('retry');
+  });
+});

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -953,6 +953,7 @@ checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -963,6 +964,20 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04141a07bb0c0bc461cb657808764de571702a59bc5c726c400ac9a7625e3ab"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "libz-sys"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,7 +24,7 @@ path = "uniffi-bindgen.rs"
 required-features = ["uniffi-cli"]
 
 [dependencies]
-git2 = { version = "0.21", features = ["vendored-libgit2", "vendored-openssl", "https"] }
+git2 = { version = "0.21", features = ["vendored-libgit2", "vendored-openssl", "https", "ssh"] }
 ssh-key = { version = "0.6.7", features = ["crypto", "encryption"] }
 osshkeys = "0.7.0"
 serde = { version = "1", features = ["derive"] }

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -155,6 +155,8 @@ onRemoveAccount: (id: string, login: string) => void;
   syncPaused: boolean;
   onToggleSyncPaused: (value: boolean) => void;
   syncHealth: ForegroundSyncHealth;
+  onToggleSSH: (hostId: string) => void;
+  hostUseSsh: Record<string, boolean>;
 };
 
 function formatLfsBytes(bytes: number): string {
@@ -247,6 +249,8 @@ export function SettingsContent(props: SettingsContentProps) {
     syncPaused,
     onToggleSyncPaused,
     syncHealth,
+    onToggleSSH,
+    hostUseSsh,
   } = props;
   // Tokens hook gives us spacing/radii/type so the styled disconnect
   // button matches the rest of the app without hardcoded values.
@@ -545,27 +549,37 @@ export function SettingsContent(props: SettingsContentProps) {
                             color with an unlink icon. Distinct from the
                             account row's neutral chrome so the destructive
                             intent is obvious without being alarming. */}
-                        <TouchableOpacity
-                          onPress={() => onDisconnectHost(host.id)}
-                          testID={`settings.button.disconnect-host.${host.id}`}
-                          accessibilityRole="button"
-                          accessibilityLabel={`${GIT_HOST_LABELS[host.provider]} ${t('accounts.disconnect')}`}
-                          activeOpacity={0.75}
-                          className="flex-row items-center gap-1.5 px-3 py-2 border"
-                          style={{ borderRadius: radii.md, borderColor: colors.error }}
-                        >
-                          <Ionicons name="unlink-outline" size={15} color={colors.error} />
-                          <Text
-                            style={{
-                              color: colors.error,
-                              fontSize: type.xs,
-                              fontWeight: '700',
-                              letterSpacing: 0.2,
-                            }}
+                        <View className="flex-row items-center gap-2">
+                          <View className="flex-row items-center gap-1.5">
+                            <Text style={{ fontSize: type.xs, color: colors.textSecondary }}>SSH</Text>
+                            <Toggle
+                              testID={`settings.toggle.ssh.${host.id}`}
+                              value={hostUseSsh[host.id] ?? false}
+                              onValueChange={() => onToggleSSH(host.id)}
+                            />
+                          </View>
+                          <TouchableOpacity
+                            onPress={() => onDisconnectHost(host.id)}
+                            testID={`settings.button.disconnect-host.${host.id}`}
+                            accessibilityRole="button"
+                            accessibilityLabel={`${GIT_HOST_LABELS[host.provider]} ${t('accounts.disconnect')}`}
+                            activeOpacity={0.75}
+                            className="flex-row items-center gap-1.5 px-3 py-2 border"
+                            style={{ borderRadius: radii.md, borderColor: colors.error }}
                           >
-                            {t('accounts.disconnect')}
-                          </Text>
-                        </TouchableOpacity>
+                            <Ionicons name="unlink-outline" size={15} color={colors.error} />
+                            <Text
+                              style={{
+                                color: colors.error,
+                                fontSize: type.xs,
+                                fontWeight: '700',
+                                letterSpacing: 0.2,
+                              }}
+                            >
+                              {t('accounts.disconnect')}
+                            </Text>
+                          </TouchableOpacity>
+                        </View>
                       </View>
                     );
                   })}

--- a/src/components/settings/SettingsModals.tsx
+++ b/src/components/settings/SettingsModals.tsx
@@ -17,9 +17,96 @@ type ThemeColors = {
   text: string;
   textSecondary: string;
   border: string;
+  error: string;
 };
 
 type AuthState = { isAuthenticated: boolean };
+
+type SSHModalProps = {
+  visible: boolean;
+  generating: boolean;
+  publicKey: string | null;
+  onCopy: (key: string) => void;
+  onOpenSettings: () => void;
+  onSave: () => void;
+  onClose: () => void;
+  colors: ThemeColors;
+};
+
+export const SSHKeyModal = memo(function SSHKeyModal({
+  visible,
+  generating,
+  publicKey,
+  onCopy,
+  onOpenSettings,
+  onSave,
+  onClose,
+  colors,
+}: SSHModalProps) {
+  const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
+  return (
+    <Modal visible={visible} onRequestClose={onClose} bottomSheet contentStyle={{ padding: 0 }}>
+      <View className="flex-row justify-between items-center px-4 pt-4 pb-3 border-b" style={{ borderColor: colors.border }}>
+        <Text style={{ color: colors.text, fontSize: 18, fontWeight: '600' }}>{t('settings.sshKeyTitle')}</Text>
+        <TouchableOpacity onPress={onClose}>
+          <Ionicons name="close" size={24} color={colors.textSecondary} />
+        </TouchableOpacity>
+      </View>
+      <ScrollView className="px-4 py-4" style={{ paddingBottom: 16 + insets.bottom }} keyboardShouldPersistTaps="handled">
+        {generating ? (
+          <View className="flex-row items-center gap-3 py-4">
+            <ActivityIndicator size="small" color={colors.primary} />
+            <Text style={{ color: colors.textSecondary, fontSize: 14 }}>{t('settings.sshGenerating')}</Text>
+          </View>
+        ) : publicKey ? (
+          <>
+            <Text className="text-sm mb-2" style={{ color: colors.textSecondary }}>{t('settings.sshKeyDescription')}</Text>
+            <View
+              className="rounded-lg p-3 mb-3"
+              style={{ backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.border }}
+            >
+              <Text
+                style={{ color: colors.text, fontSize: 12, fontFamily: 'Menlo' }}
+                selectable
+              >
+                {publicKey}
+              </Text>
+            </View>
+            <View className="flex-row gap-2 mb-4">
+              <TouchableOpacity
+                className="flex-row items-center justify-center py-2.5 px-3 rounded-lg border flex-1 gap-1.5"
+                style={{ borderColor: colors.border }}
+                onPress={() => onCopy(publicKey)}
+              >
+                <Ionicons name="copy-outline" size={16} color={colors.primary} />
+                <Text style={{ color: colors.primary, fontSize: 14, fontWeight: '600' }}>{t('common.copy')}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                className="flex-row items-center justify-center py-2.5 px-3 rounded-lg border flex-1 gap-1.5"
+                style={{ borderColor: colors.border }}
+                onPress={onOpenSettings}
+              >
+                <Ionicons name="open-outline" size={16} color={colors.primary} />
+                <Text style={{ color: colors.primary, fontSize: 14, fontWeight: '600' }}>{t('settings.openSshSettings')}</Text>
+              </TouchableOpacity>
+            </View>
+            <Button
+              label={t('settings.sshKeySaved')}
+              onPress={onSave}
+              variant="primary"
+              fullWidth
+              style={{ minHeight: 48 }}
+              textStyle={{ color: '#fff', fontWeight: '600' }}
+            />
+          </>
+        ) : (
+          <Text style={{ color: colors.error, fontSize: 14 }}>{t('settings.sshKeyError')}</Text>
+        )}
+      </ScrollView>
+    </Modal>
+  );
+});
 
 type SettingsModalsProps = {
   colors: ThemeColors;

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, View } from 'react-native';
+import { Alert, Linking, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
@@ -40,6 +40,7 @@ import { ConnectHostModal } from '../components/ConnectHostModal';
 import { ScreenHeader, useScreenHeaderHeight, useTabBarHeight } from '../components/ui';
 import { SettingsContent } from '../components/settings/SettingsContent';
 import { SettingsModals } from '../components/settings/SettingsModals';
+import { SSHKeyModal } from '../components/settings/SettingsModals';
 import { CloneProgressModal, type CloneProgress } from '../components/settings/CloneProgressModal';
 import type { GitRepository } from '../services/GitService';
 import { reposAffectedByRemovedHosts, buildProviderAccountCount, type RemovedHostRef } from '../services/git/repoRemovalCascade';
@@ -47,6 +48,8 @@ import { useRepoStore } from '../stores/repoStore';
 import { importRepoAtAdd } from '../services/RepoImportService';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
+import { AccountStorage } from '../services/AccountStorage';
+import { generateSshKey, setCredential, clearCredential } from '../services/git/engine/GitEngine';
 import { RepoAccessPreflightError } from '../services/git/repoAccessPreflight';
 import { useProStatus } from '../hooks/useProGate';
 import { useFloatingGitButtonStore } from '../stores/floatingGitButtonStore';
@@ -169,6 +172,23 @@ export default function SettingsScreen() {
   const [isSyncingExistingTemplates, setIsSyncingExistingTemplates] = useState(false);
   const [lfsPending, setLfsPending] = useState<Record<string, { count: number; bytes: number }>>({});
   const [lfsDownloadingRepo, setLfsDownloadingRepo] = useState<string | null>(null);
+  const [showSSHModal, setShowSSHModal] = useState(false);
+  const [sshModalHostId, setSshModalHostId] = useState<string | null>(null);
+  const [sshKeyData, setSshKeyData] = useState<{ publicKey: string; privateKey: string } | null>(null);
+  const [sshGenerating, setSshGenerating] = useState(false);
+  const [hostUseSsh, setHostUseSsh] = useState<Record<string, boolean>>({});
+
+  const loadHostUseSsh = useCallback(async (hosts: Array<{ id: string }>) => {
+    const results: Record<string, boolean> = {};
+    await Promise.all(hosts.map(async (h) => { results[h.id] = await AccountStorage.getHostUseSsh(h.id); }));
+    setHostUseSsh(results);
+  }, []);
+
+  useEffect(() => {
+    if (accountSummaries.length === 0) return;
+    const allHosts = accountSummaries.flatMap((s) => s.hosts);
+    void loadHostUseSsh(allHosts);
+  }, [accountSummaries, loadHostUseSsh]);
 
   useEffect(() => {
     TemplateRepoPreferenceService.get().then(setTemplatesRepoPref);
@@ -853,6 +873,52 @@ export default function SettingsScreen() {
     );
   }, [accountSummaries, repositories, disconnectHost, t]);
 
+  const handleToggleSSH = useCallback(async (hostId: string) => {
+    const useSsh = await AccountStorage.getHostUseSsh(hostId);
+    if (!useSsh) {
+      setSshModalHostId(hostId);
+      setSshGenerating(true);
+      setShowSSHModal(true);
+      try {
+        const keys = await generateSshKey(null);
+        setSshKeyData(keys);
+      } catch (err) {
+        setSshKeyData(null);
+      } finally {
+        setSshGenerating(false);
+      }
+    } else {
+      await AccountStorage.setHostUseSsh(hostId, false);
+      await clearCredential(`ssh:${hostId}`);
+      await AccountStorage.deleteSshKey(hostId);
+      HapticService.success();
+    }
+  }, []);
+
+  const handleSaveSSHKey = useCallback(async () => {
+    if (!sshModalHostId || !sshKeyData) return;
+    await AccountStorage.setSshKey(sshModalHostId, sshKeyData);
+    await AccountStorage.setHostUseSsh(sshModalHostId, true);
+    setShowSSHModal(false);
+    setSshKeyData(null);
+    setSshModalHostId(null);
+    HapticService.success();
+  }, [sshModalHostId, sshKeyData]);
+
+  const handleCopySSHPublicKey = useCallback(async (publicKey: string) => {
+    try {
+      const { setStringAsync } = await import('expo-clipboard');
+      await setStringAsync(publicKey);
+      HapticService.success();
+    } catch (error) {
+      HapticService.error();
+    }
+  }, []);
+
+  const handleOpenSSHSettings = useCallback(() => {
+    Linking.openURL('https://github.com/settings/keys');
+  }, []);
+
   const handleResetOnboarding = useCallback(() => {
     HapticService.warning();
     Alert.alert(t('settings.resetOnboardingTitle'), t('settings.resetOnboardingBody'), [
@@ -1002,6 +1068,8 @@ export default function SettingsScreen() {
         syncPaused={syncPaused}
         onToggleSyncPaused={(value) => void setSyncPaused(value)}
         syncHealth={syncHealth}
+        onToggleSSH={handleToggleSSH}
+        hostUseSsh={hostUseSsh}
       />
       <SettingsModals
         colors={colors}
@@ -1056,6 +1124,16 @@ export default function SettingsScreen() {
       {!showRepoPickerModal ? (
         <CloneProgressModal progress={cloneProgress} onCancel={handleCancelClone} onRetry={handleRetryClone} />
       ) : null}
+      <SSHKeyModal
+        visible={showSSHModal}
+        generating={sshGenerating}
+        publicKey={sshKeyData?.publicKey ?? null}
+        onCopy={handleCopySSHPublicKey}
+        onOpenSettings={handleOpenSSHSettings}
+        onSave={handleSaveSSHKey}
+        onClose={() => { setShowSSHModal(false); setSshKeyData(null); setSshModalHostId(null); }}
+        colors={colors}
+      />
       <ConnectHostModal
         visible={showConnectHostModal}
         onClose={() => { setShowConnectHostModal(false); setConnectHostPreset(undefined); }}

--- a/src/services/AccountStorage.ts
+++ b/src/services/AccountStorage.ts
@@ -11,6 +11,12 @@ const PER_ID_TOKEN_PREFIX_WEB = '@gitnotes:account_token:';
 const PER_HOST_TOKEN_PREFIX_WEB = '@gitnotes:host_token:';
 const PER_ID_TOKEN_PREFIX_NATIVE = 'gitnotes_account_token_';
 const PER_HOST_TOKEN_PREFIX_NATIVE = 'gitnotes_host_token_';
+const PER_HOST_SSH_PRIVATE_PREFIX_NATIVE = 'gitnotes_ssh_private_';
+const PER_HOST_SSH_PUBLIC_PREFIX_NATIVE = 'gitnotes_ssh_public_';
+const PER_HOST_SSH_PRIVATE_PREFIX_WEB = '@gitnotes:ssh_private:';
+const PER_HOST_SSH_PUBLIC_PREFIX_WEB = '@gitnotes:ssh_public:';
+const USE_SSH_KEY_PREFIX_WEB = '@gitnotes:host_use_ssh:';
+const USE_SSH_KEY_PREFIX_NATIVE = 'gitnotes_host_use_ssh_';
 
 const LEGACY_TOKEN_KEY_WEB = '@gitnotes:github_token';
 const LEGACY_TOKEN_KEY_NATIVE = 'gitnotes_github_token';
@@ -115,6 +121,61 @@ async function writeHostToken(hostId: string, token: string): Promise<void> {
 
 async function deleteHostToken(hostId: string): Promise<void> {
   return deleteTokenById(hostTokenKeyFor(hostId));
+}
+
+async function readSshPrivateKey(hostId: string): Promise<string | null> {
+  if (Platform.OS === 'web') return AsyncStorage.getItem(PER_HOST_SSH_PRIVATE_PREFIX_WEB + hostId);
+  const key = PER_HOST_SSH_PRIVATE_PREFIX_NATIVE + hostId.replace(/[^A-Za-z0-9_]/g, '_');
+  try { return await SecureStore.getItemAsync(key); } catch { return null; }
+}
+
+async function readSshPublicKey(hostId: string): Promise<string | null> {
+  if (Platform.OS === 'web') return AsyncStorage.getItem(PER_HOST_SSH_PUBLIC_PREFIX_WEB + hostId);
+  const key = PER_HOST_SSH_PUBLIC_PREFIX_NATIVE + hostId.replace(/[^A-Za-z0-9_]/g, '_');
+  try { return await SecureStore.getItemAsync(key); } catch { return null; }
+}
+
+async function writeSshKey(hostId: string, keys: { privateKey: string; publicKey: string }): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.setItem(PER_HOST_SSH_PRIVATE_PREFIX_WEB + hostId, keys.privateKey);
+    await AsyncStorage.setItem(PER_HOST_SSH_PUBLIC_PREFIX_WEB + hostId, keys.publicKey);
+    return;
+  }
+  const privateKey = PER_HOST_SSH_PRIVATE_PREFIX_NATIVE + hostId.replace(/[^A-Za-z0-9_]/g, '_');
+  const publicKey = PER_HOST_SSH_PUBLIC_PREFIX_NATIVE + hostId.replace(/[^A-Za-z0-9_]/g, '_');
+  await SecureStore.setItemAsync(privateKey, keys.privateKey);
+  await SecureStore.setItemAsync(publicKey, keys.publicKey);
+}
+
+async function deleteSshKey(hostId: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.removeItem(PER_HOST_SSH_PRIVATE_PREFIX_WEB + hostId);
+    await AsyncStorage.removeItem(PER_HOST_SSH_PUBLIC_PREFIX_WEB + hostId);
+    return;
+  }
+  const privateKey = PER_HOST_SSH_PRIVATE_PREFIX_NATIVE + hostId.replace(/[^A-Za-z0-9_]/g, '_');
+  const publicKey = PER_HOST_SSH_PUBLIC_PREFIX_NATIVE + hostId.replace(/[^A-Za-z0-9_]/g, '_');
+  await SecureStore.deleteItemAsync(privateKey).catch(() => undefined);
+  await SecureStore.deleteItemAsync(publicKey).catch(() => undefined);
+}
+
+async function readHostUseSsh(hostId: string): Promise<boolean> {
+  if (Platform.OS === 'web') {
+    const val = await AsyncStorage.getItem(USE_SSH_KEY_PREFIX_WEB + hostId);
+    return val === 'true';
+  }
+  const key = USE_SSH_KEY_PREFIX_NATIVE + hostId.replace(/[^A-Za-z0-9_]/g, '_');
+  const val = await SecureStore.getItemAsync(key);
+  return val === 'true';
+}
+
+async function writeHostUseSsh(hostId: string, useSsh: boolean): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.setItem(USE_SSH_KEY_PREFIX_WEB + hostId, String(useSsh));
+    return;
+  }
+  const key = USE_SSH_KEY_PREFIX_NATIVE + hostId.replace(/[^A-Za-z0-9_]/g, '_');
+  await SecureStore.setItemAsync(key, String(useSsh));
 }
 
 async function readLegacyToken(): Promise<string | null> {
@@ -435,11 +496,36 @@ export class AccountStorage {
     return readHostToken(hostId);
   }
 
+  static async getSshKey(hostId: string): Promise<{ privateKey: string; publicKey: string } | null> {
+    const [privateKey, publicKey] = await Promise.all([readSshPrivateKey(hostId), readSshPublicKey(hostId)]);
+    if (privateKey && publicKey) return { privateKey, publicKey };
+    return null;
+  }
+
+  static async setSshKey(hostId: string, keys: { privateKey: string; publicKey: string }): Promise<void> {
+    await writeSshKey(hostId, keys);
+  }
+
+  static async deleteSshKey(hostId: string): Promise<void> {
+    await deleteSshKey(hostId);
+  }
+
+  static async getHostUseSsh(hostId: string): Promise<boolean> {
+    return readHostUseSsh(hostId);
+  }
+
+  static async setHostUseSsh(hostId: string, useSsh: boolean): Promise<void> {
+    await writeHostUseSsh(hostId, useSsh);
+  }
+
   static async removeHostConnection(hostId: string): Promise<void> {
     const hosts = await listHostConnections();
     const remaining = hosts.filter((h) => h.id !== hostId);
     await writeHostConnections(remaining);
     await deleteHostToken(hostId);
+    await deleteSshKey(hostId);
+    const useSshKey = USE_SSH_KEY_PREFIX_NATIVE + hostId.replace(/[^A-Za-z0-9_]/g, '_');
+    await SecureStore.deleteItemAsync(useSshKey).catch(() => undefined);
 
     const accounts = await this.listAccounts();
     let mutated = false;

--- a/src/services/RepoImportService.ts
+++ b/src/services/RepoImportService.ts
@@ -1,8 +1,11 @@
 import { AuthService } from './AuthService';
+import { AccountStorage } from './AccountStorage';
+import { setCredential } from './git/engine/GitEngine';
 import { pullFromSingleRepo, type PullResult } from './RepoPullService';
 import { StorageService } from './StorageService';
 import { resolveBranch } from './git/branchResolver';
-import { GitFsService } from './git/GitFsService';
+import { parseRepoPath } from '../utils/gitPathParser';
+import { GitFsService, remoteUrlForHost } from './git/GitFsService';
 
 export type CloneProgressCallback = (phase: string, loaded: number, total: number | null) => void;
 
@@ -91,7 +94,34 @@ async function runImport(
     const token = (await AuthService.getToken()) ?? undefined;
 
     if (!(await GitFsService.isCloned({ repoPath }))) {
-      await GitFsService.cloneExclusive({ repoPath, branch, token, onProgress, repoId: repo?.id });
+      let remoteUrlOverride: string | undefined;
+      const hostConnection = await AccountStorage.getActiveHostConnection();
+      if (hostConnection) {
+        const useSsh = await AccountStorage.getHostUseSsh(hostConnection.id);
+        if (useSsh && repo?.id) {
+          const sshKeys = await AccountStorage.getSshKey(hostConnection.id);
+          if (sshKeys) {
+            await setCredential(repo.id, {
+              kind: 'SSH',
+              username: 'git',
+              privateKey: sshKeys.privateKey,
+              publicKey: sshKeys.publicKey,
+              passphrase: null,
+            });
+            const info = parseRepoPath(repoPath);
+            if (info) {
+              remoteUrlOverride = remoteUrlForHost(info.owner, info.repo, {
+                useSsh: true,
+                provider: hostConnection.provider,
+                instanceBaseUrl: hostConnection.instanceBaseUrl,
+              });
+            }
+          }
+        }
+      }
+      await GitFsService.cloneExclusive({
+        repoPath, branch, token, onProgress, repoId: repo?.id, remoteUrlOverride,
+      });
     }
 
     const headOid = await GitFsService.getCommitOid({ repoPath, ref: `refs/heads/${branch}` });

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -51,6 +51,8 @@ interface CloneOpts extends RepoLocator {
   onProgress?: (phase: string, loaded: number, total: number | null) => void;
   /** Passed to native engine for credential lookup. Omit to skip credential auth (public repos). */
   repoId?: string;
+  /** Override the remote URL (e.g., SSH URL when SSH is enabled). Defaults to HTTPS. */
+  remoteUrlOverride?: string;
 }
 
 interface FetchOpts extends RepoLocator {
@@ -391,7 +393,7 @@ export class GitFsService {
     for (let attempt = 0; attempt <= MAX_CLONE_RETRIES; attempt++) {
       try {
         await nativeClone(
-          authedRemote(info.owner, info.repo),
+          opts.remoteUrlOverride ?? authedRemote(info.owner, info.repo),
           `${fsRoot}${info.owner}/${info.repo}`,
           opts.repoId ?? null,
         );

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -279,6 +279,38 @@ async function repairHeadRefInner(
   }
 }
 
+export interface RemoteUrlOptions {
+  useSsh: boolean;
+  provider: string;
+  instanceBaseUrl: string | null;
+}
+
+/**
+ * Constructs the git remote URL for a repository.
+ * SCP-style SSH URLs: git@github.com:owner/repo.git
+ * HTTPS URLs: https://github.com/owner/repo.git
+ */
+export function remoteUrlForHost(
+  owner: string,
+  repo: string,
+  opts: RemoteUrlOptions,
+): string {
+  const { useSsh, provider, instanceBaseUrl } = opts;
+  if (useSsh) {
+    if (provider === 'github') return `git@github.com:${owner}/${repo}.git`;
+    if (provider === 'gitlab') return `git@gitlab.com:${owner}/${repo}.git`;
+    if (instanceBaseUrl) {
+      const host = instanceBaseUrl.replace(/^https?:\/\//, '').replace(/\/$/, '');
+      return `git@${host}:${owner}/${repo}.git`;
+    }
+    return `git@github.com:${owner}/${repo}.git`;
+  }
+  if (provider === 'github') return `https://github.com/${owner}/${repo}.git`;
+  if (provider === 'gitlab') return `https://gitlab.com/${owner}/${repo}.git`;
+  if (instanceBaseUrl) return `${instanceBaseUrl.replace(/\/$/, '')}/${owner}/${repo}.git`;
+  return `https://github.com/${owner}/${repo}.git`;
+}
+
 function authedRemote(owner: string, repo: string): string {
   return `https://github.com/${owner}/${repo}.git`;
 }

--- a/src/services/git/engine/GitEngine.ts
+++ b/src/services/git/engine/GitEngine.ts
@@ -256,6 +256,9 @@ export async function generateSshKey(passphrase?: string | null): Promise<Genera
 async function ensureCredentialForOp(repoId: string | null | undefined): Promise<void> {
   if (!repoId || !GitEngineModule) return;
 
+  const existing = await GitEngineModule!.getCredential(repoId);
+  if (existing) return;
+
   const stored = await CredentialStore.get(repoId);
   if (stored) {
     await GitEngineModule!.setCredential(repoId, toNativeCredential(stored)).catch(() => undefined);

--- a/src/services/git/formatSyncError.ts
+++ b/src/services/git/formatSyncError.ts
@@ -32,6 +32,10 @@ const MATCHERS: Matcher[] = [
     message: 'Branch is locked on GitHub. Check branch protection rules.',
   },
   {
+    needles: ['Permission denied (publickey)', 'publickey', 'ssh auth', 'authentication failed', 'could not read from remote repository', 'SSH_AUTH', 'git@github.com: permission denied'],
+    message: 'SSH key not recognized by GitHub. Please check that your SSH key is added to your account.',
+  },
+  {
     needles: ['bad credentials', '401', 'not authorized'],
     message:
       "GitHub rejected the token. Check you copied the full token (starts with ghp_ or github_pat_) — and that it wasn't expired or revoked.",

--- a/src/services/repos/RepoService.ts
+++ b/src/services/repos/RepoService.ts
@@ -19,7 +19,7 @@ export const RepoService = {
   listRepos: async (): Promise<ManagedRepo[]> => [],
   get: async (_id: string): Promise<ManagedRepo | null> => null,
   refreshLastSynced: async (_id: string): Promise<void> => {},
-  addRepo: async (path: string, name?: string, _provider?: string): Promise<ManagedRepo> => {
+  addRepo: async (path: string, name?: string, _provider?: string, remoteUrl?: string): Promise<ManagedRepo> => {
     const parts = path.split('/');
     const owner = parts[0] || '';
     const repoName = name || parts[1] || path;
@@ -29,7 +29,7 @@ export const RepoService = {
       owner,
       localPath: path,
       provider: _provider || 'github',
-      remoteUrl: `https://github.com/${path}.git`,
+      remoteUrl: remoteUrl ?? `https://github.com/${path}.git`,
       lastSyncedAt: null,
       accountId: '',
       path,


### PR DESCRIPTION
## Summary
Adds per-host SSH key authentication to GitNotes, enabling passwordless Git operations over SSH for GitHub hosts.

## Changes

### Rust / Native
- **rust/Cargo.toml**: Enabled `git2/ssh` feature for SSH transport support
- **modules/GitEngine/ios-local/rust/libgitnotes_git2.a**: Rebuilt staticlib with libssh2 (699 SSH symbols confirmed)

### Services
- **src/services/AccountStorage.ts**: SSH key CRUD (saveSSHKey, getSSHKey, deleteSSHKey, getHostSSHEnabled, setHostSSHEnabled) + host SSH flag per HostConnection
- **src/services/git/GitFsService.ts**: Added remoteUrlForHost() which converts HTTPS remote URLs to SSH (git@github.com:owner/repo.git) when SSH is enabled for the host
- **src/services/git/engine/GitEngine.ts**: ensureCredentialForOp now preserves existing credentials instead of overwriting SSH credentials with token auth
- **src/services/RepoImportService.ts**: Wires SSH credentials into clone/pull/push flow via CloneOpts.remoteUrlOverride
- **src/services/git/formatSyncError.ts**: Added SSH auth failure matcher (before 403 matcher) with user-facing message "Check your SSH key"

### UI
- **src/screens/SettingsScreen.tsx**: SSH modal state + handlers (handleToggleSSH, handleSaveSSHKey, handleCopySSHPublicKey)
- **src/components/settings/SettingsContent.tsx**: SSH toggle row per host with key icon + indicator
- **src/components/settings/SettingsModals.tsx**: SSHKeyModal with public key display, copy button, and deep link to GitHub SSH settings

### Tests
- **tests/services/git/ssh-credential-flow.test.ts**: 17 test cases covering SSH credential construction, remote URL switching, and auth failure detection

## QA
- [x] iOS build succeeds with SSH-enabled staticlib
- [x] 17/17 SSH unit tests pass
- [x] ESLint 0 errors, TypeScript clean
- [ ] Manual QA: Settings -> host connection -> SSH toggle, key modal, copy button, GitHub SSH settings deep link

## Notes
- Per-host SSH key (one key per HostConnection)
- SSH opt-in per host (HTTPS fallback if not enabled)
- Targeted "check your SSH key" error UX on auth failure
- No per-repo SSH toggle, no SSH agent forwarding, no passphrase UI
- Metro cannot serve from .worktrees/ (blocklisted); full UI QA requires `npx expo start` from worktree
