### PR TITLE
fix(ui): infinite scroll on commits tab — no more 100-commit cap

### DIFF
--- a/modules/GitEngine/android/src/main/java/uniffi/gitnotes_git2/gitnotes_git2.kt
+++ b/modules/GitEngine/android/src/main/java/uniffi/gitnotes_git2/gitnotes_git2.kt
@@ -869,7 +869,7 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_gitnotes_git2_fn_func_push_repo_with_integrate(`path`: RustBuffer.ByValue,`remoteName`: RustBuffer.ByValue,`repoId`: RustBuffer.ByValue,`credentialSource`: RustBuffer.ByValue,`listener`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
-    external fun uniffi_gitnotes_git2_fn_func_recent_commits(`path`: RustBuffer.ByValue,`limit`: Int,uniffi_out_err: UniffiRustCallStatus, 
+    external fun uniffi_gitnotes_git2_fn_func_recent_commits(`path`: RustBuffer.ByValue,`skip`: Int,`limit`: Int,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_gitnotes_git2_fn_func_remove_paths(`path`: RustBuffer.ByValue,`paths`: RustBuffer.ByValue,`keepWorktree`: Byte,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
@@ -4452,13 +4452,14 @@ public object FfiConverterSequenceTypeRemoteInfo: FfiConverterRustBuffer<List<Re
         /**
          * Recent commit history.
          */
-    @Throws(BridgeException::class) fun `recentCommits`(`path`: kotlin.String, `limit`: kotlin.UInt): List<CommitInfo> {
+    @Throws(BridgeException::class) fun `recentCommits`(`path`: kotlin.String, `skip`: kotlin.UInt, `limit`: kotlin.UInt): List<CommitInfo> {
             return FfiConverterSequenceTypeCommitInfo.lift(
     uniffiRustCallWithError(BridgeException) { _status ->
     UniffiLib.uniffi_gitnotes_git2_fn_func_recent_commits(
     
         
         FfiConverterString.lower(`path`),
+        FfiConverterUInt.lower(`skip`),
         FfiConverterUInt.lower(`limit`),_status)
 }
     )

--- a/modules/GitEngine/ios-local/GitEngineModule.swift
+++ b/modules/GitEngine/ios-local/GitEngineModule.swift
@@ -468,8 +468,8 @@ public class GitEngineModule: Module {
       )
     }.runOnQueue(engineQueue)
 
-    AsyncFunction("recentCommits") { (path: String, limit: UInt32) -> [[String: Any]] in
-      try recentCommits(path: GitEngineModule.fsPath(path), limit: limit).map(commitDict)
+    AsyncFunction("recentCommits") { (path: String, skip: UInt32, limit: UInt32) -> [[String: Any]] in
+      try recentCommits(path: GitEngineModule.fsPath(path), skip: skip, limit: limit).map(commitDict)
     }.runOnQueue(engineQueue)
 
     AsyncFunction("commitDiff") { (path: String, commitId: String) -> [[String: Any]] in

--- a/modules/GitEngine/ios-local/generated/GitNotesGit2.swift
+++ b/modules/GitEngine/ios-local/generated/GitNotesGit2.swift
@@ -4053,11 +4053,12 @@ public func pushRepoWithIntegrate(path: String, remoteName: String, repoId: Stri
 /**
  * Recent commit history.
  */
-public func recentCommits(path: String, limit: UInt32)throws  -> [CommitInfo]  {
+public func recentCommits(path: String, skip: UInt32, limit: UInt32)throws  -> [CommitInfo]  {
     return try  FfiConverterSequenceTypeCommitInfo.lift(try rustCallWithError(FfiConverterTypeBridgeError_lift) {
         uniffiCallStatus in
     uniffi_gitnotes_git2_fn_func_recent_commits(
         FfiConverterString.lower(path),
+        FfiConverterUInt32.lower(skip),
         FfiConverterUInt32.lower(limit),uniffiCallStatus
     )
 })

--- a/modules/GitEngine/ios-local/generated/GitNotesGit2FFI/GitNotesGit2FFI.h
+++ b/modules/GitEngine/ios-local/generated/GitNotesGit2FFI/GitNotesGit2FFI.h
@@ -422,7 +422,7 @@ RustBuffer uniffi_gitnotes_git2_fn_func_push_repo_with_integrate(RustBuffer path
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_GITNOTES_GIT2_FN_FUNC_RECENT_COMMITS
 #define UNIFFI_FFIDEF_UNIFFI_GITNOTES_GIT2_FN_FUNC_RECENT_COMMITS
-RustBuffer uniffi_gitnotes_git2_fn_func_recent_commits(RustBuffer path, uint32_t limit, RustCallStatus *_Nonnull out_status
+RustBuffer uniffi_gitnotes_git2_fn_func_recent_commits(RustBuffer path, uint32_t skip, uint32_t limit, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_GITNOTES_GIT2_FN_FUNC_REMOVE_PATHS

--- a/modules/GitEngine/ios/generated/GitNotesGit2.swift
+++ b/modules/GitEngine/ios/generated/GitNotesGit2.swift
@@ -4053,11 +4053,12 @@ public func pushRepoWithIntegrate(path: String, remoteName: String, repoId: Stri
 /**
  * Recent commit history.
  */
-public func recentCommits(path: String, limit: UInt32)throws  -> [CommitInfo]  {
+public func recentCommits(path: String, skip: UInt32, limit: UInt32)throws  -> [CommitInfo]  {
     return try  FfiConverterSequenceTypeCommitInfo.lift(try rustCallWithError(FfiConverterTypeBridgeError_lift) {
         uniffiCallStatus in
     uniffi_gitnotes_git2_fn_func_recent_commits(
         FfiConverterString.lower(path),
+        FfiConverterUInt32.lower(skip),
         FfiConverterUInt32.lower(limit),uniffiCallStatus
     )
 })

--- a/modules/GitEngine/ios/generated/GitNotesGit2FFI/GitNotesGit2FFI.h
+++ b/modules/GitEngine/ios/generated/GitNotesGit2FFI/GitNotesGit2FFI.h
@@ -422,7 +422,7 @@ RustBuffer uniffi_gitnotes_git2_fn_func_push_repo_with_integrate(RustBuffer path
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_GITNOTES_GIT2_FN_FUNC_RECENT_COMMITS
 #define UNIFFI_FFIDEF_UNIFFI_GITNOTES_GIT2_FN_FUNC_RECENT_COMMITS
-RustBuffer uniffi_gitnotes_git2_fn_func_recent_commits(RustBuffer path, uint32_t limit, RustCallStatus *_Nonnull out_status
+RustBuffer uniffi_gitnotes_git2_fn_func_recent_commits(RustBuffer path, uint32_t skip, uint32_t limit, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_GITNOTES_GIT2_FN_FUNC_REMOVE_PATHS

--- a/modules/GitEngine/src/GitEngine.types.ts
+++ b/modules/GitEngine/src/GitEngine.types.ts
@@ -242,7 +242,7 @@ export interface GitEngineModule {
   discardFiles(path: string, paths: string[]): Promise<void>;
   stageFileLines(path: string, filePath: string, hunks: HunkSelection[]): Promise<void>;
   commit(path: string, message: string, authorName: string, authorEmail: string): Promise<CommitInfo>;
-  recentCommits(path: string, limit: number): Promise<CommitInfo[]>;
+  recentCommits(path: string, skip: number, limit: number): Promise<CommitInfo[]>;
   commitDiff(path: string, commitId: string): Promise<FileDiff[]>;
   checkoutCommit(path: string, commitId: string): Promise<void>;
   resetSoft(path: string, commitId: string): Promise<void>;

--- a/rust/src/api/bridge.rs
+++ b/rust/src/api/bridge.rs
@@ -250,9 +250,10 @@ pub fn commit_changes(
 
 /// Recent commit history.
 #[uniffi::export]
-pub fn recent_commits(path: String, limit: u32) -> Result<Vec<CommitInfo>, BridgeError> {
+pub fn recent_commits(path: String, skip: u32, limit: u32) -> Result<Vec<CommitInfo>, BridgeError> {
     Ok(engine::ops::recent_commits(
         std::path::Path::new(&path),
+        skip,
         limit,
     )?)
 }

--- a/rust/src/engine/ops.rs
+++ b/rust/src/engine/ops.rs
@@ -400,7 +400,7 @@ pub fn commit_changes(path: &Path, message: &str, author: &Author) -> Result<Com
 }
 
 /// Recent commit history (`git log`), newest first.
-pub fn recent_commits(path: &Path, limit: u32) -> Result<Vec<CommitInfo>> {
+pub fn recent_commits(path: &Path, skip: u32, limit: u32) -> Result<Vec<CommitInfo>> {
     run_with_lock(path, || {
         let repo = open_repo(path)?;
         let mut revwalk = repo.revwalk()?;
@@ -409,6 +409,9 @@ pub fn recent_commits(path: &Path, limit: u32) -> Result<Vec<CommitInfo>> {
             Ok(()) => {}
             Err(e) if e.code() == git2::ErrorCode::UnbornBranch => return Ok(Vec::new()),
             Err(e) => return Err(EngineError::Git(e)),
+        }
+        if skip > 0 {
+            let _ = revwalk.skip(skip as usize);
         }
         let mut out = Vec::new();
         for oid in revwalk.take(limit.max(1) as usize) {

--- a/src/components/explore/CommitsSection.tsx
+++ b/src/components/explore/CommitsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, RefreshControl, View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -17,20 +17,25 @@ import { useTokens } from '@/contexts/ThemeContext';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
+const PAGE_SIZE = 50;
+
 export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus }: SectionProps) {
   const navigation = useNavigation<NavigationProp>();
   const toast = useToast();
   const { colors } = useTokens();
-  const [commits, setCommits] = useState<CommitInfo[] | null>(null);
+  const [commits, setCommits] = useState<CommitInfo[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [pushing, setPushing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notCloned, setNotCloned] = useState(false);
+  const hasMore = useRef(true);
 
-  const load = useCallback(async () => {
+  const loadInitial = useCallback(async () => {
     setLoading(true);
     setError(null);
     setNotCloned(false);
+    hasMore.current = true;
     try {
       const cloned = await GitFsService.isCloned({ repoPath: repo.path });
       if (!cloned) {
@@ -38,13 +43,30 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
         setLoading(false);
         return;
       }
-      setCommits(await GitEngine.log(repo.localPath, 100));
+      const fetched = await GitEngine.log(repo.localPath, PAGE_SIZE, 0);
+      setCommits(fetched);
+      hasMore.current = fetched.length === PAGE_SIZE;
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
     } finally {
       setLoading(false);
     }
   }, [repo.localPath, repo.path]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !hasMore.current) return;
+    setLoadingMore(true);
+    try {
+      const skip = commits.length;
+      const fetched = await GitEngine.log(repo.localPath, PAGE_SIZE, skip);
+      setCommits((prev) => [...prev, ...fetched]);
+      hasMore.current = fetched.length === PAGE_SIZE;
+    } catch {
+      // silent fail for load more — user can scroll again
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [commits.length, loadingMore, repo.localPath]);
 
   const handlePush = useCallback(async () => {
     if (loading || pushing) return;
@@ -75,7 +97,7 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
             </Toast>
           ),
         });
-        await load();
+        await loadInitial();
         await refreshStatus?.();
       } else {
         toast.show({
@@ -107,8 +129,8 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
 
   useFocusEffect(
     useCallback(() => {
-      if (active) void load();
-    }, [active, load]),
+      if (active) void loadInitial();
+    }, [active, loadInitial]),
   );
 
   const renderItem = useCallback(
@@ -144,10 +166,10 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
 
   if (error) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset + 24 }}>
         <Ionicons name="warning-outline" size={36} color={colors.error} />
         <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
-        <Button variant="outline" size="sm" className="mt-3" onPress={() => void load()}>
+        <Button variant="outline" size="sm" className="mt-3" onPress={() => void loadInitial()}>
           <ButtonText>Retry</ButtonText>
         </Button>
       </View>
@@ -156,7 +178,7 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
 
   if (notCloned) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset + 24 }}>
         <Ionicons name="folder-outline" size={36} color={colors.textSecondary} />
         <Text className="mt-2 text-center text-sm font-semibold" style={{ color: colors.text }}>Clone required</Text>
         <Text className="mt-1 text-center text-xs" style={{ color: colors.textSecondary }}>
@@ -168,17 +190,19 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
 
   return (
     <FlatList className="flex-1"
-      data={commits ?? []}
+      data={commits}
       keyExtractor={(item) => item.id}
       renderItem={renderItem}
-       contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 96, flexGrow: 1 }}
+      contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 96, flexGrow: 1 }}
+      onEndReached={loadMore}
+      onEndReachedThreshold={0.5}
       refreshControl={
-        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
+        <RefreshControl refreshing={loading} onRefresh={() => void loadInitial()} tintColor={colors.accent} />
       }
       ListHeaderComponent={
         <View className="flex-row items-center justify-between px-4 pb-2">
           <Text className="text-xs" style={{ color: colors.textSecondary }} testID="explore.commits.count">
-            {commits ? `${commits.length} commit(s)` : 'Reading history…'}
+            {loading ? 'Reading history…' : `${commits.length} commit${commits.length !== 1 ? 's' : ''}`}
           </Text>
           <View className="flex-row items-center gap-2">
             {loading || pushing ? (
@@ -196,6 +220,13 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
             )}
           </View>
         </View>
+      }
+      ListFooterComponent={
+        loadingMore ? (
+          <View className="items-center py-4">
+            <ActivityIndicator size="small" color={colors.accent} />
+          </View>
+        ) : null
       }
         ListEmptyComponent={
           !loading ? (

--- a/src/services/git/engine/GitEngine.ts
+++ b/src/services/git/engine/GitEngine.ts
@@ -38,7 +38,7 @@ type NativeGitEngineModule = {
   discardFiles(path: string, paths: string[]): Promise<void>;
   stageFileLines(path: string, filePath: string, hunks: HunkSelection[]): Promise<void>;
   commit(path: string, message: string, authorName: string, authorEmail: string): Promise<CommitInfo>;
-  recentCommits(path: string, limit: number): Promise<CommitInfo[]>;
+  recentCommits(path: string, skip: number, limit: number): Promise<CommitInfo[]>;
   commitDiff(path: string, commitId: string): Promise<FileDiff[]>;
   checkoutCommit(path: string, commitId: string): Promise<void>;
   resetSoft(path: string, commitId: string): Promise<void>;
@@ -376,9 +376,9 @@ export async function commit(repoPath: string, message: string, author: Author):
   return run(() => GitEngineModule!.commit(repoPath, message, author.name, author.email), { id: '', message: '', author: { name: '', email: '' }, timestamp: 0, parentCount: 0, authorTime: 0 });
 }
 
-export async function log(repoPath: string, limit = 50): Promise<CommitInfo[]> {
+export async function log(repoPath: string, limit = 50, skip = 0): Promise<CommitInfo[]> {
   if (!GitEngineModule) return [];
-  return run(() => GitEngineModule!.recentCommits(repoPath, limit), []);
+  return run(() => GitEngineModule!.recentCommits(repoPath, skip, limit), []);
 }
 
 /** Per-file diff of one commit against its first parent (`git show`-style). */


### PR DESCRIPTION
## What
The commits tab showed "100 commit(s)" regardless of actual count — it was hardcoded to fetch only 100 commits.

## How
Add skip-based pagination to `GitEngine.log()` wired through the full native stack (Rust git2 → FFI → Swift/Kotlin → TS). `CommitsSection` now loads pages of 50, appending on scroll via `FlatList.onEndReached`. The header count reflects the loaded total (not a hard cap).

## Files
| Layer | File | Change |
|---|---|---|
| Rust engine | `rust/src/engine/ops.rs` | `revwalk.skip(skip)` before `take(limit)` |
| Rust bridge | `rust/src/api/bridge.rs` | skip param |
| Swift FFI | `modules/GitEngine/ios*/generated/` | skip param |
| Kotlin JNA | `modules/GitEngine/android/.../gitnotes_git2.kt` | skip param |
| TS types | `modules/GitEngine/src/GitEngine.types.ts` | skip param |
| TS facade | `src/services/git/engine/GitEngine.ts` | `log(limit, skip)` — backward compat |
| UI | `src/components/explore/CommitsSection.tsx` | `onEndReached` pagination |

## Note
Rust FFI bindings need regeneration (`scripts/build-rust.sh --bindings`) before the Rust changes compile into the binary. The Swift/Kotlin generated files are committed and already updated.