### PR TITLE
fix: improve SSH key modal padding and spacing

### DIFF
--- a/src/components/settings/SettingsModals.tsx
+++ b/src/components/settings/SettingsModals.tsx
@@ -61,19 +61,19 @@ export const SSHKeyModal = memo(function SSHKeyModal({
           </View>
         ) : publicKey ? (
           <>
-            <Text className="text-sm mb-2" style={{ color: colors.textSecondary }}>{t('settings.sshKeyDescription')}</Text>
+            <Text className="text-sm mb-3 mx-2" style={{ color: colors.textSecondary }}>{t('settings.sshKeyDescription')}</Text>
             <View
-              className="rounded-lg p-3 mb-3"
+              className="rounded-lg p-4 mb-4 mx-2"
               style={{ backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.border }}
             >
               <Text
-                style={{ color: colors.text, fontSize: 12, fontFamily: 'Menlo' }}
+                style={{ color: colors.text, fontSize: 12, fontFamily: 'Menlo', lineHeight: 18 }}
                 selectable
               >
                 {publicKey}
               </Text>
             </View>
-            <View className="flex-row gap-2 mb-4">
+            <View className="flex-row gap-2 mb-4 mx-2">
               <TouchableOpacity
                 className="flex-row items-center justify-center py-2.5 px-3 rounded-lg border flex-1 gap-1.5"
                 style={{ borderColor: colors.border }}
@@ -96,12 +96,12 @@ export const SSHKeyModal = memo(function SSHKeyModal({
               onPress={onSave}
               variant="primary"
               fullWidth
-              style={{ minHeight: 48 }}
+              style={{ minHeight: 48, marginHorizontal: 8 }}
               textStyle={{ color: '#fff', fontWeight: '600' }}
             />
           </>
         ) : (
-          <Text style={{ color: colors.error, fontSize: 14 }}>{t('settings.sshKeyError')}</Text>
+          <Text className="mx-2" style={{ color: colors.error, fontSize: 14 }}>{t('settings.sshKeyError')}</Text>
         )}
       </ScrollView>
     </Modal>


### PR DESCRIPTION
## Summary

Improves padding and spacing in the SSH key modal:

- Description text: mx-2 horizontal margin for breathing room
- Key box: mx-2 + p-4 padding (was p-3 flush)
- Button row: mx-2 horizontal inset
- Primary button: marginHorizontal 8px
- Error text: mx-2 for consistent padding