### PR TITLE
fix(HoldProgressRing): inline segmentInterval in useDerivedValue worklet

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/vidwadeseram/Documents/GitHub/gitnotes/gitnotes/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/vidwadeseram/Documents/GitHub/gitnotes/gitnotes/node_modules

--- a/src/components/ui/HoldProgressRing.tsx
+++ b/src/components/ui/HoldProgressRing.tsx
@@ -19,17 +19,6 @@ interface HoldProgressRingProps {
   readonly reduceMotionEnabled: boolean;
 }
 
-function segmentInterval(
-  progress: number,
-  segmentIndex: number,
-  circumference: number,
-): [number, number] {
-  const SEGMENT_WIDTH = 1 / 3;
-  const start = segmentIndex * SEGMENT_WIDTH;
-  const fillFraction = Math.max(0, Math.min(1, (progress - start) / SEGMENT_WIDTH));
-  return [fillFraction * circumference, circumference];
-}
-
 export function HoldProgressRing({
   progress,
   size,
@@ -70,7 +59,15 @@ export function HoldProgressRing({
     >
       {[0, 1, 2].map((i) => {
         const intervals = useDerivedValue(
-          () => segmentInterval(progress.value, i, ringCircumference),
+          // Inline worklet: segmentInterval logic must be inside the worklet callback,
+          // not a cross-context plain-function call.
+          () => {
+            'worklet';
+            const SEGMENT_WIDTH = 1 / 3;
+            const start = i * SEGMENT_WIDTH;
+            const fillFraction = Math.max(0, Math.min(1, (progress.value - start) / SEGMENT_WIDTH));
+            return [fillFraction * ringCircumference, ringCircumference] as [number, number];
+          },
           [i, ringCircumference],
         );
         const opacity = useDerivedValue(


### PR DESCRIPTION
Fix runtime error:

**Error:** `[Worklets] Tried to synchronously call a non-worklet function `segmentInterval` on the UI thread.`

**Root cause:** `segmentInterval` was a plain JS function called from inside `useDerivedValue`, which runs in the worklet/UI thread context. Calling a non-worklet function from a worklet is not allowed.

**Fix:** Inlined the `segmentInterval` logic directly inside the `useDerivedValue` callback as a worklet.

Please test: hold the floating git button — ring should fill green→yellow→blue over 1s without worklet errors.