### PR TITLE
fix(conflict-resolve): keep resolver body visible

### DIFF
--- a/__tests__/ConflictResolveScreen.test.tsx
+++ b/__tests__/ConflictResolveScreen.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react-native';
+import { useRoute, useNavigation } from '@react-navigation/native';
+
+import ConflictResolveScreen from '@/screens/ConflictResolveScreen';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+  useRoute: jest.fn(),
+}));
+
+jest.mock('@/stores/repoStore', () => ({
+  useRepoStore: (selector: (state: { repositories: unknown[] }) => unknown) =>
+    selector({ repositories: [] }),
+}));
+
+jest.mock('@/stores/gitButtonActionStore', () => ({
+  useGitButtonActionStore: (selector: (state: { setPending: jest.Mock }) => unknown) =>
+    selector({ setPending: jest.fn() }),
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTokens: () => ({
+    colors: {
+      background: '#fff',
+      border: '#ddd',
+      text: '#111',
+      textSecondary: '#666',
+      accent: '#00f',
+      card: '#eee',
+      error: '#f00',
+      surface: '#fff',
+    },
+  }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: 'Ionicons' }));
+
+describe('ConflictResolveScreen', () => {
+  it('keeps the resolver body visible when the repository is unavailable', () => {
+    (useNavigation as jest.Mock).mockReturnValue({ goBack: jest.fn(), navigate: jest.fn() });
+    (useRoute as jest.Mock).mockReturnValue({ params: { repoId: 'repo-1', path: 'notes/hi2.md' } });
+
+    const screen = render(<ConflictResolveScreen />);
+
+    expect(screen.getByTestId('conflict-resolve.screen').props.style).toEqual(
+      expect.objectContaining({ flex: 1 }),
+    );
+    expect(screen.getByText('Repository not found.')).toBeTruthy();
+  });
+});

--- a/src/screens/ConflictResolveScreen.tsx
+++ b/src/screens/ConflictResolveScreen.tsx
@@ -112,7 +112,12 @@ export default function ConflictResolveScreen() {
 
   if (!storedRepo || !localPath || !fileUri) {
     return (
-      <SafeAreaView edges={['top']} className="flex-1" style={{ backgroundColor: colors.background }}>
+      <SafeAreaView
+        edges={['top']}
+        className="flex-1"
+        testID="conflict-resolve.screen"
+        style={{ flex: 1, backgroundColor: colors.background }}
+      >
         <View className="flex-row items-center gap-2 px-4 py-3" style={{ borderBottomWidth: 1, borderBottomColor: colors.border }}>
           <Pressable onPress={() => navigation.goBack()} hitSlop={8} accessibilityRole="button" accessibilityLabel="Go back">
             <Ionicons name="chevron-back" size={22} color={colors.text} />
@@ -130,7 +135,12 @@ export default function ConflictResolveScreen() {
   }
 
   return (
-    <SafeAreaView edges={['top']} className="flex-1" style={{ backgroundColor: colors.background }}>
+    <SafeAreaView
+      edges={['top']}
+      className="flex-1"
+      testID="conflict-resolve.screen"
+      style={{ flex: 1, backgroundColor: colors.background }}
+    >
       <View
         className="flex-row items-center gap-2 px-4 py-3"
         style={{ borderBottomWidth: 1, borderBottomColor: colors.border }}
@@ -153,12 +163,12 @@ export default function ConflictResolveScreen() {
       </View>
 
       {loading ? (
-        <View className="flex-1 items-center justify-center gap-2">
+        <View className="flex-1 items-center justify-center gap-2" style={{ flex: 1 }}>
           <ActivityIndicator size="small" color={colors.accent} />
           <Text className="text-sm" style={{ color: colors.textSecondary }}>Reading file…</Text>
         </View>
       ) : error || !rawContent ? (
-        <View className="flex-1 items-center justify-center px-8">
+        <View className="flex-1 items-center justify-center px-8" style={{ flex: 1 }}>
           <Ionicons name="warning-outline" size={40} color={colors.error} />
           <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>
             {error || 'File not found or empty. The conflict may already be resolved.'}
@@ -167,12 +177,14 @@ export default function ConflictResolveScreen() {
       ) : (
         <KeyboardAvoidingView
           className="flex-1"
+          style={{ flex: 1 }}
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
           keyboardVerticalOffset={0}
         >
           <ScrollView
             className="flex-1"
-            contentContainerStyle={{ padding: 16 }}
+            style={{ flex: 1 }}
+            contentContainerStyle={{ padding: 16, flexGrow: 1 }}
             keyboardShouldPersistTaps="handled"
           >
             <Text className="text-xs font-semibold mb-2" style={{ color: colors.textSecondary }}>
@@ -190,6 +202,7 @@ export default function ConflictResolveScreen() {
                   backgroundColor: colors.surface,
                   borderRadius: 8,
                   padding: 12,
+                  minHeight: 300,
                 }}
                 multiline
                 value={rawContent}


### PR DESCRIPTION
## Summary
- Explicitly size the conflict resolver root and content branches with React Native flex styles.
- Give the multiline editor a concrete minimum height and allow scroll content to grow.
- Add a regression test that protects the visible resolver body when repository data is unavailable.

## Verification
- `yarn ts:check`
- `yarn eslint src/screens/ConflictResolveScreen.tsx __tests__/ConflictResolveScreen.test.tsx`
- `yarn jest __tests__/ConflictResolveScreen.test.tsx --no-coverage --runInBand --testPathIgnorePatterns=/node_modules/`
- iPhone 17 simulator: the previously blank route displayed the warning icon and actionable GitEngine error body.

The original conflict fixture had already been consumed, so the live check verified the error branch rather than a populated editor branch.