### PR TITLE
docs: fix broken wiki link and reinforce main-clean rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,11 +40,13 @@ ln -sfn "$(pwd)/node_modules" .worktrees/<scope>-<slug>/node_modules
 
 ### Rules
 
+- **Never leave code in main.** The main working tree must always be clean — no uncommitted changes, no staged files, no dangling work. If your worktree branch is merged, remove the worktree immediately. A dirty main blocks other agents and causes race conditions.
 - **One worktree per branch.** Never branch from another worktree's branch — always branch from `main` (or the upstream you're targeting). After `git fetch origin` in the main repo, base new worktrees on the updated `origin/main`.
 - **Coordinate before touching shared files.** Before editing `conflictStore.ts`, `LocalGitWriter.ts`, or any file another agent's `git status` shows as modified in the main working tree, check `git worktree list` and `git status` in the other worktrees. If another session has uncommitted work on the same files, wait or scope your change to a different file.
 - **Metro serves from main.** The Expo dev-client connects to Metro on the main worktree's port (8081). If you need your branch code to be served by Metro (e.g. for sim surface verification), copy the changed files from your worktree into main's working tree temporarily and revert after verification — Metro cannot serve from a worktree (`.worktrees/` is in `metro.config.js`'s `resolver.blockList`).
 - **Do not commit secrets / tokens / Metro debug output** — review `git diff` before committing. This applies whether you are in a worktree or not.
 - **Clean up** with `git worktree remove <path>` when a branch is merged and the worktree is no longer needed. Branches are cheap to recreate.
+- **Main must stay clean.** After merging (squash-merge or rebase+merge), immediately remove the source worktree and verify `git status` in main shows nothing uncommitted or unstaged. A polluted main breaks Metro, blocks other agents, and corrupts shared state.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - Notes, todos, journals, and Excalidraw-style canvases — all backed by Git
 - Folders, tags, colors, pins, wiki-links, backlinks, custom templates
 - Multi-provider sync (GitHub, GitLab, Gitea-like); per-repo API or full-clone sync modes
-- Optional Pro tier with Neumorphic "Fancy UI", advanced AI, multi-host paywall, and trial/lifetime via StoreKit 2 (RevenueCat) — see the [wiki: Pro Paywall](https://github.com/gedwolmen/gitnotes/wiki/paywall-pro)
+- Optional Pro tier with Neumorphic "Fancy UI", advanced AI, multi-host paywall, and trial/lifetime via StoreKit 2 (RevenueCat) — see the [wiki: Paywall & Pro Tier](https://github.com/gedwolmen/gitnotes/wiki/paywall)
 - Optional AI chat layer (Anthropic, OpenAI-compatible providers, Apple Intelligence, on-device Llama)
 - Biometric lock, multilingual UI (EN, ES, FR, DE, JA, KO), light / dark / system themes
 


### PR DESCRIPTION
## Summary

- Fix broken README wiki link: `wiki/paywall-pro` → `wiki/paywall`
- Add explicit AGENTS.md rule: never leave uncommitted code in main working tree
- Add explicit AGENTS.md rule: main must be verified clean after merge

## Changes

| File | Change |
|------|--------|
| README.md | Fix wiki URL from paywall-pro to paywall |
| AGENTS.md | New rule: "Never leave code in main" |
| AGENTS.md | New rule: "Main must stay clean" after merge |