### PR TITLE
fix(paywall): restore-granted cache bypass + silent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-08
 
+### fix(paywall): restore-granted cache bypass + silent failures
+
+**What:** Four bugs in `GrandfatherService` and `proStore` — a critical cache-order bug that denied Pro to restore-granted users, and three medium-severity silent failure modes.
+
+**fix(paywall):** `GrandfatherService.resolveGrandfatherStatus()`: moved `RESTORE_GRANTED_KEY` check before the `GRANDFATHER_CHECKED_KEY` cache check. Previously, a warm cache from a prior high-build check would short-circuit before the restore-granted path, permanently denying Pro to legitimate restore-granted users.
+
+**fix(paywall):** `loadOfferingsIfNeeded()`: now sets `error` state when `getPackages()` returns null (no active offering), instead of silently leaving packages null with no feedback.
+
+**fix(paywall):** `purchaseMonthly/Yearly/Lifetime()`: now clear `error` on the `cancelled` result path, preventing stale error messages from a prior failed attempt from persisting after a user dismisses the purchase sheet.
+
+**fix(paywall):** `onCustomerInfoUpdate()` callback: now `await`s `evaluateInterstitial()` instead of fire-and-forget, preventing interstitial state races on rapid entitlement updates.
+
+**PR:** TBD
+
 ### fix(paywall): sync Pro state on RevenueCat callbacks and account binds
 
 **What:** Five critical/high bugs in `proStore.ts` where the Pro/grandfathered state fell out of sync after RevenueCat operations — allowing free Pro via restore exploit, stale grandfather status, and ghost Pro after account unbind.

--- a/src/services/GrandfatherService.ts
+++ b/src/services/GrandfatherService.ts
@@ -49,13 +49,13 @@ export async function resolveGrandfatherStatus(
   const flag = await getStoredValue(GRANDFATHERED_KEY);
   if (flag === 'true') return { isGrandfathered: true, reason: 'flag' };
 
+  // Check restore-granted BEFORE the cache: a warm GRANDFATHER_CHECKED_KEY
+  // must not block a legitimate restore-granted user from getting Pro.
+  const restored = await getStoredValue(RESTORE_GRANTED_KEY);
+  if (restored === 'true') return { isGrandfathered: true, reason: 'restore-granted' };
+
   const checked = await getStoredValue(GRANDFATHER_CHECKED_KEY);
   if (checked === 'true') return { isGrandfathered: false, reason: 'checked' };
-
-  if (customerInfo === null) {
-    const restored = await getStoredValue(RESTORE_GRANTED_KEY);
-    if (restored === 'true') return { isGrandfathered: true, reason: 'restore-granted' };
-  }
 
   // iOS: originalApplicationVersion is CFBundleVersion at time of original purchase.
   // Only treat as build number if it is a pure integer to avoid bypass

--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -176,7 +176,7 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
             isGrandfathered: grandfather.isGrandfathered,
             status: DEV_FORCE_PRO ? 'pro' : (derived.entitlementActive || grandfather.isGrandfathered ? 'pro' : 'free'),
           }));
-          void evaluateInterstitial(derived.entitlementActive, set);
+          await evaluateInterstitial(derived.entitlementActive, set);
         });
       }
     } catch (error) {
@@ -227,6 +227,8 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
       await get().refresh();
     } else if (result.kind === 'error') {
       set({ error: result.message });
+    } else {
+      set({ error: null });
     }
   },
 
@@ -242,6 +244,8 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
       await get().refresh();
     } else if (result.kind === 'error') {
       set({ error: result.message });
+    } else {
+      set({ error: null });
     }
   },
 
@@ -257,6 +261,8 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
       await get().refresh();
     } else if (result.kind === 'error') {
       set({ error: result.message });
+    } else {
+      set({ error: null });
     }
   },
 
@@ -302,11 +308,15 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
     if (get().offeringsReady) return;
     try {
       const packages = await getPackages();
+      if (!packages) {
+        set({ offeringsReady: false, error: 'No offerings available from RevenueCat' });
+        return;
+      }
       set({
-        monthlyPackage: packages?.monthly ?? null,
-        yearlyPackage: packages?.yearly ?? null,
-        lifetimePackage: packages?.lifetime ?? null,
-        currentOffering: packages?.offerings?.current ?? null,
+        monthlyPackage: packages.monthly ?? null,
+        yearlyPackage: packages.yearly ?? null,
+        lifetimePackage: packages.lifetime ?? null,
+        currentOffering: packages.offerings?.current ?? null,
         offeringsReady: true,
         error: null,
       });


### PR DESCRIPTION
## What

Four bugs fixed in `GrandfatherService` and `proStore`.

### Bugs fixed

| # | Severity | Location | Bug |
|---|----------|----------|-----|
| CRITICAL | GrandfatherService.ts:48-58 | `RESTORE_GRANTED_KEY` check buried behind warm `GRANDFATHER_CHECKED_KEY` cache — restore-granted users permanently denied Pro |
| M1 | proStore.ts:301-318 | `loadOfferingsIfNeeded()` silently disappears with no feedback when `getPackages()` returns null |
| M2 | proStore.ts:244-261 | Cancelled purchases leave stale `error` message from a prior failed attempt |
| M3 | proStore.ts:179 | `evaluateInterstitial()` called fire-and-forget — races on rapid entitlement updates |

### Changes

- **`GrandfatherService.resolveGrandfatherStatus()`**: moved `RESTORE_GRANTED_KEY` check before the `GRANDFATHER_CHECKED_KEY` cache check. A warm cache from a prior high-build call now cannot short-circuit the restore-granted path.

- **`loadOfferingsIfNeeded()`**: now sets `error: 'No offerings available from RevenueCat'` when `getPackages()` returns null, giving users feedback instead of a silent empty state.

- **`purchaseMonthly/Yearly/Lifetime()`**: added `else { set({ error: null }) }` on the `cancelled` result path to clear any stale error from a prior failed purchase.

- **`onCustomerInfoUpdate()`**: changed `void evaluateInterstitial(...)` to `await evaluateInterstitial(...)` to prevent race conditions when entitlement updates fire in rapid succession.

## Testing

- `yarn ts:check` passes (TypeScript clean)
- `yarn eslint src/stores/proStore.ts src/services/GrandfatherService.ts` passes (0 errors)

## PRs referenced

- #1447 — iOS grandfathering cache race condition (`GrandfatherService`)
- #1448 — proStore state sync fixes (5 bugs)