### PR TITLE
fix: remove lipo step in EAS post-install script

### DIFF
--- a/scripts/eas/post-install.sh
+++ b/scripts/eas/post-install.sh
@@ -38,18 +38,10 @@ else
   mkdir -p "$IOS_LIB_DIR"
   mkdir -p "$SWIFT_GEN_DIR/GitNotesGit2FFI"
 
-  log "Building aarch64-apple-ios-sim..."
-  (cd "$RUST_DIR" && cargo build --target aarch64-apple-ios-sim "${PROFILE_FLAGS[@]}")
-
   log "Building aarch64-apple-ios (device)..."
   (cd "$RUST_DIR" && cargo build --target aarch64-apple-ios "${PROFILE_FLAGS[@]}")
-
-  log "Creating universal staticlib..."
-  lipo -create \
-    "$RUST_DIR/target/aarch64-apple-ios-sim/$RUST_PROFILE/libgitnotes_git2.a" \
-    "$RUST_DIR/target/aarch64-apple-ios/$RUST_PROFILE/libgitnotes_git2.a" \
-    -output "$IOS_LIB_DIR/libgitnotes_git2.a"
-  log "iOS universal staticlib created"
+  cp "$RUST_DIR/target/aarch64-apple-ios/$RUST_PROFILE/libgitnotes_git2.a" "$IOS_LIB_DIR/libgitnotes_git2.a"
+  log "iOS device staticlib copied"
 fi
 
 if [ -n "${ANDROID_NDK_HOME:-}" ] && [ -d "${ANDROID_NDK_HOME:-}" ]; then


### PR DESCRIPTION
## Summary

The merged PR #1409 added a  step to combine simulator and device staticlibs into a universal binary. However, this fails on EAS Apple Silicon builders because both  and  produce arm64 code on Apple Silicon, so lipo refuses to combine them.

### Fix

Remove the lipo step since EAS device builds (which use ) only need the device staticlib.

### Testing

Re-run EAS device build after merge.