### PR TITLE
fix(ai): personalize AI setting + repo auth + error handling

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/vidwadeseram/documents/github/gitnotes/gitnotes/node_modules

--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -24,6 +24,7 @@ export interface ActionExecutorResult {
   error?: string;
   requiresConfirmation: boolean;
   proposedChanges?: ProposedChange;
+  warning?: string;
 }
 
 type ActionMode = 'auto' | 'confirm';
@@ -204,7 +205,7 @@ async function enqueueNoteSync(
   noteId: string,
   repoPath: string,
   branch: string,
-): Promise<void> {
+): Promise<boolean> {
   try {
     await NoteSyncQueueService.enqueueNoteUpsert(
       {
@@ -218,8 +219,9 @@ async function enqueueNoteSync(
       },
       noteId,
     );
-  } catch (error) {
-    console.warn('[actionExecutor] enqueueNoteUpsert failed:', error);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -273,11 +275,17 @@ export async function executeToolCall(
         }
 
         if (repoPath) {
-          await enqueueNoteSync(input, created.id, repoPath, branch);
+          const synced = await enqueueNoteSync(input, created.id, repoPath, branch);
+          if (!synced) {
+            return {
+              success: true,
+              requiresConfirmation: false,
+              data: { noteId: created.id, title: created.title, format: created.format, repo: created.repo, synced: false },
+              warning: 'Note created locally but failed to sync to GitHub.',
+            };
+          }
         }
 
-        // Return a slim summary; the previous full-Note dump filled the
-        // chat with JSON, the bubble renders this as a tappable link.
         return buildSuccessResult({
           noteId: created.id,
           title: created.title,
@@ -324,7 +332,15 @@ export async function executeToolCall(
           return { success: false, requiresConfirmation: false, error: 'Failed to create questioner note.' };
         }
         if (repoPath) {
-          await enqueueNoteSync(input, created.id, repoPath, branch);
+          const synced = await enqueueNoteSync(input, created.id, repoPath, branch);
+          if (!synced) {
+            return {
+              success: true,
+              requiresConfirmation: false,
+              data: { noteId: created.id, title: created.title, format: created.format, repo: created.repo, synced: false, questionCount, tag: 'questioner' },
+              warning: 'Note created locally but failed to sync to GitHub.',
+            };
+          }
         }
 
         return buildSuccessResult({
@@ -394,6 +410,7 @@ export async function executeToolCall(
           return { success: false, requiresConfirmation: false, error: 'Failed to save the grading.' };
         }
 
+        let syncWarning: string | undefined;
         if (repoPath) {
           try {
             await NoteSyncQueueService.enqueueNoteUpsert(
@@ -409,16 +426,16 @@ export async function executeToolCall(
               },
               gradedNote.id,
             );
-          } catch (error) {
-            console.warn('[actionExecutor] grade_questioner_answers sync enqueue failed:', error);
+          } catch {
+            syncWarning = 'Grading saved locally but failed to sync to GitHub.';
           }
         }
 
-        return buildSuccessResult({
-          noteId,
-          graded: true,
-          gradingAppended: grading.trim().length,
-        });
+        const result = { noteId, graded: true, gradingAppended: grading.trim().length };
+        if (syncWarning) {
+          return { success: true, requiresConfirmation: false, data: result, warning: syncWarning };
+        }
+        return buildSuccessResult(result);
       }
 
       case 'find_notes': {
@@ -434,6 +451,10 @@ export async function executeToolCall(
           args.limit === undefined ? 20 : Math.max(1, Math.min(100, getNumberArg(args, 'limit')));
 
         const filtered = useNoteStore.getState().notes.filter((note) => {
+          // Scope search to chat repo context when set — prevents cross-repo data leakage
+          if (repoPath && note.repo !== repoPath) {
+            return false;
+          }
           if (
             query &&
             !(
@@ -597,7 +618,15 @@ export async function executeToolCall(
           return { success: false, requiresConfirmation: false, error: 'Failed to create summary note.' };
         }
         if (repoPath) {
-          await enqueueNoteSync(input, created.id, repoPath, branch);
+          const synced = await enqueueNoteSync(input, created.id, repoPath, branch);
+          if (!synced) {
+            return {
+              success: true,
+              requiresConfirmation: false,
+              data: { noteId: created.id, title: created.title, sourceCount: sources.length, synced: false },
+              warning: 'Note created locally but failed to sync to GitHub.',
+            };
+          }
         }
 
         return buildSuccessResult({
@@ -641,7 +670,15 @@ export async function executeToolCall(
           return { success: false, requiresConfirmation: false, error: 'Failed to create distilled note.' };
         }
         if (repoPath) {
-          await enqueueNoteSync(input, created.id, repoPath, branch);
+          const synced = await enqueueNoteSync(input, created.id, repoPath, branch);
+          if (!synced) {
+            return {
+              success: true,
+              requiresConfirmation: false,
+              data: { noteId: created.id, title: created.title, sourceIds, synced: false },
+              warning: 'Note created locally but failed to sync to GitHub.',
+            };
+          }
         }
 
         return buildSuccessResult({
@@ -685,6 +722,7 @@ export async function executeToolCall(
         }
 
         let linked = 0;
+        const syncFailed: string[] = [];
         for (const self of targets) {
           const siblings = targets.filter((note) => note.id !== self.id);
           const linkBlock =
@@ -709,17 +747,26 @@ export async function executeToolCall(
                 },
                 updated.id,
               );
-            } catch (error) {
-              console.warn('[actionExecutor] link_notes sync enqueue failed:', error);
+            } catch {
+              syncFailed.push(updated.title);
             }
           }
           linked += 1;
         }
 
-        return buildSuccessResult({
+        const result = {
           linked,
           noteIds: targets.map((note) => note.id),
-        });
+        };
+        if (syncFailed.length > 0) {
+          return {
+            success: true,
+            requiresConfirmation: false,
+            data: result,
+            warning: `Linked ${linked} notes, but ${syncFailed.length} failed to sync: ${syncFailed.join(', ')}`,
+          };
+        }
+        return buildSuccessResult(result);
       }
 
       case 'generate_daily_brief': {
@@ -752,7 +799,15 @@ export async function executeToolCall(
           return { success: false, requiresConfirmation: false, error: 'Failed to create daily brief.' };
         }
         if (repoPath) {
-          await enqueueNoteSync(input, created.id, repoPath, branch);
+          const synced = await enqueueNoteSync(input, created.id, repoPath, branch);
+          if (!synced) {
+            return {
+              success: true,
+              requiresConfirmation: false,
+              data: { noteId: created.id, date: today, synced: false },
+              warning: 'Note created locally but failed to sync to GitHub.',
+            };
+          }
         }
 
         return buildSuccessResult({
@@ -764,6 +819,14 @@ export async function executeToolCall(
 
       case 'edit_note': {
         const noteId = getStringArg(args, 'noteId');
+        const existing = useNoteStore.getState().getNoteById(noteId);
+        if (!existing) {
+          return { success: false, requiresConfirmation: false, error: `Note '${noteId}' not found.` };
+        }
+        if (repoPath && existing.repo !== repoPath) {
+          return { success: false, requiresConfirmation: false, error: `Note '${noteId}' not found.` };
+        }
+
         const input: NoteUpdateInput = {
           id: noteId,
           title: getOptionalStringArg(args, 'title'),
@@ -800,8 +863,13 @@ export async function executeToolCall(
               },
               result.id,
             );
-          } catch (error) {
-            console.warn('[actionExecutor] edit_note sync enqueue failed:', error);
+          } catch {
+            return {
+              success: true,
+              requiresConfirmation: false,
+              data: { noteId: result.id, title: result.title },
+              warning: 'Note updated locally but failed to sync to GitHub.',
+            };
           }
         }
 
@@ -810,6 +878,15 @@ export async function executeToolCall(
 
       case 'delete_note': {
         const noteId = getStringArg(args, 'noteId');
+        const note = useNoteStore.getState().getNoteById(noteId);
+
+        if (!note) {
+          return { success: false, requiresConfirmation: false, error: `Note '${noteId}' not found.` };
+        }
+        // Scope to chat repo context when set — prevents deleting notes from other repos
+        if (repoPath && note.repo !== repoPath) {
+          return { success: false, requiresConfirmation: false, error: `Note '${noteId}' not found.` };
+        }
 
         if (mode === 'confirm') {
           return buildConfirmationResult({
@@ -821,6 +898,9 @@ export async function executeToolCall(
         }
 
         const result = await useNoteStore.getState().deleteNote(noteId);
+        if (!result) {
+          return { success: false, requiresConfirmation: false, error: `Failed to delete note '${noteId}'.` };
+        }
         return buildSuccessResult(result);
       }
 
@@ -829,6 +909,10 @@ export async function executeToolCall(
         const matches = useNoteStore
           .getState()
           .notes.filter((note) => {
+            // Scope search to chat repo context when set — prevents cross-repo data leakage
+            if (repoPath && note.repo !== repoPath) {
+              return false;
+            }
             if (!query) {
               return true;
             }
@@ -850,6 +934,13 @@ export async function executeToolCall(
       case 'get_note': {
         const noteId = getStringArg(args, 'noteId');
         const note = useNoteStore.getState().getNoteById(noteId);
+        if (!note) {
+          return { success: false, requiresConfirmation: false, error: `Note '${noteId}' not found.` };
+        }
+        // Scope to chat repo context when set — prevents cross-repo data leakage
+        if (repoPath && note.repo !== repoPath) {
+          return { success: false, requiresConfirmation: false, error: `Note '${noteId}' not found.` };
+        }
         return buildSuccessResult(note);
       }
 

--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -308,6 +308,13 @@ export async function executeToolCall(
         const sourceList = sourceNotes.length
           ? `## Sources\n\n${sourceNotes.map((id) => `- ${id}`).join('\n')}\n\n`
           : '';
+        if (repoPath && sourceNotes.length > 0) {
+          const noteStore = useNoteStore.getState();
+          const sources = sourceNotes.map((id) => noteStore.getNoteById(id)).filter((f): f is Note => f !== undefined);
+          if (sources.some((s) => s.repo !== repoPath)) {
+            return { success: false, requiresConfirmation: false, error: 'One or more source notes are not in the current repo context.' };
+          }
+        }
         const marker = `<!-- sl-item-id: chat-gen-${Date.now()} -->\n`;
 
         const input: NoteCreateInput = {
@@ -366,6 +373,9 @@ export async function executeToolCall(
             requiresConfirmation: false,
             error: "Note doesn't have the 'questioner' tag required for grading.",
           };
+        }
+        if (repoPath && note.repo !== repoPath) {
+          return { success: false, requiresConfirmation: false, error: `Note '${noteId}' not found.` };
         }
 
         if (mode === 'confirm') {
@@ -518,6 +528,9 @@ export async function executeToolCall(
         const priorityRank: Record<TodoPriority, number> = { high: 0, medium: 1, low: 2 };
 
         const filtered = useTodoStore.getState().todos.filter((todo) => {
+          if (repoPath && todo.repo !== repoPath) {
+            return false;
+          }
           if (status === 'pending' && todo.completed) {
             return false;
           }
@@ -588,6 +601,9 @@ export async function executeToolCall(
         if (sources.length === 0) {
           return { success: false, requiresConfirmation: false, error: 'None of the source notes exist.' };
         }
+        if (repoPath && sources.some((s) => s.repo !== repoPath)) {
+          return { success: false, requiresConfirmation: false, error: 'One or more source notes are not in the current repo context.' };
+        }
 
         const title = getOptionalStringArg(args, 'outputTitle') ?? `Summary (${sources.length} notes)`;
         const tags = Array.from(new Set([...outputTags, 'summary']));
@@ -647,6 +663,14 @@ export async function executeToolCall(
         const userTags = getOptionalStringArrayArg(args, 'outputTags') ?? [];
         const tags = Array.from(new Set([...userTags, 'distilled']));
         const marker = `<!-- distilled-from: ${sourceIds.join(',')} -->\n`;
+
+        if (repoPath) {
+          const noteStore = useNoteStore.getState();
+          const sources = sourceIds.map((id) => noteStore.getNoteById(id)).filter((f): f is Note => f !== undefined);
+          if (sources.some((s) => s.repo !== repoPath)) {
+            return { success: false, requiresConfirmation: false, error: 'One or more source notes are not in the current repo context.' };
+          }
+        }
 
         const input: NoteCreateInput = {
           title,
@@ -711,6 +735,9 @@ export async function executeToolCall(
           .filter((found): found is Note => found !== undefined);
         if (targets.length < 2) {
           return { success: false, requiresConfirmation: false, error: 'At least 2 of the given noteIds must exist' };
+        }
+        if (repoPath && targets.some((t) => t.repo !== repoPath)) {
+          return { success: false, requiresConfirmation: false, error: 'One or more notes are not in the current repo context.' };
         }
 
         if (mode === 'confirm') {
@@ -951,6 +978,7 @@ export async function executeToolCall(
           priority: getOptionalTodoPriorityArg(args, 'priority'),
           tags: getOptionalStringArrayArg(args, 'tags'),
           reminderBeforeMinutes: getOptionalNumberArg(args, 'reminderBeforeMinutes'),
+          ...(repoPath ? { repo: repoPath, branch } : {}),
         };
 
         if (mode === 'confirm') {
@@ -967,6 +995,14 @@ export async function executeToolCall(
 
       case 'edit_todo': {
         const todoId = getStringArg(args, 'todoId');
+        const existing = useTodoStore.getState().todos.find((t) => t.id === todoId);
+        if (!existing) {
+          return { success: false, requiresConfirmation: false, error: `Todo '${todoId}' not found.` };
+        }
+        if (repoPath && existing.repo !== repoPath) {
+          return { success: false, requiresConfirmation: false, error: `Todo '${todoId}' not found.` };
+        }
+
         const input: TodoUpdateInput = {
           id: todoId,
           text: getOptionalStringArg(args, 'text'),
@@ -991,6 +1027,13 @@ export async function executeToolCall(
 
       case 'delete_todo': {
         const todoId = getStringArg(args, 'todoId');
+        const existing = useTodoStore.getState().todos.find((t) => t.id === todoId);
+        if (!existing) {
+          return { success: false, requiresConfirmation: false, error: `Todo '${todoId}' not found.` };
+        }
+        if (repoPath && existing.repo !== repoPath) {
+          return { success: false, requiresConfirmation: false, error: `Todo '${todoId}' not found.` };
+        }
 
         if (mode === 'confirm') {
           return buildConfirmationResult({
@@ -1011,6 +1054,9 @@ export async function executeToolCall(
         const matches = useTodoStore
           .getState()
           .todos.filter((todo) => {
+            if (repoPath && todo.repo !== repoPath) {
+              return false;
+            }
             if (!includeCompleted && todo.completed) {
               return false;
             }
@@ -1034,6 +1080,9 @@ export async function executeToolCall(
         }
 
         const todos = useTodoStore.getState().todos.filter((todo) => {
+          if (repoPath && todo.repo !== repoPath) {
+            return false;
+          }
           if (filter === 'pending') {
             return !todo.completed;
           }

--- a/src/services/ai/tools.ts
+++ b/src/services/ai/tools.ts
@@ -127,7 +127,7 @@ export const createQuestionerNoteParameters = z.object({
 
 export const create_questioner_note = tool({
   description:
-    "Create a quiz-style note with open questions on a topic for the user to answer. The result is automatically tagged 'questioner'; use grade_questioner_answers later to grade the user's answers.",
+    "Create a quiz-style note with open questions on a topic. Use when the user says things like 'make me a quiz', 'create a test', 'ask me questions about [topic]', 'generate a practice quiz', or 'I want to be tested on [topic]'. The result is automatically tagged 'questioner'; use grade_questioner_answers later to grade the user's answers.",
   inputSchema: createQuestionerNoteParameters,
   execute: async (params) => params,
 });
@@ -138,7 +138,7 @@ export const gradeQuestionerNoteParameters = z.object({
 
 export const grade_questioner_answers = tool({
   description:
-    "Grade a questioner note with the currently selected AI model — strips any previous grading section and appends a fresh '## Grading & Corrections' block. The note must carry the 'questioner' tag.",
+    "Grade or check a completed quiz. Use when the user says things like 'grade my answers', 'check my quiz', 'review my responses', 'how did I do', 'grade this test', or 'evaluate my answers to the quiz'. The note must carry the 'questioner' tag. If the user hasn't specified a note, first use find_notes with tag='questioner' to locate the most recent quiz.",
   inputSchema: gradeQuestionerNoteParameters,
   execute: async (params) => params,
 });


### PR DESCRIPTION
## Summary

AI security and privacy fixes — two related branches merged conceptually:

### Branch 1: `fix/personalize-ai-setting`
**Fixes the "Personalize AI with my notes" setting** that was being ignored.

- `useChatScreenController.ts`: `memoryBlock` (thought dump RAG enrichment) now gated behind `aiPersonalizationEnabled` check — when OFF, no thought dumps injected into AI context

### Branch 2: `fix/ai-security-p0`
**Universal repo authorization + error handling + sync warnings.**

#### Repo Authorization (cross-repo data leakage prevention)
All AI tools now scope to the chat's repo context when set:

**Notes:** `find_notes`, `search_notes`, `get_note`, `edit_note`, `delete_note`

**Todos:** `find_todos`, `search_todos`, `get_todos`, `edit_todo`, `delete_todo`, `create_todo`

**Note-adjacent tools** that reference other notes: `summarize_notes`, `distill_thought_dump`, `create_questioner_note`, `grade_questioner_answers`, `link_notes` — all validate source notes belong to current repo before operating.

#### Error Handling
- `get_note`: Returns proper error instead of `null` when not found
- `delete_note`: Validates `deleteNote()` result before reporting success
- `edit_todo`, `delete_todo`: Pre-existence + repo checks before modify

#### Sync Failure Surfacing
8 tools now surface GitHub sync failures to users instead of silent `console.warn`:
`create_note`, `create_questioner_note`, `summarize_notes`, `distill_thought_dump`, `generate_daily_brief`, `edit_note`, `link_notes`, `grade_questioner_answers`

#### Tool Description Improvements
- `create_questioner_note`: Trigger phrases added ("make me a quiz", "create a test", etc.)
- `grade_questioner_answers`: Trigger phrases added ("grade my answers", "check my quiz", etc.)

## Files Changed
- `src/services/ai/actionExecutor.ts` — +165/-25 lines
- `src/services/ai/tools.ts` — +2 lines  
- `src/components/chat/useChatScreenController.ts` — +4/-1 lines

## Testing
- ✅ TypeScript clean
- ✅ ESLint clean (1 pre-existing warning)
- ✅ All AI tools now properly scoped to repo context