### PR TITLE
fix(tags): add borders to tag chips in notes editor

### DIFF
--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -21,6 +21,14 @@ export default function TagInput({
   const [showSuggestions, setShowSuggestions] = useState(false);
   const { colors } = useTheme();
 
+  const tagChipBorderStyle = React.useMemo(
+    () => ({
+      borderWidth: 1,
+      borderColor: colors.border,
+    }),
+    [colors.border],
+  );
+
   const handleAddTag = useCallback(
     (tag: string) => {
       const trimmedTag = tag.trim().toLowerCase();
@@ -67,7 +75,7 @@ export default function TagInput({
               active
               onLongPress={() => handleRemoveTag(tag)}
               trailing={<Ionicons name="close-circle" size={16} color={colors.primary} />}
-              style={styles.tagChip}
+              style={[styles.tagChip, tagChipBorderStyle]}
             />
           ))}
         </ScrollView>


### PR DESCRIPTION
Add visible borders to tags in the notes edit/add page for better visibility.

Changes:
- Added `tagChipBorderStyle` with `borderWidth: 1` and `borderColor: colors.border` in `TagInput.tsx`
- Applied border style to tag chips (matching existing `canvasChip` pattern)