### PR TITLE
fix(conflict-resolve): use contrasting surface bg + red border for editor

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/vidwadeseram/Documents/GitHub/gitnotes/gitnotes/node_modules

--- a/src/screens/ConflictResolveScreen.tsx
+++ b/src/screens/ConflictResolveScreen.tsx
@@ -178,14 +178,14 @@ export default function ConflictResolveScreen() {
             </Text>
             <View
               className="rounded-lg mb-4 p-3"
-              style={{ backgroundColor: colors.card, borderColor: colors.border, borderWidth: 1 }}
+              style={{ backgroundColor: colors.card, borderColor: colors.error, borderWidth: 2 }}
             >
               <TextInput
                 testID="conflict-resolve.editor"
                 className="text-sm font-mono min-h-[300]"
                 style={{
                   color: colors.text,
-                  backgroundColor: colors.surfaceSecondary,
+                  backgroundColor: colors.surface,
                   borderRadius: 8,
                   padding: 12,
                 }}


### PR DESCRIPTION
Fix blank editor issue in ConflictResolveScreen.

**Root cause**: In FLAT_LIGHT mode, `surfaceSecondary` (#f2f2f7) equals `background` (#f2f2f7), making TextInput invisible.

**Changes**:
- Use `colors.surface` (white) for TextInput background - always contrasts
- Use `colors.error` (red) for editor container border with `borderWidth: 2`

Closes #1436