### PR TITLE
fix(paywall): use locally stored build for Android grandfathering

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -48,6 +48,8 @@ import { reconcileThoughtDumps } from './src/services/ai/thoughtDumpIndexing';
 import { LastSelectionPreferenceService } from './src/services/LastSelectionPreferenceService';
 import { useProStore } from './src/stores/proStore';
 import { enforceTierLimits } from './src/services/TierLimits';
+import { setAndroidFirstSeenBuild } from './src/services/GrandfatherService';
+import Constants from 'expo-constants';
 import * as PushNotificationService from './src/services/PushNotificationService';
 import { hideDevMenuFloatingActionButton } from './src/utils/devMenuFab';
 
@@ -81,6 +83,12 @@ export default function App() {
     // repo/account caps can be enforced on data brought back by Android backup
     // restore (#1233) — before the stores render it, not after.
     try {
+      if (Platform.OS === 'android') {
+        const build = Constants.expoConfig?.android?.versionCode;
+        if (build !== undefined) {
+          void setAndroidFirstSeenBuild(String(build));
+        }
+      }
       await useProStore.getState().initialize();
       await enforceTierLimits();
       await rebindRevenueCatToActiveAccount();

--- a/src/services/GrandfatherService.ts
+++ b/src/services/GrandfatherService.ts
@@ -5,8 +5,9 @@ export const PRO_PAYWALL_FIRST_BUILD = 9;
 
 export const GRANDFATHERED_KEY = '@gitnotes:pro_grandfathered';
 export const GRANDFATHER_CHECKED_KEY = '@gitnotes:grandfather_checked';
+export const FIRST_SEEN_BUILD_KEY = '@gitnotes:first_seen_build';
 
-export type GrandfatherReason = 'flag' | 'onboarding' | 'ios-build' | 'none' | 'checked';
+export type GrandfatherReason = 'flag' | 'onboarding' | 'ios-build' | 'android-build' | 'none' | 'checked';
 
 export interface GrandfatherResult {
   isGrandfathered: boolean;
@@ -15,7 +16,6 @@ export interface GrandfatherResult {
 
 export interface GrandfatherCustomerInfo {
   originalApplicationVersion?: string | null;
-  firstSeenAppVersion?: string | null;
 }
 
 async function getStoredValue(key: string): Promise<string | null> {
@@ -31,6 +31,17 @@ async function markGrandfathered(): Promise<void> {
   ]);
 }
 
+export async function getAndroidFirstSeenBuild(): Promise<string | null> {
+  return getStoredValue(FIRST_SEEN_BUILD_KEY);
+}
+
+export async function setAndroidFirstSeenBuild(build: string): Promise<void> {
+  const existing = await getStoredValue(FIRST_SEEN_BUILD_KEY);
+  if (existing === null) {
+    await AsyncStorage.setItem(FIRST_SEEN_BUILD_KEY, build);
+  }
+}
+
 export async function resolveGrandfatherStatus(
   customerInfo: GrandfatherCustomerInfo | null,
 ): Promise<GrandfatherResult> {
@@ -40,17 +51,27 @@ export async function resolveGrandfatherStatus(
   const checked = await getStoredValue(GRANDFATHER_CHECKED_KEY);
   if (checked === 'true') return { isGrandfathered: false, reason: 'checked' };
 
-  // ios-build path: originalApplicationVersion on iOS, firstSeenAppVersion on Android.
-  // Only treat as build number if it is a pure integer — marketing version strings
-  // like '1.0.0' must NOT grant free Pro (parseInt('1.0.0') = 1 < 9 would bypass).
-  const version =
-    customerInfo?.originalApplicationVersion ?? customerInfo?.firstSeenAppVersion;
-  if (version != null) {
-    const isPureBuildNumber = /^\d+$/.test(version);
-    const parsed = isPureBuildNumber ? Number.parseInt(version, 10) : NaN;
+  // iOS: originalApplicationVersion is CFBundleVersion at time of original purchase.
+  // Only treat as build number if it is a pure integer to avoid bypass
+  // (parseInt('1.0.0') = 1 < 9 would incorrectly grant Pro).
+  const iosVersion = customerInfo?.originalApplicationVersion;
+  if (iosVersion != null) {
+    const isPureBuildNumber = /^\d+$/.test(iosVersion);
+    const parsed = isPureBuildNumber ? Number.parseInt(iosVersion, 10) : NaN;
     if (Number.isFinite(parsed) && parsed < PRO_PAYWALL_FIRST_BUILD) {
       await markGrandfathered();
       return { isGrandfathered: true, reason: 'ios-build' };
+    }
+  }
+
+  // Android: check the locally stored first-seen build number.
+  const androidBuild = await getStoredValue(FIRST_SEEN_BUILD_KEY);
+  if (androidBuild != null) {
+    const isPureBuildNumber = /^\d+$/.test(androidBuild);
+    const parsed = isPureBuildNumber ? Number.parseInt(androidBuild, 10) : NaN;
+    if (Number.isFinite(parsed) && parsed < PRO_PAYWALL_FIRST_BUILD) {
+      await markGrandfathered();
+      return { isGrandfathered: true, reason: 'android-build' };
     }
   }
 

--- a/src/services/StorageBootstrap.ts
+++ b/src/services/StorageBootstrap.ts
@@ -25,6 +25,7 @@ const STARTUP_KEYS = [
   '@gitnotes:templates_repo',
   '@gitnotes:pro_grandfathered',
   '@gitnotes:grandfather_checked',
+  '@gitnotes:first_seen_build',
   '@gitnotes:trial_was_active',
   '@gitnotes:trial_expired_at',
 ] as const;


### PR DESCRIPTION
## Problem

Android grandfathering has never worked. `GrandfatherService` referenced `firstSeenAppVersion` from RevenueCat's `CustomerInfo`, but that field **does not exist** on the RevenueCat type — it's only declared in a local interface and is always undefined.

As a result, all Android users (including pre-paywall ones) were shown the paywall.

## Root Cause

`GrandfatherCustomerInfo` in `GrandfatherService.ts` declared `firstSeenAppVersion`, but RevenueCat's `CustomerInfo` type (v10.7.1) has no such field. The fallback chain always resolved to undefined on Android.

## Fix

**Android path**: store the Android versionCode in AsyncStorage (`@gitnotes:first_seen_build`) on first app launch, before the grandfathering check runs. The grandfathering logic reads this stored value.

**iOS path**: unchanged — still uses `originalApplicationVersion` from RevenueCat.

### Files changed

- `src/services/StorageBootstrap.ts`: add FIRST_SEEN_BUILD_KEY to STARTUP_KEYS
- `src/services/GrandfatherService.ts`: remove non-existent firstSeenAppVersion, add Android path using locally stored build number
- `App.tsx`: record Android first-seen build before useProStore.initialize()

## Test plan

1. Android device with build < 9 (pre-paywall): should be grandfathered as Pro
2. Android device with build >= 9 (post-paywall): should see paywall
3. iOS: unchanged behavior (relies on RevenueCat originalApplicationVersion)
