### PR TITLE
docs: update pricing in paywall wiki

### DIFF
--- a/docs/wiki/paywall.md
+++ b/docs/wiki/paywall.md
@@ -66,9 +66,9 @@ Three subscription packages are offered:
 
 ```typescript
 interface Packages {
-  monthly: PurchasesPackage;    // $4.99/month
+  monthly: PurchasesPackage;    // $3.99/month
   yearly?: PurchasesPackage;   // $29.99/year (optional)
-  lifetime?: PurchasesPackage;  // $79.99 one-time (optional)
+  lifetime?: PurchasesPackage;  // $39.99 one-time (optional)
   offerings: PurchasesOfferings;
 }
 ```


### PR DESCRIPTION
Update pricing documentation:
- Monthly: $4.99 → $3.99
- Lifetime: $79.99 → $39.99