### PR TITLE
fix: use label prop for Button to fix invisible text

### DIFF
--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -143,12 +143,8 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
           </Pressable>
           {!item.staged && (
             <View className="mt-2 flex-row justify-end gap-2">
-              <Button size="sm" variant="ghost" onPress={() => void discardFile(item.path)}>
-                <ButtonText>Discard</ButtonText>
-              </Button>
-              <Button size="sm" variant="outline" onPress={() => void stageFile(item.path)}>
-                <ButtonText>Stage</ButtonText>
-              </Button>
+              <Button size="sm" variant="ghost" onPress={() => void discardFile(item.path)} label="Discard" />
+              <Button size="sm" variant="outline" onPress={() => void stageFile(item.path)} label="Stage" />
             </View>
           )}
         </View>

--- a/src/components/explore/CommitComposer.tsx
+++ b/src/components/explore/CommitComposer.tsx
@@ -127,9 +127,8 @@ export function CommitComposer({ repo, changedPaths, statuses, stagedCount, onCo
               onPress={clearMessage}
               accessibilityLabel={t('common.clear')}
               testID="explore.commit-composer.clear"
-            >
-              {t('common.clear')}
-            </Button>
+              label={t('common.clear')}
+            />
           </View>
         )}
       </View>
@@ -201,10 +200,9 @@ export function CommitComposer({ repo, changedPaths, statuses, stagedCount, onCo
           onPress={() => void runCommit('stageAll')}
           style={{ minHeight: 44 }}
           testID="explore.commit-composer.stage-all-commit"
-        >
-          {busy === 'stageAll' ? <ActivityIndicator size="small" color="#fff" /> : null}
-          Stage all + Commit
-        </Button>
+          label={busy === 'stageAll' ? undefined : 'Stage all + Commit'}
+          leadingIcon={busy === 'stageAll' ? <ActivityIndicator size="small" color="#fff" /> : undefined}
+        />
         <Button
           fullWidth
           variant="outline"
@@ -212,10 +210,9 @@ export function CommitComposer({ repo, changedPaths, statuses, stagedCount, onCo
           onPress={() => void runCommit('commit')}
           style={{ minHeight: 44 }}
           testID="explore.commit-composer.commit"
-        >
-          {busy === 'commit' ? <ActivityIndicator size="small" color={colors.text} /> : null}
-          Commit staged
-        </Button>
+          label={busy === 'commit' ? undefined : 'Commit staged'}
+          leadingIcon={busy === 'commit' ? <ActivityIndicator size="small" color={colors.text} /> : undefined}
+        />
       </View>
     </View>
   );

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -169,20 +169,16 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
               disabled={busyPath !== null}
               onPress={() => void discardFile(item.path)}
               testID={`explore.discard.${item.path}`}
-            >
-              {busyPath === item.path ? <Text className="text-xs" style={{ color: colors.textSecondary }}>…</Text> : null}
-              <ButtonText>Discard</ButtonText>
-            </Button>
+              label={busyPath === item.path ? '…' : 'Discard'}
+            />
             <Button
               size="sm"
               variant="outline"
               disabled={busyPath !== null}
               onPress={() => void unstage(item.path)}
               testID={`explore.unstage.${item.path}`}
-            >
-              {busyPath === item.path ? <Text className="text-xs" style={{ color: colors.textSecondary }}>…</Text> : null}
-              <ButtonText>Unstage</ButtonText>
-            </Button>
+              label={busyPath === item.path ? '…' : 'Unstage'}
+            />
           </View>
         </View>
       );


### PR DESCRIPTION
Fix invisible button text by using label prop instead of children strings. This ensures buttons like Discard, Stage, Commit, and Clear display text correctly with proper theme colors.