### PR TITLE
fix(explore): pad error views under floating header in commits/tabs

### DIFF
--- a/src/components/explore/BranchesSection.tsx
+++ b/src/components/explore/BranchesSection.tsx
@@ -270,7 +270,7 @@ export function BranchesSection({ repo, active, onChanged, chromeTopInset = 0 }:
 
   if (error) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset + 24 }}>
         <Ionicons name="warning-outline" size={36} color={colors.error} />
         <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
         <Button variant="outline" size="sm" className="mt-3" onPress={() => void load()}>
@@ -282,7 +282,7 @@ export function BranchesSection({ repo, active, onChanged, chromeTopInset = 0 }:
 
   if (notCloned) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset + 24 }}>
         <Ionicons name="folder-outline" size={36} color={colors.textSecondary} />
         <Text className="mt-2 text-center text-sm font-semibold" style={{ color: colors.text }}>Clone required</Text>
         <Text className="mt-1 text-center text-xs" style={{ color: colors.textSecondary }}>

--- a/src/components/explore/CommitsSection.tsx
+++ b/src/components/explore/CommitsSection.tsx
@@ -144,7 +144,7 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
 
   if (error) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset + 24 }}>
         <Ionicons name="warning-outline" size={36} color={colors.error} />
         <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
         <Button variant="outline" size="sm" className="mt-3" onPress={() => void load()}>
@@ -156,7 +156,7 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
 
   if (notCloned) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset + 24 }}>
         <Ionicons name="folder-outline" size={36} color={colors.textSecondary} />
         <Text className="mt-2 text-center text-sm font-semibold" style={{ color: colors.text }}>Clone required</Text>
         <Text className="mt-1 text-center text-xs" style={{ color: colors.textSecondary }}>


### PR DESCRIPTION
## Summary\nError and notCloned views in CommitsSection and BranchesSection were rendered without accounting for the floating chrome header in ExploreScreen, causing content to appear clipped underneath the header.\n\nAdded  to match the pattern already used in IssuesSection and PullRequestsSection.\n\n## Files changed\n-  - error + notCloned views\n-  - error + notCloned views