### PR TITLE
feat(explore): navigate to staging/commits tab after stage/commit all

### DIFF
--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -22,7 +22,7 @@ interface ChangesData {
   diffs: Record<string, FileDiff>;
 }
 
-export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: SectionProps) {
+export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0, onNavigate }: SectionProps) {
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTokens();
   const [data, setData] = useState<ChangesData | null>(null);
@@ -88,10 +88,11 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
       await Promise.all(unstaged.map((s) => GitEngine.stage(repo.localPath, [s.path])));
       onChanged();
       setVersion((value) => value + 1);
+      onNavigate?.('staging');
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
     }
-  }, [data, repo.localPath, onChanged]);
+  }, [data, repo.localPath, onChanged, onNavigate]);
 
   const discardFile = useCallback(
     async (path: string) => {

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -26,7 +26,7 @@ interface StagingData {
   diffs: Record<string, FileDiff>;
 }
 
-export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: SectionProps) {
+export function StagingSection({ repo, active, onChanged, chromeTopInset = 0, onNavigate }: SectionProps) {
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTokens();
   const [data, setData] = useState<StagingData | null>(null);
@@ -264,6 +264,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
             setCommitOpen(false);
             onChanged();
             setVersion((value) => value + 1);
+            onNavigate?.('commits');
           }}
         />
       </Modal>

--- a/src/components/explore/exploreShared.tsx
+++ b/src/components/explore/exploreShared.tsx
@@ -40,6 +40,7 @@ export interface SectionProps {
   active: boolean;
   onChanged: () => void;
   chromeTopInset?: number;
+  onNavigate?: (section: ExploreSection) => void;
 }
 
 export function relativeTime(timestamp: number | null): string {

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -218,7 +218,7 @@ export default function ExploreScreen() {
 
   const renderSection = () => {
     const repoTyped = repo as RepoLike;
-    const props = { repo: repoTyped, status, onChanged, chromeTopInset: chromeTotalHeight + 8 };
+    const props = { repo: repoTyped, status, onChanged, chromeTopInset: chromeTotalHeight + 8, onNavigate: setSection };
     switch (section) {
       case 'files':
         return <FilesSection key={repo.id} {...props} active />;


### PR DESCRIPTION
## What

- **Stage All** button (Changes tab) → after staging, navigates to **Staging** tab
- **Stage all + Commit** and **Commit staged** buttons (Staging tab) → after commit, navigates to **Commits** tab

## How

- Add `onNavigate` callback to `SectionProps` and thread it from `ExploreScreen`
- ChangesSection: Stage All → staging tab
- StagingSection: Commit → commits tab

## Files
- src/components/explore/exploreShared.tsx
- src/screens/ExploreScreen.tsx
- src/components/explore/ChangesSection.tsx
- src/components/explore/StagingSection.tsx