### PR TITLE
fix(paywall): sync Pro state on RevenueCat callbacks and account binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-08
 
+### fix(paywall): sync Pro state on RevenueCat callbacks and account binds
+
+**What:** Five critical/high bugs in `proStore.ts` where the Pro/grandfathered state fell out of sync after RevenueCat operations — allowing free Pro via restore exploit, stale grandfather status, and ghost Pro after account unbind.
+
+**fix(paywall):** `restore()`: removed exploit path that granted free Pro when RevenueCat was not configured — no RevenueCat call means no free tier.
+
+**fix(paywall):** `onCustomerInfoUpdate()`: re-checks `resolveGrandfatherStatus()` on every subscriber callback so `isGrandfathered` stays current.
+
+**fix(paywall):** `refresh()`: re-checks `resolveGrandfatherStatus()` with fresh `customerInfo` so `isGrandfathered` reflects current entitlement state.
+
+**fix(paywall):** `bindAccount()`: re-checks `resolveGrandfatherStatus()` for the newly bound account so `isGrandfathered` reflects that user's entitlement.
+
+**fix(paywall):** `unbindAccount()`: resets `entitlementActive`, `isGrandfathered`, `trialActive`, `trialEndsAt`, `entitlementExpiresAt`, and `status: 'free'` after `logOutAppUser()`.
+
+**PR:** #1448
+
 ### fix(sync): add complete conflict resolution actions
 
 **What:** Conflict resolution now offers Accept ours, Accept theirs, Accept both, and Full edit. Saving writes the resolved content, stages and commits it, pushes immediately, then pulls and refreshes Notes, Canvases, and Todos. The conflict list no longer renders the stray red square indicator.

--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -168,11 +168,13 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
       if (configured) {
         customerInfo = await getCustomerInfo();
         _customerInfoCleanup?.();
-        _customerInfoCleanup = onCustomerInfoUpdate((info) => {
+        _customerInfoCleanup = onCustomerInfoUpdate(async (info) => {
           const derived = deriveTrialInfo(info);
-          set((state) => ({
+          const grandfather = await resolveGrandfatherStatus(info);
+          set(() => ({
             ...derived,
-            status: DEV_FORCE_PRO ? 'pro' : (derived.entitlementActive || state.isGrandfathered ? 'pro' : 'free'),
+            isGrandfathered: grandfather.isGrandfathered,
+            status: DEV_FORCE_PRO ? 'pro' : (derived.entitlementActive || grandfather.isGrandfathered ? 'pro' : 'free'),
           }));
           void evaluateInterstitial(derived.entitlementActive, set);
         });
@@ -200,9 +202,11 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
     try {
       const customerInfo = await getCustomerInfo();
       const derived = deriveTrialInfo(customerInfo);
-      set((state) => ({
+      const grandfather = await resolveGrandfatherStatus(customerInfo);
+      set(() => ({
         ...derived,
-        status: DEV_FORCE_PRO ? 'pro' : (derived.entitlementActive || state.isGrandfathered ? 'pro' : 'free'),
+        isGrandfathered: grandfather.isGrandfathered,
+        status: DEV_FORCE_PRO ? 'pro' : (derived.entitlementActive || grandfather.isGrandfathered ? 'pro' : 'free'),
         error: null,
       }));
       await evaluateInterstitial(derived.entitlementActive, set);
@@ -260,14 +264,6 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
     set({ isRestoring: true, error: null });
     PaywallAnalytics.trackRestoreTap();
     try {
-      const isConfigured = get().configured;
-      if (!isConfigured) {
-        set({ isGrandfathered: true, status: 'pro' });
-        await AsyncStorage.setItem(RESTORE_GRANTED_KEY, 'true');
-        set({ isRestoring: false });
-        PaywallAnalytics.trackRestoreOutcome('restored');
-        return 'restored';
-      }
       const result = await restorePurchases();
       if (result.kind === 'error') {
         set({ isRestoring: false, error: result.message });
@@ -275,13 +271,10 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
         return 'error';
       }
       if (result.kind === 'cancelled') {
-        // User dismissed the Apple sign-in sheet — neutral, no state change.
         set({ isRestoring: false });
         PaywallAnalytics.trackRestoreOutcome('cancelled');
         return 'cancelled';
       }
-      // 'purchased' alone does not distinguish found vs not-found: derive it
-      // from the returned customerInfo entitlements.
       const proActive = Boolean(
         result.customerInfo?.entitlements?.active?.[PRO_ENTITLEMENT_ID]?.isActive,
       );
@@ -335,14 +328,24 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
     const customerInfo = await logInAppUser(appUserID);
     if (!customerInfo) return;
     const derived = deriveTrialInfo(customerInfo);
-    set((state) => ({
+    const grandfather = await resolveGrandfatherStatus(customerInfo);
+    set(() => ({
       ...derived,
-      status: DEV_FORCE_PRO ? 'pro' : (derived.entitlementActive || state.isGrandfathered ? 'pro' : 'free'),
+      isGrandfathered: grandfather.isGrandfathered,
+      status: DEV_FORCE_PRO ? 'pro' : (derived.entitlementActive || grandfather.isGrandfathered ? 'pro' : 'free'),
     }));
   },
 
   unbindAccount: async () => {
     if (!get().configured) return;
     await logOutAppUser();
+    set({
+      entitlementActive: false,
+      isGrandfathered: false,
+      trialActive: false,
+      trialEndsAt: null,
+      entitlementExpiresAt: null,
+      status: 'free',
+    });
   },
 }));


### PR DESCRIPTION
## What

Fix 5 critical/high bugs in `proStore.ts` paywall state machine where Pro/grandfathered state fell out of sync after RevenueCat operations.

### Bugs fixed

| # | Severity | Location | Bug |
|---|----------|----------|-----|
| 1 | CRITICAL | `restore()` | Exploit path granted free Pro when RevenueCat was not configured - no API call meant free tier |
| 2 | CRITICAL | `onCustomerInfoUpdate()` | Never re-checked `isGrandfathered` on subscriber callbacks - stale after entitlement changes |
| 3 | CRITICAL | `refresh()` | Did not re-check `resolveGrandfatherStatus()` with fresh `customerInfo` |
| 4 | HIGH | `bindAccount()` | Did not update `isGrandfathered` from the newly bound account's `customerInfo` |
| 5 | HIGH | `unbindAccount()` | Did not clear Pro state after `logOutAppUser()` - ghost Pro persisted |

### Changes

- **`restore()`**: removed the `if (!isConfigured)` exploit block. RevenueCat must be called for any Pro access.
- **`onCustomerInfoUpdate()`**: added `await resolveGrandfatherStatus(info)` call; `isGrandfathered` now stays current.
- **`refresh()`**: added `await resolveGrandfatherStatus(customerInfo)` call before updating state.
- **`bindAccount()`**: added `await resolveGrandfatherStatus(customerInfo)` call for the newly bound account.
- **`unbindAccount()`**: resets `entitlementActive`, `isGrandfathered`, `trialActive`, `trialEndsAt`, `entitlementExpiresAt`, `status: 'free'` after `logOutAppUser()`.

## Testing

- `yarn ts:check` passes (TypeScript clean)
- `yarn eslint src/stores/proStore.ts` passes (0 errors)

## PRs referenced

- #1447 - iOS grandfathering cache race condition in `GrandfatherService.ts`