### PR TITLE
fix(conflict-resolve): empty file shows error not blank screen

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/vidwadeseram/Documents/GitHub/gitnotes/gitnotes/node_modules

--- a/src/screens/ConflictResolveScreen.tsx
+++ b/src/screens/ConflictResolveScreen.tsx
@@ -155,6 +155,13 @@ export default function ConflictResolveScreen() {
           <Ionicons name="warning-outline" size={40} color={colors.error} />
           <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
         </View>
+      ) : rawContent === '' ? (
+        <View className="flex-1 items-center justify-center px-8">
+          <Ionicons name="warning-outline" size={40} color={colors.error} />
+          <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>
+            File is empty. The conflict may already be resolved.
+          </Text>
+        </View>
       ) : (
         <KeyboardAvoidingView
           className="flex-1"


### PR DESCRIPTION
When readAsStringAsync returns empty content, show explicit error message instead of blank screen.