### PR TITLE
fix: add staticlib verification and fix OTHER_LDFLAGS quoting

### DIFF
--- a/modules/GitEngine/plugin/withGitEngineRust.js
+++ b/modules/GitEngine/plugin/withGitEngineRust.js
@@ -82,7 +82,7 @@ function withGitEngineRust(config) {
       const existing = settings.OTHER_LDFLAGS || '$(inherited)';
       if (!existing.includes('libgitnotes_git2.a')) {
         settings.OTHER_LDFLAGS =
-          '$(inherited) ' + '"$(SRCROOT)/../modules/GitEngine/ios-local/rust/libgitnotes_git2.a"';
+          '$(inherited) $(SRCROOT)/../modules/GitEngine/ios-local/rust/libgitnotes_git2.a';
       }
     }
 

--- a/scripts/eas/post-install.sh
+++ b/scripts/eas/post-install.sh
@@ -40,8 +40,22 @@ else
 
   log "Building aarch64-apple-ios (device)..."
   (cd "$RUST_DIR" && cargo build --target aarch64-apple-ios "${PROFILE_FLAGS[@]}")
+
+  log "Verifying staticlib..."
+  if [ ! -f "$RUST_DIR/target/aarch64-apple-ios/$RUST_PROFILE/libgitnotes_git2.a" ]; then
+    log "ERROR: Rust staticlib not found at $RUST_DIR/target/aarch64-apple-ios/$RUST_PROFILE/libgitnotes_git2.a"
+    exit 1
+  fi
+
   cp "$RUST_DIR/target/aarch64-apple-ios/$RUST_PROFILE/libgitnotes_git2.a" "$IOS_LIB_DIR/libgitnotes_git2.a"
-  log "iOS device staticlib copied"
+
+  if [ -f "$IOS_LIB_DIR/libgitnotes_git2.a" ]; then
+    log "iOS device staticlib copied successfully"
+    ls -la "$IOS_LIB_DIR/libgitnotes_git2.a"
+  else
+    log "ERROR: Failed to copy staticlib to $IOS_LIB_DIR"
+    exit 1
+  fi
 fi
 
 if [ -n "${ANDROID_NDK_HOME:-}" ] && [ -d "${ANDROID_NDK_HOME:-}" ]; then


### PR DESCRIPTION
## Summary

The EAS build is still failing with linker errors. This PR adds debugging verification and fixes a potential quoting issue.

### Changes

1. **Post-install verification**: Added steps to verify the Rust staticlib exists before copying and confirms the copy succeeded. If the staticlib is missing, the script now fails with a clear error message.

2. **Remove quotes from OTHER_LDFLAGS**: The path in OTHER_LDFLAGS had errant quotes that could cause the linker to not recognize it as a valid file path.

### Testing

After merging, run:Nonexistent flag: --no-cache
See more help with --help

If the build still fails, the logs will now show whether the staticlib was found and copied successfully.