### PR TITLE
fix(git): leave note saves unstaged

### DIFF
--- a/__tests__/services/cloneSyncServiceImpl.test.ts
+++ b/__tests__/services/cloneSyncServiceImpl.test.ts
@@ -1,0 +1,36 @@
+import * as FileSystem from 'expo-file-system/legacy';
+
+import * as GitEngine from '@/services/git/engine/GitEngine';
+import { CloneSyncService } from '@/services/cloneSyncServiceImpl';
+
+jest.mock('expo-file-system/legacy', () => ({
+  documentDirectory: 'file:///documents/',
+  makeDirectoryAsync: jest.fn(),
+  writeAsStringAsync: jest.fn(),
+  deleteAsync: jest.fn(),
+}));
+
+jest.mock('@/services/git/engine/GitEngine', () => ({
+  stage: jest.fn(),
+  remove: jest.fn(),
+}));
+
+describe('CloneSyncService.save', () => {
+  it('writes clone-mode saves without staging them', async () => {
+    const result = await CloneSyncService.save({
+      repoPath: 'owner/repo',
+      branch: 'main',
+      filePath: 'notes/example.md',
+      content: '# Example',
+      message: 'Update example',
+      intent: 'upsert',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(FileSystem.writeAsStringAsync).toHaveBeenCalledWith(
+      'file:///documents/GitNotes/owner/repo/notes/example.md',
+      '# Example',
+    );
+    expect(GitEngine.stage).not.toHaveBeenCalled();
+  });
+});

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -148,14 +148,13 @@ User edits note
   → NoteEditorScreen.save()
     → noteStore.updateNote()
       → FileSystem.writeAsStringAsync(fullPath, content)
-        → GitEngine.stage(repoDir, [relPath])
-          → GitEngine.commit(repoDir, message, author, email)
+        → User stages and commits from the Git workspace or floating Git button
       → ForegroundSyncService / BackgroundSyncService triggers push
         → GitEngine.push(repoDir, 'origin', branch)
           → 409 Conflict → ConflictResolverScreen
 ```
 
-> **Note:** `CloneSyncService.save()` is a thin write + stage wrapper. The actual sync trigger (`ForegroundSyncService` watching store changes, or a direct call from the editor) initiates the push loop. See [Sync Architecture](./sync-architecture.md) for full push trigger details.
+> **Note:** `CloneSyncService.save()` writes the working-tree file without staging it. Users stage and commit from the Git workspace or floating Git button, then push through the normal clone-mode triggers. See [Sync Architecture](./sync-architecture.md) for full push trigger details.
 
 ### Note Load
 

--- a/docs/wiki/git-engine.md
+++ b/docs/wiki/git-engine.md
@@ -408,14 +408,12 @@ The TypeScript facade at `src/services/git/engine/GitEngine.ts` is the single im
 import * as GitEngine from './git/engine/GitEngine';
 
 await FileSystem.writeAsStringAsync(fullPath, content);
-await GitEngine.stage(repoDir, [relPath]);
-// Commit is triggered separately by the push trigger system
-// (ForegroundSyncService, ClonePushTriggers, BackgroundSyncService)
+// The user stages and commits from the Git workspace or floating Git button.
 ```
 
 Key integration points:
-- **`CloneSyncService.save()`** (`src/services/syncStubs.ts`) — writes the file, then calls `GitEngine.stage()`
-- **`CommitService`** or **`commitOps.ts`** — creates commits (stage is done by CloneSyncService; commit is triggered by push triggers)
+- **`CloneSyncService.save()`** (`src/services/cloneSyncServiceImpl.ts`) — writes the file without staging it
+- **`CommitService`** or **`commitOps.ts`** — stages and creates explicit commits
 - **`ConflictResolverScreen`** — calls `GitEngine.conflicts()`, `GitEngine.getConflictBlobs()`, `GitEngine.markConflictResolved()`
 - **`BackgroundSyncService`** / **`ForegroundSyncService`** — call `GitEngine.push()` and `GitEngine.pull()`
 

--- a/docs/wiki/sync-architecture.md
+++ b/docs/wiki/sync-architecture.md
@@ -19,16 +19,15 @@ GitNotēs supports two synchronization modes, controlled per-repository via the 
 
 Clone mode is designed for **offline-first** usage. Changes are committed locally and pushed asynchronously.
 
-### Commit-on-Save Flow
+### Save Flow
 
 ```
 User edits note
   → NoteEditorScreen saves
     → CloneSyncService.save({ intent: 'upsert', content, filePath, ... })
       → File written to working tree: <documentDir>/GitNotes/<owner>/<repo>/<path>.md
-        → GitEngine.stage(repoDir, [relPath])
-          → Local git commit created (author: GitNotēs, message: "Update <path>")
-            → CloneSyncService returns { success: true }
+        → CloneSyncService returns { success: true }
+          → User stages and commits from the Git workspace or floating Git button
 ```
 
 ### Push Triggers

--- a/src/services/cloneSyncServiceImpl.ts
+++ b/src/services/cloneSyncServiceImpl.ts
@@ -1,8 +1,8 @@
 /**
  * Stub implementations for deleted sync services.
  * These services are no-ops as the sync architecture has evolved —
- * except CloneSyncService.save, which performs the real worktree write +
- * staging that clone-mode saves depend on.
+ * except CloneSyncService.save, which performs the real worktree write that
+ * clone-mode saves depend on.
  */
 
 import * as FileSystem from 'expo-file-system/legacy';
@@ -183,7 +183,6 @@ export const CloneSyncService = {
       const dirPath = lastSlash === -1 ? repoDir : `${repoDir}/${relPath.slice(0, lastSlash)}`;
       await FileSystem.makeDirectoryAsync(dirPath, { intermediates: true });
       await FileSystem.writeAsStringAsync(fullPath, content ?? '');
-      await GitEngine.stage(repoDir, [relPath]);
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : String(error) };


### PR DESCRIPTION
## Summary
- stop clone-mode note saves from staging files automatically
- keep explicit commit flows responsible for staging before commit
- update Git sync documentation to describe manual staging
- add regression coverage for the save behavior

## Verification
- `yarn jest --no-coverage --forceExit --testPathIgnorePatterns="^$"` passed: 4 suites, 8 tests
- `yarn ts:check` passed
- targeted ESLint passed
- changed-file diagnostics passed
- `git diff --check` passed

Follow-up to #1470.