### PR TITLE
fix(git-button): hold-to-release ring + tap guard + fix git ops local path bug

### DIFF
--- a/src/components/git/AppFloatingGitButton.tsx
+++ b/src/components/git/AppFloatingGitButton.tsx
@@ -73,6 +73,7 @@ export default function AppFloatingGitButton({ currentRouteName }: AppFloatingGi
 
   const handleReleaseSegment = useCallback(
     async (segment: ReleaseSegment) => {
+      console.log('[handleReleaseSegment]', { segment, reposLen: repos.length, authorExists: !!author });
       toast.show({
         placement: 'top',
         duration: 4000,

--- a/src/components/git/AppFloatingGitButton.tsx
+++ b/src/components/git/AppFloatingGitButton.tsx
@@ -113,7 +113,9 @@ export default function AppFloatingGitButton({ currentRouteName }: AppFloatingGi
         return;
       }
 
+      console.log('[handleReleaseSegment] calling stageAllPending, repos =', repos.map(r => r.name));
       const stageResult = await stageAllPending(repos);
+      console.log('[handleReleaseSegment] stageAllPending result =', JSON.stringify(stageResult));
       if (segment === 'stage') {
         toast.show({
           placement: 'top',

--- a/src/components/git/FloatingGitButton.tsx
+++ b/src/components/git/FloatingGitButton.tsx
@@ -19,7 +19,7 @@ import {
   type ReleaseSegment,
 } from './useFloatingGitButtonAffordances';
 import { useFloatingButtonCollision } from '../floatingButtonLayout';
-import { HoldProgressRing } from '../ui/HoldProgressRing';
+import { GitButtonRing } from './GitButtonRing';
 
 interface FloatingGitButtonProps {
   aggregatedState?: AggregatedGitState;
@@ -161,11 +161,9 @@ export default function FloatingGitButton({
             color={hueColor ?? undefined}
             testID="gitbutton.halo"
           />
-          <HoldProgressRing
+          <GitButtonRing
             progress={holdProgress}
-            size={GIT_BUTTON_SIZE}
             colors={[colors.success, '#f59e0b', colors.primary]}
-            reduceMotionEnabled={false}
           />
           <Pressable
             testID="gitbutton.press"

--- a/src/components/git/FloatingGitButton.tsx
+++ b/src/components/git/FloatingGitButton.tsx
@@ -119,20 +119,22 @@ export default function FloatingGitButton({
     onReleaseSegment,
   });
 
+  const { entranceProgress, pressProgress, holdProgress } = affordances;
+  const { translateX, translateY } = position;
+
+  const handleTap = useCallback(() => {
+    if (disabled) return;
+    const wasHoldRelease = holdProgress.value >= 1 / 3;
+    if (wasHoldRelease) return;
+    onQuickTap?.();
+  }, [disabled, onQuickTap, holdProgress]);
+
   const panGesture = useFloatingGitButtonPanGesture(position, {
     closeMenu: () => undefined,
     setHorizontalDirection: () => undefined,
     setVerticalDirection: () => undefined,
     cancelAffordances: affordances.cancelAffordances,
   });
-
-  const handleTap = useCallback(() => {
-    if (disabled) return;
-    onQuickTap?.();
-  }, [disabled, onQuickTap]);
-
-  const { translateX, translateY } = position;
-  const { entranceProgress, pressProgress, holdProgress } = affordances;
 
   const containerStyle = useAnimatedStyle(() => ({
     opacity: entranceProgress.value,

--- a/src/components/git/GitButtonRing.tsx
+++ b/src/components/git/GitButtonRing.tsx
@@ -1,0 +1,65 @@
+import { StyleSheet } from 'react-native';
+import { Canvas, Path, Skia } from '@shopify/react-native-skia';
+import { type SharedValue } from 'react-native-reanimated';
+import { GIT_BUTTON_SIZE } from '../git/gitButtonGeometry';
+
+export const GIT_RING_STROKE_WIDTH = 3.5;
+const GIT_RING_PADDING = 2;
+const GIT_RING_RADIUS_OFFSET = 6;
+export const GIT_RING_RADIUS = GIT_BUTTON_SIZE / 2 + GIT_RING_RADIUS_OFFSET;
+
+interface GitButtonRingProps {
+  readonly progress: SharedValue<number>;
+  readonly colors: [string, string, string];
+}
+
+function makeCirclePath(cx: number, cy: number, r: number): ReturnType<typeof Skia.Path.Make> {
+  return Skia.Path.Make().addCircle(cx, cy, r).close();
+}
+
+export function GitButtonRing({ progress, colors }: GitButtonRingProps) {
+  const ringRadius = GIT_BUTTON_SIZE / 2 + GIT_RING_RADIUS_OFFSET;
+  const canvasSize = ringRadius * 2 + GIT_RING_STROKE_WIDTH * 2 + GIT_RING_PADDING * 2;
+  const cx = canvasSize / 2;
+  const cy = canvasSize / 2;
+
+  const basePath = makeCirclePath(cx, cy, ringRadius);
+
+  return (
+    <Canvas
+      pointerEvents="none"
+      style={[
+        styles.canvas,
+        {
+          width: canvasSize,
+          height: canvasSize,
+          top: -(canvasSize - GIT_BUTTON_SIZE) / 2,
+          left: -(canvasSize - GIT_BUTTON_SIZE) / 2,
+        },
+      ]}
+    >
+      {[0, 1, 2].map((i) => {
+        const segStart = i / 3;
+        const segEnd = (i + 1) / 3;
+        return (
+          <Path
+            key={i}
+            path={basePath}
+            color={colors[i]}
+            style="stroke"
+            strokeWidth={GIT_RING_STROKE_WIDTH}
+            strokeCap="round"
+            start={segStart}
+            end={segEnd}
+          />
+        );
+      })}
+    </Canvas>
+  );
+}
+
+const styles = StyleSheet.create({
+  canvas: {
+    position: 'absolute',
+  },
+});

--- a/src/components/git/GitButtonRing.tsx
+++ b/src/components/git/GitButtonRing.tsx
@@ -1,7 +1,10 @@
 import { StyleSheet } from 'react-native';
 import { Canvas, Path, Skia } from '@shopify/react-native-skia';
-import { type SharedValue } from 'react-native-reanimated';
-import { GIT_BUTTON_SIZE } from '../git/gitButtonGeometry';
+import {
+  useDerivedValue,
+  type SharedValue,
+} from 'react-native-reanimated';
+import { GIT_BUTTON_SIZE } from './gitButtonGeometry';
 
 export const GIT_RING_STROKE_WIDTH = 3.5;
 const GIT_RING_PADDING = 2;
@@ -13,17 +16,12 @@ interface GitButtonRingProps {
   readonly colors: [string, string, string];
 }
 
-function makeCirclePath(cx: number, cy: number, r: number): ReturnType<typeof Skia.Path.Make> {
-  return Skia.Path.Make().addCircle(cx, cy, r).close();
-}
+const cx = GIT_RING_RADIUS + GIT_RING_STROKE_WIDTH + GIT_RING_PADDING;
+const cy = cx;
+const basePath = Skia.Path.Make().addCircle(cx, cy, GIT_RING_RADIUS).close();
 
 export function GitButtonRing({ progress, colors }: GitButtonRingProps) {
-  const ringRadius = GIT_BUTTON_SIZE / 2 + GIT_RING_RADIUS_OFFSET;
-  const canvasSize = ringRadius * 2 + GIT_RING_STROKE_WIDTH * 2 + GIT_RING_PADDING * 2;
-  const cx = canvasSize / 2;
-  const cy = canvasSize / 2;
-
-  const basePath = makeCirclePath(cx, cy, ringRadius);
+  const canvasSize = GIT_RING_RADIUS * 2 + GIT_RING_STROKE_WIDTH * 2 + GIT_RING_PADDING * 2;
 
   return (
     <Canvas
@@ -41,6 +39,15 @@ export function GitButtonRing({ progress, colors }: GitButtonRingProps) {
       {[0, 1, 2].map((i) => {
         const segStart = i / 3;
         const segEnd = (i + 1) / 3;
+
+        const segEndVal = useDerivedValue(() => {
+          'worklet';
+          const p = progress.value;
+          if (p <= segStart) return segStart;
+          if (p >= segEnd) return segEnd;
+          return Math.max(segStart, p);
+        }, [i]);
+
         return (
           <Path
             key={i}
@@ -50,7 +57,7 @@ export function GitButtonRing({ progress, colors }: GitButtonRingProps) {
             strokeWidth={GIT_RING_STROKE_WIDTH}
             strokeCap="round"
             start={segStart}
-            end={segEnd}
+            end={segEndVal}
           />
         );
       })}

--- a/src/components/git/useFloatingGitButtonAffordances.ts
+++ b/src/components/git/useFloatingGitButtonAffordances.ts
@@ -73,8 +73,8 @@ export function useFloatingGitButtonAffordances(
   const handlePressIn = useCallback(() => {
     holdCompletedRef.current = false;
     pressProgress.value = withSpring(1, PRESS_SPRING);
+    console.log('[DEBUG handlePressIn] starting hold animation, reduceMotionEnabledState =', reduceMotionEnabledState);
     if (!reduceMotionEnabledState) {
-      // Start filling the ring from 0→1.
       holdProgress.value = withTiming(1, { duration: HOLD_FILL_MS });
     }
   }, [reduceMotionEnabledState, pressProgress, holdProgress]);

--- a/src/components/git/useFloatingGitButtonAffordances.ts
+++ b/src/components/git/useFloatingGitButtonAffordances.ts
@@ -12,7 +12,7 @@ const PRESS_SPRING = { mass: 0.6, damping: 16, stiffness: 480 } as const;
 const ENTRANCE_SPRING = { mass: 0.9, damping: 14, stiffness: 240 } as const;
 const HOLD_DRAIN_MS = 150;
 /** Time for the hold ring to fill from 0→1 (1/3 ≈ 333ms, 2/3 ≈ 667ms). */
-const HOLD_FILL_MS = 1000;
+const HOLD_FILL_MS = 3000;
 /** Threshold fractions for stage / commit / push segments. */
 const STAGE_FRACTION = 1 / 3;   // 0.333…
 const COMMIT_FRACTION = 2 / 3;   // 0.666…

--- a/src/components/ui/HoldProgressRing.tsx
+++ b/src/components/ui/HoldProgressRing.tsx
@@ -12,10 +12,7 @@ export const HOLD_RING_CIRCUMFERENCE = 2 * Math.PI * HOLD_RING_RADIUS;
 interface HoldProgressRingProps {
   readonly progress: SharedValue<number>;
   readonly size: number;
-  /** Single color for backward compat with AI button; ignored when colors is set. */
-  readonly color?: string;
-  /** Three colors for git button: [green=stage, yellow=commit, blue=push]. */
-  readonly colors?: [string, string, string];
+  readonly color: string;
   readonly reduceMotionEnabled: boolean;
 }
 
@@ -23,26 +20,21 @@ export function HoldProgressRing({
   progress,
   size,
   color,
-  colors,
   reduceMotionEnabled,
 }: HoldProgressRingProps) {
   const ringRadius = size / 2 + HOLD_RING_RADIUS_OFFSET;
   const ringCircumference = 2 * Math.PI * ringRadius;
   const ringCanvasSize = ringRadius * 2 + HOLD_RING_STROKE_WIDTH * 2 + HOLD_RING_PADDING * 2;
   const ringCenter = ringCanvasSize / 2;
+  const ringIntervals = useDerivedValue(() => [
+    progress.value * ringCircumference,
+    ringCircumference,
+  ]);
+  const ringOpacity = useDerivedValue(() => Math.min(1, progress.value * 3));
 
   if (reduceMotionEnabled) {
     return null;
   }
-
-  const isMultiColor = Boolean(colors);
-  const ringColors: [string, string, string] = isMultiColor
-    ? colors!
-    : [
-        color ?? '#22c55e',
-        color ?? '#22c55e',
-        color ?? '#22c55e',
-      ];
 
   return (
     <Canvas
@@ -57,40 +49,20 @@ export function HoldProgressRing({
         },
       ]}
     >
-      {[0, 1, 2].map((i) => {
-        const intervals = useDerivedValue(
-          () => {
-            'worklet';
-            const SEGMENT_WIDTH = 1 / 3;
-            const start = i * SEGMENT_WIDTH;
-            const fillFraction = Math.max(0, Math.min(1, (progress.value - start) / SEGMENT_WIDTH));
-            return [fillFraction * ringCircumference, ringCircumference] as [number, number];
-          },
-          [i, ringCircumference],
-        );
-        const opacity = useDerivedValue(
-          () => (progress.value > i / 3 ? 1 : 0),
-          [i],
-        );
-        const rotation = -Math.PI / 2 + (i * 2 * Math.PI) / 3;
-        return (
-          <Circle
-            key={i}
-            cx={ringCenter}
-            cy={ringCenter}
-            r={ringRadius}
-            color={ringColors[i]}
-            style="stroke"
-            strokeWidth={HOLD_RING_STROKE_WIDTH}
-            strokeCap="round"
-            opacity={opacity}
-            origin={{ x: ringCenter, y: ringCenter }}
-            transform={[{ rotate: rotation }]}
-          >
-            <DashPathEffect intervals={intervals} />
-          </Circle>
-        );
-      })}
+      <Circle
+        cx={ringCenter}
+        cy={ringCenter}
+        r={ringRadius}
+        color={color}
+        style="stroke"
+        strokeWidth={HOLD_RING_STROKE_WIDTH}
+        strokeCap="round"
+        opacity={ringOpacity}
+        origin={{ x: ringCenter, y: ringCenter }}
+        transform={[{ rotate: -Math.PI / 2 }]}
+      >
+        <DashPathEffect intervals={ringIntervals} />
+      </Circle>
     </Canvas>
   );
 }

--- a/src/components/ui/HoldProgressRing.tsx
+++ b/src/components/ui/HoldProgressRing.tsx
@@ -12,7 +12,9 @@ export const HOLD_RING_CIRCUMFERENCE = 2 * Math.PI * HOLD_RING_RADIUS;
 interface HoldProgressRingProps {
   readonly progress: SharedValue<number>;
   readonly size: number;
+  /** Single color for backward compat with AI button; ignored when colors is set. */
   readonly color?: string;
+  /** Three colors for git button: [green=stage, yellow=commit, blue=push]. */
   readonly colors?: [string, string, string];
   readonly reduceMotionEnabled: boolean;
 }
@@ -25,6 +27,7 @@ export function HoldProgressRing({
   reduceMotionEnabled,
 }: HoldProgressRingProps) {
   const ringRadius = size / 2 + HOLD_RING_RADIUS_OFFSET;
+  const ringCircumference = 2 * Math.PI * ringRadius;
   const ringCanvasSize = ringRadius * 2 + HOLD_RING_STROKE_WIDTH * 2 + HOLD_RING_PADDING * 2;
   const ringCenter = ringCanvasSize / 2;
 
@@ -32,19 +35,14 @@ export function HoldProgressRing({
     return null;
   }
 
-  const ringColors: [string, string, string] = colors
-    ?? [
+  const isMultiColor = Boolean(colors);
+  const ringColors: [string, string, string] = isMultiColor
+    ? colors!
+    : [
         color ?? '#22c55e',
         color ?? '#22c55e',
         color ?? '#22c55e',
       ];
-
-  const BAND_OFFSET = 10;
-  const bandRadii = [
-    ringRadius,
-    ringRadius + BAND_OFFSET,
-    ringRadius + BAND_OFFSET * 2,
-  ];
 
   return (
     <Canvas
@@ -60,46 +58,27 @@ export function HoldProgressRing({
       ]}
     >
       {[0, 1, 2].map((i) => {
-        const segRadius = bandRadii[i];
-        const segCircumference = 2 * Math.PI * segRadius;
-
         const intervals = useDerivedValue(
           () => {
             'worklet';
             const SEGMENT_WIDTH = 1 / 3;
-            const segStart = i * SEGMENT_WIDTH;
-            const fillFraction = Math.max(
-              0,
-              Math.min(1, (progress.value - segStart) / SEGMENT_WIDTH),
-            );
-            return [
-              fillFraction * segCircumference,
-              segCircumference,
-            ] as [number, number];
+            const start = i * SEGMENT_WIDTH;
+            const fillFraction = Math.max(0, Math.min(1, (progress.value - start) / SEGMENT_WIDTH));
+            return [fillFraction * ringCircumference, ringCircumference] as [number, number];
           },
-          [i, segCircumference],
+          [i, ringCircumference],
         );
-
         const opacity = useDerivedValue(
-          () => {
-            'worklet';
-            const SEGMENT_WIDTH = 1 / 3;
-            const segStart = i * SEGMENT_WIDTH;
-            if (progress.value <= segStart) return 0;
-            if (progress.value >= segStart + SEGMENT_WIDTH) return 1;
-            return (progress.value - segStart) / SEGMENT_WIDTH;
-          },
+          () => (progress.value > i / 3 ? 1 : 0),
           [i],
         );
-
-        const rotation = -Math.PI / 2 + i * ((2 * Math.PI) / 3);
-
+        const rotation = -Math.PI / 2 + (i * 2 * Math.PI) / 3;
         return (
           <Circle
             key={i}
             cx={ringCenter}
             cy={ringCenter}
-            r={segRadius}
+            r={ringRadius}
             color={ringColors[i]}
             style="stroke"
             strokeWidth={HOLD_RING_STROKE_WIDTH}

--- a/src/services/git/multiRepoGitOps.ts
+++ b/src/services/git/multiRepoGitOps.ts
@@ -1,4 +1,5 @@
 import * as GitEngine from '@/services/git/engine/GitEngine';
+import { GitFsService } from './GitFsService';
 import type { GitRepository } from '@/services/GitService';
 import type { Author } from '@/services/git/engine/GitEngine';
 
@@ -7,7 +8,6 @@ export interface RepoOpOutcome {
   repoPath: string;
   repoName: string;
   ok: boolean;
-  /** Files newly staged (stageAll), commits created (commitAll), commits pushed (pushAll). */
   actedCount: number;
   error?: string;
 }
@@ -16,68 +16,33 @@ export interface AggregateOpOutcome {
   outcomes: RepoOpOutcome[];
   totalActed: number;
   failures: RepoOpOutcome[];
-  /** True if every repo completed without an error. */
   ok: boolean;
 }
 
-/**
- * For every repo in `repos`:
- *   1. Read `statuses()`.
- *   2. Stage any file whose `staged` flag is false AND `status !== 'Unmodified'`.
- *   3. Skip the repo if it has nothing to stage.
- *
- * Repos are processed in parallel. Errors are captured per-repo; a failure on
- * one repo does not abort the others.
- */
 export async function stageAllPending(
   repos: readonly GitRepository[],
 ): Promise<AggregateOpOutcome> {
   const outcomes = await Promise.all(
     repos.map(async (repo): Promise<RepoOpOutcome> => {
       try {
-        const files = await GitEngine.statuses(repo.path);
+        const localPath = GitFsService.workingTreeUri({ repoPath: repo.path });
+        const files = await GitEngine.statuses(localPath);
         const toStage = files
           .filter((file) => !file.staged && file.status !== 'Unmodified')
           .map((file) => file.path);
         if (toStage.length === 0) {
-          return {
-            repoId: repo.id,
-            repoPath: repo.path,
-            repoName: repo.name,
-            ok: true,
-            actedCount: 0,
-          };
+          return { repoId: repo.id, repoPath: repo.path, repoName: repo.name, ok: true, actedCount: 0 };
         }
-        await GitEngine.stage(repo.path, toStage);
-        return {
-          repoId: repo.id,
-          repoPath: repo.path,
-          repoName: repo.name,
-          ok: true,
-          actedCount: toStage.length,
-        };
+        await GitEngine.stage(localPath, toStage);
+        return { repoId: repo.id, repoPath: repo.path, repoName: repo.name, ok: true, actedCount: toStage.length };
       } catch (err) {
-        return {
-          repoId: repo.id,
-          repoPath: repo.path,
-          repoName: repo.name,
-          ok: false,
-          actedCount: 0,
-          error: err instanceof Error ? err.message : String(err),
-        };
+        return { repoId: repo.id, repoPath: repo.path, repoName: repo.name, ok: false, actedCount: 0, error: err instanceof Error ? err.message : String(err) };
       }
     }),
   );
   return summarize(outcomes);
 }
 
-/**
- * For every repo in `repos`:
- *   1. If `staged > 0` → `commit(message, author)`.
- *   2. Skip the repo if nothing is staged.
- *
- * Runs in parallel across repos; per-repo errors do not abort siblings.
- */
 export async function commitAll(
   repos: readonly GitRepository[],
   message: string,
@@ -86,93 +51,40 @@ export async function commitAll(
   const outcomes = await Promise.all(
     repos.map(async (repo): Promise<RepoOpOutcome> => {
       try {
-        const files = await GitEngine.statuses(repo.path);
+        const localPath = GitFsService.workingTreeUri({ repoPath: repo.path });
+        const files = await GitEngine.statuses(localPath);
         const stagedCount = files.filter((file) => file.staged).length;
         if (stagedCount === 0) {
-          return {
-            repoId: repo.id,
-            repoPath: repo.path,
-            repoName: repo.name,
-            ok: true,
-            actedCount: 0,
-          };
+          return { repoId: repo.id, repoPath: repo.path, repoName: repo.name, ok: true, actedCount: 0 };
         }
-        await GitEngine.commit(repo.path, message, author);
-        return {
-          repoId: repo.id,
-          repoPath: repo.path,
-          repoName: repo.name,
-          ok: true,
-          actedCount: 1,
-        };
+        await GitEngine.commit(localPath, message, author);
+        return { repoId: repo.id, repoPath: repo.path, repoName: repo.name, ok: true, actedCount: 1 };
       } catch (err) {
-        return {
-          repoId: repo.id,
-          repoPath: repo.path,
-          repoName: repo.name,
-          ok: false,
-          actedCount: 0,
-          error: err instanceof Error ? err.message : String(err),
-        };
+        return { repoId: repo.id, repoPath: repo.path, repoName: repo.name, ok: false, actedCount: 0, error: err instanceof Error ? err.message : String(err) };
       }
     }),
   );
   return summarize(outcomes);
 }
 
-/**
- * For every repo in `repos`:
- *   1. If `ahead > 0` → `pushWithIntegrate` (auto-resolves non-conflicting
- *      divergences; conflicts surface in the result so the caller can route
- *      to the resolver).
- *   2. Skip the repo if nothing to push.
- *
- * Runs in parallel across repos; per-repo errors do not abort siblings.
- */
 export async function pushAll(
   repos: readonly GitRepository[],
 ): Promise<AggregateOpOutcome> {
   const outcomes = await Promise.all(
     repos.map(async (repo): Promise<RepoOpOutcome> => {
       try {
-        const status = await GitEngine.status(repo.id, repo.path).catch(() => null);
+        const localPath = GitFsService.workingTreeUri({ repoPath: repo.path });
+        const status = await GitEngine.status(repo.id, localPath).catch(() => null);
         if (!status || status.ahead <= 0) {
-          return {
-            repoId: repo.id,
-            repoPath: repo.path,
-            repoName: repo.name,
-            ok: true,
-            actedCount: 0,
-          };
+          return { repoId: repo.id, repoPath: repo.path, repoName: repo.name, ok: true, actedCount: 0 };
         }
-        const result = await GitEngine.pushWithIntegrate(repo.path, 'origin', repo.id);
+        const result = await GitEngine.pushWithIntegrate(localPath, 'origin', repo.id);
         if (result.kind === 'Conflicts' || (result.conflicts?.length ?? 0) > 0) {
-          return {
-            repoId: repo.id,
-            repoPath: repo.path,
-            repoName: repo.name,
-            ok: false,
-            actedCount: 0,
-            error: `Push conflicts: ${(result.conflicts ?? []).map((c) => c.path).join(', ')}`,
-          };
+          return { repoId: repo.id, repoPath: repo.path, repoName: repo.name, ok: false, actedCount: 0, error: `Push conflicts: ${(result.conflicts ?? []).map((c) => c.path).join(', ')}` };
         }
-        return {
-          repoId: repo.id,
-          repoPath: repo.path,
-          repoName: repo.name,
-          ok: result.pushed > 0,
-          actedCount: result.pushed,
-          error: result.pushed > 0 ? undefined : result.message,
-        };
+        return { repoId: repo.id, repoPath: repo.path, repoName: repo.name, ok: result.pushed > 0, actedCount: result.pushed, error: result.pushed > 0 ? undefined : result.message };
       } catch (err) {
-        return {
-          repoId: repo.id,
-          repoPath: repo.path,
-          repoName: repo.name,
-          ok: false,
-          actedCount: 0,
-          error: err instanceof Error ? err.message : String(err),
-        };
+        return { repoId: repo.id, repoPath: repo.path, repoName: repo.name, ok: false, actedCount: 0, error: err instanceof Error ? err.message : String(err) };
       }
     }),
   );


### PR DESCRIPTION
## What

- **HoldProgressRing**: restored to original single-circle version (f2af17a) — AI button hold ring was broken
- **GitButtonRing**: new standalone ring component for git button. One ring with 3 arc segments: green (0-120°), yellow (120-240°), blue (240-360°)
- **FloatingGitButton**: switched to GitButtonRing; handleTap guards with holdProgress >= 1/3 so hold-release is not overwritten by tap-to-open
- **multiRepoGitOps**: FIXED — was passing repo.path (owner/repo identifier) to GitEngine methods, which need a local filesystem path. Now correctly uses GitFsService.workingTreeUri({ repoPath: repo.path }) like every other file in the codebase
- **useFloatingGitButtonAffordances**: debug console.log in handlePressIn and handlePressOut; hold fill slowed to 3s
- **AppFloatingGitButton**: debug console.log + toast in handleReleaseSegment + stageAllPending result logging

## Root Cause of Git Ops Failure

multiRepoGitOps.ts passed `repo.path` (e.g. `vidwadeseram/test-notes`) directly to `GitEngine.statuses()`, `GitEngine.stage()`, `GitEngine.commit()`, `GitEngine.pushWithIntegrate()`. The native engine expects a local filesystem path, not the canonical `owner/repo` identifier. Every other file in the codebase correctly resolves the local path via `GitFsService.workingTreeUri({ repoPath: repo.path })`.