### PR TITLE
fix: correct ROOT_DIR calculation in eas post-install script

### DIFF
--- a/scripts/eas/post-install.sh
+++ b/scripts/eas/post-install.sh
@@ -11,7 +11,7 @@ export PATH="$CARGO_HOME/bin:$PATH"
 export RUST_PROFILE="${RUST_PROFILE:-release}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 RUST_DIR="$ROOT_DIR/rust"
 MODULE_DIR="$ROOT_DIR/modules/GitEngine"
 IOS_LIB_DIR="$MODULE_DIR/ios/rust"


### PR DESCRIPTION
Fixes EAS build crash by correcting the ROOT_DIR calculation. The script was using `dirname SCRIPT_DIR` which gave `scripts/` instead of the repo root. Fixed by using `dirname dirname SCRIPT_DIR`.