### PR TITLE
fix(ExploreScreen): guard repo useMemo against corrupted repo data

### DIFF
--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -81,10 +81,14 @@ export default function ExploreScreen() {
     const found = lookupId ? repos.find((r) => r.id === lookupId) : undefined;
     const r = found ?? repos[0] ?? null;
     if (!r) return null;
-    return {
-      ...r,
-      localPath: GitFsService.workingTreeUri({ repoPath: r.path }),
-    } as RepoLike;
+    try {
+      return {
+        ...r,
+        localPath: GitFsService.workingTreeUri({ repoPath: r.path }),
+      } as RepoLike;
+    } catch {
+      return null;
+    }
   }, [repos, selectedRepoId]);
 
   const handlePickRepo = useCallback((picked: GitRepository) => {


### PR DESCRIPTION
## Problem

On fresh install: app works fine (no repos yet, empty state renders).
On update: app crashes when opening Git tab. Uninstall/reinstall fixes it.

Root cause: corrupted `repo.path` in AsyncStorage causes `GitFsService.workingTreeUri` to throw. The `parseRepoPath` function returns `null` for invalid paths, and `workingTreeUri` throws `"Invalid repo path: ${opts.repoPath}"` when passed null.

The crash happens in the `repo` useMemo during render — an unhandled exception propagates up and crashes the component.

## Fix

Wrap the `localPath` construction in try-catch inside the `repo` useMemo. If `workingTreeUri` throws (corrupted path), return `null` and show the empty state instead of crashing.

## Test plan

1. Corrupt a repo path in AsyncStorage (set to empty string or invalid format)
2. Open Git tab — should show empty state, not crash
3. Fresh install still works (no repos → empty state)
