### PR TITLE
fix(git-button): route taps to matching Explore section

### DIFF
--- a/__tests__/components/git/floatingGitButtonNavigation.test.ts
+++ b/__tests__/components/git/floatingGitButtonNavigation.test.ts
@@ -1,0 +1,53 @@
+import { getFloatingGitNavigationTarget } from '@/components/git/floatingGitButtonNavigation';
+import type { RepoGitState } from '@/hooks/useAllReposStatus';
+
+function repoState(repoId: string, updates: Partial<RepoGitState> = {}): RepoGitState {
+  return {
+    repoId,
+    repoPath: `/repos/${repoId}`,
+    uncommitted: 0,
+    staged: 0,
+    ahead: 0,
+    behind: 0,
+    currentBranch: 'main',
+    conflicts: false,
+    loading: false,
+    sampledAt: 1,
+    ...updates,
+  };
+}
+
+describe('getFloatingGitNavigationTarget', () => {
+  it('routes yellow staged state before blue ahead state', () => {
+    const perRepo = new Map([
+      ['ahead', repoState('ahead', { ahead: 1 })],
+      ['staged', repoState('staged', { staged: 1 })],
+    ]);
+
+    expect(getFloatingGitNavigationTarget({ perRepo })).toEqual({
+      repoId: 'staged',
+      section: 'staging',
+    });
+  });
+
+  it('routes green unstaged state before blue ahead state', () => {
+    const perRepo = new Map([
+      ['ahead', repoState('ahead', { ahead: 1 })],
+      ['changed', repoState('changed', { uncommitted: 1 })],
+    ]);
+
+    expect(getFloatingGitNavigationTarget({ perRepo })).toEqual({
+      repoId: 'changed',
+      section: 'changes',
+    });
+  });
+
+  it('routes blue state to commits when no local changes exist', () => {
+    const perRepo = new Map([['ahead', repoState('ahead', { ahead: 1 })]]);
+
+    expect(getFloatingGitNavigationTarget({ perRepo })).toEqual({
+      repoId: 'ahead',
+      section: 'commits',
+    });
+  });
+});

--- a/src/components/git/AppFloatingGitButton.tsx
+++ b/src/components/git/AppFloatingGitButton.tsx
@@ -13,7 +13,7 @@ import { emitGitContentRefresh } from '@/hooks/useGitRefreshEvent';
 import FloatingGitButton from './FloatingGitButton';
 import type { ReleaseSegment } from './useFloatingGitButtonAffordances';
 import type { RootStackParamList } from '@/navigation/types';
-
+import { getFloatingGitNavigationTarget } from './floatingGitButtonNavigation';
 
 const HINT_SEEN_KEY = '@gitnotes:gitbutton_hint_seen';
 
@@ -22,7 +22,7 @@ const HINT_SEEN_KEY = '@gitnotes:gitbutton_hint_seen';
  *   - the aggregated per-repo state from `useAllReposStatus`
  *   - the smart-navigate tap: queues a pending action (target repo +
  *     section) and jumps to ExploreTab. ExploreScreen reads the pending
- *     action on focus, applies repo + section, then clears it.
+ *     action on mount/update, applies repo + section, then clears it.
  *
  * Hold-to-release performs git stage/commit/push across all repos.
  * Disabled (grayed out) when nothing is pending anywhere.
@@ -220,24 +220,9 @@ export default function AppFloatingGitButton() {
       navigation.navigate('ExploreConflict', { repoId: conflictRepoId });
       return;
     }
-    if (aggregatedState.totalAhead > 0) {
-      const aheadRepoId = Array.from(aggregatedState.perRepo.entries()).find(([, entry]) => entry.ahead > 0)?.[0]
-        ?? aggregatedState.latestChangedRepoId
-        ?? repos[0]?.id;
-      if (!aheadRepoId) return;
-      setPending({ repoId: aheadRepoId, section: 'commits' });
-      navigation.navigate('MainTabs', { screen: 'ExploreTab' });
-      return;
-    }
-    const targetRepoId = aggregatedState.latestChangedRepoId ?? repos[0]?.id ?? null;
-    const section =
-      aggregatedState.totalStaged > 0
-        ? 'staging'
-        : aggregatedState.totalUncommitted > 0
-          ? 'changes'
-          : aggregatedState.totalAhead > 0
-            ? 'commits'
-            : null;
+    const target = getFloatingGitNavigationTarget(aggregatedState);
+    const targetRepoId = target?.repoId ?? repos[0]?.id ?? null;
+    const section = target?.section ?? null;
     if (!section || !targetRepoId) return;
     setPending({ repoId: targetRepoId, section });
     navigation.navigate('MainTabs', { screen: 'ExploreTab' });
