### PR TITLE
feat(explore): add commit message placeholder and clear button

### DIFF
--- a/__tests__/components/explore/CommitComposer.test.tsx
+++ b/__tests__/components/explore/CommitComposer.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTokens: () => ({
+    colors: {
+      background: '#000',
+      card: '#222',
+      border: '#444',
+      accent: '#09f',
+      text: '#fff',
+      textSecondary: '#aaa',
+      success: '#0f0',
+      error: '#f00',
+    },
+  }),
+}));
+
+jest.mock('@/contexts/AccountsContext', () => ({
+  useAccounts: () => ({
+    accounts: [{ id: 'a1', name: 'Test User', email: 'test@example.com' }],
+    activeAccountId: 'a1',
+  }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('@/services/git/engine/GitEngine', () => ({
+  __esModule: true,
+  stage: jest.fn(async () => undefined),
+  commit: jest.fn(async () => ({ shortId: 'abc1234', summary: 'test' })),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => (key === 'common.clear' ? 'Clear' : key) }),
+}));
+
+jest.mock('@/components/ui/Button', () => {
+  const { Pressable: MockPressable, Text: MockText } = require('react-native');
+  return {
+    Button: ({ children, onPress, testID, disabled, accessibilityLabel }: {
+      children: React.ReactNode;
+      onPress?: () => void;
+      testID?: string;
+      disabled?: boolean;
+      accessibilityLabel?: string;
+    }) => (
+      <MockPressable testID={testID} onPress={onPress} disabled={disabled} accessibilityLabel={accessibilityLabel}>
+        {children}
+      </MockPressable>
+    ),
+    ButtonText: ({ children }: { children: React.ReactNode }) => <MockText>{children}</MockText>,
+  };
+});
+
+jest.mock('@/components/ui/text', () => {
+  const { Text: MockText } = require('react-native');
+  return { Text: MockText, ButtonText: MockText };
+});
+
+jest.mock('@/components/ui/heading', () => {
+  const { Text: MockText } = require('react-native');
+  return { Heading: MockText };
+});
+
+jest.mock('@/components/ui/textarea', () => {
+  const { TextInput: MockTextInput } = require('react-native');
+  return {
+    TextareaInput: (props: import('react-native').TextInputProps) => <MockTextInput {...props} />,
+  };
+});
+
+jest.mock('@/components/ui/Input', () => {
+  const { forwardRef } = require('react');
+  const { TextInput: MockTextInput } = require('react-native');
+  return {
+    InputField: forwardRef((props: import('react-native').TextInputProps, ref: import('react').Ref<import('react-native').TextInput>) => (
+      <MockTextInput ref={ref} {...props} />
+    )),
+  };
+});
+
+import { CommitComposer } from '../../../src/components/explore/CommitComposer';
+import * as GitEngine from '../../../src/services/git/engine/GitEngine';
+import type { RepoLike } from '../../../src/components/explore/exploreShared';
+import type { FileStatus } from '../../../src/services/git/engine/GitEngine';
+
+const stageMock = jest.mocked(GitEngine.stage);
+const commitMock = jest.mocked(GitEngine.commit);
+
+const REPO: RepoLike = { id: 'repo', path: 'owner/repo', name: 'repo', localPath: '/repo' };
+const MESSAGE_INPUT = 'explore.commit-composer.message.input';
+const CLEAR_BUTTON = 'explore.commit-composer.clear';
+
+function renderComposer(statuses: FileStatus[]) {
+  return render(
+    <CommitComposer
+      repo={REPO}
+      changedPaths={statuses.map((entry) => entry.path)}
+      statuses={statuses}
+      stagedCount={statuses.filter((entry) => entry.staged === true).length}
+      onCommitted={() => undefined}
+    />,
+  );
+}
+
+describe('CommitComposer commit message draft', () => {
+  beforeEach(() => {
+    stageMock.mockClear();
+    commitMock.mockClear();
+  });
+
+  it('auto-fills the message input with the drafted statuses', () => {
+    const screen = renderComposer([
+      { path: 'todo.md', status: 'Added', staged: true },
+      { path: 'notes.md', status: 'Modified', staged: false },
+    ]);
+    expect(screen.getByTestId(MESSAGE_INPUT).props.value).toBe('Add: todo.md\nEdit: notes.md');
+  });
+
+  it('keeps user-typed text when statuses change', () => {
+    const screen = renderComposer([{ path: 'todo.md', status: 'Added', staged: true }]);
+    const input = screen.getByTestId(MESSAGE_INPUT);
+    fireEvent.changeText(input, 'my own message');
+    expect(screen.getByTestId(MESSAGE_INPUT).props.value).toBe('my own message');
+
+    screen.rerender(
+      <CommitComposer
+        repo={REPO}
+        changedPaths={['other.md']}
+        statuses={[{ path: 'other.md', status: 'Modified', staged: true }]}
+        stagedCount={1}
+        onCommitted={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId(MESSAGE_INPUT).props.value).toBe('my own message');
+  });
+
+  it('clears the message with the Clear button and dismisses future drafts', () => {
+    const screen = renderComposer([{ path: 'todo.md', status: 'Added', staged: true }]);
+    expect(screen.getByTestId(CLEAR_BUTTON)).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId(CLEAR_BUTTON));
+    expect(screen.getByTestId(MESSAGE_INPUT).props.value).toBe('');
+    expect(screen.queryByTestId(CLEAR_BUTTON)).toBeNull();
+
+    screen.rerender(
+      <CommitComposer
+        repo={REPO}
+        changedPaths={['later.md']}
+        statuses={[{ path: 'later.md', status: 'Modified', staged: true }]}
+        stagedCount={1}
+        onCommitted={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId(MESSAGE_INPUT).props.value).toBe('');
+    expect(screen.queryByTestId(CLEAR_BUTTON)).toBeNull();
+  });
+
+  it('leaves the message empty when statuses are empty', () => {
+    const screen = renderComposer([]);
+    expect(screen.getByTestId(MESSAGE_INPUT).props.value).toBe('');
+    expect(screen.queryByTestId(CLEAR_BUTTON)).toBeNull();
+  });
+
+  it('stages all changes and commits with the drafted message', async () => {
+    const screen = renderComposer([
+      { path: 'todo.md', status: 'Added', staged: false },
+      { path: 'notes.md', status: 'Modified', staged: false },
+    ]);
+    fireEvent.press(screen.getByTestId('explore.commit-composer.stage-all-commit'));
+
+    await waitFor(() => {
+      expect(stageMock).toHaveBeenCalledWith('/repo', ['todo.md', 'notes.md']);
+    });
+    await waitFor(() => {
+      expect(commitMock).toHaveBeenCalledWith('/repo', 'Add: todo.md\nEdit: notes.md', {
+        name: 'Test User',
+        email: 'test@example.com',
+      });
+    });
+  });
+});

--- a/__tests__/components/explore/commitMessageDraft.test.ts
+++ b/__tests__/components/explore/commitMessageDraft.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { buildCommitMessageDraft } from '../../../src/components/explore/commitMessageDraft';
+import type { FileStatus } from '../../../src/services/git/engine/GitEngine';
+
+describe('buildCommitMessageDraft', () => {
+  it('maps Added and Untracked statuses to the Add category', () => {
+    const statuses: FileStatus[] = [
+      { path: 'new-note.md', status: 'Added' },
+      { path: 'draft.md', status: 'Untracked' },
+    ];
+    expect(buildCommitMessageDraft(statuses)).toBe('Add: new-note.md, draft.md');
+  });
+
+  it('maps Modified status to the Edit category', () => {
+    const statuses: FileStatus[] = [{ path: 'notes.md', status: 'Modified' }];
+    expect(buildCommitMessageDraft(statuses)).toBe('Edit: notes.md');
+  });
+
+  it('maps Deleted status to the Delete category', () => {
+    const statuses: FileStatus[] = [{ path: 'old.md', status: 'Deleted' }];
+    expect(buildCommitMessageDraft(statuses)).toBe('Delete: old.md');
+  });
+
+  it('maps Renamed, TypeChange and Conflicted statuses to the Update category', () => {
+    const statuses: FileStatus[] = [
+      { path: 'moved.md', status: 'Renamed' },
+      { path: 'link.md', status: 'TypeChange' },
+      { path: 'merged.md', status: 'Conflicted' },
+    ];
+    expect(buildCommitMessageDraft(statuses)).toBe('Update: moved.md, link.md, merged.md');
+  });
+
+  it('skips Unmodified entries entirely', () => {
+    const statuses: FileStatus[] = [
+      { path: 'same.md', status: 'Unmodified' },
+      { path: 'notes.md', status: 'Modified' },
+    ];
+    expect(buildCommitMessageDraft(statuses)).toBe('Edit: notes.md');
+  });
+
+  it('emits categories in fixed Add, Edit, Delete, Update order joined by newlines', () => {
+    const statuses: FileStatus[] = [
+      { path: 'moved.md', status: 'Renamed' },
+      { path: 'gone.md', status: 'Deleted' },
+      { path: 'changed.md', status: 'Modified' },
+      { path: 'fresh.md', status: 'Added' },
+    ];
+    expect(buildCommitMessageDraft(statuses)).toBe(
+      'Add: fresh.md\nEdit: changed.md\nDelete: gone.md\nUpdate: moved.md',
+    );
+  });
+
+  it('caps each category at 8 paths and appends the overflow count', () => {
+    const statuses: FileStatus[] = [];
+    for (let index = 0; index < 11; index += 1) {
+      statuses.push({ path: `note-${index}.md`, status: 'Modified' });
+    }
+    expect(buildCommitMessageDraft(statuses)).toBe(
+      'Edit: note-0.md, note-1.md, note-2.md, note-3.md, note-4.md, note-5.md, note-6.md, note-7.md, … (+3 more)',
+    );
+  });
+
+  it('returns an empty string when there are no entries', () => {
+    expect(buildCommitMessageDraft([])).toBe('');
+  });
+
+  it('skips entries whose trimmed path is empty', () => {
+    const statuses: FileStatus[] = [
+      { path: '', status: 'Added' },
+      { path: '   ', status: 'Modified' },
+      { path: '  real.md  ', status: 'Modified' },
+    ];
+    expect(buildCommitMessageDraft(statuses)).toBe('Edit: real.md');
+  });
+});

--- a/src/components/explore/CommitComposer.tsx
+++ b/src/components/explore/CommitComposer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
 
 import { Text } from '@/components/ui/text';
 import { Heading } from '@/components/ui/heading';
@@ -8,9 +9,11 @@ import { Button, ButtonText } from '@/components/ui/Button';
 import { InputField } from '@/components/ui/Input';
 import { TextareaInput } from '@/components/ui/textarea';
 import * as GitEngine from '@/services/git/engine/GitEngine';
+import type { FileStatus } from '@/services/git/engine/GitEngine';
 import { useAccounts } from '@/contexts/AccountsContext';
 import type { RepoLike } from './exploreShared';
 import { useTokens } from '@/contexts/ThemeContext';
+import { buildCommitMessageDraft } from './commitMessageDraft';
 
 const MESSAGE_PLACEHOLDER = 'feat: what changed? (conventional commit)';
 
@@ -18,16 +21,19 @@ interface CommitComposerProps {
   repo: RepoLike;
   /** Every path with any working-tree change (staged + unstaged), for "Stage all". */
   changedPaths: string[];
+  /** Every working-tree status entry, used to draft the commit message. */
+  statuses: FileStatus[];
   stagedCount: number;
   /** Reload section data + refresh the shell header after a commit lands. */
   onCommitted: () => void;
   embedded?: boolean;
 }
 
-export function CommitComposer({ repo, changedPaths, stagedCount, onCommitted, embedded = false }: CommitComposerProps) {
+export function CommitComposer({ repo, changedPaths, statuses, stagedCount, onCommitted, embedded = false }: CommitComposerProps) {
   const { accounts, activeAccountId } = useAccounts();
   const activeAccount = accounts.find((account) => account.id === activeAccountId) ?? null;
   const { colors } = useTokens();
+  const { t } = useTranslation();
   const [message, setMessage] = useState('');
   const [authorName, setAuthorName] = useState('');
   const [authorEmail, setAuthorEmail] = useState('');
@@ -35,12 +41,26 @@ export function CommitComposer({ repo, changedPaths, stagedCount, onCommitted, e
   const [busy, setBusy] = useState<'stageAll' | 'commit' | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [draftDismissed, setDraftDismissed] = useState(false);
 
   useEffect(() => {
     if (!activeAccount || authorTouched) return;
     setAuthorName(activeAccount.name);
     setAuthorEmail(activeAccount.email ?? '');
   }, [activeAccount, authorTouched]);
+
+  useEffect(() => {
+    if (draftDismissed) return;
+    const draft = buildCommitMessageDraft(statuses);
+    if (draft.length === 0) return;
+    setMessage((prev) => (prev.trim().length === 0 ? draft : prev));
+  }, [statuses, draftDismissed]);
+
+  const clearMessage = useCallback(() => {
+    setMessage('');
+    setError(null);
+    setDraftDismissed(true);
+  }, []);
 
   const validate = useCallback((): string | null => {
     if (message.trim().length === 0) return 'Enter a commit message first.';
@@ -69,6 +89,7 @@ export function CommitComposer({ repo, changedPaths, stagedCount, onCommitted, e
           email: authorEmail.trim(),
         });
         setMessage('');
+        setDraftDismissed(false);
         setSuccess(`Committed ${commit.shortId} — ${commit.summary}`);
         onCommitted();
       } catch (caught) {
@@ -96,6 +117,19 @@ export function CommitComposer({ repo, changedPaths, stagedCount, onCommitted, e
         {stagedCount > 0 && (
           <View className="rounded px-1.5 py-0.5" style={{ backgroundColor: `${colors.accent}26` }} testID="explore.commit-composer.staged-count">
             <Text className="text-[10px] font-semibold" style={{ color: colors.accent }}>{stagedCount} staged</Text>
+          </View>
+        )}
+        {message.length > 0 && (
+          <View className="ml-auto">
+            <Button
+              size="sm"
+              variant="ghost"
+              onPress={clearMessage}
+              accessibilityLabel={t('common.clear')}
+              testID="explore.commit-composer.clear"
+            >
+              <ButtonText>{t('common.clear')}</ButtonText>
+            </Button>
           </View>
         )}
       </View>

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -22,6 +22,7 @@ type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 interface StagingData {
   staged: FileStatus[];
   changedPaths: string[];
+  statuses: FileStatus[];
   diffs: Record<string, FileDiff>;
 }
 
@@ -65,7 +66,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
       for (const diff of diffResults) {
         if (diff && diff.path) diffs[diff.path] = diff;
       }
-      setData({ staged, changedPaths, diffs });
+      setData({ staged, changedPaths, statuses, diffs });
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
     } finally {
@@ -261,6 +262,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
           embedded
           repo={repo}
           changedPaths={data?.changedPaths ?? []}
+          statuses={data?.statuses ?? []}
           stagedCount={data?.staged.length ?? 0}
           onCommitted={() => {
             setCommitOpen(false);

--- a/src/components/explore/commitMessageDraft.ts
+++ b/src/components/explore/commitMessageDraft.ts
@@ -1,0 +1,46 @@
+import type { FileStatus } from '@/services/git/engine/GitEngine';
+
+type DraftCategory = 'Add' | 'Edit' | 'Delete' | 'Update';
+
+const CATEGORY_ORDER: readonly DraftCategory[] = ['Add', 'Edit', 'Delete', 'Update'];
+
+const MAX_PATHS_PER_CATEGORY = 8;
+
+function categoryForStatus(status: string): DraftCategory | null {
+  switch (status) {
+    case 'Added':
+    case 'Untracked':
+      return 'Add';
+    case 'Modified':
+      return 'Edit';
+    case 'Deleted':
+      return 'Delete';
+    case 'Unmodified':
+      return null;
+    default:
+      return 'Update';
+  }
+}
+
+/** Draft a conventional-commit-style message from working-tree statuses:
+ * one `Label: path, path` line per non-empty category (Add → Edit → Delete →
+ * Update), capped at 8 paths with a `… (+N more)` overflow suffix. */
+export function buildCommitMessageDraft(statuses: FileStatus[]): string {
+  const buckets: Record<DraftCategory, string[]> = { Add: [], Edit: [], Delete: [], Update: [] };
+  for (const entry of statuses) {
+    const path = entry.path.trim();
+    if (path.length === 0) continue;
+    const category = categoryForStatus(entry.status);
+    if (category === null) continue;
+    buckets[category].push(path);
+  }
+  return CATEGORY_ORDER.filter((category) => buckets[category].length > 0)
+    .map((category) => {
+      const paths = buckets[category];
+      const shown = paths.slice(0, MAX_PATHS_PER_CATEGORY);
+      const hidden = paths.length - shown.length;
+      const suffix = hidden > 0 ? `, … (+${hidden} more)` : '';
+      return `${category}: ${shown.join(', ')}${suffix}`;
+    })
+    .join('\n');
+}


### PR DESCRIPTION
## What
CommitComposer now auto-fills the message with a conventional-commit draft based on changed file statuses: `Add:`, `Edit:`, `Delete:`, or `Update:` per file, capped at 8 paths per category with overflow count. The draft only fills empty messages and is skipped once the user starts typing or clears it.

A **Clear** button appears when the message is non-empty, letting the user discard the draft and write a custom message freely. The button is localized via the existing `common.clear` i18n key.

The clear state resets on successful commit so the next composer session starts fresh.

## Files changed
- `src/components/explore/commitMessageDraft.ts` — pure suggestion generator with full test coverage (46 lines, 8 cases)
- `src/components/explore/CommitComposer.tsx` — draft useEffect, clearMessage callback, `statuses` prop, clear button
- `src/components/explore/StagingSection.tsx` — passes `FileStatus[]` to CommitComposer
- `__tests__/components/explore/commitMessageDraft.test.ts` — 76 lines, 8 test cases
- `__tests__/components/explore/CommitComposer.test.tsx` — 186 lines, 5 test cases

## Tests
`yarn jest __tests__/components/explore/commitMessageDraft.test.ts __tests__/components/explore/CommitComposer.test.tsx` — 14 tests, all passing.

i18n: `common.clear` already existed; no new keys needed.