### PR TITLE
fix(paywall): await setAndroidFirstSeenBuild + preserve null boot cache entries

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -86,7 +86,7 @@ export default function App() {
       if (Platform.OS === 'android') {
         const build = Constants.expoConfig?.android?.versionCode;
         if (build !== undefined) {
-          void setAndroidFirstSeenBuild(String(build));
+          await setAndroidFirstSeenBuild(String(build));
         }
       }
       await useProStore.getState().initialize();

--- a/src/services/StorageBootstrap.ts
+++ b/src/services/StorageBootstrap.ts
@@ -65,6 +65,7 @@ export function getBootValue(key: StartupKey): string | null | undefined {
   if (!bootCache) return undefined;
   if (!bootCache.has(key)) return undefined;
   const value = bootCache.get(key);
+  if (value === null) return null;
   bootCache.delete(key);
   return value;
 }


### PR DESCRIPTION
## Problem

Two bugs prevented Android grandfathering from working correctly on first launch / upgrade.

### Bug 1 - Race condition (critical)

`setAndroidFirstSeenBuild` was called with `void` (not awaited), so `proStore.initialize()` ran the grandfathering check **before** the build was written to AsyncStorage.

Result: users were incorrectly shown as free-tier on first launch, and `GRAND_FATHER_CHECKED_KEY` was set to `true`, permanently blocking grandfathering on subsequent launches.

### Bug 2 - Boot cache consumption

`getBootValue` always deleted the cache entry after reading, including when the value was `null` (not yet set). On first launch (or upgrade from an old version that didn't have `FIRST_SEEN_BUILD_KEY`), the boot cache has `FIRST_SEEN_BUILD_KEY: null`. `getBootValue` consumed it, so `setAndroidFirstSeenBuild` saw `existing===undefined` and skipped the write. The grandfather check then ran with no value stored → user rejected.

## Fix

1. `App.tsx`: `await setAndroidFirstSeenBuild(...)` so the write completes before `proStore.initialize()` runs the grandfather check.

2. `StorageBootstrap.ts`: `getBootValue` now preserves null entries (doesn't delete them). Null in boot cache means "key exists but not yet set" — it stays available for the full launch so `setAndroidFirstSeenBuild` can detect it and write the actual value before `initialize()` runs.

## Test plan

1. Fresh install on Android build < 9: should be grandfathered as Pro
2. Fresh install on Android build >= 9: should see paywall
3. Upgrade from old version (without FIRST_SEEN_BUILD_KEY) to new version, Android build < 9: should be grandfathered on first launch of new version
4. iOS: unchanged behavior
