### PR TITLE
fix: remove @xmldom/xmldom resolution that breaks expo prebuild

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/vidwadeseram/Documents/GitHub/gitnotes/gitnotes/node_modules

--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
   "resolutions": {
     "@ai-sdk/provider-utils": "4.0.40",
     "**/lightningcss": "1.30.1",
-    "**/@xmldom/xmldom": "^0.9.5",
     "**/image-size": "^2.0.0",
     "**/decode-uri-component": "^0.5.0",
     "uuid": "^11.1.1"


### PR DESCRIPTION
The @xmldom/xmldom 0.9.x security patch causes DOMParser.parseFromString to require a valid mimeType, but @expo/plist calls it without one, breaking expo prebuild.

This removes the xmldom resolution while keeping image-size and decode-uri-component patches.