### PR TITLE
fix(conflict-resolve): add complete resolution flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 >
 > **History**: prior fixes (pre-2026-08) lived in single-PR wiki pages. Those pages were retired in [#1047](https://github.com/gedwolmen/gitnotes/pull/1047); their full diagnostic content is preserved in git history via `git log -p -- docs/wiki/<file>.md`.
 
+## 2026-09-08
+
+### fix(sync): add complete conflict resolution actions
+
+**What:** Conflict resolution now offers Accept ours, Accept theirs, Accept both, and Full edit. Saving writes the resolved content, stages and commits it, pushes immediately, then pulls and refreshes Notes, Canvases, and Todos. The conflict list no longer renders the stray red square indicator.
+
+**PR:** TBD
+
 ## 2026-09-06
 
 ### fix(explore): guard Git tab against corrupted repo data on app update

--- a/__tests__/ConflictResolveScreen.test.tsx
+++ b/__tests__/ConflictResolveScreen.test.tsx
@@ -1,7 +1,11 @@
-import { render } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { useRoute, useNavigation } from '@react-navigation/native';
 
 import ConflictResolveScreen from '@/screens/ConflictResolveScreen';
+import * as GitEngine from '@/services/git/engine/GitEngine';
+import type { GitRepository } from '@/services/GitService';
+
+let mockRepositories: GitRepository[] = [];
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
@@ -9,8 +13,8 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('@/stores/repoStore', () => ({
-  useRepoStore: (selector: (state: { repositories: unknown[] }) => unknown) =>
-    selector({ repositories: [] }),
+  useRepoStore: (selector: (state: { repositories: GitRepository[] }) => unknown) =>
+    selector({ repositories: mockRepositories }),
 }));
 
 jest.mock('@/stores/gitButtonActionStore', () => ({
@@ -30,12 +34,52 @@ jest.mock('@/contexts/ThemeContext', () => ({
       error: '#f00',
       surface: '#fff',
     },
+    type: { xs: 12, sm: 14, md: 16 },
   }),
+  useTheme: () => ({ style: {} }),
 }));
 
 jest.mock('@expo/vector-icons', () => ({ Ionicons: 'Ionicons' }));
 
+jest.mock('@/components/ui/Button', () => {
+  const React = require('react');
+  const { Pressable, Text } = require('react-native');
+  return {
+    Button: ({ children, onPress, disabled, testID }: {
+      children: unknown;
+      onPress?: () => void;
+      disabled?: boolean;
+      testID?: string;
+    }) => React.createElement(Pressable, { onPress, disabled, testID }, children),
+    ButtonText: ({ children }: { children: unknown }) => React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('@/services/git/GitFsService', () => ({
+  GitFsService: { workingTreeUri: jest.fn(() => 'file:///repo') },
+}));
+
+jest.mock('@/services/git/engine/GitEngine', () => ({
+  getConflictBlobs: jest.fn(),
+  markConflictResolved: jest.fn(),
+}));
+
+jest.mock('@/services/git/conflictResolution', () => ({
+  getConflictChoiceContent: jest.fn((blobs: { ours: string; theirs: string }, choice: string) => {
+    if (choice === 'ours') return blobs.ours;
+    if (choice === 'theirs') return blobs.theirs;
+    if (choice === 'both') return `${blobs.ours}\n${blobs.theirs}`;
+    return `<<<<<<< ours\n${blobs.ours}\n=======\n${blobs.theirs}\n>>>>>>> theirs\n`;
+  }),
+  resolveConflictAndSync: jest.fn(),
+}));
+
 describe('ConflictResolveScreen', () => {
+  beforeEach(() => {
+    mockRepositories = [];
+    jest.clearAllMocks();
+  });
+
   it('keeps the resolver body visible when the repository is unavailable', () => {
     (useNavigation as jest.Mock).mockReturnValue({ goBack: jest.fn(), navigate: jest.fn() });
     (useRoute as jest.Mock).mockReturnValue({ params: { repoId: 'repo-1', path: 'notes/hi2.md' } });
@@ -46,5 +90,25 @@ describe('ConflictResolveScreen', () => {
       expect.objectContaining({ flex: 1 }),
     );
     expect(screen.getByText('Repository not found.')).toBeTruthy();
+  });
+
+  it('offers ours, theirs, both, and full edit choices', async () => {
+    mockRepositories = [{ id: 'repo-1', path: 'owner/repo', name: 'repo', branch: 'main' }];
+    (GitEngine.getConflictBlobs as jest.Mock).mockResolvedValue({
+      ours: 'local',
+      theirs: 'remote',
+      base: 'common',
+    });
+    (useNavigation as jest.Mock).mockReturnValue({ goBack: jest.fn(), navigate: jest.fn() });
+    (useRoute as jest.Mock).mockReturnValue({ params: { repoId: 'repo-1', path: 'notes/hi2.md' } });
+
+    const screen = render(<ConflictResolveScreen />);
+
+    await waitFor(() => expect(screen.getByTestId('conflict-resolve.accept-ours')).toBeTruthy());
+    fireEvent.press(screen.getByTestId('conflict-resolve.accept-both'));
+
+    expect(screen.getByTestId('conflict-resolve.accept-theirs')).toBeTruthy();
+    expect(screen.getByTestId('conflict-resolve.full-edit')).toBeTruthy();
+    expect(screen.getByTestId('conflict-resolve.editor').props.value).toBe('local\nremote');
   });
 });

--- a/__tests__/services/git/conflictResolution.test.ts
+++ b/__tests__/services/git/conflictResolution.test.ts
@@ -1,0 +1,76 @@
+import * as FileSystem from 'expo-file-system/legacy';
+
+import * as GitEngine from '@/services/git/engine/GitEngine';
+import { CommitService } from '@/services/git/CommitService';
+import { syncNow } from '@/services/git/manualSync';
+import {
+  getConflictChoiceContent,
+  resolveConflictAndSync,
+} from '@/services/git/conflictResolution';
+
+jest.mock('expo-file-system/legacy', () => ({
+  writeAsStringAsync: jest.fn(),
+}));
+
+jest.mock('@/services/git/engine/GitEngine', () => ({
+  markConflictResolved: jest.fn(),
+  commit: jest.fn(),
+  push: jest.fn(),
+}));
+
+jest.mock('@/services/git/CommitService', () => ({
+  CommitService: { resolveAuthor: jest.fn() },
+}));
+
+jest.mock('@/services/git/GitFsService', () => ({
+  GitFsService: { workingTreeUri: jest.fn(() => 'file:///repo') },
+}));
+
+jest.mock('@/services/git/manualSync', () => ({
+  syncNow: jest.fn(),
+}));
+
+describe('conflictResolution', () => {
+  it('builds marker-free content for ours, theirs, and both choices', () => {
+    const blobs = { ours: 'local', theirs: 'remote', base: 'common' };
+
+    expect(getConflictChoiceContent(blobs, 'ours')).toBe('local');
+    expect(getConflictChoiceContent(blobs, 'theirs')).toBe('remote');
+    expect(getConflictChoiceContent(blobs, 'both')).toBe('local\nremote');
+    expect(getConflictChoiceContent(blobs, 'edit')).toContain('<<<<<<< ours');
+  });
+
+  it('writes, stages, commits, pushes, then pulls the resolved repository', async () => {
+    (CommitService.resolveAuthor as jest.Mock).mockResolvedValue({ name: 'Test User', email: 'test@example.com' });
+    (GitEngine.push as jest.Mock).mockResolvedValue({ ok: true, pushed: 1 });
+    (syncNow as jest.Mock).mockResolvedValue({ ok: true });
+
+    await resolveConflictAndSync(
+      { id: 'repo-1', path: 'owner/repo', name: 'repo', branch: 'main' },
+      'notes/readme.md',
+      'resolved content',
+    );
+
+    expect(FileSystem.writeAsStringAsync).toHaveBeenCalledWith(
+      'file:///repo/notes/readme.md',
+      'resolved content',
+    );
+    expect(GitEngine.markConflictResolved).toHaveBeenCalledWith('file:///repo', 'notes/readme.md');
+    expect(GitEngine.commit).toHaveBeenCalledWith(
+      'file:///repo',
+      'Resolve conflict: notes/readme.md',
+      { name: 'Test User', email: 'test@example.com' },
+    );
+    expect(GitEngine.push).toHaveBeenCalledWith('file:///repo', 'origin', 'repo-1');
+    expect(syncNow).toHaveBeenCalledWith({ repos: ['owner/repo'], source: 'manual' });
+
+    const operationOrder = [
+      FileSystem.writeAsStringAsync,
+      GitEngine.markConflictResolved,
+      GitEngine.commit,
+      GitEngine.push,
+      syncNow,
+    ].map((operation) => (operation as jest.Mock).mock.invocationCallOrder[0]);
+    expect(operationOrder).toEqual([...operationOrder].sort((left, right) => left - right));
+  });
+});

--- a/src/screens/ConflictResolveScreen.tsx
+++ b/src/screens/ConflictResolveScreen.tsx
@@ -12,14 +12,19 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import * as FileSystem from 'expo-file-system/legacy';
 import { Ionicons } from '@expo/vector-icons';
 
 import { Text } from '@/components/ui/text';
 import { Heading } from '@/components/ui/heading';
 import { Button, ButtonText } from '@/components/ui/Button';
 import * as GitEngine from '@/services/git/engine/GitEngine';
+import type { ConflictBlobs } from '@/services/git/engine/GitEngine';
 import { GitFsService } from '@/services/git/GitFsService';
+import {
+  getConflictChoiceContent,
+  resolveConflictAndSync,
+  type ConflictChoice,
+} from '@/services/git/conflictResolution';
 import { useRepoStore } from '@/stores/repoStore';
 import { useGitButtonActionStore } from '@/stores/gitButtonActionStore';
 import { useTokens } from '@/contexts/ThemeContext';
@@ -27,12 +32,6 @@ import type { RootStackParamList } from '@/navigation/types';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 type Route = RouteProp<RootStackParamList, 'ConflictResolve'>;
-
-function conflictMarkerContent(ours: string, theirs: string): string {
-  const oursContent = ours.endsWith('\n') ? ours : `${ours}\n`;
-  const theirsContent = theirs.endsWith('\n') ? theirs : `${theirs}\n`;
-  return `<<<<<<< ours\n${oursContent}=======\n${theirsContent}>>>>>>> theirs\n`;
-}
 
 export default function ConflictResolveScreen() {
   const navigation = useNavigation<NavigationProp>();
@@ -57,6 +56,8 @@ export default function ConflictResolveScreen() {
   }
 
   const [rawContent, setRawContent] = useState('');
+  const [blobs, setBlobs] = useState<ConflictBlobs | null>(null);
+  const [selectedChoice, setSelectedChoice] = useState<ConflictChoice>('edit');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [resolving, setResolving] = useState(false);
@@ -71,12 +72,12 @@ export default function ConflictResolveScreen() {
     (async () => {
       try {
         const blobs = await GitEngine.getConflictBlobs(localPath, path);
-        const content = conflictMarkerContent(blobs.ours, blobs.theirs);
         if (!cancelled) {
           if (blobs.ours === '' && blobs.theirs === '') {
             setError('File is empty. The conflict may already be resolved.');
           } else {
-            setRawContent(content);
+            setBlobs(blobs);
+            setRawContent(getConflictChoiceContent(blobs, 'edit'));
           }
         }
       } catch (caught) {
@@ -94,11 +95,10 @@ export default function ConflictResolveScreen() {
   }, [fileUri, localPath, path]);
 
   const handleResolve = async () => {
-    if (!fileUri || !localPath) return;
+    if (!storedRepo || !fileUri || !localPath) return;
     setResolving(true);
     try {
-      await FileSystem.writeAsStringAsync(fileUri, rawContent);
-      await GitEngine.markConflictResolved(localPath, path);
+      await resolveConflictAndSync(storedRepo, path, rawContent);
       setPending({ repoId, section: 'staging' });
       navigation.navigate('MainTabs', { screen: 'ExploreTab' });
     } catch (caught) {
@@ -108,6 +108,12 @@ export default function ConflictResolveScreen() {
         caught instanceof Error ? caught.message : String(caught),
       );
     }
+  };
+
+  const handleChoice = (choice: ConflictChoice) => {
+    if (!blobs || resolving) return;
+    setSelectedChoice(choice);
+    setRawContent(getConflictChoiceContent(blobs, choice));
   };
 
   if (!storedRepo || !localPath || !fileUri) {
@@ -188,8 +194,46 @@ export default function ConflictResolveScreen() {
             keyboardShouldPersistTaps="handled"
           >
             <Text className="text-xs font-semibold mb-2" style={{ color: colors.textSecondary }}>
-              Edit the file below — remove the conflict markers (&lt;&lt;&lt;&lt;&lt;&lt;&lt; / ======= / &gt;&gt;&gt;&gt;&gt;&gt;&gt;) and keep what you want, then tap Mark resolved.
+              Choose a version or edit the combined file below, then tap Mark resolved.
             </Text>
+            <View className="flex-row flex-wrap gap-2 mb-4">
+              <Button
+                size="sm"
+                variant={selectedChoice === 'ours' ? 'primary' : 'outline'}
+                disabled={resolving}
+                onPress={() => handleChoice('ours')}
+                testID="conflict-resolve.accept-ours"
+              >
+                <ButtonText>Accept ours</ButtonText>
+              </Button>
+              <Button
+                size="sm"
+                variant={selectedChoice === 'theirs' ? 'primary' : 'outline'}
+                disabled={resolving}
+                onPress={() => handleChoice('theirs')}
+                testID="conflict-resolve.accept-theirs"
+              >
+                <ButtonText>Accept theirs</ButtonText>
+              </Button>
+              <Button
+                size="sm"
+                variant={selectedChoice === 'both' ? 'primary' : 'outline'}
+                disabled={resolving}
+                onPress={() => handleChoice('both')}
+                testID="conflict-resolve.accept-both"
+              >
+                <ButtonText>Accept both</ButtonText>
+              </Button>
+              <Button
+                size="sm"
+                variant={selectedChoice === 'edit' ? 'primary' : 'outline'}
+                disabled={resolving}
+                onPress={() => handleChoice('edit')}
+                testID="conflict-resolve.full-edit"
+              >
+                <ButtonText>Full edit</ButtonText>
+              </Button>
+            </View>
             <View
               className="rounded-lg mb-4 p-3"
               style={{ backgroundColor: colors.card, borderColor: colors.error, borderWidth: 2 }}

--- a/src/screens/ExploreConflictScreen.tsx
+++ b/src/screens/ExploreConflictScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, FlatList, Pressable, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
@@ -96,11 +96,6 @@ export default function ExploreConflictScreen() {
       <View className="flex-row items-center justify-between">
         <View className="min-w-0 flex-1 mr-2">
           <View className="flex-row items-center gap-2 mb-1">
-            <View
-              className="w-2 h-2 rounded-sm"
-              style={{ backgroundColor: colors.error }}
-              testID={`explore-conflict.indicator.${item.path}`}
-            />
             <Text className="text-sm font-semibold" style={{ color: colors.text }} numberOfLines={2}>
               {item.path}
             </Text>

--- a/src/services/git/conflictResolution.ts
+++ b/src/services/git/conflictResolution.ts
@@ -1,0 +1,56 @@
+import * as FileSystem from 'expo-file-system/legacy';
+
+import type { GitRepository } from '../GitService';
+import * as GitEngine from './engine/GitEngine';
+import { GitFsService } from './GitFsService';
+import { CommitService } from './CommitService';
+import { syncNow } from './manualSync';
+
+export type ConflictChoice = 'ours' | 'theirs' | 'both' | 'edit';
+
+export function getConflictChoiceContent(
+  blobs: GitEngine.ConflictBlobs,
+  choice: ConflictChoice,
+): string {
+  switch (choice) {
+    case 'ours':
+      return blobs.ours;
+    case 'theirs':
+      return blobs.theirs;
+    case 'both':
+      return [blobs.ours, blobs.theirs].filter((content) => content.length > 0).join('\n');
+    case 'edit': {
+      const ours = blobs.ours.endsWith('\n') ? blobs.ours : `${blobs.ours}\n`;
+      const theirs = blobs.theirs.endsWith('\n') ? blobs.theirs : `${blobs.theirs}\n`;
+      return `<<<<<<< ours\n${ours}=======\n${theirs}>>>>>>> theirs\n`;
+    }
+  }
+}
+
+export async function resolveConflictAndSync(
+  repo: GitRepository,
+  filePath: string,
+  content: string,
+): Promise<void> {
+  const localPath = GitFsService.workingTreeUri({ repoPath: repo.path });
+  const fileUri = `${localPath}/${filePath}`;
+  await FileSystem.writeAsStringAsync(fileUri, content);
+  await GitEngine.markConflictResolved(localPath, filePath);
+
+  const author = await CommitService.resolveAuthor();
+  await GitEngine.commit(
+    localPath,
+    `Resolve conflict: ${filePath}`,
+    author,
+  );
+
+  const pushResult = await GitEngine.push(localPath, 'origin', repo.id);
+  if (!pushResult.ok) {
+    throw new Error(pushResult.error ?? 'Failed to push resolved conflict');
+  }
+
+  const pullResult = await syncNow({ repos: [repo.path], source: 'manual' });
+  if (!pullResult.ok) {
+    throw new Error(pullResult.error ?? 'Resolved conflict pushed, but pull failed');
+  }
+}


### PR DESCRIPTION
## Summary
- remove the stray red conflict square from the conflict list
- add Accept ours, Accept theirs, Accept both, and Full edit actions
- write, stage, commit, push, then pull and refresh Notes, Canvases, and Todos after resolution

## Verification
- `yarn ts:check`
- `yarn jest --no-coverage --runInBand --testPathIgnorePatterns=^$` (4 tests passed)
- targeted ESLint
- Prettier check
- LSP diagnostics clean on changed production files

## QA note
The branch bundle loaded through Metro on the iOS simulator, but the installed development client hit the pre-existing `useAccounts must be used within an AccountsProvider` startup error. A native rebuild was also blocked by the generated Xcode project referencing `/rust/libgitnotes_git2.a`.