### PR TITLE
fix: wrap Discard button text in ButtonText

### DIFF
--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -144,7 +144,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
           {!item.staged && (
             <View className="mt-2 flex-row justify-end gap-2">
               <Button size="sm" variant="ghost" onPress={() => void discardFile(item.path)}>
-                Discard
+                <ButtonText>Discard</ButtonText>
               </Button>
               <Button size="sm" variant="outline" onPress={() => void stageFile(item.path)}>
                 <ButtonText>Stage</ButtonText>

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -171,7 +171,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
               testID={`explore.discard.${item.path}`}
             >
               {busyPath === item.path ? <Text className="text-xs" style={{ color: colors.textSecondary }}>…</Text> : null}
-              Discard
+              <ButtonText>Discard</ButtonText>
             </Button>
             <Button
               size="sm"


### PR DESCRIPTION
Wrap Discard button text in ButtonText component to fix 'Text strings must be rendered within a <Text> component' error and show the button label properly.