### PR TITLE
fix: shorten pauseForegroundSyncSub text

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -366,7 +366,7 @@
     "syncFrequently": "Sync frequently",
     "syncFrequentlySub": "Recommended for multi-device",
     "pauseForegroundSync": "Pause foreground sync",
-    "pauseForegroundSyncSub": "Debug: stops automatic pulls so local commits can diverge (#1174)",
+    "pauseForegroundSyncSub": "Debug: stops automatic",
     "syncInterval": "Sync interval",
     "backgroundSync": "Background Sync",
     "floatingGitButton": "Show floating git button",


### PR DESCRIPTION
Shortens the pauseForegroundSyncSub text from 'Debug: stops automatic pulls so local commits can diverge (#1174)' to 'Debug: stops automatic'