### PR TITLE
fix(git-button): refresh Explore screen when floating button stages/commits/pushes

### DIFF
--- a/src/components/git/AppFloatingGitButton.tsx
+++ b/src/components/git/AppFloatingGitButton.tsx
@@ -9,7 +9,7 @@ import { stageAllPending, commitAll, pushAll } from '@/services/git/multiRepoGit
 import type { Author } from '@/services/git/engine/GitEngine';
 import { useAccounts } from '@/contexts/AccountsContext';
 import { githubActivity } from '@/stores/githubActivityStore';
-import { emitGitContentRefresh } from '@/hooks/useGitRefreshEvent';
+import { emitGitContentRefresh, emitGitRefresh } from '@/hooks/useGitRefreshEvent';
 import FloatingGitButton from './FloatingGitButton';
 import type { ReleaseSegment } from './useFloatingGitButtonAffordances';
 import type { RootStackParamList } from '@/navigation/types';
@@ -110,6 +110,7 @@ export default function AppFloatingGitButton() {
           ),
         });
         void aggregatedState.refresh();
+        emitGitRefresh();
         emitGitContentRefresh();
         return;
       }
@@ -129,6 +130,7 @@ export default function AppFloatingGitButton() {
           ),
         });
         void aggregatedState.refresh();
+        emitGitRefresh();
         emitGitContentRefresh();
         return;
       }
@@ -173,6 +175,7 @@ export default function AppFloatingGitButton() {
         }
       }
       void aggregatedState.refresh();
+      emitGitRefresh();
       emitGitContentRefresh();
     },
     [repos, author, toast, aggregatedState, navigation],


### PR DESCRIPTION
## Summary

When using the floating git button to stage, commit, or push, the Git tab pages were not updating because AppFloatingGitButton only emitted emitGitContentRefresh but useGitRepoStatus subscribes to a different event (subscribeGitRefresh).

## Fix

Added emitGitRefresh calls at all three operation completion points (stage, commit, push) alongside the existing emitGitContentRefresh calls.

## Testing

1. Open Explore tab on a repo with pending changes
2. Use the floating git button to stage/commit/push  
3. Verify the header status (ahead/behind count) updates correctly