### PR TITLE
fix(conflict-ui): badge contrast + error handling for resolve page

### DIFF
--- a/src/screens/ExploreConflictScreen.tsx
+++ b/src/screens/ExploreConflictScreen.tsx
@@ -148,9 +148,9 @@ export default function ExploreConflictScreen() {
           {conflicts && conflicts.length > 0 && (
             <View
               className="mt-0.5 rounded px-1.5 py-0.5 self-start"
-              style={{ backgroundColor: `${colors.error}26` }}
+              style={{ backgroundColor: colors.error }}
             >
-              <Text className="text-[10px] font-semibold" style={{ color: colors.error }}>
+              <Text className="text-[10px] font-semibold" style={{ color: '#fff' }}>
                 {conflicts.length} file{conflicts.length !== 1 ? 's' : ''}
               </Text>
             </View>


### PR DESCRIPTION
## What

**1. ExploreConflictScreen badge contrast**:
The conflict count badge ("1 file") had a semi-transparent red background (15% opacity) with low-contrast red text, making it appear as a barely-visible red blob. Changed to solid red background + white text.

**2. ConflictResolveScreen error handling**:
When the file path is unavailable (repo not cloned), the screen now shows a clear error instead of an empty/blank body. Also shows an error when the file exists but is empty. Previously a null fileUri caused setLoading(false) to fire silently, rendering an empty TextInput that appeared blank to the user.