### PR TITLE
fix: prevent keyboard on token/key TextInput fields

### DIFF
--- a/src/components/ConnectHostModal.tsx
+++ b/src/components/ConnectHostModal.tsx
@@ -313,6 +313,7 @@ export function ConnectHostModal({
             autoCapitalize="none"
             autoCorrect={false}
             secureTextEntry={!tokenVisible}
+            showSoftInputOnFocus={false}
             testID="connect-host-token-input"
             style={{
               flex: 1,

--- a/src/components/ai/ProviderConfigModal.tsx
+++ b/src/components/ai/ProviderConfigModal.tsx
@@ -368,6 +368,7 @@ export function ProviderConfigModal({ visible, onClose, provider }: ProviderConf
                         value={apiKey}
                         onChangeText={setApiKey}
                         secureTextEntry={!apiKeyVisible}
+                        showSoftInputOnFocus={false}
                         autoCapitalize="none"
                         autoCorrect={false}
                       />


### PR DESCRIPTION
## Summary

Token and API key TextInput fields now have `showSoftInputOnFocus={false}` to prevent the keyboard from opening when users tap these fields. Users can still paste, and the show/hide toggle works.

## Changes

- **ConnectHostModal.tsx**: Added `showSoftInputOnFocus={false}` to the GitHub/GitLab/etc token input
- **ProviderConfigModal.tsx**: Added `showSoftInputOnFocus={false}` to the API key input
- **SettingsModals.tsx**: Already had this — no changes needed

## Testing

Manual: tap any token/key field — no keyboard should appear.