### PR TITLE
fix(conflict-ui): solid red badge + robust error on resolve page

### DIFF
--- a/src/screens/ConflictResolveScreen.tsx
+++ b/src/screens/ConflictResolveScreen.tsx
@@ -56,7 +56,7 @@ export default function ConflictResolveScreen() {
   const [resolving, setResolving] = useState(false);
 
   useEffect(() => {
-    if (!fileUri) {
+    if (!fileUri || fileUri.trim() === '') {
       setError('File not found on device. The repository may not be cloned.');
       setLoading(false);
       return;
@@ -66,14 +66,17 @@ export default function ConflictResolveScreen() {
       try {
         const content = await FileSystem.readAsStringAsync(fileUri);
         if (!cancelled) {
-          if (content.trim() === '') {
+          if (!content || content.trim() === '') {
             setError('File is empty. The conflict may already be resolved.');
           } else {
             setRawContent(content);
           }
         }
       } catch (caught) {
-        if (!cancelled) setError(caught instanceof Error ? caught.message : String(caught));
+        if (!cancelled) {
+          const msg = caught instanceof Error ? caught.message : String(caught);
+          setError(msg || 'Failed to read file. The conflict may already be resolved.');
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/src/screens/ExploreConflictScreen.tsx
+++ b/src/screens/ExploreConflictScreen.tsx
@@ -108,9 +108,9 @@ export default function ExploreConflictScreen() {
           <View className="flex-row items-center gap-1">
             <View
               className="rounded px-1.5 py-0.5"
-              style={{ backgroundColor: `${colors.error}26` }}
+              style={{ backgroundColor: colors.error }}
             >
-              <Text className="text-[10px] font-semibold" style={{ color: colors.error }}>
+              <Text className="text-[10px] font-semibold" style={{ color: '#fff' }}>
                 {item.kind}
               </Text>
             </View>


### PR DESCRIPTION
Fixes two conflict UI bugs:

1. **Semi-transparent kind badge**: The per-item kind tag (e.g. 'both modified') was using semi-transparent red background (`${colors.error}26`). Changed to solid red (`colors.error`) with white text - matching the header count badge fix in #1432.

2. **Blank resolve page**: The ConflictResolveScreen could show a blank screen if fileUri was an empty string, or if readAsStringAsync failed with an empty error message. Now:
   - Guards against empty/whitespace-only fileUri
   - Guards against null/undefined content from file read
   - Provides fallback error message if caught error has no message