### PR TITLE
fix: sync ExploreScreen status after floating git button stage/commit/push

### DIFF
--- a/src/hooks/useAllReposStatus.ts
+++ b/src/hooks/useAllReposStatus.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import * as GitEngine from '@/services/git/engine/GitEngine';
 import { GitFsService } from '@/services/git/GitFsService';
 import { useRepoStore } from '@/stores/repoStore';
+import { emitGitRefresh } from '@/hooks/useGitRefreshEvent';
 import type { GitRepository } from '@/services/GitService';
 
 export type GitStateMode = 'conflicts' | 'changes' | 'push' | 'clean';
@@ -131,6 +132,8 @@ export function useAllReposStatus(pollMs: number = POLL_MS): AggregatedGitState 
     const next = new Map<string, RepoGitState>();
     for (const entry of results) next.set(entry.repoId, entry);
     setPerRepo(next);
+    // Notify other hooks (like useGitRepoStatus) to refresh
+    emitGitRefresh();
   }, [repositories]);
 
   useEffect(() => {

--- a/src/hooks/useGitRefreshEvent.ts
+++ b/src/hooks/useGitRefreshEvent.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useReducer } from 'react';
+
+/**
+ * Simple event emitter for signaling git status refresh across hooks.
+ * useAllReposStatus emits after stage/commit/push operations.
+ * useGitRepoStatus listens to stay in sync.
+ */
+
+type GitRefreshListener = () => void;
+
+const listeners = new Set<GitRefreshListener>();
+
+export function emitGitRefresh(): void {
+  listeners.forEach((listener) => listener());
+}
+
+export function subscribeGitRefresh(listener: GitRefreshListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * Hook for components/hooks to react to git refresh events.
+ * Returns a trigger count that increments whenever a refresh is emitted.
+ * Components can use this in their useEffect deps to trigger refreshes.
+ */
+export function useGitRefreshSignal(): number {
+  const countRef = useRef(0);
+  const [, forceUpdate] = useReducer((x) => x + 1, 0);
+
+  useEffect(() => {
+    const unsubscribe = subscribeGitRefresh(() => {
+      countRef.current += 1;
+      forceUpdate();
+    });
+    return unsubscribe;
+  }, []);
+
+  return countRef.current;
+}

--- a/src/hooks/useGitRepoStatus.ts
+++ b/src/hooks/useGitRepoStatus.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import * as GitEngine from '@/services/git/engine/GitEngine';
 import type { RepoStatus } from '@/services/git/engine/GitEngine';
+import { subscribeGitRefresh } from '@/hooks/useGitRefreshEvent';
 
 export interface UseGitRepoStatusResult {
   /** Latest engine status for the repo (null until the first poll resolves). */
@@ -53,15 +54,20 @@ export function useGitRepoStatus(
   useEffect(() => {
     mountedRef.current = true;
     void refresh();
+    const unsubscribe = subscribeGitRefresh(() => {
+      void refresh();
+    });
     if (!repoId || !repoPath) {
       return () => {
         mountedRef.current = false;
+        unsubscribe();
       };
     }
     const timer = setInterval(() => void refresh(), pollMs);
     return () => {
       mountedRef.current = false;
       clearInterval(timer);
+      unsubscribe();
     };
   }, [repoId, repoPath, pollMs, refresh]);
 


### PR DESCRIPTION
## Problem

When the floating git button was used to stage, commit, or push, the ExploreScreen's changes page wasn't updating - only the floating button's internal state refreshed. Users had to navigate away and back to see the updated status.

## Root Cause

The floating git button and ExploreScreen used separate, independent polling hooks:
- `useAllReposStatus` (floating button) calls `refresh()` after stage/commit/push
- `useGitRepoStatus` (ExploreScreen) polls on its own 4-second interval

When the floating button was used, only `useAllReposStatus` refreshed. `useGitRepoStatus` kept stale data until the next poll interval or until navigation triggered `useFocusEffect`.

## Fix

Created a shared event emitter (`useGitRefreshEvent.ts`) that synchronizes the two hooks:

`stage/commit/push → useAllReposStatus.refresh() → emitGitRefresh() → useGitRepoStatus.refresh()`

### Files changed
- `src/hooks/useGitRefreshEvent.ts` — new shared event emitter module
- `src/hooks/useAllReposStatus.ts` — emits `emitGitRefresh()` after each poll  
- `src/hooks/useGitRepoStatus.ts` — subscribes and calls `refresh()` on event

## Testing
TypeScript compiles cleanly. ESLint passes. Test the flow: make changes, use floating git button to stage/commit/push from any screen, verify ExploreScreen's changes/staging/commits sections update immediately.