### PR TITLE
fix(git-button): show debug toast when no repos connected

### DIFF
--- a/src/components/git/AppFloatingGitButton.tsx
+++ b/src/components/git/AppFloatingGitButton.tsx
@@ -73,7 +73,19 @@ export default function AppFloatingGitButton({ currentRouteName }: AppFloatingGi
 
   const handleReleaseSegment = useCallback(
     async (segment: ReleaseSegment) => {
-      if (repos.length === 0) return;
+      if (repos.length === 0) {
+        toast.show({
+          placement: 'top',
+          duration: 3000,
+          render: ({ id }: { id: string }) => (
+            <Toast action="error" nativeID={`gitbutton-norepos-${id}`}>
+              <ToastTitle>Cannot {segment}</ToastTitle>
+              <ToastDescription>No repositories connected. Add a repo in Settings.</ToastDescription>
+            </Toast>
+          ),
+        });
+        return;
+      }
       if (!author) {
         toast.show({
           placement: 'top',

--- a/src/components/git/FloatingGitButton.tsx
+++ b/src/components/git/FloatingGitButton.tsx
@@ -144,7 +144,6 @@ export default function FloatingGitButton({
   }));
 
   if (currentRouteName && HIDDEN_ROUTES.has(currentRouteName)) return null;
-  if (repos.length === 0) return null;
 
   return (
     <Animated.View

--- a/src/components/ui/HoldProgressRing.tsx
+++ b/src/components/ui/HoldProgressRing.tsx
@@ -7,7 +7,6 @@ export const HOLD_RING_STROKE_WIDTH = 3.5;
 export const HOLD_RING_RADIUS_OFFSET = 6;
 const HOLD_RING_PADDING = 2;
 export const HOLD_RING_RADIUS = FLOATING_AI_BUTTON_SIZE / 2 + HOLD_RING_RADIUS_OFFSET;
-export const HOLD_RING_CIRCUMFERENCE = 2 * Math.PI * HOLD_RING_RADIUS;
 
 interface HoldProgressRingProps {
   readonly progress: SharedValue<number>;
@@ -59,8 +58,6 @@ export function HoldProgressRing({
     >
       {[0, 1, 2].map((i) => {
         const intervals = useDerivedValue(
-          // Inline worklet: segmentInterval logic must be inside the worklet callback,
-          // not a cross-context plain-function call.
           () => {
             'worklet';
             const SEGMENT_WIDTH = 1 / 3;


### PR DESCRIPTION
## What

- **FloatingGitButton**: remove early return when `repos.length === 0` so the button stays visible (disabled) and users can trigger hold-to-release and see the debug toast
- **AppFloatingGitButton**: add visible Toast for `repos.length === 0` case instead of silent return in `handleReleaseSegment`
- **HoldProgressRing**: remove unused `HOLD_RING_CIRCUMFERENCE` export + stale comment

## Why

The ring color issue (concentric circles only showing blue) is a known Skia limitation — concentric circles at the same radius render only the outermost stroke. A Path-arc rewrite was investigated but Skia `Path` does not support reactive `useAnimatedProps`, making it non-viable without significant rearchitecture.

The git-ops-not-firing issue: `handleReleaseSegment` was returning silently when `repos.length === 0`, and the button was hidden entirely at that point (`FloatingGitButton` line 147). Now the button stays visible and the user gets an actionable toast.