### PR TITLE
fix: apply chromeTopInset to PR/Issues FlatList during initial load

### DIFF
--- a/src/components/explore/IssuesSection.tsx
+++ b/src/components/explore/IssuesSection.tsx
@@ -152,11 +152,11 @@ export function IssuesSection({ repo, active, chromeTopInset = 0 }: SectionProps
 
   const listContentContainerStyle = useMemo(
     () => ({
-      paddingTop: issues !== null ? chromeTopInset : 0,
+      paddingTop: chromeTopInset,
       paddingBottom: 96,
       flexGrow: 1,
     }),
-    [issues, chromeTopInset],
+    [chromeTopInset],
   );
 
   return (

--- a/src/components/explore/PullRequestsSection.tsx
+++ b/src/components/explore/PullRequestsSection.tsx
@@ -137,11 +137,11 @@ export function PullRequestsSection({ repo, active, chromeTopInset = 0 }: Sectio
 
   const listContentContainerStyle = useMemo(
     () => ({
-      paddingTop: prs !== null ? chromeTopInset : 0,
+      paddingTop: chromeTopInset,
       paddingBottom: 96,
       flexGrow: 1,
     }),
-    [prs, chromeTopInset],
+    [chromeTopInset],
   );
 
   return (


### PR DESCRIPTION
Fixed a layout bug where Pull Requests and Issues tabs would render content under the safe area notch during initial load.

**Root cause:**  was only applied after data loaded (), causing 0 padding during the loading state.

**Fix:** Always apply  regardless of data load state.