### PR TITLE
fix: add top margin to SSH modal description

### DIFF
--- a/src/components/settings/SettingsModals.tsx
+++ b/src/components/settings/SettingsModals.tsx
@@ -61,7 +61,7 @@ export const SSHKeyModal = memo(function SSHKeyModal({
           </View>
         ) : publicKey ? (
           <>
-            <Text className="text-sm mb-3 mx-2" style={{ color: colors.textSecondary }}>{t('settings.sshKeyDescription')}</Text>
+            <Text className="text-sm mt-4 mb-3 mx-2" style={{ color: colors.textSecondary }}>{t('settings.sshKeyDescription')}</Text>
             <View
               className="rounded-lg p-4 mb-4 mx-2"
               style={{ backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.border }}


### PR DESCRIPTION
Adds mt-4 (16px) top margin to the description text in the SSH key modal for better visual breathing room from the modal header.