### PR TITLE
fix(ExploreScreen): make Add repository button navigate to Settings tab

### DIFF
--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -204,7 +204,7 @@ export default function ExploreScreen() {
             No repository to explore yet. Add a remote repository to clone it into your
             library, then open its workspace here.
           </Text>
-          <Button className="mt-4" onPress={() => (navigation as any).navigate('AddRepo')} testID="explore.empty.add">
+          <Button className="mt-4" onPress={() => navigation.navigate('MainTabs', { screen: 'SettingsTab' })} testID="explore.empty.add">
             <ButtonText>Add a repository</ButtonText>
           </Button>
         </View>


### PR DESCRIPTION
Fixes the Git tab empty state button that was non-functional because `AddRepo` route doesn't exist. Now navigates to Settings tab where users can add repositories.

**Changes:**
- `src/screens/ExploreScreen.tsx`: Change `navigate('AddRepo')` to `navigation.navigate('MainTabs', { screen: 'SettingsTab' })` - follows established navigation pattern