### PR TITLE
fix: improve SSH key modal padding and spacing

### DIFF
--- a/src/components/settings/SettingsModals.tsx
+++ b/src/components/settings/SettingsModals.tsx
@@ -61,19 +61,19 @@ export const SSHKeyModal = memo(function SSHKeyModal({
           </View>
         ) : publicKey ? (
           <>
-            <Text className="text-sm mb-2" style={{ color: colors.textSecondary }}>{t('settings.sshKeyDescription')}</Text>
+            <Text className="text-sm mb-3 mx-1" style={{ color: colors.textSecondary }}>{t('settings.sshKeyDescription')}</Text>
             <View
-              className="rounded-lg p-3 mb-3"
+              className="rounded-lg p-4 mb-4"
               style={{ backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.border }}
             >
               <Text
-                style={{ color: colors.text, fontSize: 12, fontFamily: 'Menlo' }}
+                style={{ color: colors.text, fontSize: 12, fontFamily: 'Menlo', lineHeight: 18 }}
                 selectable
               >
                 {publicKey}
               </Text>
             </View>
-            <View className="flex-row gap-2 mb-4">
+            <View className="flex-row gap-2 mb-4 mx-1">
               <TouchableOpacity
                 className="flex-row items-center justify-center py-2.5 px-3 rounded-lg border flex-1 gap-1.5"
                 style={{ borderColor: colors.border }}
@@ -101,7 +101,7 @@ export const SSHKeyModal = memo(function SSHKeyModal({
             />
           </>
         ) : (
-          <Text style={{ color: colors.error, fontSize: 14 }}>{t('settings.sshKeyError')}</Text>
+          <Text className="mx-1" style={{ color: colors.error, fontSize: 14 }}>{t('settings.sshKeyError')}</Text>
         )}
       </ScrollView>
     </Modal>


### PR DESCRIPTION
## Summary

Improves padding and spacing in the SSH key modal:

- Description text: more vertical margin + horizontal inset (mx-1)
- Key box: more padding (p-3 -> p-4) for better key readability
- Key text: added lineHeight 18 for readability
- Button row: horizontal inset (mx-1)
- Error text: consistent horizontal padding