### PR TITLE
fix(ios): pass libgitnotes_git2.a to app target linker

### DIFF
--- a/modules/GitEngine/plugin/withGitEngineRust.js
+++ b/modules/GitEngine/plugin/withGitEngineRust.js
@@ -73,6 +73,19 @@ function withGitEngineRust(config) {
       ...nativeTarget.buildPhases.filter((phase) => phase.value !== uuid),
     ];
 
+    const buildConfigs = (nativeTarget.buildConfigurationList.value || [])
+      .map((ref) => project.hash.project.objects.PBXBuildConfiguration[ref.value])
+      .filter(Boolean);
+    for (const buildConfig of buildConfigs) {
+      const settings = buildConfig.buildSettings;
+      if (!settings) continue;
+      const existing = settings.OTHER_LDFLAGS || '$(inherited)';
+      if (!existing.includes('libgitnotes_git2.a')) {
+        settings.OTHER_LDFLAGS =
+          '$(inherited) ' + '"$(SRCROOT)/../modules/GitEngine/ios-local/rust/libgitnotes_git2.a"';
+      }
+    }
+
     return modConfig;
   });
 }


### PR DESCRIPTION
## Problem

EAS iOS builds fail at the link step with:

```
ld: symbol(s) not found for architecture arm64
Undefined symbols: uniffi_gitnotes_git2_fn_func_*
```

The Rust staticlib `libgitnotes_git2.a` IS built and copied to `modules/GitEngine/ios-local/rust/` during the build, but it was never passed to the final app linker's `OTHER_LDFLAGS`.

 in GitEngine.podspec makes the archive available to the GitEngine pod's own link step, but CocoaPods does not propagate vendored static libs to the **app target's** linker flags.

## Fix

In `withGitEngineRust.js`, after adding the Rust build script phase to the app target, also enumerate the target's build configurations and append `libgitnotes_git2.a` to `OTHER_LDFLAGS`.

```js
const buildConfigs = (nativeTarget.buildConfigurationList.value || [])
  .map((ref) => project.hash.project.objects.PBXBuildConfiguration[ref.value])
  .filter(Boolean);
for (const buildConfig of buildConfigs) {
  const settings = buildConfig.buildSettings;
  if (!settings) continue;
  const existing = settings.OTHER_LDFLAGS || '$(inherited)';
  if (!existing.includes('libgitnotes_git2.a')) {
    settings.OTHER_LDFLAGS = '$(inherited) ' + '"/../modules/GitEngine/ios-local/rust/libgitnotes_git2.a"';
  }
}
```

This ensures the linker can resolve the UniFFI FFI entry points (`uniffi_gitnotes_git2_fn_func_*`) that the Swift FFI wrapper calls.

## Testing

- [ ] Trigger EAS iOS build and confirm link succeeds
- [ ] Confirm `uniffi_gitnotes_git2_*` symbols are resolved in the binary