### PR TITLE
fix(auth): use connectHost instead of deprecated setToken

### DIFF
--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -353,7 +353,7 @@ class GitHubServiceClass {
       return null;
     }
     this.user = resolvedUser;
-    await AuthService.setToken(token);
+    await AuthService.connectHost({ provider: 'github', token });
     await AsyncStorage.setItem(USER_KEY, JSON.stringify(resolvedUser));
     return resolvedUser;
   }


### PR DESCRIPTION
GitHubService.setToken was calling the deprecated AuthService.setToken. Replace with direct call to connectHost({ provider: 'github', token }) which is the preferred entry point per the @deprecated notice.

## Changes
- Replace `AuthService.setToken(token)` with `AuthService.connectHost({ provider: 'github', token })` in GitHubService.setToken

## Testing
- TypeScript compilation passes