### PR TITLE
fix(sync): derive ok from native push result + conflict UX improvements

### DIFF
--- a/src/screens/ConflictResolveScreen.tsx
+++ b/src/screens/ConflictResolveScreen.tsx
@@ -103,10 +103,15 @@ export default function ConflictResolveScreen() {
       navigation.navigate('MainTabs', { screen: 'ExploreTab' });
     } catch (caught) {
       setResolving(false);
-      Alert.alert(
-        'Failed to resolve',
-        caught instanceof Error ? caught.message : String(caught),
-      );
+      const message = caught instanceof Error ? caught.message : String(caught);
+      if (message.includes('already-running')) {
+        navigation.navigate('MainTabs', { screen: 'ExploreTab' });
+      } else {
+        Alert.alert(
+          'Failed to resolve',
+          message,
+        );
+      }
     }
   };
 
@@ -196,7 +201,7 @@ export default function ConflictResolveScreen() {
             <Text className="text-xs font-semibold mb-2" style={{ color: colors.textSecondary }}>
               Choose a version or edit the combined file below, then tap Mark resolved.
             </Text>
-            <View className="flex-row flex-wrap gap-2 mb-4">
+            <View className="gap-2 mb-4">
               <Button
                 size="sm"
                 variant={selectedChoice === 'ours' ? 'primary' : 'outline'}

--- a/src/services/git/engine/GitEngine.ts
+++ b/src/services/git/engine/GitEngine.ts
@@ -493,7 +493,15 @@ export async function push(
     return { ok: false, error: 'GitEngine native module unavailable' };
   }
   await ensureCredentialForOp(repoId);
-  return run(() => GitEngineModule!.push(repoPath, remoteName, repoId ?? null, false), { ok: false, error: 'unavailable' });
+  const result = await run(
+    () => GitEngineModule!.push(repoPath, remoteName, repoId ?? null, false) as Promise<{ pushed: number; nonFastForward: boolean; message: string }>,
+    null,
+  );
+  if (result === null) {
+    return { ok: false, error: 'unavailable' };
+  }
+  // Derive ok from native result: push succeeds when at least one ref was pushed
+  return { ok: result.pushed > 0, error: result.message || undefined };
 }
 
 /**


### PR DESCRIPTION
## What

**Root cause**: The native push() on iOS/Android returns { pushed, nonFastForward, message } but the TypeScript wrapper passed this through directly as PushResult. Callers expect { ok, error }, so ok was always undefined (falsy) - every push was treated as failed, throwing 'Failed to push resolved conflict' on every successful resolve.

**Changes**:

1. GitEngine.push() - derive ok from native result  
   Native returns { pushed: N, nonFastForward, message }. The wrapper now maps pushed > 0 to ok: true, and propagates message as error when pushed === 0.

2. ConflictResolveScreen - do not block on already-running sync  
   When syncNow is already running (another pull in progress) it returns { ok: false, error: 'already-running' }. The resolve flow now navigates away gracefully instead of showing an error alert - the push already succeeded.

3. Stacked full-width choice buttons  
   Accept ours / Accept theirs / Accept both / Full edit are now flex-col gap-2 (full-width stacked rows) instead of flex-row flex-wrap (wrapped).

## Tests
yarn jest + yarn ts:check + yarn eslint all pass.