### PR TITLE
fix(ai): disable agent tools when AI personalization is off

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/vidwadeseram/documents/github/gitnotes/gitnotes/node_modules

--- a/src/components/chat/useChatScreenController.ts
+++ b/src/components/chat/useChatScreenController.ts
@@ -353,15 +353,16 @@ export function useChatScreenController(threadId: string) {
       const aggregatedContexts = dedupeContexts([...runtimeThread.messages.flatMap((message) => message.attachedContexts ?? []), ...contexts]);
       const contextString = aggregatedContexts.length ? await buildContextString(aggregatedContexts) : undefined;
       const history = runtimeThread.messages.filter((message) => message.id !== assistantMessageId).map(formatHistoryMessage);
-      const basePrompt = buildSystemPrompt({ attachedContexts: contextString, noteCount, todoCount, actionMode: aiState.actionMode, githubToolsEnabled, githubAccountLogin });
+      const toolsEnabled = aiState.aiPersonalizationEnabled;
+      const basePrompt = buildSystemPrompt({ attachedContexts: contextString, noteCount, todoCount, actionMode: aiState.actionMode, githubToolsEnabled, githubAccountLogin, toolsEnabled });
       const memoryBlock = await buildMemoryBlockForQuery(trimmedText, model, basePrompt.length);
       const prompt = memoryBlock
-        ? buildSystemPrompt({ attachedContexts: contextString, noteCount, todoCount, actionMode: aiState.actionMode, memoryBlock, githubToolsEnabled, githubAccountLogin })
+        ? buildSystemPrompt({ attachedContexts: contextString, noteCount, todoCount, actionMode: aiState.actionMode, memoryBlock, githubToolsEnabled, githubAccountLogin, toolsEnabled })
         : basePrompt;
       const modelInstance = await AIService.initializeModel(model, provider as AIProviderConfig | undefined);
       const requestMessages: Parameters<typeof AIService.streamChatResponse>[1] = [{ role: 'system', content: prompt }, ...history];
 
-      for await (const chunk of AIService.streamChatResponse(modelInstance, requestMessages, buildChatToolsMap(), abortController.signal)) {
+      for await (const chunk of AIService.streamChatResponse(modelInstance, requestMessages, toolsEnabled ? buildChatToolsMap() : undefined, abortController.signal)) {
         if (abortController.signal.aborted) break;
         const toolEvent = parseToolEvent(chunk);
         if (!toolEvent) {

--- a/src/services/ai/systemPrompt.ts
+++ b/src/services/ai/systemPrompt.ts
@@ -6,15 +6,19 @@ type SystemPromptContext = {
   memoryBlock?: string;
   githubToolsEnabled?: boolean;
   githubAccountLogin?: string;
+  toolsEnabled?: boolean;
 };
+
+const BASE_PROMPT_NO_TOOLS =
+  'You are GitNotes AI, an assistant. You can answer questions, have conversations, and help with general tasks. Always be helpful, concise, and accurate.';
 
 const BASE_PROMPT =
   'You are GitNotes AI, an assistant that helps users manage their notes and todos. You can create, edit, search, and delete notes and todos using the tools available to you. Always be helpful, concise, and accurate.';
 
 export function buildSystemPrompt(context: SystemPromptContext): string {
-  const sections = [BASE_PROMPT];
+  const sections = [context.toolsEnabled !== false ? BASE_PROMPT : BASE_PROMPT_NO_TOOLS];
 
-  if (context.actionMode === 'confirm') {
+  if (context.toolsEnabled !== false && context.actionMode === 'confirm') {
     sections.push(
       'IMPORTANT: Before making any changes (create, edit, or delete), describe what you plan to do and wait for user confirmation.'
     );
@@ -49,12 +53,13 @@ Use these tools when the user asks about their repos, issues, PRs, or reviews. A
     );
   }
 
-  sections.push(
-    `Current state: The user has ${context.noteCount} notes and ${context.todoCount} todos.`
-  );
+  if (context.toolsEnabled !== false) {
+    sections.push(
+      `Current state: The user has ${context.noteCount} notes and ${context.todoCount} todos.`
+    );
 
-  sections.push(
-    `=== Reminder Tools ===
+    sections.push(
+      `=== Reminder Tools ===
 You have access to reminder tools:
 - create_reminder: Set a reminder to revisit a note, folder, repo, or tagged notes at a specific time (HH:MM, 24-hour). Supports daily, weekly, or one-time schedules.
 - list_reminders: View all reminders with their schedules and entity labels.
@@ -62,7 +67,8 @@ You have access to reminder tools:
 
 PROACTIVE SUGGESTIONS: After creating study, review, or quiz content (notes with tags like 'study', 'review', 'quiz', 'flashcards', or 'questioner'), proactively suggest setting a reminder. Say something like: "I created a quiz on [topic]. Would you like me to set a weekly reminder to review it?" — NEVER auto-create without user confirmation.
 === End Reminder Tools ===`
-  );
+    );
+  }
 
   return sections.join('\n\n');
 }


### PR DESCRIPTION
When `aiPersonalizationEnabled` is false, the agent no longer receives any tools. This ensures user data is not accessible to the AI when the user has opted out of AI personalization for data safety.

## Changes

- **systemPrompt.ts**: Add `toolsEnabled` parameter to conditionally include tool-related content in the system prompt
- **useChatScreenController.ts**: Pass `undefined` for tools when `aiPersonalizationEnabled` is false, preventing the AI from knowing about or using any tools

## Behavior

| Setting | Tools Available | System Prompt |
|---------|---------------|---------------|
| `aiPersonalizationEnabled: true` | Yes | Full prompt with tool descriptions |
| `aiPersonalizationEnabled: false` | No | Basic conversational prompt only |

Fixes the data safety concern where users who opt out of AI personalization still had tools available to the AI.