### PR TITLE
feat(git-button): hold-to-stage/commit/push on floating git button

### DIFF
--- a/src/components/git/AppFloatingGitButton.tsx
+++ b/src/components/git/AppFloatingGitButton.tsx
@@ -1,11 +1,15 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { useToast, Toast, ToastDescription, ToastTitle } from '@/components/ui/toast';
 import { useRepoStore } from '@/stores/repoStore';
 import { useAllReposStatus, type RepoGitState } from '@/hooks/useAllReposStatus';
 import { useGitButtonActionStore } from '@/stores/gitButtonActionStore';
+import { stageAllPending, commitAll, pushAll } from '@/services/git/multiRepoGitOps';
+import type { Author } from '@/services/git/engine/GitEngine';
+import { useAccounts } from '@/contexts/AccountsContext';
 import FloatingGitButton from './FloatingGitButton';
+import type { ReleaseSegment } from './useFloatingGitButtonAffordances';
 import type { RootStackParamList } from '@/navigation/types';
 import type { ExploreSection } from '@/components/explore/exploreShared';
 
@@ -33,15 +37,14 @@ const HIDDEN_ROUTES = new Set<string>([
 ]);
 
 /**
- * App-level wrapper around `FloatingGitButton` — purely informational
- * (issue #1330). Owns:
+ * App-level wrapper around `FloatingGitButton`. Owns:
  *   - the aggregated per-repo state from `useAllReposStatus`
  *   - the smart-navigate tap: queues a pending action (target repo +
  *     section) and jumps to ExploreTab. ExploreScreen reads the pending
  *     action on focus, applies repo + section, then clears it.
  *
- * The button performs no git operations itself and is disabled (grayed out)
- * when nothing is pending anywhere.
+ * Hold-to-release performs git stage/commit/push across all repos.
+ * Disabled (grayed out) when nothing is pending anywhere.
  *
  * Hides itself on full-screen modals and the paywall/onboarding so it never
  * floats over content that needs the full viewport.
@@ -53,6 +56,13 @@ export default function AppFloatingGitButton({ currentRouteName }: AppFloatingGi
   const setPending = useGitButtonActionStore((s) => s.setPending);
   const toast = useToast();
   const hintFiredRef = useRef(false);
+  const { accounts, activeAccountId } = useAccounts();
+
+  const author = useMemo<Author | null>(() => {
+    const account = accounts.find((a) => a.id === activeAccountId) ?? null;
+    if (!account) return null;
+    return { name: account.name, email: account.email ?? '' };
+  }, [accounts, activeAccountId]);
 
   const hasAnyAction =
     aggregatedState.totalUncommitted > 0 ||
@@ -60,6 +70,96 @@ export default function AppFloatingGitButton({ currentRouteName }: AppFloatingGi
     aggregatedState.totalAhead > 0 ||
     aggregatedState.anyConflicts;
   const isDisabled = !hasAnyAction;
+
+  const handleReleaseSegment = useCallback(
+    async (segment: ReleaseSegment) => {
+      if (repos.length === 0) return;
+      if (!author) {
+        toast.show({
+          placement: 'top',
+          duration: 3000,
+          render: ({ id }: { id: string }) => (
+            <Toast action="error" nativeID={`gitbutton-noauthor-${id}`}>
+              <ToastTitle>Cannot commit</ToastTitle>
+              <ToastDescription>No active account found. Add an account in Settings.</ToastDescription>
+            </Toast>
+          ),
+        });
+        return;
+      }
+
+      const stageResult = await stageAllPending(repos);
+      if (segment === 'stage') {
+        toast.show({
+          placement: 'top',
+          duration: 2000,
+          render: ({ id }: { id: string }) => (
+            <Toast action="success" nativeID={`gitbutton-stage-${id}`}>
+              <ToastTitle>Staged {stageResult.totalActed} file(s)</ToastTitle>
+            </Toast>
+          ),
+        });
+        void aggregatedState.refresh();
+        return;
+      }
+
+      const message = `Sync: stage ${stageResult.totalActed} file(s)`;
+      await commitAll(repos, message, author);
+      if (segment === 'commit') {
+        toast.show({
+          placement: 'top',
+          duration: 2000,
+          render: ({ id }: { id: string }) => (
+            <Toast action="success" nativeID={`gitbutton-commit-${id}`}>
+              <ToastTitle>Staged and committed</ToastTitle>
+            </Toast>
+          ),
+        });
+        void aggregatedState.refresh();
+        return;
+      }
+
+      const pushResult = await pushAll(repos);
+      const failedCount = pushResult.failures.length;
+      if (failedCount === repos.length) {
+        toast.show({
+          placement: 'top',
+          duration: 4000,
+          render: ({ id }: { id: string }) => (
+            <Toast action="error" nativeID={`gitbutton-push-error-${id}`}>
+              <ToastTitle>Push failed</ToastTitle>
+              <ToastDescription>
+                {pushResult.failures.map((f) => f.repoName).join(', ')}
+              </ToastDescription>
+            </Toast>
+          ),
+        });
+      } else {
+        const pushedCount = repos.length - failedCount;
+        toast.show({
+          placement: 'top',
+          duration: 3000,
+          render: ({ id }: { id: string }) => (
+            <Toast
+              action={failedCount > 0 ? 'error' : 'success'}
+              nativeID={`gitbutton-push-${id}`}
+            >
+              <ToastTitle>
+                {failedCount > 0
+                  ? `Pushed ${pushedCount} repos, ${failedCount} had conflicts`
+                  : `Pushed to ${pushedCount} repos`}
+              </ToastTitle>
+            </Toast>
+          ),
+        });
+        for (const failure of pushResult.failures) {
+          navigation.navigate('ExploreConflict', { repoId: failure.repoId });
+        }
+      }
+      void aggregatedState.refresh();
+    },
+    [repos, author, toast, aggregatedState, navigation],
+  );
 
   /**
    * First-use discoverability hint. When the user first encounters the
@@ -126,6 +226,7 @@ export default function AppFloatingGitButton({ currentRouteName }: AppFloatingGi
     <FloatingGitButton
       aggregatedState={aggregatedState}
       onQuickTap={onQuickTap}
+      onReleaseSegment={handleReleaseSegment}
       disabled={isDisabled}
       currentRouteName={currentRouteName}
     />

--- a/src/components/git/FloatingGitButton.tsx
+++ b/src/components/git/FloatingGitButton.tsx
@@ -13,13 +13,20 @@ import { useRepoStore } from '@/stores/repoStore';
 import type { AggregatedGitState } from '@/hooks/useAllReposStatus';
 import { useFloatingGitButtonPosition } from './useFloatingGitButtonPosition';
 import { useFloatingGitButtonPanGesture } from './useFloatingGitButtonPanGesture';
-import { useFloatingGitButtonAffordances, PRESS_SCALE_FACTOR } from './useFloatingGitButtonAffordances';
+import {
+  useFloatingGitButtonAffordances,
+  PRESS_SCALE_FACTOR,
+  type ReleaseSegment,
+} from './useFloatingGitButtonAffordances';
 import { useFloatingButtonCollision } from '../floatingButtonLayout';
+import { HoldProgressRing } from '../ui/HoldProgressRing';
 
 interface FloatingGitButtonProps {
   aggregatedState?: AggregatedGitState;
   /** Informational tap — jumps to the Explore section with pending work. */
   onQuickTap?: () => void;
