### PR TITLE
fix(ios): resolve ExpoSQLite Xcode 26 build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **fix(ios):** Add an Expo config plugin that disables Swift explicit modules only for the generated `ExpoSQLite` CocoaPod target during prebuild.
 
-**PR:** TBD
+**PR:** #1490
 
 ### fix(explore): render staged diff action label
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-09
 
+### fix(ios): disable explicit modules for ExpoSQLite on Xcode 26
+
+**What:** iOS builds with Xcode 26 failed in `expo-sqlite` because Swift could not resolve the vendored `exsqlite3_*` symbols.
+
+**fix(ios):** Add an Expo config plugin that disables Swift explicit modules only for the generated `ExpoSQLite` CocoaPod target during prebuild.
+
+**PR:** TBD
+
 ### fix(explore): render staged diff action label
 
 **What:** The staged-diff action button rendered a bare string alongside its loading indicator, causing the React Native text-node warning and leaving the button label blank.

--- a/app.json
+++ b/app.json
@@ -78,6 +78,7 @@
       "expo-font",
       "expo-web-browser",
       "./plugins/withGitQuicWorkaround",
+      "./plugins/withExpoSqliteXcode26",
       [
         "expo-notifications",
         {

--- a/plugins/withExpoSqliteXcode26.js
+++ b/plugins/withExpoSqliteXcode26.js
@@ -1,0 +1,39 @@
+const { withDangerousMod } = require('@expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+const EXPLICIT_MODULES_WORKAROUND = `    installer.pods_project.targets.each do |target|
+      next unless target.name == 'ExpoSQLite'
+
+      target.build_configurations.each do |build_configuration|
+        build_configuration.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'
+      end
+    end
+`;
+
+function withExpoSqliteXcode26(config) {
+  return withDangerousMod(config, [
+    'ios',
+    async (config) => {
+      const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+      const podfile = await fs.promises.readFile(podfilePath, 'utf8');
+
+      if (podfile.includes("build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'")) {
+        return config;
+      }
+
+      const marker = '    react_native_post_install(\n';
+      if (!podfile.includes(marker)) {
+        throw new Error('expo-sqlite-xcode26: could not locate the Podfile post_install hook');
+      }
+
+      await fs.promises.writeFile(
+        podfilePath,
+        podfile.replace(marker, `${EXPLICIT_MODULES_WORKAROUND}\n${marker}`),
+      );
+      return config;
+    },
+  ]);
+}
+
+module.exports = withExpoSqliteXcode26;


### PR DESCRIPTION
## Summary
- Add an Expo config plugin for the generated iOS project.
- Disable Swift explicit modules only for the `ExpoSQLite` CocoaPod target.
- Record the fix in `CHANGELOG.md`.

## Verification
- `npx expo prebuild --platform ios --no-install`
- `npx pod-install ios`
- `yarn ts:check`
- `npx expo run:ios --no-bundler --no-build-cache`

`ExpoSQLite` now compiles and packages successfully; the original `exsqlite3_*` errors are gone.

## Known follow-up
The full build currently stops later on a separate Xcode 26.5 `SwiftUICore` forbidden-client linker error. That is outside ExpoSQLite and is not addressed by this PR.