### PR TITLE
fix: MarkdownToolbar dark mode text visibility

### DIFF
--- a/src/components/MarkdownToolbar.tsx
+++ b/src/components/MarkdownToolbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ScrollView, StyleSheet, TouchableOpacity, Text, View } from 'react-native';
 
+import { useTheme } from '../contexts/ThemeContext';
 import type { FormatAction } from '../utils/markdownFormatting';
 import { getToolbarButtons } from '../utils/formatToolbarPresets';
 import type { NoteFormat } from '../models/Note';
@@ -14,6 +15,7 @@ type Props = {
 };
 
 export function MarkdownToolbar({ onFormat, format }: Props) {
+  const { colors } = useTheme();
   const buttons = getToolbarButtons(format);
 
   return (
@@ -29,11 +31,11 @@ export function MarkdownToolbar({ onFormat, format }: Props) {
             key={label}
             testID={btnTestID}
             onPress={() => onFormat(action)}
-            style={styles.button}
+            style={[styles.button, { backgroundColor: colors.surfaceSecondary }]}
             accessibilityLabel={label}
             accessibilityRole="button"
           >
-            <Text style={styles.buttonText}>{label}</Text>
+            <Text style={[styles.buttonText, { color: colors.text }]}>{label}</Text>
           </TouchableOpacity>
         ))}
       </ScrollView>


### PR DESCRIPTION
Fixes black text on dark mode toolbar buttons in the MarkdownToolbar component used on NoteEditorScreen and AddNoteScreen.

## Changes
- Added `useTheme()` hook to MarkdownToolbar
- Button text now uses `colors.text` instead of default black
- Button background now uses `colors.surfaceSecondary` for better contrast

## Testing
- TypeScript compilation passes
- ESLint passes
- Verified in dark mode on NoteEditorScreen