### PR TITLE
fix: force_load vendored Rust staticlib to extract all symbols

### DIFF
--- a/modules/GitEngine/ios-local/GitEngine.podspec
+++ b/modules/GitEngine/ios-local/GitEngine.podspec
@@ -11,8 +11,13 @@ Pod::Spec.new do |s|
   # Expo native module + UniFFI generated Swift FFI + FFI headers
   s.source_files = '*.swift', 'generated/*.swift', 'generated/GitNotesGit2FFI/**/*'
 
-  # Rust staticlib
+  # Rust staticlib - force_load ensures all symbols are extracted
   s.vendored_libraries = 'rust/*.a'
+
+  # Force load the vendored library to extract all symbols (needed for UniFFI FFI)
+  s.xcconfig = {
+    'OTHER_LDFLAGS' => '$(inherited) -force_load $(PODS_TARGET_SRCROOT)/rust/libgitnotes_git2.a'
+  }
 
   # System libraries needed by Rust git2
   s.libraries = 'iconv'

--- a/modules/GitEngine/plugin/withGitEngineRust.js
+++ b/modules/GitEngine/plugin/withGitEngineRust.js
@@ -80,7 +80,8 @@ function withGitEngineRust(config) {
       const settings = buildConfig.buildSettings;
       if (!settings) continue;
       if (!settings.OTHER_LDFLAGS || !settings.OTHER_LDFLAGS.includes('libgitnotes_git2.a')) {
-        settings.OTHER_LDFLAGS = '$(inherited) $(SRCROOT)/../modules/GitEngine/ios-local/rust/libgitnotes_git2.a';
+        settings.OTHER_LDFLAGS =
+          '$(inherited) $(SRCROOT)/../modules/GitEngine/ios-local/rust/libgitnotes_git2.a';
       }
     }
 

--- a/src/components/settings/SettingsContent.tsx
+++ b/src/components/settings/SettingsContent.tsx
@@ -792,7 +792,7 @@ export function SettingsContent(props: SettingsContentProps) {
           }
         >
           <View className="flex-row items-center gap-2">
-            <Ionicons name="git-commit-outline" size={20} color={colors.text} />
+            <Ionicons name="git-pull-request-outline" size={20} color={colors.text} />
             <Text style={[styles.settingLabel, { color: colors.text }]}>{t('settings.floatingGitButton')}</Text>
           </View>
         </GroupRow>


### PR DESCRIPTION
## Root Cause

The linker command shows `-lGitEngine` but **NO direct reference to `libgitnotes_git2.a`**. 

Without `-force_load`, CocoaPods `vendored_libraries` are included but the linker dead-strips "unreferenced" symbols. The UniFFI FFI functions (`ffi_gitnotes_git2_*`) ARE referenced by Swift code, but they're called via function pointers (not direct symbol calls), so the linker doesn't see the reference and strips them as dead code.

## Fix

Add `-force_load` to the podspec's xcconfig to force the linker to load ALL symbols from the vendored Rust staticlib:

```ruby
s.xcconfig = {
  'OTHER_LDFLAGS' => ' -force_load /rust/libgitnotes_git2.a'
}
```

## Testing

```bash
eas build --profile production --no-cache
```