### PR TITLE
fix(ios): update local UniFFI checksum for commits pagination

### DIFF
--- a/modules/GitEngine/ios-local/generated/GitNotesGit2.swift
+++ b/modules/GitEngine/ios-local/generated/GitNotesGit2.swift
@@ -4343,7 +4343,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_gitnotes_git2_checksum_func_push_repo_with_integrate() != 54095) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_gitnotes_git2_checksum_func_recent_commits() != 41752) {
+    if (uniffi_gitnotes_git2_checksum_func_recent_commits() != 15673) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_gitnotes_git2_checksum_func_remove_paths() != 44845) {


### PR DESCRIPTION
## Root cause

The commits-tab pagination change updated the UniFFI API to three arguments, changing the recent_commits checksum from 41752 to 15673. The non-local iOS generated binding was updated, but the simulator/dev build uses ios-local/generated/GitNotesGit2.swift, which still expected 41752.

The app crashed during GitEngine initialization with:

Fatal error: UniFFI API checksum mismatch

## Fix

Update the active ios-local generated binding to expect checksum 15673, matching the rebuilt Rust library.

Verified against the simulator log from the gitnotes tmux session.