### PR TITLE
fix(explore): remove auto-stage on save; reload AsyncStorage on discard

### DIFF
--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -14,6 +14,7 @@ import { GitFsService } from '@/services/git/GitFsService';
 import type { RootStackParamList } from '@/navigation/types';
 import { resolveStatusTone, STATUS_META, type SectionProps } from './exploreShared';
 import { useTokens } from '@/contexts/ThemeContext';
+import { useNoteStore } from '@/stores/noteStore';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -100,15 +101,16 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0, on
       setBusyPath(path);
       try {
         await GitEngine.discardFiles(repo.localPath, [path]);
+        await useNoteStore.getState().reloadNoteFromFile(repo.path, path);
         onChanged();
-        setVersion((value) => value + 1);
+        await load();
       } catch (caught) {
         setError(caught instanceof Error ? caught.message : String(caught));
       } finally {
         setBusyPath(null);
       }
     },
-    [repo.localPath, onChanged],
+    [repo.localPath, repo.path, onChanged, load],
   );
 
   const renderItem = useCallback(

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -16,6 +16,7 @@ import { GitFsService } from '@/services/git/GitFsService';
 import type { RootStackParamList } from '@/navigation/types';
 import type { SectionProps } from './exploreShared';
 import { useTokens } from '@/contexts/ThemeContext';
+import { useNoteStore } from '@/stores/noteStore';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -121,15 +122,16 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0, on
       try {
         await GitEngine.unstage(repo.localPath, [path]);
         await GitEngine.discardFiles(repo.localPath, [path]);
+        await useNoteStore.getState().reloadNoteFromFile(repo.path, path);
         onChanged();
-        setVersion((value) => value + 1);
+        await load();
       } catch (caught) {
         setError(caught instanceof Error ? caught.message : String(caught));
       } finally {
         setBusyPath(null);
       }
     },
-    [repo.localPath, onChanged],
+    [repo.localPath, repo.path, onChanged, load],
   );
 
   const renderItem = useCallback(

--- a/src/services/cloneSyncServiceImpl.ts
+++ b/src/services/cloneSyncServiceImpl.ts
@@ -155,7 +155,6 @@ export const CloneSyncService = {
     try {
       if (intent === 'delete') {
         await FileSystem.deleteAsync(fullPath, { idempotent: true });
-        await GitEngine.remove(repoDir, [relPath]);
         return { success: true };
       }
 
@@ -163,7 +162,6 @@ export const CloneSyncService = {
       const dirPath = lastSlash === -1 ? repoDir : `${repoDir}/${relPath.slice(0, lastSlash)}`;
       await FileSystem.makeDirectoryAsync(dirPath, { intermediates: true });
       await FileSystem.writeAsStringAsync(fullPath, content ?? '');
-      await GitEngine.stage(repoDir, [relPath]);
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : String(error) };

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { create } from 'zustand';
+import * as FileSystem from 'expo-file-system/legacy';
 import { Note, NoteCreateInput, NoteUpdateInput, sortNotesWithPinnedFirst, filterNotesBySearch } from '../models/Note';
 import { StorageService } from '../services/StorageService';
 import { NoteSyncQueueService, SyncEngineService, CloneSyncService, type MutationSucceededEvent, type DroppedMutationEvent, type NoteDeleteParams, type SaveResult } from '../services/cloneSyncServiceImpl';
@@ -44,6 +45,8 @@ interface NoteActions {
   getNoteById: (id: string) => Note | undefined;
   togglePin: (id: string) => Promise<boolean>;
   refreshNotes: () => Promise<void>;
+  /** Reload note content from git working tree and sync to AsyncStorage after discard. */
+  reloadNoteFromFile: (repo: string, filePath: string) => Promise<void>;
   clearError: () => void;
 }
 
@@ -460,6 +463,38 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
 
   refreshNotes: async () => {
     await get().loadNotes();
+  },
+
+  reloadNoteFromFile: async (repo: string, filePath: string) => {
+    const info = parseRepoPath(repo);
+    if (!info) return;
+    const relPath = filePath.replace(/^\/+/, '');
+    const repoDir = `${FileSystem.documentDirectory ?? ''}GitNotes/${info.owner}/${info.repo}`;
+    const fullPath = `${repoDir}/${relPath}`;
+    try {
+      const content = await FileSystem.readAsStringAsync(fullPath);
+      const pathSet = new Set([relPath]);
+      const matches = get().notes.filter((note) => {
+        if (!note.repo) return false;
+        const sameRepo =
+          note.repo === repo || (!!info && pathsEqual(parseRepoPath(note.repo), info));
+        if (!sameRepo) return false;
+        const notePath = note.filePath ?? deriveDefaultNotePath(note);
+        return !!notePath && pathSet.has(notePath);
+      });
+      for (const note of matches) {
+        const updated = await StorageService.updateNote({ id: note.id, content });
+        if (updated) {
+          set((state) => ({
+            notes: sortNotesWithPinnedFirst(
+              state.notes.map((n) => (n.id === updated.id ? updated : n)),
+            ),
+          }));
+        }
+      }
+    } catch {
+      // File may not exist or be readable —silently ignore
+    }
   },
 
   clearError: () => set({ error: null }),


### PR DESCRIPTION
## What

1. **No more auto-stage on save** — CloneSyncService.save no longer calls GitEngine.stage(). Saves write to the git working tree as unstaged changes, giving users full control over staging and committing.
2. **AsyncStorage stays in sync after discard** — when discarding a file in the Git UI, reloadNoteFromFile reads the restored content from the working tree and syncs it to AsyncStorage so notes show the correct content without needing a manual refresh.

## Why

- **Auto-stage was surprising**: saving a note immediately staged it, causing the same file to appear in both Staged and Changes tabs simultaneously.
- **Discard left stale cache**: discarding a file from the Git UI restored the working tree file but left AsyncStorage with the modified content, so navigating back to a note showed old data.

## Testing

- [ ] Save a note — it should appear in Changes (unstaged), not Staged
- [ ] Stage and commit from the Git UI — confirm commit is created
- [ ] Edit a note, discard from Git UI — navigate back to note and confirm it shows the discarded (pre-edit) content
- [ ] Same for staged discard (unstage + discard)