### PR TITLE
fix(notes): leave deletes for manual commit

### DIFF
--- a/__tests__/services/cloneSyncServiceImpl.test.ts
+++ b/__tests__/services/cloneSyncServiceImpl.test.ts
@@ -33,4 +33,21 @@ describe('CloneSyncService.save', () => {
     );
     expect(GitEngine.stage).not.toHaveBeenCalled();
   });
+
+  it('deletes clone-mode files without staging the deletion', async () => {
+    const result = await CloneSyncService.save({
+      repoPath: 'owner/repo',
+      branch: 'main',
+      filePath: 'notes/example.md',
+      message: 'Delete example',
+      intent: 'delete',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith(
+      'file:///documents/GitNotes/owner/repo/notes/example.md',
+      { idempotent: true },
+    );
+    expect(GitEngine.remove).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/stores/noteStoreDelete.test.ts
+++ b/__tests__/stores/noteStoreDelete.test.ts
@@ -1,0 +1,80 @@
+import type { Note } from '@/models/Note';
+import { StorageService } from '@/services/StorageService';
+import { CloneSyncService, SyncEngineService } from '@/services/cloneSyncServiceImpl';
+import { CommitService } from '@/services/git/CommitService';
+import { useNoteStore } from '@/stores/noteStore';
+
+jest.mock('@/services/StorageService', () => ({
+  StorageService: {
+    deleteNote: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/cloneSyncServiceImpl', () => ({
+  CloneSyncService: { save: jest.fn() },
+  SyncEngineService: { getMode: jest.fn() },
+  NoteSyncQueueService: {
+    onMutationSucceeded: jest.fn(),
+    onDroppedMutation: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/git/CommitService', () => ({
+  CommitService: { commit: jest.fn() },
+}));
+
+jest.mock('@/services/git/defaultsPolicy', () => ({
+  resolveDefaultFolder: jest.fn(() => 'notes/'),
+  resolveDefaultRepo: jest.fn(),
+}));
+
+jest.mock('@/services/NoteGitHubSyncService', () => ({
+  applyNoteTagsToContent: (content: string) => content,
+  applyNoteColorToContent: (content: string) => content,
+}));
+
+jest.mock('@/services/git/deleteFailures', () => ({
+  recordDeleteFailure: jest.fn(),
+}));
+
+jest.mock('@/stores/gitOperationStore', () => ({
+  gitOperationRegistry: {
+    begin: jest.fn(() => 'delete-op'),
+    fail: jest.fn(),
+    succeed: jest.fn(),
+  },
+  useGitOperationStore: { getState: jest.fn() },
+}));
+
+describe('noteStore delete flows', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (SyncEngineService.getMode as jest.Mock).mockResolvedValue('clone');
+    (CloneSyncService.save as jest.Mock).mockResolvedValue({ success: true });
+    (StorageService.deleteNote as jest.Mock).mockResolvedValue(true);
+  });
+
+  it('deletes a clone-mode note without creating a commit', async () => {
+    const note: Note = {
+      id: 'note-1',
+      title: 'Example',
+      content: 'content',
+      createdAt: 1,
+      updatedAt: 1,
+      tags: [],
+      repo: 'owner/repo',
+      branch: 'main',
+      filePath: 'notes/example.md',
+    };
+    useNoteStore.setState({ notes: [note], error: null });
+
+    await expect(useNoteStore.getState().deleteNote(note.id)).resolves.toBe(true);
+
+    expect(CloneSyncService.save).toHaveBeenCalledWith(expect.objectContaining({
+      repoPath: 'owner/repo',
+      filePath: 'notes/example.md',
+      intent: 'delete',
+    }));
+    expect(CommitService.commit).not.toHaveBeenCalled();
+  });
+});

--- a/docs/wiki/sync-architecture.md
+++ b/docs/wiki/sync-architecture.md
@@ -17,7 +17,7 @@ GitNotēs supports two synchronization modes, controlled per-repository via the 
 
 ## Clone Mode (Default)
 
-Clone mode is designed for **offline-first** usage. Changes are committed locally and pushed asynchronously.
+Clone mode is designed for **offline-first** usage. Changes are written locally, then staged and committed by the user before being pushed asynchronously.
 
 ### Save Flow
 
@@ -29,6 +29,8 @@ User edits note
         → CloneSyncService returns { success: true }
           → User stages and commits from the Git workspace or floating Git button
 ```
+
+Delete operations remove the working-tree file without staging the deletion, so the user can review, stage, and commit it from the Git workspace.
 
 ### Push Triggers
 

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -324,11 +324,11 @@ export async function deleteNoteFromGitHub(params: {
   accountId?: string;
   provider?: GitHostProvider;
   /**
-   * Clone-mode only. When false, the delete commit is created locally
-   * but the push to origin is deferred. The drain in
-   * `NoteSyncQueueService` uses this to coalesce delete+upsert pushes
-   * into one round-trip per `(repo, branch)` group (issue #565 phases
-   * B.1 + A). Ignored on the Contents-API path.
+   * Clone-mode only. When false, the local deletion is left unstaged and
+   * the push to origin is deferred. The drain in `NoteSyncQueueService`
+   * uses this to coalesce delete+upsert pushes into one round-trip per
+   * `(repo, branch)` group (issue #565 phases B.1 + A). Ignored on the
+   * Contents-API path.
    */
   push?: boolean;
 }): Promise<NoteGitHubSyncResult> {

--- a/src/services/TodoGitHubSyncService.ts
+++ b/src/services/TodoGitHubSyncService.ts
@@ -156,12 +156,6 @@ export async function deleteTodoFromGitHub(params: {
 
   const mode = await SyncEngineService.getMode(repoPath);
   if (mode === 'clone' && (await GitFsService.isCloned({ repoPath }))) {
-    // Clone-mode delete goes through the shared clone writer (#514 pattern):
-    // CloneSyncService.save's delete intent removes the worktree file and
-    // stages the removal (`git rm` semantics), so the Changes tab lists it
-    // as a staged "deleted" entry for the user to commit. Idempotent — a
-    // file the clone never tracked leaves nothing to stage. No credentials
-    // needed; the remote copy is purged when the staged deletion is pushed.
     const targetBranch = await resolveBranch(repoPath, branch);
     const saveResult = await CloneSyncService.save({
       repoPath,

--- a/src/services/cloneSyncServiceImpl.ts
+++ b/src/services/cloneSyncServiceImpl.ts
@@ -7,7 +7,6 @@
 
 import * as FileSystem from 'expo-file-system/legacy';
 import { parseRepoPath } from '../utils/gitPathParser';
-import * as GitEngine from './git/engine/GitEngine';
 
 const CLONES_SUBDIR = 'GitNotes/';
 
@@ -175,7 +174,6 @@ export const CloneSyncService = {
     try {
       if (intent === 'delete') {
         await FileSystem.deleteAsync(fullPath, { idempotent: true });
-        await GitEngine.remove(repoDir, [relPath]);
         return { success: true };
       }
 

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -329,22 +329,18 @@ export const useNoteStore = create<NoteState & NoteActions>()((set, get) => ({
             });
           const mode = await SyncEngineService.getMode(repoPath);
           if (mode === 'clone') {
-            // Clone mode: real local delete commit via CommitService (same
-            // primitive as create/rename); push happens via the clone push
-            // triggers. The local commit keeps the next pull from
-            // resurrecting the file (#1030).
             const opId = beginDeleteOp();
             try {
-              const commitResult = await CommitService.commit({
-                repo: repoPath,
+              const saveResult = await CloneSyncService.save({
+                repoPath,
                 branch: note.branch ?? 'main',
                 filePath,
                 message: `Delete note: ${note.title ?? filePath}`,
-                delete: true,
+                intent: 'delete',
               });
-              if (!commitResult.success) {
-                gitOperationRegistry.fail(opId, commitResult.error ?? 'Failed to delete note');
-                set({ error: commitResult.error ?? 'Failed to delete note' });
+              if (!saveResult.success) {
+                gitOperationRegistry.fail(opId, saveResult.error ?? 'Failed to delete note');
+                set({ error: saveResult.error ?? 'Failed to delete note' });
                 return false;
               }
             } catch (commitError) {


### PR DESCRIPTION
## Summary
- stop clone-mode single note deletes from creating commits automatically
- make bulk note deletes use the same unstaged deletion path
- preserve explicit commit flows for users who choose to commit
- add regression coverage for service and note-store deletion behavior
- update sync documentation and stale delete-flow comments

## Verification
- red-green regression cycle completed for service and store delete tests
- focused tests passed: 2 suites, 3 tests
- `yarn ts:check` passed
- targeted ESLint passed
- changed-file diagnostics passed
- `git diff --check` passed

Follow-up to the merged save-staging fix.