### PR TITLE
fix(TagInput): always show border on tags textbox using colors.border

### DIFF
--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -82,7 +82,7 @@ export default function TagInput({
         autoCapitalize="none"
         autoCorrect={false}
         returnKeyType="done"
-        containerStyle={{ backgroundColor: colors.surface }}
+        containerStyle={{ backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.border }}
       />
 
       {showSuggestions && filteredSuggestions.length > 0 && (


### PR DESCRIPTION
Fixes the tags textbox in the notes edit/add page so it displays a gray border even when inactive (not focused), matching the active state appearance.