### PR TITLE
fix: remove unused makeRepoFs, fix useless escape, restore missing GitEngine import

### DIFF
--- a/src/services/cloneSyncServiceImpl.ts
+++ b/src/services/cloneSyncServiceImpl.ts
@@ -7,6 +7,7 @@
 
 import * as FileSystem from 'expo-file-system/legacy';
 import { parseRepoPath } from '../utils/gitPathParser';
+import * as GitEngine from './git/engine/GitEngine';
 
 const CLONES_SUBDIR = 'GitNotes/';
 

--- a/src/services/git/commitOps.ts
+++ b/src/services/git/commitOps.ts
@@ -40,10 +40,6 @@ function toRepoRelativePath(filePath: string): string {
   return filePath.replace(/^\/+/, '');
 }
 
-function makeRepoFs() {
-  return makeGitFs(clonesRoot());
-}
-
 async function ensureParentDirs(rootDir: string, virtualPath: string): Promise<void> {
   const parts = virtualPath.split('/').filter(Boolean);
   parts.pop();

--- a/src/utils/gitPathParser.ts
+++ b/src/utils/gitPathParser.ts
@@ -23,7 +23,7 @@ export function parseRepoPath(repoPath: string): { owner: string; repo: string }
 
   // ssh URL: ssh://git@github.com/owner/repo.git -> owner/repo.git
   cleaned = cleaned.replace(/^ssh:\/\//i, '');
-  cleaned = cleaned.replace(/^[^@\s]+@[^\/\s]+\/?/, '');
+  cleaned = cleaned.replace(/^[^@\s]+@[^/\s]+\/?/, '');
 
   // Drop the trailing `.git`.
   cleaned = cleaned.replace(/\.git$/, '');


### PR DESCRIPTION
## Summary

Three targeted fixes for lint issues found after PR #1466:

1. `src/services/git/commitOps.ts` - removed unused `makeRepoFs()` helper
2. `src/utils/gitPathParser.ts` - fixed `\/` useless escape in SSH URL regex
3. `src/services/cloneSyncServiceImpl.ts` - restored missing `import * as GitEngine` that was accidentally removed during cleanup

## Verification

- `yarn eslint src --ext .ts,.tsx`: 0 errors, 106 warnings (all `no-explicit-any` / `react-hooks/exhaustive-deps` - not in scope)
