### PR TITLE
fix: prevent AI-created notes from bypassing git staging flow

### DIFF
--- a/modules/GitEngine/plugin/withGitEngineRust.js
+++ b/modules/GitEngine/plugin/withGitEngineRust.js
@@ -57,7 +57,9 @@ function withGitEngineRust(config) {
       return modConfig;
     }
 
-    const shellScript = ['set -e', '"$PROJECT_DIR/../scripts/build-rust.sh" --xcode', ''].join('\n');
+    const shellScript = ['set -e', '"$PROJECT_DIR/../scripts/build-rust.sh" --xcode', ''].join(
+      '\n',
+    );
 
     const { uuid } = project.addBuildPhase([], 'PBXShellScriptBuildPhase', PHASE_NAME, targetUuid, {
       inputPaths: [],
@@ -79,10 +81,10 @@ function withGitEngineRust(config) {
     for (const buildConfig of buildConfigs) {
       const settings = buildConfig.buildSettings;
       if (!settings) continue;
-        if (!settings.OTHER_LDFLAGS || !settings.OTHER_LDFLAGS.includes('libgitnotes_git2.a')) {
-          settings.OTHER_LDFLAGS =
-            '$(inherited) $(PROJECT_DIR)/modules/GitEngine/ios-local/rust/libgitnotes_git2.a';
-        }
+      if (!settings.OTHER_LDFLAGS || !settings.OTHER_LDFLAGS.includes('libgitnotes_git2.a')) {
+        settings.OTHER_LDFLAGS =
+          '$(inherited) $(PROJECT_DIR)/modules/GitEngine/ios-local/rust/libgitnotes_git2.a';
+      }
     }
 
     return modConfig;

--- a/src/models/Note.ts
+++ b/src/models/Note.ts
@@ -62,6 +62,8 @@ export interface NoteCreateInput {
   format?: NoteFormat;
   attachments?: Attachment[];
   accountId?: string;
+  /** When true, skip the immediate clone-mode commit so the note goes through normal sync flow. */
+  isAiCreated?: boolean;
 }
 
 export interface NoteUpdateInput {

--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -241,10 +241,7 @@ export async function executeToolCall(
           content: getStringArg(args, 'content'),
           tags: getOptionalStringArrayArg(args, 'tags'),
           format: getOptionalNoteFormatArg(args, 'format'),
-          // Attach chat-thread repo so the note shows up under the same
-          // repo in the notes list and gets pushed by the sync queue.
-          // Without this, AI-created notes were local-only and never
-          // synced to other sessions until a manual push.
+          isAiCreated: true,
           ...(repoPath ? { repo: repoPath, branch } : {}),
         };
 
@@ -296,6 +293,7 @@ export async function executeToolCall(
           content: `${marker}${sourceList}${content}`,
           tags,
           format: format ?? 'markdown',
+          isAiCreated: true,
           ...(repoPath ? { repo: repoPath, branch } : {}),
         };
 
@@ -568,6 +566,7 @@ export async function executeToolCall(
           content: `${marker}${sourceListMd}${content}`,
           tags,
           format: format ?? 'markdown',
+          isAiCreated: true,
           ...(repoPath ? { repo: repoPath, branch } : {}),
         };
 
@@ -611,6 +610,7 @@ export async function executeToolCall(
           content: `${marker}${content}`,
           tags,
           format: 'markdown',
+          isAiCreated: true,
           ...(repoPath ? { repo: repoPath, branch } : {}),
         };
 
@@ -721,6 +721,7 @@ export async function executeToolCall(
           content: `${marker}${content}`,
           tags,
           format: 'markdown',
+          isAiCreated: true,
           ...(repoPath ? { repo: repoPath, branch } : {}),
         };
 

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -101,43 +101,55 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
     try {
       set({ error: null });
 
-      // Derive filePath for clone-mode commit (same logic as deriveDefaultNotePath
-      // but computed from input fields since the Note object doesn't exist yet)
       const title = (input.title ?? '').trim();
       const slug = title ? slugifyLocal(title) : `note-${Date.now()}`;
       const ext = getExtensionForFormat(input.format ?? 'markdown');
       const folderPath = input.folderPath ?? resolveDefaultFolder('note');
       const filePath = `${folderPath}/${slug}${ext}`;
 
-      // Clone mode: commit the new note to git BEFORE saving to storage.
       const mode = await SyncEngineService.getMode(repo);
       if (mode === 'clone') {
-        const opId = gitOperationRegistry.begin({
-          kind: 'upsert',
-          repo,
-          branch: input.branch ?? 'main',
-          path: filePath,
-          entityIds: [],
-          status: 'running',
-          attempts: 0,
-        });
-        try {
-          const commitResult = await CommitService.commit({
-            repo,
+        if (input.isAiCreated) {
+          const saveResult = await CloneSyncService.save({
+            repoPath: repo,
             branch: input.branch ?? 'main',
             filePath,
             content: input.content ?? '',
             message: `Create note: ${title || filePath}`,
+            intent: 'upsert',
           });
-          if (!commitResult.success) {
-            gitOperationRegistry.fail(opId, commitResult.error ?? 'Failed to create note');
-            set({ error: commitResult.error ?? 'Failed to create note' });
+          if (!saveResult.success) {
+            set({ error: saveResult.error ?? 'Failed to write note to disk' });
             return null;
           }
-          gitOperationRegistry.succeed(opId);
-        } catch (commitError) {
-          gitOperationRegistry.fail(opId, commitError instanceof Error ? commitError.message : 'Commit failed');
-          throw commitError;
+        } else {
+          const opId = gitOperationRegistry.begin({
+            kind: 'upsert',
+            repo,
+            branch: input.branch ?? 'main',
+            path: filePath,
+            entityIds: [],
+            status: 'running',
+            attempts: 0,
+          });
+          try {
+            const commitResult = await CommitService.commit({
+              repo,
+              branch: input.branch ?? 'main',
+              filePath,
+              content: input.content ?? '',
+              message: `Create note: ${title || filePath}`,
+            });
+            if (!commitResult.success) {
+              gitOperationRegistry.fail(opId, commitResult.error ?? 'Failed to create note');
+              set({ error: commitResult.error ?? 'Failed to create note' });
+              return null;
+            }
+            gitOperationRegistry.succeed(opId);
+          } catch (commitError) {
+            gitOperationRegistry.fail(opId, commitError instanceof Error ? commitError.message : 'Commit failed');
+            throw commitError;
+          }
         }
       }
 


### PR DESCRIPTION
## Problem

When AI builds a note, it gets staged (committed) immediately without appearing in 'changes' for user staging - bypassing the normal git staging flow.

## Root Cause

In `noteStore.createNote()`, when in clone mode, notes were immediately committed via `CommitService.commit()`. This happened for both user-created and AI-created notes, but AI notes should follow the same flow as user notes (written to disk but not committed until the sync triggers push).

## Fix

- **`src/models/Note.ts`**: Added `isAiCreated?: boolean` to `NoteCreateInput` interface
- **`src/stores/noteStore.ts`**: Modified `createNote()` to check `input.isAiCreated`. When true, uses `CloneSyncService.save()` (writes to disk without committing) instead of `CommitService.commit()` (writes AND commits immediately)
- **`src/services/ai/actionExecutor.ts`**: Added `isAiCreated: true` to all AI note creation tools: `create_note`, `create_questioner_note`, `summarize_notes`, `distill_thought_dump`, `generate_daily_brief`

## Behavior Change

| Note Type | Before | After |
|-----------|--------|-------|
| User-created (editor) | File written + committed | File written + committed (unchanged) |
| AI-created | File written + committed immediately | File written (committed via sync triggers) |

AI-created notes now follow the same sync flow as user-created notes - they appear in 'changes' and are pushed via the normal CloneSyncService triggers (foreground-active, online-transition, idle timer, background task).