### PR TITLE
fix(explore): make discard button red in ChangesSection

### DIFF
--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -143,7 +143,13 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
           </Pressable>
           {!item.staged && (
             <View className="mt-2 flex-row justify-end gap-2">
-              <Button size="sm" variant="ghost" onPress={() => void discardFile(item.path)} label="Discard" />
+              <Button
+                size="sm"
+                variant="danger"
+                onPress={() => void discardFile(item.path)}
+                testID={`explore.discard.${item.path}`}
+                label="Discard"
+              />
               <Button size="sm" variant="outline" onPress={() => void stageFile(item.path)} label="Stage" />
             </View>
           )}

--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -30,6 +30,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
   const [error, setError] = useState<string | null>(null);
   const [version, setVersion] = useState(0);
   const [notCloned, setNotCloned] = useState(false);
+  const [busyPath, setBusyPath] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -95,12 +96,15 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
 
   const discardFile = useCallback(
     async (path: string) => {
+      setBusyPath(path);
       try {
         await GitEngine.discardFiles(repo.localPath, [path]);
         onChanged();
         setVersion((value) => value + 1);
       } catch (caught) {
         setError(caught instanceof Error ? caught.message : String(caught));
+      } finally {
+        setBusyPath(null);
       }
     },
     [repo.localPath, onChanged],
@@ -146,9 +150,10 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
               <Button
                 size="sm"
                 variant="danger"
+                disabled={busyPath !== null}
                 onPress={() => void discardFile(item.path)}
                 testID={`explore.discard.${item.path}`}
-                label="Discard"
+                label={busyPath === item.path ? '…' : 'Discard'}
               />
               <Button size="sm" variant="outline" onPress={() => void stageFile(item.path)} label="Stage" />
             </View>
@@ -156,7 +161,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
         </View>
       );
     },
-    [data, navigation, repo.id, stageFile, discardFile],
+    [data, navigation, repo.id, stageFile, discardFile, busyPath],
   );
 
   if (error) {


### PR DESCRIPTION
## Summary
- Change Discard button variant from `ghost` to `danger` in ChangesSection (red styling)
- Add `testID` for better testability matching StagingSection pattern
- Add `busyPath` state to show loading indicator during discard operation
- Disable button while discard is in progress to prevent double-clicks

## Bug
- Discard button in ChangesSection was using `variant="ghost"` which has no background color and was hard to see
- No loading feedback when discard was triggered, making it seem like button did nothing
- Now with danger variant (red), button is clearly visible and shows loading state

## Testing
- TypeScript check passes
- ESLint passes (1 pre-existing warning unrelated to this change)