### PR TITLE
fix(Explore): guard workingTreeUri against corrupted repo paths in commit and diff screens

### DIFF
--- a/src/screens/ExploreCommitScreen.tsx
+++ b/src/screens/ExploreCommitScreen.tsx
@@ -42,9 +42,14 @@ export default function ExploreCommitScreen() {
     state.repositories.find((candidate) => candidate.id === repoId),
   );
   const { activeAccount } = useActiveAccount();
-  const localPath = storedRepo
-    ? GitFsService.workingTreeUri({ repoPath: storedRepo.path })
-    : null;
+  let localPath: string | null = null;
+  if (storedRepo) {
+    try {
+      localPath = GitFsService.workingTreeUri({ repoPath: storedRepo.path });
+    } catch {
+      localPath = null;
+    }
+  }
 
   const [commit, setCommit] = useState<CommitInfo | null>(null);
   const [diffs, setDiffs] = useState<FileDiff[] | null>(null);

--- a/src/screens/ExploreDiffScreen.tsx
+++ b/src/screens/ExploreDiffScreen.tsx
@@ -31,7 +31,14 @@ export default function ExploreDiffScreen() {
   const repo = useRepoStore((state) =>
     state.repositories.find((candidate) => candidate.id === repoId),
   );
-  const localPath = repo ? GitFsService.workingTreeUri({ repoPath: repo.path }) : null;
+  let localPath: string | null = null;
+  if (repo) {
+    try {
+      localPath = GitFsService.workingTreeUri({ repoPath: repo.path });
+    } catch {
+      localPath = null;
+    }
+  }
 
   const [diff, setDiff] = useState<FileDiff | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Problem

Corrupted `repo.path` in AsyncStorage causes `GitFsService.workingTreeUri` to throw (via `parseRepoPath` returning null) in two more screens:

1. **ExploreCommitScreen** — line 45: `workingTreeUri` called at render time without try-catch. Crashes when navigated to with a corrupted repo.
2. **ExploreDiffScreen** — line 34: same issue.

These are stack screens navigated to from ExploreScreen. If the user navigates to a commit or file diff and that repo has a corrupted path, the screen crashes.

## Fix

Wrap `workingTreeUri` in try-catch in both screens. Falls back to `localPath = null` so screens degrade gracefully (show empty/loading state with guard `if (!localPath) return`).

Follows the same pattern as the ExploreScreen crash fix in PR #1389.

## Test plan

1. Navigate to ExploreCommitScreen with a corrupted repo path — should show empty/error state, not crash
2. Navigate to ExploreDiffScreen with a corrupted repo path — same
3. Normal navigation still works
