### PR TITLE
fix(fab): tap navigates to matching section by button color

### DIFF
--- a/src/components/git/AppFloatingGitButton.tsx
+++ b/src/components/git/AppFloatingGitButton.tsx
@@ -226,9 +226,15 @@ export default function AppFloatingGitButton() {
       return;
     }
     const targetRepoId = aggregatedState.latestChangedRepoId ?? repos[0]?.id ?? null;
-    if (!targetRepoId) return;
-    const section = targetSectionFor(aggregatedState.perRepo.get(targetRepoId));
-    if (!section) return;
+    const section =
+      aggregatedState.totalStaged > 0
+        ? 'staging'
+        : aggregatedState.totalUncommitted > 0
+          ? 'changes'
+          : aggregatedState.totalAhead > 0
+            ? 'commits'
+            : null;
+    if (!section || !targetRepoId) return;
     setPending({ repoId: targetRepoId, section });
     navigation.navigate('MainTabs', { screen: 'ExploreTab' });
   }, [aggregatedState, repos, setPending, navigation]);


### PR DESCRIPTION
Fix floating git button tap to navigate based on its color:

- Yellow (staged) -> Staged section
- Green (uncommitted changes) -> Changes section  
- Blue (ahead/unpushed) -> Commits section
- Red (conflicts) -> Conflicts screen (unchanged)