### PR TITLE
fix(conflict-resolve): show error when fileUri is null or file is empty

### DIFF
--- a/src/screens/ConflictResolveScreen.tsx
+++ b/src/screens/ConflictResolveScreen.tsx
@@ -57,6 +57,7 @@ export default function ConflictResolveScreen() {
 
   useEffect(() => {
     if (!fileUri) {
+      setError('File not found on device. The repository may not be cloned.');
       setLoading(false);
       return;
     }
@@ -64,7 +65,13 @@ export default function ConflictResolveScreen() {
     (async () => {
       try {
         const content = await FileSystem.readAsStringAsync(fileUri);
-        if (!cancelled) setRawContent(content);
+        if (!cancelled) {
+          if (content.trim() === '') {
+            setError('File is empty. The conflict may already be resolved.');
+          } else {
+            setRawContent(content);
+          }
+        }
       } catch (caught) {
         if (!cancelled) setError(caught instanceof Error ? caught.message : String(caught));
       } finally {


### PR DESCRIPTION
## What

ConflictResolveScreen: when fileUri is null (repo not cloned / path unavailable), the screen previously showed a blank body. Now shows a clear error message. Also shows an error when the file exists but is empty (conflict may already be resolved).