@@ -252,4 +237,3 @@ export default function AppFloatingGitButton() {
     />
   );
 }
-

--- a/src/components/git/floatingGitButtonNavigation.ts
+++ b/src/components/git/floatingGitButtonNavigation.ts
@@ -1,0 +1,22 @@
+import type { ExploreSection } from '@/components/explore/exploreShared';
+import type { AggregatedGitState } from '@/hooks/useAllReposStatus';
+
+export interface FloatingGitNavigationTarget {
+  repoId: string;
+  section: Extract<ExploreSection, 'changes' | 'staging' | 'commits'>;
+}
+
+export function getFloatingGitNavigationTarget(
+  state: Pick<AggregatedGitState, 'perRepo'>,
+): FloatingGitNavigationTarget | null {
+  const stagedRepoId = Array.from(state.perRepo.values()).find((entry) => entry.staged > 0)?.repoId;
+  if (stagedRepoId) return { repoId: stagedRepoId, section: 'staging' };
+
+  const changedRepoId = Array.from(state.perRepo.values()).find((entry) => entry.uncommitted > 0)?.repoId;
+  if (changedRepoId) return { repoId: changedRepoId, section: 'changes' };
+
+  const aheadRepoId = Array.from(state.perRepo.values()).find((entry) => entry.ahead > 0)?.repoId;
+  if (aheadRepoId) return { repoId: aheadRepoId, section: 'commits' };
+
+  return null;
+}

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -71,6 +71,7 @@ export default function ExploreScreen() {
   const loadRepos = useRepoStore((state) => state.loadRepos);
   const aggregatedState = useAllReposStatus();
   const gitContentRefresh = useGitContentRefreshSignal();
+  const pendingGitButtonAction = useGitButtonActionStore((state) => state.pending);
 
   const [section, setSection] = useState<ExploreSection>('files');
   const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null);
@@ -171,27 +172,20 @@ export default function ExploreScreen() {
   /**
    * The floating git button is rendered at the app level. When the user
    * taps it from any screen, the app-level wrapper sets a pending action
-   * (target repo + section) and navigates here. On focus we apply it:
+   * (target repo + section) and navigates here. On mount or update we apply it:
    *   - swap the active repo if it changed
    *   - jump the section tab to whatever surfaces the repo's current state
    *     (changes / staging / commits / conflicts / files)
-   * Then clear the pending action so a normal re-focus doesn't re-apply it.
+   * Then clear the pending action so a normal re-render doesn't re-apply it.
    */
   useEffect(() => {
-    let prevPending = useGitButtonActionStore.getState().pending;
-    const unsubscribe = useGitButtonActionStore.subscribe((state) => {
-      const pending = state.pending;
-      if (pending === prevPending) return;
-      prevPending = pending;
-      if (!pending) return;
-      if (pending.repoId !== repo?.id) {
-        setSelectedRepoId(pending.repoId);
-      }
-      setSection(pending.section);
-      useGitButtonActionStore.getState().clear();
-    });
-    return unsubscribe;
-  }, [repo?.id]);
+    if (!pendingGitButtonAction) return;
+    if (pendingGitButtonAction.repoId !== repo?.id) {
+      setSelectedRepoId(pendingGitButtonAction.repoId);
+    }
+    setSection(pendingGitButtonAction.section);
+    useGitButtonActionStore.getState().clear();
+  }, [pendingGitButtonAction, repo?.id]);
 
   if (!repo) {
     return (


### PR DESCRIPTION
## Summary
- Route floating Git button taps to the section matching its current color: staged, changes, or commits.
- Consume queued navigation actions on Explore mount and updates so taps work from every screen and when Explore is already open.
- Add regression coverage for mixed clone-mode repository states.

## Test Plan
- `yarn ts:check`
- `yarn eslint src/components/git/AppFloatingGitButton.tsx src/components/git/floatingGitButtonNavigation.ts src/screens/ExploreScreen.tsx __tests__/components/git/floatingGitButtonNavigation.test.ts`
- `yarn jest --no-coverage --runInBand --testPathIgnorePatterns=/node_modules/`