### PR TITLE
feat(ai): add reminder tools for create/list/cancel reminders

### DIFF
--- a/modules/GitEngine/plugin/withGitEngineRust.js
+++ b/modules/GitEngine/plugin/withGitEngineRust.js
@@ -57,7 +57,9 @@ function withGitEngineRust(config) {
       return modConfig;
     }
 
-    const shellScript = ['set -e', '"$PROJECT_DIR/../scripts/build-rust.sh" --xcode', ''].join('\n');
+    const shellScript = ['set -e', '"$PROJECT_DIR/../scripts/build-rust.sh" --xcode', ''].join(
+      '\n',
+    );
 
     const { uuid } = project.addBuildPhase([], 'PBXShellScriptBuildPhase', PHASE_NAME, targetUuid, {
       inputPaths: [],
@@ -79,10 +81,10 @@ function withGitEngineRust(config) {
     for (const buildConfig of buildConfigs) {
       const settings = buildConfig.buildSettings;
       if (!settings) continue;
-        if (!settings.OTHER_LDFLAGS || !settings.OTHER_LDFLAGS.includes('libgitnotes_git2.a')) {
-          settings.OTHER_LDFLAGS =
-            '$(inherited) $(PROJECT_DIR)/modules/GitEngine/ios-local/rust/libgitnotes_git2.a';
-        }
+      if (!settings.OTHER_LDFLAGS || !settings.OTHER_LDFLAGS.includes('libgitnotes_git2.a')) {
+        settings.OTHER_LDFLAGS =
+          '$(inherited) $(PROJECT_DIR)/modules/GitEngine/ios-local/rust/libgitnotes_git2.a';
+      }
     }
 
     return modConfig;

--- a/src/services/ai/actionExecutor.ts
+++ b/src/services/ai/actionExecutor.ts
@@ -3,6 +3,9 @@ import { Note, NoteCreateInput, NoteFormat, NoteUpdateInput } from '../../models
 import { TodoCreateInput, TodoPriority, TodoUpdateInput } from '../../models/Todo';
 import { useNoteStore } from '../../stores/noteStore';
 import { useTodoStore } from '../../stores/todoStore';
+import { useReminderStore } from '../../stores/reminderStore';
+import { ReminderService } from '../ReminderService';
+import { formatReminderSchedule } from '../../models/Reminder';
 import { useAIStore } from '../../stores/aiStore';
 import { initializeModel } from '../AIService';
 import { GITHUB_ITEM_STATES, GitHubItemState, GitHubService } from '../GitHubService';
@@ -76,6 +79,17 @@ function getOptionalBooleanArg(args: Record<string, unknown>, key: string): bool
     return undefined;
   }
   if (typeof value !== 'boolean') {
+    throw new Error(`Invalid '${key}'`);
+  }
+  return value;
+}
+
+function getOptionalNumberArg(args: Record<string, unknown>, key: string): number | undefined {
+  const value = args[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
     throw new Error(`Invalid '${key}'`);
   }
   return value;
@@ -844,6 +858,7 @@ export async function executeToolCall(
           dueDate: getOptionalDueDateArg(args, 'dueDate'),
           priority: getOptionalTodoPriorityArg(args, 'priority'),
           tags: getOptionalStringArrayArg(args, 'tags'),
+          reminderBeforeMinutes: getOptionalNumberArg(args, 'reminderBeforeMinutes'),
         };
 
         if (mode === 'confirm') {
@@ -866,6 +881,7 @@ export async function executeToolCall(
           completed: getOptionalBooleanArg(args, 'completed'),
           dueDate: getOptionalDueDateArg(args, 'dueDate'),
           priority: getOptionalTodoPriorityArg(args, 'priority'),
+          reminderBeforeMinutes: getOptionalNumberArg(args, 'reminderBeforeMinutes'),
         };
 
         if (mode === 'confirm') {
@@ -1074,6 +1090,106 @@ export async function executeToolCall(
           return { success: false, requiresConfirmation: false, error: 'Failed to post review.' };
         }
         return buildSuccessResult({ id: review.id, state: review.state, html_url: review.html_url });
+      }
+
+      case 'create_reminder': {
+        const entityType = getStringArg(args, 'entityType') as 'note' | 'folder' | 'repo' | 'tag';
+        const noteId = getOptionalStringArg(args, 'noteId');
+        const repoPath = getOptionalStringArg(args, 'repoPath');
+        const folderPath = getOptionalStringArg(args, 'folderPath');
+        const tag = getOptionalStringArg(args, 'tag');
+        const entityLabel = getStringArg(args, 'entityLabel');
+        const time = getStringArg(args, 'time');
+        const repeat = getOptionalStringArg(args, 'repeat') as 'daily' | 'weekly' | 'one-time' | undefined;
+        const daysOfWeek = getOptionalStringArrayArg(args, 'daysOfWeek') as ('monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday')[] | undefined;
+
+        if (mode === 'confirm') {
+          return buildConfirmationResult({
+            type: 'create_reminder',
+            description: `Create ${repeat ?? 'weekly'} reminder for ${entityLabel}`,
+            details: { entityType, entityLabel, time, repeat, daysOfWeek },
+          });
+        }
+
+        const created = await useReminderStore.getState().createItem({
+          entityType,
+          noteId,
+          repoPath,
+          folderPath,
+          tag,
+          entityLabel,
+          time,
+          repeat,
+          daysOfWeek,
+        });
+
+        if (!created) {
+          return { success: false, requiresConfirmation: false, error: 'Failed to create reminder.' };
+        }
+
+        await ReminderService.scheduleNotification(created);
+
+        return buildSuccessResult({
+          reminderId: created.id,
+          entityLabel: created.entityLabel,
+          schedule: formatReminderSchedule(created),
+        });
+      }
+
+      case 'list_reminders': {
+        const items = useReminderStore.getState().items;
+        return buildSuccessResult({
+          reminders: items.map((item) => ({
+            id: item.id,
+            entityLabel: item.entityLabel,
+            entityType: item.entityType,
+            schedule: formatReminderSchedule(item),
+            isEnabled: item.isEnabled,
+          })),
+          total: items.length,
+        });
+      }
+
+      case 'cancel_reminder': {
+        const reminderId = getOptionalStringArg(args, 'reminderId');
+        let targetId = reminderId;
+
+        if (!targetId) {
+          const entityType = getOptionalStringArg(args, 'entityType');
+          if (!entityType) {
+            return { success: false, requiresConfirmation: false, error: 'Must provide reminderId or entityType for content matching.' };
+          }
+
+          const items = useReminderStore.getState().items;
+          const match = items.find((item) => {
+            if (item.entityType !== entityType) return false;
+            switch (entityType) {
+              case 'note':
+                return item.noteId === getOptionalStringArg(args, 'noteId');
+              case 'folder':
+                return item.folderPath === getOptionalStringArg(args, 'folderPath') && item.repoPath === getOptionalStringArg(args, 'repoPath');
+              case 'repo':
+                return item.repoPath === getOptionalStringArg(args, 'repoPath');
+              case 'tag':
+                return item.tag === getOptionalStringArg(args, 'tag');
+              default:
+                return false;
+            }
+          });
+
+          if (!match) {
+            return { success: false, requiresConfirmation: false, error: `No reminder found for ${entityType}.` };
+          }
+          targetId = match.id;
+        }
+
+        const item = useReminderStore.getState().getItem(targetId!);
+        if (item) {
+          await ReminderService.cancelNotification(item);
+        }
+
+        await useReminderStore.getState().deleteItem(targetId!);
+        return buildSuccessResult({ reminderId: targetId, cancelled: true });
       }
 
       default:

--- a/src/services/ai/systemPrompt.ts
+++ b/src/services/ai/systemPrompt.ts
@@ -53,5 +53,16 @@ Use these tools when the user asks about their repos, issues, PRs, or reviews. A
     `Current state: The user has ${context.noteCount} notes and ${context.todoCount} todos.`
   );
 
+  sections.push(
+    `=== Reminder Tools ===
+You have access to reminder tools:
+- create_reminder: Set a reminder to revisit a note, folder, repo, or tagged notes at a specific time (HH:MM, 24-hour). Supports daily, weekly, or one-time schedules.
+- list_reminders: View all reminders with their schedules and entity labels.
+- cancel_reminder: Remove a reminder by ID or by matching the entity it points to.
+
+PROACTIVE SUGGESTIONS: After creating study, review, or quiz content (notes with tags like 'study', 'review', 'quiz', 'flashcards', or 'questioner'), proactively suggest setting a reminder. Say something like: "I created a quiz on [topic]. Would you like me to set a weekly reminder to review it?" — NEVER auto-create without user confirmation.
+=== End Reminder Tools ===`
+  );
+
   return sections.join('\n\n');
 }

--- a/src/services/ai/tools.ts
+++ b/src/services/ai/tools.ts
@@ -62,6 +62,7 @@ export const createTodoParameters = z.object({
   dueDate: z.string().optional(),
   priority: z.enum(['low', 'medium', 'high']).optional(),
   tags: z.array(z.string()).optional(),
+  reminderBeforeMinutes: z.number().optional(),
 });
 
 export const create_todo = tool({
@@ -76,6 +77,7 @@ export const editTodoParameters = z.object({
   completed: z.boolean().optional(),
   dueDate: z.string().optional(),
   priority: z.enum(['low', 'medium', 'high']).optional(),
+  reminderBeforeMinutes: z.number().optional(),
 });
 
 export const edit_todo = tool({
@@ -224,6 +226,65 @@ export const generate_daily_brief = tool({
   execute: async (params) => params,
 });
 
+export const createReminderParameters = z.object({
+  entityType: z.enum(['note', 'folder', 'repo', 'tag']),
+  noteId: z.string().optional(),
+  repoPath: z.string().optional(),
+  folderPath: z.string().optional(),
+  tag: z.string().optional(),
+  entityLabel: z.string(),
+  time: z.string().regex(/^\d{1,2}:\d{2}$/, 'HH:MM in 24-hour format'),
+  repeat: z.enum(['daily', 'weekly', 'one-time']).optional().default('weekly'),
+  daysOfWeek: z
+    .array(z.enum(['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']))
+    .optional(),
+});
+
+export const create_reminder = tool({
+  description: `Create a reminder to revisit a note, folder, repo, or tagged notes at a specific time.
+    - entityType selects what is being reminded: 'note', 'folder', 'repo', or 'tag'
+    - For notes: pass noteId + entityLabel (AI should infer noteId from the conversation context)
+    - For folders: pass repoPath + folderPath + entityLabel
+    - For repos: pass repoPath + entityLabel
+    - For tags: pass tag + entityLabel
+    - time is HH:MM in 24-hour format (e.g., "09:00", "14:30")
+    - repeat: 'daily' (every day), 'weekly' (on daysOfWeek), 'one-time' (once, then auto-disables)
+    - daysOfWeek is required when repeat='weekly'`,
+  inputSchema: createReminderParameters,
+  execute: async (params) => params,
+});
+
+export const listRemindersParameters = z.object({});
+
+export const list_reminders = tool({
+  description: `List all reminders. Returns a formatted summary: id, entityLabel, entityType, schedule description, and isEnabled.
+    Use this to find reminder IDs before calling cancel_reminder.`,
+  inputSchema: listRemindersParameters,
+  execute: async (params) => params,
+});
+
+export const cancelReminderParameters = z.object({
+  reminderId: z.string().optional(),
+  entityType: z.enum(['note', 'folder', 'repo', 'tag']).optional(),
+  noteId: z.string().optional(),
+  repoPath: z.string().optional(),
+  folderPath: z.string().optional(),
+  tag: z.string().optional(),
+});
+
+export const cancel_reminder = tool({
+  description: `Cancel (delete) a reminder.
+    - Prefer passing reminderId from a prior list_reminders call
+    - If reminderId is not available, pass entityType + the corresponding entity ID:
+      * For 'note': noteId
+      * For 'folder': repoPath + folderPath
+      * For 'repo': repoPath
+      * For 'tag': tag
+    - Returns success even if reminder was already cancelled or never existed (idempotent)`,
+  inputSchema: cancelReminderParameters,
+  execute: async (params) => params,
+});
+
 export const chatTools = {
   create_note,
   edit_note,
@@ -243,6 +304,9 @@ export const chatTools = {
   distill_thought_dump,
   link_notes,
   generate_daily_brief,
+  create_reminder,
+  list_reminders,
+  cancel_reminder,
 };
 
 export const listReposParameters = z.object({});


### PR DESCRIPTION
## Summary

Add AI tools so the assistant can create, list, and cancel standalone reminders on notes, folders, repos, and tags. Also expose reminderBeforeMinutes on todo tools.

## Changes

### src/services/ai/tools.ts
- create_reminder, list_reminders, cancel_reminder tool schemas added
- Add reminderBeforeMinutes to createTodoParameters and editTodoParameters

### src/services/ai/actionExecutor.ts
- Implement create_reminder: validates input, calls useReminderStore.createItem, then ReminderService.scheduleNotification
- Implement list_reminders: reads from store, formats with formatReminderSchedule
- Implement cancel_reminder: resolves by id or content-match, cancels then deletes from store
- Wire reminderBeforeMinutes through create_todo and edit_todo
- Add getOptionalNumberArg helper

### src/services/ai/systemPrompt.ts
- Add Reminder Tools section with proactive suggestion guidance for study/review/quiz content

## Testing
- yarn ts:check passes
- yarn eslint passes
- Pre-existing test failure in GrandfatherService.test.ts (unrelated)