### PR TITLE
fix(paywall): persist restore-granted flag so TestFlight iOS users keep Pro across launches

### DIFF
--- a/src/services/GrandfatherService.ts
+++ b/src/services/GrandfatherService.ts
@@ -6,8 +6,9 @@ export const PRO_PAYWALL_FIRST_BUILD = 9;
 export const GRANDFATHERED_KEY = '@gitnotes:pro_grandfathered';
 export const GRANDFATHER_CHECKED_KEY = '@gitnotes:grandfather_checked';
 export const FIRST_SEEN_BUILD_KEY = '@gitnotes:first_seen_build';
+export const RESTORE_GRANTED_KEY = '@gitnotes:restore_granted';
 
-export type GrandfatherReason = 'flag' | 'onboarding' | 'ios-build' | 'android-build' | 'none' | 'checked';
+export type GrandfatherReason = 'flag' | 'onboarding' | 'ios-build' | 'android-build' | 'restore-granted' | 'none' | 'checked';
 
 export interface GrandfatherResult {
   isGrandfathered: boolean;
@@ -50,6 +51,11 @@ export async function resolveGrandfatherStatus(
 
   const checked = await getStoredValue(GRANDFATHER_CHECKED_KEY);
   if (checked === 'true') return { isGrandfathered: false, reason: 'checked' };
+
+  if (customerInfo === null) {
+    const restored = await getStoredValue(RESTORE_GRANTED_KEY);
+    if (restored === 'true') return { isGrandfathered: true, reason: 'restore-granted' };
+  }
 
   // iOS: originalApplicationVersion is CFBundleVersion at time of original purchase.
   // Only treat as build number if it is a pure integer to avoid bypass

--- a/src/services/StorageBootstrap.ts
+++ b/src/services/StorageBootstrap.ts
@@ -26,6 +26,7 @@ const STARTUP_KEYS = [
   '@gitnotes:pro_grandfathered',
   '@gitnotes:grandfather_checked',
   '@gitnotes:first_seen_build',
+  '@gitnotes:restore_granted',
   '@gitnotes:trial_was_active',
   '@gitnotes:trial_expired_at',
 ] as const;

--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -12,7 +12,7 @@ import {
   purchasePackage as purchasePackageWith,
   restorePurchases,
 } from '../services/RevenueCatService';
-import { resolveGrandfatherStatus } from '../services/GrandfatherService';
+import { resolveGrandfatherStatus, RESTORE_GRANTED_KEY } from '../services/GrandfatherService';
 import * as PaywallAnalytics from '../services/PaywallAnalytics';
 
 let _isDevice: boolean | null = null;
@@ -283,6 +283,7 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
         return 'nothing';
       }
       await get().refresh();
+      await AsyncStorage.setItem(RESTORE_GRANTED_KEY, 'true');
       set({ isRestoring: false });
       PaywallAnalytics.trackRestoreOutcome('restored');
       return 'restored';


### PR DESCRIPTION
## Summary

Fixes iOS TestFlight users needing to press Restore Purchases on every app launch to get Pro.

**Root cause**: On iOS TestFlight, `EXPO_PUBLIC_REVENUECAT_API_KEY_IOS` may not be embedded in the binary (env vars not baked into TestFlight builds). This causes `configureRevenueCat()` → `configured = false` → `getCustomerInfo()` never called → `customerInfo = null` when `resolveGrandfatherStatus` runs. The iOS grandfathering check relies on `originalApplicationVersion` from `customerInfo`, which is unavailable, so `isGrandfathered` is always `false` and users see the paywall.

Restore worked because `restorePurchases()` calls StoreKit directly, bypassing RevenueCat SDK. But since `getCustomerInfo()` was never called, RevenueCat never learned about the restored entitlement — so on next launch, same problem.

**Fix**:
1. `proStore.restore()` now writes `RESTORE_GRANTED_KEY = 'true'` to AsyncStorage after a successful restore
2. `resolveGrandfatherStatus` checks `RESTORE_GRANTED_KEY` when `customerInfo` is `null` — if set, returns `isGrandfathered: true` so the user keeps Pro without needing to restore again
3. `StorageBootstrap.STARTUP_KEYS` includes the new key so it's boot-cached

**Files**: `GrandfatherService.ts`, `StorageBootstrap.ts`, `proStore.ts`