### PR TITLE
fix(ui): use label prop for primary variant buttons

### DIFF
--- a/src/components/chat/ChatConfirmationCard.tsx
+++ b/src/components/chat/ChatConfirmationCard.tsx
@@ -30,7 +30,7 @@ export function ChatConfirmationCard({ pendingConfirmation, colors, spacing, typ
         {JSON.stringify(pendingConfirmation.details, null, 2)}
       </Text>
       <View className="flex-row gap-2">
-        <Button testID="chat-confirmation.button.apply" variant="primary" onPress={onApply} style={{ flex: 1 }}>{t('common.apply')}</Button>
+        <Button testID="chat-confirmation.button.apply" variant="primary" onPress={onApply} style={{ flex: 1 }} label={t('common.apply')} />
         <Button testID="chat-confirmation.button.cancel" variant="secondary" onPress={onCancel} style={{ flex: 1 }}>{t('common.cancel')}</Button>
       </View>
     </Surface>

--- a/src/components/chat/ChatErrorCard.tsx
+++ b/src/components/chat/ChatErrorCard.tsx
@@ -26,7 +26,7 @@ export function ChatErrorCard({ message, colors, spacing, type, canRetry, isStre
     >
       <Text className="text-md font-semibold mb-2 text-text">{message}</Text>
       <View className="flex-row gap-2">
-        <Button testID="chat-error.button.retry" variant="primary" onPress={onRetry} disabled={!canRetry || isStreaming}>{t('common.retry')}</Button>
+        <Button testID="chat-error.button.retry" variant="primary" onPress={onRetry} disabled={!canRetry || isStreaming} label={t('common.retry')} />
         <Button testID="chat-error.button.dismiss" variant="secondary" onPress={onDismiss}>{t('common.dismiss')}</Button>
       </View>
     </Surface>

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -229,9 +229,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0 }: 
             <View className="flex-row items-center gap-2">
               {loading && <ActivityIndicator size="small" color={colors.accent} />}
               {(data?.changedPaths.length ?? 0) > 0 && (
-                <Button size="sm" variant="primary" onPress={() => setCommitOpen(true)} testID="explore.staging.commit-open">
-                  Commit pending
-                </Button>
+                <Button size="sm" variant="primary" onPress={() => setCommitOpen(true)} testID="explore.staging.commit-open" label="Commit pending" />
               )}
               {(data?.staged.length ?? 0) > 0 && (
                 <Button size="sm" variant="outline" disabled={busyPath !== null} onPress={() => void unstageAll()}>


### PR DESCRIPTION
## Summary
Fixes blue primary buttons with invisible/missing text by using the label prop instead of string children.

## Bug
Three buttons with variant="primary" were using string children instead of the label prop:
- StagingSection.tsx - "Commit pending" button
- ChatConfirmationCard.tsx - "Apply" button  
- ChatErrorCard.tsx - "Retry" button

This was inconsistent with other buttons fixed in commit 95c8218 which migrated to use label prop.

## Fix
Changed all three buttons to use label="..." prop instead of children text.

## Testing
- TypeScript check: passed
- ESLint: passed (only pre-existing warnings)