### PR TITLE
fix(explore): handle untracked files in discard functionality

### DIFF
--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -7,6 +7,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Text } from '@/components/ui/text';
 import { Button, ButtonText } from '@/components/ui/Button';
 import { FlatList } from '@/components/ui/flat-list';
+import * as FileSystem from 'expo-file-system';
 import { DiffLineList, previewLines } from './DiffLineList';
 import * as GitEngine from '@/services/git/engine/GitEngine';
 import type { FileDiff, FileStatus } from '@/services/git/engine/GitEngine';
@@ -96,10 +97,14 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0, on
   }, [data, repo.localPath, onChanged, onNavigate]);
 
   const discardFile = useCallback(
-    async (path: string) => {
+    async (path: string, status: string) => {
       setBusyPath(path);
       try {
-        await GitEngine.discardFiles(repo.localPath, [path]);
+        if (status === 'Untracked') {
+          await FileSystem.deleteAsync(`${repo.localPath}/${path}`, { idempotent: true });
+        } else {
+          await GitEngine.discardFiles(repo.localPath, [path]);
+        }
         onChanged();
         setVersion((value) => value + 1);
       } catch (caught) {
@@ -152,7 +157,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0, on
                 size="sm"
                 variant="danger"
                 disabled={busyPath !== null}
-                onPress={() => void discardFile(item.path)}
+                onPress={() => void discardFile(item.path, item.status)}
                 testID={`explore.discard.${item.path}`}
                 label={busyPath === item.path ? '…' : 'Discard'}
               />

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -7,6 +7,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Text } from '@/components/ui/text';
 import { Button, ButtonText } from '@/components/ui/Button';
 import { FlatList } from '@/components/ui/flat-list';
+import * as FileSystem from 'expo-file-system';
 import { DiffLineList, previewLines } from './DiffLineList';
 import { CommitComposer } from './CommitComposer';
 import { Modal } from '@/components/ui/Modal';
@@ -116,11 +117,15 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0, on
   }, [data, repo.localPath, onChanged]);
 
   const discardFile = useCallback(
-    async (path: string) => {
+    async (path: string, originalStatus: string) => {
       setBusyPath(path);
       try {
         await GitEngine.unstage(repo.localPath, [path]);
-        await GitEngine.discardFiles(repo.localPath, [path]);
+        if (originalStatus === 'Added') {
+          await FileSystem.deleteAsync(`${repo.localPath}/${path}`, { idempotent: true });
+        } else {
+          await GitEngine.discardFiles(repo.localPath, [path]);
+        }
         onChanged();
         setVersion((value) => value + 1);
       } catch (caught) {
@@ -167,7 +172,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0, on
               size="sm"
               variant="danger"
               disabled={busyPath !== null}
-              onPress={() => void discardFile(item.path)}
+              onPress={() => void discardFile(item.path, item.status)}
               testID={`explore.discard.${item.path}`}
               label={busyPath === item.path ? '…' : 'Discard'}
             />


### PR DESCRIPTION
## Summary
Fixes the Discard button in ChangesSection and StagingSection to properly handle untracked files.

## Bug
When discarding changes to untracked files (new files that were never committed), the `discardFiles` Git command fails because there is no HEAD version to restore to. The file should simply be deleted from the working tree.

Similarly, for staged new files (status "Added" in staging area), after unstaging, the file becomes untracked and needs to be deleted, not restored.

## Fix
- **ChangesSection**: Check if file status is "Untracked" before calling `discardFiles`. If untracked, delete the file using `FileSystem.deleteAsync()` instead.
- **StagingSection**: Check if original file status was "Added" (staged new file). After unstaging, delete the file instead of calling `discardFiles`.

## Testing
- TypeScript check: passed
- ESLint: passed