### PR TITLE
fix: conflict UX improvements

### DIFF
--- a/src/components/git/AppFloatingGitButton.tsx
+++ b/src/components/git/AppFloatingGitButton.tsx
@@ -95,7 +95,14 @@ export default function AppFloatingGitButton({ currentRouteName }: AppFloatingGi
   // changes while the component stays mounted, and an early return before a
   // hook would change the hook count between renders.
   const onQuickTap = useCallback(() => {
-    // Blue button (totalAhead > 0) always navigates to commits tab
+    if (aggregatedState.anyConflicts) {
+      const conflictRepoId = Array.from(aggregatedState.perRepo.entries()).find(
+        ([, entry]) => entry.conflicts,
+      )?.[0];
+      if (!conflictRepoId) return;
+      navigation.navigate('ExploreConflict', { repoId: conflictRepoId });
+      return;
+    }
     if (aggregatedState.totalAhead > 0) {
       const aheadRepoId = Array.from(aggregatedState.perRepo.entries()).find(([, entry]) => entry.ahead > 0)?.[0]
         ?? aggregatedState.latestChangedRepoId

--- a/src/screens/ConflictResolveScreen.tsx
+++ b/src/screens/ConflictResolveScreen.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, Alert, Pressable, ScrollView, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -13,21 +22,19 @@ import * as GitEngine from '@/services/git/engine/GitEngine';
 import type { ConflictBlobs } from '@/services/git/engine/GitEngine';
 import { GitFsService } from '@/services/git/GitFsService';
 import { useRepoStore } from '@/stores/repoStore';
+import { useGitButtonActionStore } from '@/stores/gitButtonActionStore';
 import { useTokens } from '@/contexts/ThemeContext';
 import type { RootStackParamList } from '@/navigation/types';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 type Route = RouteProp<RootStackParamList, 'ConflictResolve'>;
 
-const PREVIEW_LINES = 20;
-
-/** Per-file conflict resolution: shows ours / theirs / base blobs and lets
- * the user pick which version to keep as the resolved file. */
 export default function ConflictResolveScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<Route>();
   const { colors } = useTokens();
   const { repoId, path } = route.params;
+  const setPending = useGitButtonActionStore((s) => s.setPending);
 
   const storedRepo = useRepoStore((state) =>
     state.repositories.find((candidate) => candidate.id === repoId),
@@ -47,7 +54,8 @@ export default function ConflictResolveScreen() {
   const [blobs, setBlobs] = useState<ConflictBlobs | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [resolving, setResolving] = useState<'ours' | 'theirs' | 'base' | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const [content, setContent] = useState('');
 
   useEffect(() => {
     if (!localPath) {
@@ -58,7 +66,10 @@ export default function ConflictResolveScreen() {
     (async () => {
       try {
         const result = await GitEngine.getConflictBlobs(localPath, path);
-        if (!cancelled) setBlobs(result);
+        if (!cancelled) {
+          setBlobs(result);
+          setContent(result.ours);
+        }
       } catch (caught) {
         if (!cancelled) setError(caught instanceof Error ? caught.message : String(caught));
       } finally {
@@ -70,25 +81,20 @@ export default function ConflictResolveScreen() {
     };
   }, [localPath, path]);
 
-  const handleResolve = async (version: 'ours' | 'theirs' | 'base') => {
+  const handleResolve = async () => {
     if (!fileUri || !localPath) return;
-    const content = blobs?.[version] ?? '';
-    setResolving(version);
+    setResolving(true);
     try {
       await FileSystem.writeAsStringAsync(fileUri, content);
       await GitEngine.markConflictResolved(localPath, path);
-      Alert.alert(
-        'Conflict resolved',
-        `Using the "${version}" version for "${path}".`,
-        [{ text: 'OK', onPress: () => navigation.goBack() }],
-      );
+      setPending({ repoId, section: 'commits' });
+      navigation.navigate('MainTabs', { screen: 'ExploreTab' });
     } catch (caught) {
+      setResolving(false);
       Alert.alert(
         'Failed to resolve',
         caught instanceof Error ? caught.message : String(caught),
       );
-    } finally {
-      setResolving(null);
     }
   };
 
@@ -110,59 +116,6 @@ export default function ConflictResolveScreen() {
       </SafeAreaView>
     );
   }
-
-  const renderVersion = (version: 'ours' | 'theirs' | 'base', label: string, _color: string) => {
-    const content = blobs?.[version] ?? '';
-    const lines = content.split('\n').slice(0, PREVIEW_LINES);
-    const truncated = content.split('\n').length > PREVIEW_LINES;
-    const isResolving = resolving === version;
-
-    return (
-      <View
-        key={version}
-        className="rounded-lg p-4 mb-3"
-        style={{ backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }}
-        testID={`conflict-resolve.${version}`}
-      >
-        <View className="flex-row items-center justify-between mb-2">
-          <Text className="text-sm font-bold" style={{ color: colors.text }}>{label}</Text>
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={resolving !== null}
-            onPress={() => handleResolve(version)}
-            testID={`conflict-resolve.use.${version}`}
-          >
-            {isResolving ? (
-              <ActivityIndicator size="small" color={colors.accent} />
-            ) : (
-              <ButtonText style={{ color: colors.accent }}>Use this</ButtonText>
-            )}
-          </Button>
-        </View>
-        <View
-          className="rounded p-2"
-          style={{ backgroundColor: colors.surfaceSecondary, borderColor: colors.border, borderWidth: 1 }}
-        >
-          {lines.map((line, i) => (
-            <Text
-              key={i}
-              className="text-xs font-mono"
-              style={{ color: colors.textSecondary }}
-              numberOfLines={1}
-            >
-              {line}
-            </Text>
-          ))}
-          {truncated && (
-            <Text className="text-[10px] italic mt-1" style={{ color: colors.textSecondary }}>
-              … {content.split('\n').length - PREVIEW_LINES} more lines
-            </Text>
-          )}
-        </View>
-      </View>
-    );
-  };
 
   return (
     <SafeAreaView edges={['top']} className="flex-1" style={{ flex: 1, backgroundColor: colors.background }}>
@@ -197,16 +150,81 @@ export default function ConflictResolveScreen() {
           <Ionicons name="warning-outline" size={40} color={colors.error} />
           <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
         </View>
-      ) : blobs ? (
-        <ScrollView className="flex-1" contentContainerStyle={{ padding: 16 }}>
-          <Text className="text-xs font-semibold mb-3" style={{ color: colors.textSecondary }}>
-            Choose which version to keep for each conflicted file:
-          </Text>
-          {renderVersion('ours', 'Ours (current branch)', colors.accent)}
-          {renderVersion('theirs', 'Theirs (incoming change)', colors.warning)}
-          {renderVersion('base', 'Base (common ancestor)', colors.textSecondary)}
-        </ScrollView>
-      ) : null}
+      ) : (
+        <KeyboardAvoidingView
+          className="flex-1"
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          keyboardVerticalOffset={0}
+        >
+          <ScrollView className="flex-1" contentContainerStyle={{ padding: 16 }} keyboardShouldPersistTaps="handled">
+            <Text className="text-xs font-semibold mb-2" style={{ color: colors.textSecondary }}>
+              Edit the file content below, or pick a version:
+            </Text>
+            <View
+              className="rounded-lg mb-4 p-3"
+              style={{ backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }}
+            >
+              <TextInput
+                testID="conflict-resolve.editor"
+                className="text-sm font-mono min-h-[200]"
+                style={{ color: colors.text, backgroundColor: colors.surfaceSecondary, borderRadius: 8, padding: 12 }}
+                multiline
+                value={content}
+                onChangeText={setContent}
+                placeholder="Edit the resolved content here…"
+                placeholderTextColor={colors.textSecondary}
+                textAlignVertical="top"
+              />
+            </View>
+
+            <Text className="text-xs font-semibold mb-2" style={{ color: colors.textSecondary }}>
+              Or pick a version to fill the editor:
+            </Text>
+            <View className="flex-row gap-2 mb-4">
+              <Button
+                className="flex-1"
+                size="sm"
+                variant="outline"
+                onPress={() => setContent(blobs?.ours ?? '')}
+                testID="conflict-resolve.use.ours"
+              >
+                <ButtonText style={{ color: colors.accent }}>Use Ours</ButtonText>
+              </Button>
+              <Button
+                className="flex-1"
+                size="sm"
+                variant="outline"
+                onPress={() => setContent(blobs?.theirs ?? '')}
+                testID="conflict-resolve.use.theirs"
+              >
+                <ButtonText style={{ color: colors.warning }}>Use Theirs</ButtonText>
+              </Button>
+              <Button
+                className="flex-1"
+                size="sm"
+                variant="outline"
+                onPress={() => setContent(blobs?.base ?? '')}
+                testID="conflict-resolve.use.base"
+              >
+                <ButtonText>Use Base</ButtonText>
+              </Button>
+            </View>
+
+            <Button
+              className="mt-2"
+              disabled={resolving}
+              onPress={handleResolve}
+              testID="conflict-resolve.save"
+            >
+              {resolving ? (
+                <ActivityIndicator size="small" color={colors.accent} />
+              ) : (
+                <ButtonText>Mark resolved &amp; go to push</ButtonText>
+              )}
+            </Button>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      )}
     </SafeAreaView>
   );
 }

--- a/src/screens/ExploreConflictScreen.tsx
+++ b/src/screens/ExploreConflictScreen.tsx
@@ -95,10 +95,17 @@ export default function ExploreConflictScreen() {
     >
       <View className="flex-row items-center justify-between">
         <View className="min-w-0 flex-1 mr-2">
-          <Text className="text-sm font-semibold" style={{ color: colors.text }} numberOfLines={2}>
-            {item.path}
-          </Text>
-          <View className="mt-1 flex-row items-center gap-1">
+          <View className="flex-row items-center gap-2 mb-1">
+            <View
+              className="w-2 h-2 rounded-sm"
+              style={{ backgroundColor: colors.error }}
+              testID={`explore-conflict.indicator.${item.path}`}
+            />
+            <Text className="text-sm font-semibold" style={{ color: colors.text }} numberOfLines={2}>
+              {item.path}
+            </Text>
+          </View>
+          <View className="flex-row items-center gap-1">
             <View
               className="rounded px-1.5 py-0.5"
               style={{ backgroundColor: `${colors.error}26` }}


### PR DESCRIPTION
## Summary

Re-apply UX improvements from #1417 that were overwritten by a force-push:

- **Editable editor on ConflictResolveScreen** — users can manually edit the resolved content instead of being forced to pick one of the three versions (ours / theirs / base)
- **Red button navigates to conflict screen** —  on the floating git button now prioritises showing the conflict list when  is true, before the "ahead" case
- **Post-resolve navigation to commits tab** — after marking a conflict as resolved, the user is navigated to the commits tab (via ) instead of staying on the conflict screen

## Files changed

-  — conflict check added to 
-  — full rewrite: editable , three version-fill buttons, post-resolve navigation
-  — red dot indicator added to each conflict list item

## Testing

```bash
yarn ts:check   # ✅ passes
```