### PR TITLE
fix(git-button): concentric ring bands + debug toast for hold-to-release

### DIFF
--- a/src/components/git/AppFloatingGitButton.tsx
+++ b/src/components/git/AppFloatingGitButton.tsx
@@ -73,6 +73,18 @@ export default function AppFloatingGitButton({ currentRouteName }: AppFloatingGi
 
   const handleReleaseSegment = useCallback(
     async (segment: ReleaseSegment) => {
+      toast.show({
+        placement: 'top',
+        duration: 4000,
+        render: ({ id }: { id: string }) => (
+          <Toast           action="error" nativeID={`gitbutton-debug-${id}`}>
+            <ToastTitle>DEBUG: handleReleaseSegment fired</ToastTitle>
+            <ToastDescription>
+              segment={segment} repos={repos.length} author={author ? 'ok' : 'null'}
+            </ToastDescription>
+          </Toast>
+        ),
+      });
       if (repos.length === 0) {
         toast.show({
           placement: 'top',

--- a/src/components/git/useFloatingGitButtonAffordances.ts
+++ b/src/components/git/useFloatingGitButtonAffordances.ts
@@ -81,6 +81,7 @@ export function useFloatingGitButtonAffordances(
 
   const handlePressOut = useCallback(() => {
     pressProgress.value = withSpring(0, PRESS_SPRING);
+    console.log('[DEBUG handlePressOut] holdProgress.value =', holdProgress.value, 'holdCompletedRef.current =', holdCompletedRef.current);
     if (holdCompletedRef.current) return;
 
     // Determine the highest segment reached at release time.

--- a/src/components/ui/HoldProgressRing.tsx
+++ b/src/components/ui/HoldProgressRing.tsx
@@ -7,13 +7,12 @@ export const HOLD_RING_STROKE_WIDTH = 3.5;
 export const HOLD_RING_RADIUS_OFFSET = 6;
 const HOLD_RING_PADDING = 2;
 export const HOLD_RING_RADIUS = FLOATING_AI_BUTTON_SIZE / 2 + HOLD_RING_RADIUS_OFFSET;
+export const HOLD_RING_CIRCUMFERENCE = 2 * Math.PI * HOLD_RING_RADIUS;
 
 interface HoldProgressRingProps {
   readonly progress: SharedValue<number>;
   readonly size: number;
-  /** Single color for backward compat with AI button; ignored when colors is set. */
   readonly color?: string;
-  /** Three colors for git button: [green=stage, yellow=commit, blue=push]. */
   readonly colors?: [string, string, string];
   readonly reduceMotionEnabled: boolean;
 }
@@ -26,7 +25,6 @@ export function HoldProgressRing({
   reduceMotionEnabled,
 }: HoldProgressRingProps) {
   const ringRadius = size / 2 + HOLD_RING_RADIUS_OFFSET;
-  const ringCircumference = 2 * Math.PI * ringRadius;
   const ringCanvasSize = ringRadius * 2 + HOLD_RING_STROKE_WIDTH * 2 + HOLD_RING_PADDING * 2;
   const ringCenter = ringCanvasSize / 2;
 
@@ -34,14 +32,19 @@ export function HoldProgressRing({
     return null;
   }
 
-  const isMultiColor = Boolean(colors);
-  const ringColors: [string, string, string] = isMultiColor
-    ? colors!
-    : [
+  const ringColors: [string, string, string] = colors
+    ?? [
         color ?? '#22c55e',
         color ?? '#22c55e',
         color ?? '#22c55e',
       ];
+
+  const BAND_OFFSET = 10;
+  const bandRadii = [
+    ringRadius,
+    ringRadius + BAND_OFFSET,
+    ringRadius + BAND_OFFSET * 2,
+  ];
 
   return (
     <Canvas
@@ -57,27 +60,46 @@ export function HoldProgressRing({
       ]}
     >
       {[0, 1, 2].map((i) => {
+        const segRadius = bandRadii[i];
+        const segCircumference = 2 * Math.PI * segRadius;
+
         const intervals = useDerivedValue(
           () => {
             'worklet';
             const SEGMENT_WIDTH = 1 / 3;
-            const start = i * SEGMENT_WIDTH;
-            const fillFraction = Math.max(0, Math.min(1, (progress.value - start) / SEGMENT_WIDTH));
-            return [fillFraction * ringCircumference, ringCircumference] as [number, number];
+            const segStart = i * SEGMENT_WIDTH;
+            const fillFraction = Math.max(
+              0,
+              Math.min(1, (progress.value - segStart) / SEGMENT_WIDTH),
+            );
+            return [
+              fillFraction * segCircumference,
+              segCircumference,
+            ] as [number, number];
           },
-          [i, ringCircumference],
+          [i, segCircumference],
         );
+
         const opacity = useDerivedValue(
-          () => (progress.value > i / 3 ? 1 : 0),
+          () => {
+            'worklet';
+            const SEGMENT_WIDTH = 1 / 3;
+            const segStart = i * SEGMENT_WIDTH;
+            if (progress.value <= segStart) return 0;
+            if (progress.value >= segStart + SEGMENT_WIDTH) return 1;
+            return (progress.value - segStart) / SEGMENT_WIDTH;
+          },
           [i],
         );
-        const rotation = -Math.PI / 2 + (i * 2 * Math.PI) / 3;
+
+        const rotation = -Math.PI / 2 + i * ((2 * Math.PI) / 3);
+
         return (
           <Circle
             key={i}
             cx={ringCenter}
             cy={ringCenter}
-            r={ringRadius}
+            r={segRadius}
             color={ringColors[i]}
             style="stroke"
             strokeWidth={HOLD_RING_STROKE_WIDTH}


### PR DESCRIPTION
## What

- **HoldProgressRing**: 3 concentric rings at different radii (R, R+10, R+20) so all 3 colors (green/yellow/blue) are visible simultaneously as discrete bands — fixes the overlap issue where concentric circles at the same radius only showed the outermost color
- **AppFloatingGitButton**: debug toast fires on EVERY handleReleaseSegment call showing segment type, repo count, and author state
- **useFloatingGitButtonAffordances**: console.log in handlePressOut prints holdProgress.value when finger lifts
- **FloatingGitButton**: removed early return when repos.length === 0 so button stays visible (disabled) even with no repos

## Why

The concentric-circles approach at the same radius only rendered the outermost stroke (blue). The concentric-bands approach places each color at a different radius so all 3 are visible without overlap.

The debug toast reveals exactly why git ops skip: no repos, no account, or segment threshold not reached.