### PR TITLE
fix(explore): render staged diff action label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable fixes and feature changes to GitNotēs are documented here.
 >
 > **History**: prior fixes (pre-2026-08) lived in single-PR wiki pages. Those pages were retired in [#1047](https://github.com/gedwolmen/gitnotes/pull/1047); their full diagnostic content is preserved in git history via `git log -p -- docs/wiki/<file>.md`.
 
+## 2026-09-09
+
+### fix(explore): render staged diff action label
+
+**What:** The staged-diff action button rendered a bare string alongside its loading indicator, causing the React Native text-node warning and leaving the button label blank.
+
+**fix(explore):** Wrap the `Stage selected` label in `ButtonText` so it renders as a native text component.
+
+**PR:** TBD
+
 ## 2026-09-08
 
 ### fix(paywall): restore-granted cache bypass + silent failures

--- a/__tests__/ExploreDiffScreen.test.tsx
+++ b/__tests__/ExploreDiffScreen.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals';
+
+declare const __dirname: string;
+declare const require: (moduleName: string) => {
+  readFileSync: (path: string, encoding: string) => string;
+};
+
+const { readFileSync } = require('fs');
+
+describe('ExploreDiffScreen stage action', () => {
+  it('keeps the stage action label inside a Text component', () => {
+    const source = readFileSync(`${__dirname}/../src/screens/ExploreDiffScreen.tsx`, 'utf8');
+
+    expect(source).toContain('<ButtonText>Stage selected</ButtonText>');
+    expect(source).not.toMatch(/\n\s+Stage selected\n/);
+  });
+});

--- a/src/screens/ExploreDiffScreen.tsx
+++ b/src/screens/ExploreDiffScreen.tsx
@@ -255,7 +255,7 @@ export default function ExploreDiffScreen() {
               testID="explore-diff.stage-selected"
             >
               {staging ? <ActivityIndicator size="small" color="#ffffff" /> : null}
-              Stage selected
+              <ButtonText>Stage selected</ButtonText>
             </Button>
           </View>
         </View>


### PR DESCRIPTION
## Summary
- Wrap the staged diff action label in `ButtonText`.
- Add a regression test for the React Native text-node contract.
- Document the fix in `CHANGELOG.md`.

## Validation
- `yarn ts:check`
- Targeted Jest regression test
- ESLint
- Prettier