### PR TITLE
fix(paywall): grandfathering reliability

### DIFF
--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -260,6 +260,14 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
     set({ isRestoring: true, error: null });
     PaywallAnalytics.trackRestoreTap();
     try {
+      const isConfigured = get().configured;
+      if (!isConfigured) {
+        set({ isGrandfathered: true, status: 'pro' });
+        await AsyncStorage.setItem(RESTORE_GRANTED_KEY, 'true');
+        set({ isRestoring: false });
+        PaywallAnalytics.trackRestoreOutcome('restored');
+        return 'restored';
+      }
       const result = await restorePurchases();
       if (result.kind === 'error') {
         set({ isRestoring: false, error: result.message });


### PR DESCRIPTION
Fixes 3 paywall issues:

1. **setAndroidFirstSeenBuild unconditional useEffect** — Moved out of checkOnboarding so returning Android users are properly grandfathered on every launch (fix #1392)
2. **RESTORE_GRANTED_KEY persistence** — Key is written to AsyncStorage after every successful restore, and resolveGrandfatherStatus checks it when customerInfo is null (RevenueCat unconfigured on TestFlight), preventing transient errors from permanently blocking grandfathering (fix #1393)
3. **restore() configured=false fallback** — When RevenueCat is not configured (TestFlight iOS without API key), restore() now sets isGrandfathered=true directly instead of calling refresh() which would fail silently