### PR TITLE
fix(rust): use iterator chaining for revwalk.skip to avoid move bug

### DIFF
--- a/modules/GitEngine/ios/generated/GitNotesGit2.swift
+++ b/modules/GitEngine/ios/generated/GitNotesGit2.swift
@@ -4343,7 +4343,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_gitnotes_git2_checksum_func_push_repo_with_integrate() != 54095) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_gitnotes_git2_checksum_func_recent_commits() != 41752) {
+    if (uniffi_gitnotes_git2_checksum_func_recent_commits() != 15673) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_gitnotes_git2_checksum_func_remove_paths() != 44845) {

--- a/rust/src/engine/ops.rs
+++ b/rust/src/engine/ops.rs
@@ -410,13 +410,11 @@ pub fn recent_commits(path: &Path, skip: u32, limit: u32) -> Result<Vec<CommitIn
             Err(e) if e.code() == git2::ErrorCode::UnbornBranch => return Ok(Vec::new()),
             Err(e) => return Err(EngineError::Git(e)),
         }
-        if skip > 0 {
-            let _ = revwalk.skip(skip as usize);
-        }
-        let mut out = Vec::new();
-        for oid in revwalk.take(limit.max(1) as usize) {
-            out.push(commit_to_info(&repo.find_commit(oid?)?)?);
-        }
+        let out: Vec<CommitInfo> = revwalk
+            .skip(skip as usize)
+            .take(limit.max(1) as usize)
+            .map(|oid| commit_to_info(&repo.find_commit(oid?)?))
+            .collect::<std::result::Result<Vec<_>, EngineError>>()?;
         Ok(out)
     })
 }


### PR DESCRIPTION
## What
PR #1480 merged the skip-based pagination for the commits tab, but the Rust implementation had a move bug: `revwalk.skip()` takes ownership of the iterator, then the subsequent for loop tried to use the moved `revwalk` — causing a runtime panic.

## How
Replace the imperative loop with iterator chaining:
```rust
let out: Vec<CommitInfo> = revwalk
    .skip(skip as usize)
    .take(limit.max(1) as usize)
    .map(|oid| commit_to_info(&repo.find_commit(oid?)?))
    .collect::<std::result::Result<Vec<_>, EngineError>>()?;
```

Also updates the UniFFI checksum in `ios/generated/GitNotesGit2.swift` (41752 → 15673) to match the 3-arg `recent_commits` signature.

## Files
- `rust/src/engine/ops.rs` — iterator chain instead of skip-then-loop
- `modules/GitEngine/ios/generated/GitNotesGit2.swift` — checksum update

## Note
Rebuild Rust with `scripts/build-rust.sh --all` to get the corrected staticlib locally.