### PR TITLE
fix(conflict-resolve): load staged conflict content

### DIFF
--- a/src/screens/ConflictResolveScreen.tsx
+++ b/src/screens/ConflictResolveScreen.tsx
@@ -28,6 +28,12 @@ import type { RootStackParamList } from '@/navigation/types';
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 type Route = RouteProp<RootStackParamList, 'ConflictResolve'>;
 
+function conflictMarkerContent(ours: string, theirs: string): string {
+  const oursContent = ours.endsWith('\n') ? ours : `${ours}\n`;
+  const theirsContent = theirs.endsWith('\n') ? theirs : `${theirs}\n`;
+  return `<<<<<<< ours\n${oursContent}=======\n${theirsContent}>>>>>>> theirs\n`;
+}
+
 export default function ConflictResolveScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<Route>();
@@ -56,7 +62,7 @@ export default function ConflictResolveScreen() {
   const [resolving, setResolving] = useState(false);
 
   useEffect(() => {
-    if (!fileUri || fileUri.trim() === '') {
+    if (!fileUri || fileUri.trim() === '' || !localPath) {
       setError('File not found on device. The repository may not be cloned.');
       setLoading(false);
       return;
@@ -64,9 +70,10 @@ export default function ConflictResolveScreen() {
     let cancelled = false;
     (async () => {
       try {
-        const content = await FileSystem.readAsStringAsync(fileUri);
+        const blobs = await GitEngine.getConflictBlobs(localPath, path);
+        const content = conflictMarkerContent(blobs.ours, blobs.theirs);
         if (!cancelled) {
-          if (!content || content.trim() === '') {
+          if (blobs.ours === '' && blobs.theirs === '') {
             setError('File is empty. The conflict may already be resolved.');
           } else {
             setRawContent(content);
@@ -84,7 +91,7 @@ export default function ConflictResolveScreen() {
     return () => {
       cancelled = true;
     };
-  }, [fileUri]);
+  }, [fileUri, localPath, path]);
 
   const handleResolve = async () => {
     if (!fileUri || !localPath) return;


### PR DESCRIPTION
The resolver was reading the working-tree file, but unresolved conflicts are represented in Git index stages and the working-tree path may be absent or empty. Load the native engine's ours/theirs conflict blobs and render standard conflict markers in the editor. This fixes the blank resolve page while preserving the existing write-and-mark-resolved flow.