### PR TITLE
fix: address UI overlap issues on small Android screens (Redmi Note 10 class)

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, TouchableOpacity, Text, StyleSheet, Platform } from 'react-native';
+import { View, TouchableOpacity, Text, StyleSheet, Platform, useWindowDimensions } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
 import { Modal } from './ui';
@@ -40,6 +40,7 @@ export default function ContextMenu({
   bottomSheet,
 }: ContextMenuProps) {
   const { colors } = useTheme();
+  const { width: viewportWidth } = useWindowDimensions();
   const groups: ContextMenuSection[] = sections ?? (items ? [{ items }] : []);
 
   return (
@@ -47,7 +48,7 @@ export default function ContextMenu({
       visible={visible}
       onRequestClose={onClose}
       bottomSheet={bottomSheet}
-      contentStyle={{ padding: 0, overflow: 'hidden', minWidth: 280 }}
+      contentStyle={{ padding: 0, overflow: 'hidden', minWidth: Math.min(280, viewportWidth * 0.85) }}
     >
       {(title || subtitle) ? (
         <View style={[styles.header, { borderBottomColor: colors.border }]}>

--- a/src/components/ai/ChatMessageBubble.tsx
+++ b/src/components/ai/ChatMessageBubble.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
-import { View, Text, Platform, Pressable, useColorScheme } from 'react-native';
+import { View, Text, Platform, Pressable, useColorScheme, useWindowDimensions } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { ChatMessage } from '../../models/Chat';
@@ -57,6 +57,7 @@ function ChatMessageBubbleImpl({ message, isStreaming, onLongPress }: ChatMessag
   const { colors, spacing, type } = useTokens();
   const { isDark } = useTheme();
   const colorScheme = useColorScheme();
+  const { width: viewportWidth } = useWindowDimensions();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const [thoughtExpanded, setThoughtExpanded] = useState(false);
@@ -153,7 +154,7 @@ function ChatMessageBubbleImpl({ message, isStreaming, onLongPress }: ChatMessag
     alignSelf: isUser ? 'flex-end' : 'flex-start',
     maxWidth: '85%',
     marginVertical: spacing[1],
-    ...(!isUser && message.toolCallName ? { minWidth: 220 } : null),
+    ...(!isUser && message.toolCallName ? { minWidth: Math.min(220, viewportWidth * 0.5) } : null),
   };
 
   const surfaceBg = isDark ? '#2c2c2e' : '#f0f0f0';

--- a/src/components/editor/EditorHeader.tsx
+++ b/src/components/editor/EditorHeader.tsx
@@ -56,7 +56,8 @@ const styles = StyleSheet.create({
   headerLeft: {
     flexDirection: 'row',
     alignItems: 'center',
-    minWidth: 80,
+    minWidth: 0,
+    flexShrink: 1,
   },
   headerButtonText: {
     fontSize: 16,
@@ -68,7 +69,8 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   headerRight: {
-    minWidth: 80,
+    minWidth: 0,
+    flexShrink: 1,
     alignItems: 'flex-end',
   },
   saveButtonText: {

--- a/src/components/git/useFloatingGitButtonPosition.ts
+++ b/src/components/git/useFloatingGitButtonPosition.ts
@@ -12,7 +12,7 @@ import {
   type FloatingButtonPosition,
 } from './floatingGitButtonGeometry';
 
-const EDGE_INSET = 16;
+const EDGE_INSET = 24;
 const MINIMUM_TOP_BOUND = 60;
 const MINIMUM_BOTTOM_CLEARANCE = 100;
 const STORAGE_KEY = 'git-button-position';

--- a/src/components/home/BentoTile.tsx
+++ b/src/components/home/BentoTile.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import type { LayoutChangeEvent } from 'react-native';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import type { TextLayoutEvent } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -139,6 +140,22 @@ export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hid
   const isPinned = size === 'pinned';
   const isCanvas = item.kind === 'canvas';
   const [titleLines, setTitleLines] = useState(1);
+  const [measuredWidth, setMeasuredWidth] = useState<number | null>(null);
+  const [hasMeasured, setHasMeasured] = useState(false);
+
+  const handleLayout = useCallback((e: LayoutChangeEvent) => {
+    const w = e.nativeEvent.layout.width;
+    setMeasuredWidth(w);
+    setHasMeasured(true);
+  }, []);
+
+  // Hide badges until we've measured: on first render badges would flash-visible
+  // then disappear on narrow tiles. Once measured, hide if width < 170.
+  const hideBadges = hasMeasured && measuredWidth !== null && measuredWidth < 170;
+
+  // Pin size/inset is smaller on medium/small tiles to reduce overlap
+  const pinSize = isMedium || size === 'small' ? 18 : 22;
+  const pinRight = isMedium || size === 'small' ? 6 : 8;
   const handleTitleLayout = useCallback(
     (e: TextLayoutEvent) => {
       const lines = e.nativeEvent.lines.length;
@@ -168,6 +185,7 @@ export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hid
         testID={`bento-tile.button.press-${testIDSlot}`}
         onPress={onPress}
         onLongPress={onLongPress}
+        onLayout={handleLayout}
         style={({ pressed }) => [
           styles.tile,
           {
@@ -221,6 +239,7 @@ export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hid
         testID={`bento-tile.button.press-${testIDSlot}`}
         onPress={onPress}
         onLongPress={onLongPress}
+        onLayout={handleLayout}
         style={({ pressed }) => [
           styles.tile,
           {
@@ -241,14 +260,16 @@ export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hid
         <View style={[styles.badge, { backgroundColor: accent + '1F' }]}>
           <Ionicons name={iconFor(item.kind)} size={ICON_SIZE[size]} color={accent} />
         </View>
-        {showPinGlyph ? (
-          <View style={[styles.pin, { backgroundColor: colors.background }]}>
+        {showPinGlyph && !hideBadges ? (
+          <View style={[styles.pin, { backgroundColor: colors.background, width: pinSize, height: pinSize, right: pinRight }]}>
             <Ionicons name="pin" size={11} color={accent} />
           </View>
         ) : null}
-        <View style={[styles.formatChip, { backgroundColor: accent + '20' }]}>
-          <Text style={[styles.formatChipText, { color: accent }]}>PDF</Text>
-        </View>
+        {!hideBadges ? (
+          <View style={[styles.formatChip, { backgroundColor: accent + '20' }]}>
+            <Text style={[styles.formatChipText, { color: accent }]}>PDF</Text>
+          </View>
+        ) : null}
         <View style={styles.body}>
           <Text style={[styles.title, { color: colors.text, fontSize: TITLE_SIZE[size], lineHeight: Math.round(TITLE_SIZE[size] * 1.3) }]} numberOfLines={isLarge ? 2 : 1}>
             {titleFor(item)}
@@ -283,6 +304,7 @@ export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hid
       testID={`bento-tile.button.press-${testIDSlot}`}
       onPress={onPress}
       onLongPress={onLongPress}
+      onLayout={handleLayout}
       style={({ pressed }) => [
         styles.tile,
         {
@@ -303,12 +325,12 @@ export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hid
       <View style={[styles.badge, { backgroundColor: accent + '1F' }]}>
         <Ionicons name={iconFor(item.kind)} size={ICON_SIZE[size]} color={accent} />
       </View>
-      {showPinGlyph ? (
-        <View style={[styles.pin, { backgroundColor: colors.background }]}>
+      {showPinGlyph && !hideBadges ? (
+        <View style={[styles.pin, { backgroundColor: colors.background, width: pinSize, height: pinSize, right: pinRight }]}>
           <Ionicons name="pin" size={11} color={accent} />
         </View>
       ) : null}
-      {formatChip ? (
+      {!hideBadges ? (
         <View style={[styles.formatChip, { backgroundColor: accent + '20' }]}>
           <Text style={[styles.formatChipText, { color: accent }]}>{formatChip}</Text>
         </View>
@@ -399,7 +421,7 @@ const styles = StyleSheet.create({
   },
   body: {
     flexShrink: 1,
-    minHeight: 0,
+    minHeight: 24,
     marginTop: 10,
   },
   title: {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -308,9 +308,11 @@ export default function HomeScreen() {
             <View className="absolute top-4 left-4 w-9 h-9 rounded-full bg-white items-center justify-center">
               <Ionicons name="document-text" size={18} color={colors.primary} />
             </View>
+            {isTablet && (
             <View className="absolute" style={{ top: -50, right: -50, opacity: 0.3 }}>
               <Ionicons name="document-text" size={120} color="#FFFFFF" />
             </View>
+            )}
             <View className="gap-1">
               <Text className="text-xl font-bold text-white" style={{ letterSpacing: -0.3 }}>{t('notes.newNote')}</Text>
               <Text className="text-xs font-medium text-white opacity-80">{t('home.bento.blankNote')}</Text>
@@ -327,9 +329,11 @@ export default function HomeScreen() {
             <View className="absolute top-4 left-4 w-9 h-9 rounded-full bg-white items-center justify-center">
               <Ionicons name="journal-outline" size={18} color={colors.primary} />
             </View>
+            {isTablet && (
             <View className="absolute" style={{ top: -50, right: -50, opacity: 0.3 }}>
               <Ionicons name="journal-outline" size={120} color="#FFFFFF" />
             </View>
+            )}
             <View className="gap-1">
               <Text className="text-xl font-bold text-white" style={{ letterSpacing: -0.3 }} numberOfLines={1}>
                 {hasTodaysJournal ? t('home.bento.todaysJournal') : t('home.bento.newJournal')}


### PR DESCRIPTION
## What
Fix UI overlap, padding, and clipping issues on small-screen / tall-narrow Android devices (Redmi Note 10 class) by making fixed-dimension components responsive to viewport width.

## Changes

### FloatingGitButton badge clipping (Corner overflow)
- `useFloatingGitButtonPosition.ts`: increase `EDGE_INSET` from 16 to 24 — pushes button further from right edge so badge never clips at corners

### BentoTile badge overlap (Narrow tile text overlap)
- `BentoTile.tsx`: 
  - Add `onLayout` width measurement; hide `pin` and `formatChip` badges on tiles narrower than 170px
  - Reduce `pin` size from 22×22 to 18×18 on `medium`/`small` tiles
  - Add `minHeight: 24` to `.body` style for breathing room

### HomeScreen decorative icons (Clipped tile decorations)
- `HomeScreen.tsx`: wrap the two decorative `{ top: -50, right: -50, size: 120 }` icons with `{ isTablet && ... }` — only render on tablet

### ContextMenu overflow (Narrow screen modal)
- `ContextMenu.tsx`: `minWidth: 280` → `minWidth: Math.min(280, viewportWidth * 0.85)`

### ChatMessageBubble overflow (Narrow screen bubbles)
- `ChatMessageBubble.tsx`: `minWidth: 220` for tool-call bubbles → `Math.min(220, viewportWidth * 0.5)`

### EditorHeader squeeze (Narrow screen header)
- `EditorHeader.tsx`: replace `minWidth: 80` with `minWidth: 0, flexShrink: 1` on `headerLeft` and `headerRight` — side sections now shrink naturally before title is squeezed

## Testing
- TypeScript: `yarn ts:check` ✅
- ESLint: 0 errors ✅
- All changes scoped to the 6 specific component files — no architecture changes