### PR TITLE
fix: refresh visible Git pages after floating actions

### DIFF
--- a/src/components/git/AppFloatingGitButton.tsx
+++ b/src/components/git/AppFloatingGitButton.tsx
@@ -9,6 +9,7 @@ import { stageAllPending, commitAll, pushAll } from '@/services/git/multiRepoGit
 import type { Author } from '@/services/git/engine/GitEngine';
 import { useAccounts } from '@/contexts/AccountsContext';
 import { githubActivity } from '@/stores/githubActivityStore';
+import { emitGitContentRefresh } from '@/hooks/useGitRefreshEvent';
 import FloatingGitButton from './FloatingGitButton';
 import type { ReleaseSegment } from './useFloatingGitButtonAffordances';
 import type { RootStackParamList } from '@/navigation/types';
@@ -109,6 +110,7 @@ export default function AppFloatingGitButton() {
           ),
         });
         void aggregatedState.refresh();
+        emitGitContentRefresh();
         return;
       }
 
@@ -127,6 +129,7 @@ export default function AppFloatingGitButton() {
           ),
         });
         void aggregatedState.refresh();
+        emitGitContentRefresh();
         return;
       }
 
@@ -170,6 +173,7 @@ export default function AppFloatingGitButton() {
         }
       }
       void aggregatedState.refresh();
+      emitGitContentRefresh();
     },
     [repos, author, toast, aggregatedState, navigation],
   );
@@ -248,5 +252,4 @@ export default function AppFloatingGitButton() {
     />
   );
 }
-
 

--- a/src/hooks/useGitRefreshEvent.ts
+++ b/src/hooks/useGitRefreshEvent.ts
@@ -9,6 +9,7 @@ import { useEffect, useRef, useReducer } from 'react';
 type GitRefreshListener = () => void;
 
 const listeners = new Set<GitRefreshListener>();
+const contentListeners = new Set<GitRefreshListener>();
 
 export function emitGitRefresh(): void {
   listeners.forEach((listener) => listener());
@@ -17,6 +18,15 @@ export function emitGitRefresh(): void {
 export function subscribeGitRefresh(listener: GitRefreshListener): () => void {
   listeners.add(listener);
   return () => listeners.delete(listener);
+}
+
+export function emitGitContentRefresh(): void {
+  contentListeners.forEach((listener) => listener());
+}
+
+export function subscribeGitContentRefresh(listener: GitRefreshListener): () => void {
+  contentListeners.add(listener);
+  return () => contentListeners.delete(listener);
 }
 
 /**
@@ -30,6 +40,21 @@ export function useGitRefreshSignal(): number {
 
   useEffect(() => {
     const unsubscribe = subscribeGitRefresh(() => {
+      countRef.current += 1;
+      forceUpdate();
+    });
+    return unsubscribe;
+  }, []);
+
+  return countRef.current;
+}
+
+export function useGitContentRefreshSignal(): number {
+  const countRef = useRef(0);
+  const [, forceUpdate] = useReducer((x) => x + 1, 0);
+
+  useEffect(() => {
+    const unsubscribe = subscribeGitContentRefresh(() => {
       countRef.current += 1;
       forceUpdate();
     });

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -31,6 +31,7 @@ import { AuthService } from '@/services/AuthService';
 
 import { LastUsedRepoService } from '@/services/LastUsedRepoService';
 import { useGitButtonActionStore } from '@/stores/gitButtonActionStore';
+import { useGitContentRefreshSignal } from '@/hooks/useGitRefreshEvent';
 import type { GitRepository } from '@/services/GitService';
 import type { RepoLike } from '@/components/explore/exploreShared';
 import type { RootStackParamList } from '@/navigation/types';
@@ -69,6 +70,7 @@ export default function ExploreScreen() {
   const isLoading = useRepoStore((state) => state.isLoading);
   const loadRepos = useRepoStore((state) => state.loadRepos);
   const aggregatedState = useAllReposStatus();
+  const gitContentRefresh = useGitContentRefreshSignal();
 
   const [section, setSection] = useState<ExploreSection>('files');
   const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null);
@@ -225,27 +227,27 @@ export default function ExploreScreen() {
     const props = { repo: repoTyped, status, onChanged, chromeTopInset: chromeTotalHeight + 8, onNavigate: setSection, refreshStatus };
     switch (section) {
       case 'files':
-        return <FilesSection key={repo.id} {...props} active />;
+        return <FilesSection key={`${repo.id}:${gitContentRefresh}`} {...props} active />;
       case 'changes':
-        return <ChangesSection key={repo.id} {...props} active />;
+        return <ChangesSection key={`${repo.id}:${gitContentRefresh}`} {...props} active />;
       case 'staging':
-        return <StagingSection key={repo.id} {...props} active />;
+        return <StagingSection key={`${repo.id}:${gitContentRefresh}`} {...props} active />;
       case 'commits':
-        return <CommitsSection key={repo.id} {...props} active />;
+        return <CommitsSection key={`${repo.id}:${gitContentRefresh}`} {...props} active />;
       case 'branches':
-        return <BranchesSection key={repo.id} {...props} active />;
+        return <BranchesSection key={`${repo.id}:${gitContentRefresh}`} {...props} active />;
       case 'remotes':
-        return <RemotesSection key={repo.id} {...props} active />;
+        return <RemotesSection key={`${repo.id}:${gitContentRefresh}`} {...props} active />;
       case 'conflicts':
-        return <ConflictsSection key={repo.id} {...props} active />;
+        return <ConflictsSection key={`${repo.id}:${gitContentRefresh}`} {...props} active />;
       case 'pulls':
-        return <PullRequestsSection repo={repoTyped} status={status} active={section === 'pulls'} onChanged={onChanged} chromeTopInset={chromeTotalHeight + 8} />;
+        return <PullRequestsSection key={`${repo.id}:${gitContentRefresh}`} repo={repoTyped} status={status} active={section === 'pulls'} onChanged={onChanged} chromeTopInset={chromeTotalHeight + 8} />;
       case 'issues':
-        return <IssuesSection repo={repoTyped} status={status} active={section === 'issues'} onChanged={onChanged} chromeTopInset={chromeTotalHeight + 8} />;
+        return <IssuesSection key={`${repo.id}:${gitContentRefresh}`} repo={repoTyped} status={status} active={section === 'issues'} onChanged={onChanged} chromeTopInset={chromeTotalHeight + 8} />;
       case 'info':
         return (
           <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 24 }}>
-            <RepoInfoSection key={repo.id} {...props} active />
+            <RepoInfoSection key={`${repo.id}:${gitContentRefresh}`} {...props} active />
           </ScrollView>
         );
       default:


### PR DESCRIPTION
## Summary
- add a dedicated content refresh event for completed floating Git actions
- refresh the currently visible Explore/Git section after stage, commit, or push
- avoid remounting Git pages on routine background status polling

## Verification
- `yarn ts:check` passed
- `yarn eslint . --ext .ts,.tsx` passed with existing warnings only
- changed-file LSP diagnostics passed
- `git diff --check` passed

Jest could not discover tests from the worktree because the repository Jest config intentionally ignores `/.worktrees/`; no test files were changed.