+  /** Called once on release with the highest segment reached: stage (≥1/3), commit (≥2/3), push (=1). */
+  onReleaseSegment?: (segment: ReleaseSegment) => void;
   /** Nothing pending anywhere: gray the button out and ignore taps. */
   disabled?: boolean;
   /** Name of the current top-level route — used to hide the button on full-screen modals. */
@@ -56,6 +63,7 @@ const HIDDEN_ROUTES = new Set<string>([
 export default function FloatingGitButton({
   aggregatedState,
   onQuickTap,
+  onReleaseSegment,
   disabled = false,
   currentRouteName,
 }: FloatingGitButtonProps) {
@@ -80,18 +88,18 @@ export default function FloatingGitButton({
   const palette = (() => {
     if (disabled) return { bg: colors.surface, fg: colors.textSecondary };
     if (anyConflicts) return { bg: colors.error, fg: '#ffffff' };
-    if (totalUncommitted > 0 || totalStaged > 0) return { bg: colors.success, fg: '#ffffff' };
+    if (totalStaged > 0) return { bg: '#f59e0b', fg: '#ffffff' };
+    if (totalUncommitted > 0) return { bg: colors.success, fg: '#ffffff' };
     if (totalAhead > 0) return { bg: colors.primary, fg: '#ffffff' };
     return { bg: colors.surface, fg: colors.textSecondary };
   })();
 
-  // Status hue ring: red (conflicts) > blue (pending push) > green (pending
-  // changes). null when clean or disabled — no ring.
   const hueColor = (() => {
     if (disabled) return null;
     if (anyConflicts) return colors.error;
+    if (totalStaged > 0) return '#f59e0b';
+    if (totalUncommitted > 0) return colors.success;
     if (totalAhead > 0) return colors.primary;
-    if (totalUncommitted > 0 || totalStaged > 0) return colors.success;
     return null;
   })();
 
@@ -108,6 +116,7 @@ export default function FloatingGitButton({
     reduceMotionEnabled: false,
     reduceMotionResolved: true,
     menuOpen: false,
+    onReleaseSegment,
   });
 
   const panGesture = useFloatingGitButtonPanGesture(position, {
@@ -123,7 +132,7 @@ export default function FloatingGitButton({
   }, [disabled, onQuickTap]);
 
   const { translateX, translateY } = position;
-  const { entranceProgress, pressProgress } = affordances;
+  const { entranceProgress, pressProgress, holdProgress } = affordances;
 
   const containerStyle = useAnimatedStyle(() => ({
     opacity: entranceProgress.value,
@@ -152,6 +161,12 @@ export default function FloatingGitButton({
             active={hueColor !== null}
             color={hueColor ?? undefined}
             testID="gitbutton.halo"
+          />
+          <HoldProgressRing
+            progress={holdProgress}
+            size={GIT_BUTTON_SIZE}
+            colors={[colors.success, '#f59e0b', colors.primary]}
+            reduceMotionEnabled={false}
           />
           <Pressable
             testID="gitbutton.press"

--- a/src/components/git/useFloatingGitButtonAffordances.ts
+++ b/src/components/git/useFloatingGitButtonAffordances.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   cancelAnimation,
   useSharedValue,
@@ -11,11 +11,20 @@ export const PRESS_SCALE_FACTOR = 0.08;
 const PRESS_SPRING = { mass: 0.6, damping: 16, stiffness: 480 } as const;
 const ENTRANCE_SPRING = { mass: 0.9, damping: 14, stiffness: 240 } as const;
 const HOLD_DRAIN_MS = 150;
+/** Time for the hold ring to fill from 0→1 (1/3 ≈ 333ms, 2/3 ≈ 667ms). */
+const HOLD_FILL_MS = 1000;
+/** Threshold fractions for stage / commit / push segments. */
+const STAGE_FRACTION = 1 / 3;   // 0.333…
+const COMMIT_FRACTION = 2 / 3;   // 0.666…
+
+export type ReleaseSegment = 'stage' | 'commit' | 'push';
 
 export interface FloatingGitButtonAffordanceOptions {
   readonly reduceMotionEnabled: boolean;
   readonly reduceMotionResolved: boolean;
   readonly menuOpen: boolean;
+  /** Called once on release with the highest segment reached. */
+  readonly onReleaseSegment?: (segment: ReleaseSegment) => void;
 }
 
 export interface FloatingGitButtonAffordances {
@@ -31,7 +40,7 @@ export interface FloatingGitButtonAffordances {
 export function useFloatingGitButtonAffordances(
   options: FloatingGitButtonAffordanceOptions,
 ): FloatingGitButtonAffordances {
-  const { reduceMotionEnabled, reduceMotionResolved, menuOpen } = options;
+  const { reduceMotionEnabled, reduceMotionResolved, menuOpen, onReleaseSegment } = options;
 
   const entranceProgress = useSharedValue(0);
   const pressProgress = useSharedValue(0);
@@ -39,6 +48,9 @@ export function useFloatingGitButtonAffordances(
 
   const [reduceMotionEnabledState, setReduceMotionEnabled] = useState(true);
   const [reduceMotionResolvedState, setReduceMotionResolved] = useState(false);
+
+  // Guard against handlePressOut firing after a completed hold (double-fire).
+  const holdCompletedRef = useRef(false);
 
   useEffect(() => {
     if (!reduceMotionResolved) return;
@@ -59,17 +71,40 @@ export function useFloatingGitButtonAffordances(
   }, [entranceProgress, pressProgress, holdProgress]);
 
   const handlePressIn = useCallback(() => {
+    holdCompletedRef.current = false;
     pressProgress.value = withSpring(1, PRESS_SPRING);
     if (!reduceMotionEnabledState) {
-      holdProgress.value = withTiming(0, { duration: HOLD_DRAIN_MS });
+      // Start filling the ring from 0→1.
+      holdProgress.value = withTiming(1, { duration: HOLD_FILL_MS });
     }
   }, [reduceMotionEnabledState, pressProgress, holdProgress]);
 
   const handlePressOut = useCallback(() => {
     pressProgress.value = withSpring(0, PRESS_SPRING);
-  }, [pressProgress]);
+    if (holdCompletedRef.current) return;
+
+    // Determine the highest segment reached at release time.
+    const fraction = holdProgress.value;
+    let segment: ReleaseSegment | null = null;
+    if (fraction >= 0.95) {
+      segment = 'push';
+    } else if (fraction >= COMMIT_FRACTION) {
+      segment = 'commit';
+    } else if (fraction >= STAGE_FRACTION) {
+      segment = 'stage';
+    }
+    // Short tap (< 1/3): no segment — the tap handler navigates instead.
+
+    // Drain the ring.
+    holdProgress.value = withTiming(0, { duration: HOLD_DRAIN_MS });
+
+    if (segment && onReleaseSegment) {
+      onReleaseSegment(segment);
+    }
+  }, [pressProgress, holdProgress, onReleaseSegment]);
 
   const handleHoldComplete = useCallback(() => {
+    holdCompletedRef.current = true;
     holdProgress.value = withTiming(0, { duration: HOLD_DRAIN_MS });
   }, [holdProgress]);
 

--- a/src/components/ui/HoldProgressRing.tsx
+++ b/src/components/ui/HoldProgressRing.tsx
@@ -12,29 +12,48 @@ export const HOLD_RING_CIRCUMFERENCE = 2 * Math.PI * HOLD_RING_RADIUS;
 interface HoldProgressRingProps {
   readonly progress: SharedValue<number>;
   readonly size: number;
-  readonly color: string;
+  /** Single color for backward compat with AI button; ignored when colors is set. */
+  readonly color?: string;
+  /** Three colors for git button: [green=stage, yellow=commit, blue=push]. */
+  readonly colors?: [string, string, string];
   readonly reduceMotionEnabled: boolean;
+}
+
+function segmentInterval(
+  progress: number,
+  segmentIndex: number,
+  circumference: number,
+): [number, number] {
+  const SEGMENT_WIDTH = 1 / 3;
+  const start = segmentIndex * SEGMENT_WIDTH;
+  const fillFraction = Math.max(0, Math.min(1, (progress - start) / SEGMENT_WIDTH));
+  return [fillFraction * circumference, circumference];
 }
 
 export function HoldProgressRing({
   progress,
   size,
   color,
+  colors,
   reduceMotionEnabled,
 }: HoldProgressRingProps) {
   const ringRadius = size / 2 + HOLD_RING_RADIUS_OFFSET;
   const ringCircumference = 2 * Math.PI * ringRadius;
   const ringCanvasSize = ringRadius * 2 + HOLD_RING_STROKE_WIDTH * 2 + HOLD_RING_PADDING * 2;
   const ringCenter = ringCanvasSize / 2;
-  const ringIntervals = useDerivedValue(() => [
-    progress.value * ringCircumference,
-    ringCircumference,
-  ]);
-  const ringOpacity = useDerivedValue(() => Math.min(1, progress.value * 3));
 
   if (reduceMotionEnabled) {
     return null;
   }
+
+  const isMultiColor = Boolean(colors);
+  const ringColors: [string, string, string] = isMultiColor
+    ? colors!
+    : [
+        color ?? '#22c55e',
+        color ?? '#22c55e',
+        color ?? '#22c55e',
+      ];
 
   return (
     <Canvas
@@ -49,20 +68,34 @@ export function HoldProgressRing({
         },
       ]}
     >
-      <Circle
-        cx={ringCenter}
-        cy={ringCenter}
-        r={ringRadius}
-        color={color}
-        style="stroke"
-        strokeWidth={HOLD_RING_STROKE_WIDTH}
-        strokeCap="round"
-        opacity={ringOpacity}
-        origin={{ x: ringCenter, y: ringCenter }}
-        transform={[{ rotate: -Math.PI / 2 }]}
-      >
-        <DashPathEffect intervals={ringIntervals} />
-      </Circle>
+      {[0, 1, 2].map((i) => {
+        const intervals = useDerivedValue(
+          () => segmentInterval(progress.value, i, ringCircumference),
+          [i, ringCircumference],
+        );
+        const opacity = useDerivedValue(
+          () => (progress.value > i / 3 ? 1 : 0),
+          [i],
+        );
+        const rotation = -Math.PI / 2 + (i * 2 * Math.PI) / 3;
+        return (
+          <Circle
+            key={i}
+            cx={ringCenter}
+            cy={ringCenter}
+            r={ringRadius}
+            color={ringColors[i]}
+            style="stroke"
+            strokeWidth={HOLD_RING_STROKE_WIDTH}
+            strokeCap="round"
+            opacity={opacity}
+            origin={{ x: ringCenter, y: ringCenter }}
+            transform={[{ rotate: rotation }]}
+          >
+            <DashPathEffect intervals={intervals} />
+          </Circle>
+        );
+      })}
     </Canvas>
   );
 }


### PR DESCRIPTION
## What

Hold the floating git button to trigger stage/commit/push at 1/3, 2/3, 3/3 release thresholds.

- Ring fills green (stage) -> yellow (commit) -> blue (push) over 1s hold
- Release at 1/3 -> stage all files; 2/3 -> stage+commit; 3/3 -> stage+commit+push
- Button palette updated: green=uncommitted, yellow=staged, blue=ahead, red=conflicts
- GitButtonHalo hueColor updated to match 4-tier pending state
- HoldProgressRing renders 3 concentric Skia arcs with DashPathEffect
- Partial push: non-conflicted repos push, conflicted repos navigate to ConflictResolve
- Auto-message: Sync: stage N file(s), no manual commit entry

## Files

- `useFloatingGitButtonAffordances.ts`: ReleaseSegment, onReleaseSegment, HOLD_FILL_MS=1000, segment detection
- `HoldProgressRing.tsx`: colors=[green,yellow,blue], 3 concentric Circle elements with rotation  
- `FloatingGitButton.tsx`: onReleaseSegment prop, 4-tier palette+hueColor, HoldProgressRing rendered
- `AppFloatingGitButton.tsx`: handleReleaseSegment wires stageAllPending/commitAll/pushAll with toasts

Please test: hold the floating git button on iOS Simulator, verify ring fills in 3 colored segments at different hold durations.