### PR TITLE
fix: guard against undefined repo in load callbacks

### DIFF
--- a/src/components/explore/IssuesSection.tsx
+++ b/src/components/explore/IssuesSection.tsx
@@ -32,6 +32,7 @@ export function IssuesSection({ repo, active, chromeTopInset = 0 }: SectionProps
   const [isPermissionError, setIsPermissionError] = useState(false);
 
   const load = useCallback(async () => {
+    if (!repo?.accountId) return;
     setLoading(true);
     setError(null);
     setIsPermissionError(false);

--- a/src/components/explore/PullRequestsSection.tsx
+++ b/src/components/explore/PullRequestsSection.tsx
@@ -32,6 +32,7 @@ export function PullRequestsSection({ repo, active, chromeTopInset = 0 }: Sectio
   const [isPermissionError, setIsPermissionError] = useState(false);
 
   const load = useCallback(async () => {
+    if (!repo?.accountId) return;
     setLoading(true);
     setError(null);
     setIsPermissionError(false);


### PR DESCRIPTION
Fixes 'Rendered fewer hooks than expected' error when opening PRs/Issues tabs.

Added early return guard `if (!repo?.accountId) return;` in both IssuesSection and PullRequestsSection load callbacks to prevent accessing properties on undefined repo during concurrent render interruptions.