### PR TITLE
fix: correct misleading save failed error message

### DIFF
--- a/src/components/editor/useNoteEditorDocument.ts
+++ b/src/components/editor/useNoteEditorDocument.ts
@@ -429,7 +429,7 @@ export function useNoteEditorDocument({
           if (!syncResult.success) {
             Alert.alert(
               'Save Failed',
-              'Your note was saved locally but could not be synced. Please try again.',
+              'Your note could not be saved. Please try again.',
               [{ text: 'OK' }],
             );
           }


### PR DESCRIPTION
## Problem

The error message 'Your note was saved locally but could not be synced. Please try again.' was shown when `CloneSyncService.save()` failed, but the note was not actually saved anywhere at that point.

## Root Cause

When `CloneSyncService.save()` fails (git working tree write/stage/commit error), it returns `{ success: false }` and the code returns early without calling `StorageService.updateNote()`. The note existed in `DocumentService` document index but no file was written to the git working tree.

The original error message was misleading because it implied the note WAS saved locally when it was NOT.

## Fix

Changed error message from:
> 'Your note was saved locally but could not be synced. Please try again.'

To:
> 'Your note could not be saved. Please try again.'

This is accurate - if this error shows, the note save actually failed completely.