### PR TITLE
fix(paywall): run setAndroidFirstSeenBuild unconditionally at startup

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -83,12 +83,6 @@ export default function App() {
     // repo/account caps can be enforced on data brought back by Android backup
     // restore (#1233) — before the stores render it, not after.
     try {
-      if (Platform.OS === 'android') {
-        const build = Constants.expoConfig?.android?.versionCode;
-        if (build !== undefined) {
-          await setAndroidFirstSeenBuild(String(build));
-        }
-      }
       await useProStore.getState().initialize();
       await enforceTierLimits();
       await rebindRevenueCatToActiveAccount();
@@ -147,6 +141,21 @@ export default function App() {
 
     void reconcileThoughtDumps().catch(() => {});
     void LastSelectionPreferenceService.migrateFromLegacy();
+  }, []);
+
+  // Record the Android first-seen build unconditionally at startup — this must run
+  // on every app launch (not just first launch) because it writes to AsyncStorage
+  // only when the key is absent. Gating it inside checkOnboarding would skip it for
+  // returning users who have already completed onboarding, breaking Android
+  // grandfathering: resolveGrandfatherStatus would find no FIRST_SEEN_BUILD_KEY and
+  // incorrectly classify pre-paywall users as non-grandfathered (#1387).
+  useEffect(() => {
+    if (Platform.OS === 'android') {
+      const build = Constants.expoConfig?.android?.versionCode;
+      if (build !== undefined) {
+        void setAndroidFirstSeenBuild(String(build));
+      }
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes Android grandfathering being broken for returning users (existing installs that updated to a new version).

**Root cause**: `setAndroidFirstSeenBuild` was inside `checkOnboarding`, which only runs when `showOnboarding === null` (first launch only). For any user who had already completed onboarding, `checkOnboarding` was never called, so `FIRST_SEEN_BUILD_KEY` was never written to AsyncStorage. This meant `resolveGrandfatherStatus` would find no build record and incorrectly classify pre-paywall users as non-grandfathered, causing them to see the paywall and need to press Restore Purchases.

**Fix**: Moved `setAndroidFirstSeenBuild` into a standalone `useEffect` with empty deps that runs unconditionally on every app launch. Since `setAndroidFirstSeenBuild` only writes when the key is absent, this is safe — it writes on first launch, then is a no-op thereafter.

**PRs superseded**: #1387 (incomplete fix — correct logic but wrong placement)