### PR TITLE
fix(git-button): initialize reduceMotionEnabledState to false

### DIFF
--- a/src/components/git/useFloatingGitButtonAffordances.ts
+++ b/src/components/git/useFloatingGitButtonAffordances.ts
@@ -46,7 +46,7 @@ export function useFloatingGitButtonAffordances(
   const pressProgress = useSharedValue(0);
   const holdProgress = useSharedValue(0);
 
-  const [reduceMotionEnabledState, setReduceMotionEnabled] = useState(true);
+  const [reduceMotionEnabledState, setReduceMotionEnabled] = useState(false);
   const [reduceMotionResolvedState, setReduceMotionResolved] = useState(false);
 
   // Guard against handlePressOut firing after a completed hold (double-fire).


### PR DESCRIPTION
**Bug:** Ring never fills, hold does nothing.

**Root cause:** reduceMotionEnabledState was initialized to true, so the guard !reduceMotionEnabledState was always false and the ring fill animation (withTiming) was never called.

**Fix:** Initialize to false — ring now fills on hold, stage/commit/push fires correctly on release.

Please test: hold the floating git button — ring should fill green→yellow→blue, release at 1/3→stage, 2/3→commit, 3/3→push.