### PR TITLE
fix: remove -force_load xcconfig causing absolute path error

### DIFF
--- a/modules/GitEngine/ios-local/GitEngine.podspec
+++ b/modules/GitEngine/ios-local/GitEngine.podspec
@@ -11,13 +11,8 @@ Pod::Spec.new do |s|
   # Expo native module + UniFFI generated Swift FFI + FFI headers
   s.source_files = '*.swift', 'generated/*.swift', 'generated/GitNotesGit2FFI/**/*'
 
-  # Rust staticlib - force_load ensures all symbols are extracted
+  # Rust staticlib (vendored)
   s.vendored_libraries = 'rust/*.a'
-
-  # Force load the vendored library to extract all symbols (needed for UniFFI FFI)
-  s.xcconfig = {
-    'OTHER_LDFLAGS' => '$(inherited) -force_load $(PODS_TARGET_SRCROOT)/rust/libgitnotes_git2.a'
-  }
 
   # System libraries needed by Rust git2
   s.libraries = 'iconv'


### PR DESCRIPTION
## Problem

EAS build fails with:


The  in the podspec's xcconfig causes Xcode to interpret  as an **absolute path input file** when  is empty/undefined in the aggregate target context.

## Fix

Remove the xcconfig  directive and rely on  alone. CocoaPods handles library linking correctly without the explicit force_load flag.

## Testing

Nonexistent flag: --no-cache
See more help with --help