### PR TITLE
fix(ui): align floating git button margin with AI button (16px)

### DIFF
--- a/src/components/git/useFloatingGitButtonPosition.ts
+++ b/src/components/git/useFloatingGitButtonPosition.ts
@@ -12,7 +12,7 @@ import {
   type FloatingButtonPosition,
 } from './floatingGitButtonGeometry';
 
-const EDGE_INSET = 24;
+const EDGE_INSET = 16;
 const MINIMUM_TOP_BOUND = 60;
 const MINIMUM_BOTTOM_CLEARANCE = 100;
 const STORAGE_KEY = 'git-button-position';


### PR DESCRIPTION
Change EDGE_INSET from 24 to 16 in useFloatingGitButtonPosition.ts to match AI button's edge margin.