### PR TITLE
fix(ios): suppress Xcode 26 private SwiftUI autolinks

### DIFF
--- a/plugins/withExpoSqliteXcode26.js
+++ b/plugins/withExpoSqliteXcode26.js
@@ -2,14 +2,50 @@ const { withDangerousMod } = require('@expo/config-plugins');
 const fs = require('fs');
 const path = require('path');
 
-const EXPLICIT_MODULES_WORKAROUND = `    installer.pods_project.targets.each do |target|
+const SWIFTUI_PRIVATE_AUTOLINK_FLAGS =
+  '-Xfrontend -disable-autolink-framework -Xfrontend SwiftUICore ' +
+  '-Xfrontend -disable-autolink-framework -Xfrontend UIUtilities';
+
+const SQLITE_EXPLICIT_MODULES_WORKAROUND = `    installer.pods_project.targets.each do |target|
       next unless target.name == 'ExpoSQLite'
 
       target.build_configurations.each do |build_configuration|
+        build_configuration.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'
         build_configuration.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'
       end
     end
+
 `;
+
+const SWIFTUICORE_WORKAROUND = `    installer.aggregate_targets.each do |aggregate_target|
+      next unless aggregate_target.user_project
+
+      aggregate_target.user_project.native_targets.each do |target|
+        target.build_configurations.each do |build_configuration|
+          swift_flags = build_configuration.build_settings['OTHER_SWIFT_FLAGS'] || '$(inherited)'
+          swift_flags = swift_flags.join(' ') if swift_flags.is_a?(Array)
+          unless swift_flags.include?('${SWIFTUI_PRIVATE_AUTOLINK_FLAGS}')
+            build_configuration.build_settings['OTHER_SWIFT_FLAGS'] = "\#{swift_flags} ${SWIFTUI_PRIVATE_AUTOLINK_FLAGS}"
+          end
+        end
+      end
+
+      aggregate_target.user_project.save
+    end
+
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |build_configuration|
+        swift_flags = build_configuration.build_settings['OTHER_SWIFT_FLAGS'] || '$(inherited)'
+        swift_flags = swift_flags.join(' ') if swift_flags.is_a?(Array)
+        unless swift_flags.include?('${SWIFTUI_PRIVATE_AUTOLINK_FLAGS}')
+          build_configuration.build_settings['OTHER_SWIFT_FLAGS'] = "\#{swift_flags} ${SWIFTUI_PRIVATE_AUTOLINK_FLAGS}"
+        end
+      end
+    end
+`;
+
+const EXPLICIT_MODULES_WORKAROUND = `${SQLITE_EXPLICIT_MODULES_WORKAROUND}
+${SWIFTUICORE_WORKAROUND}`;
 
 function withExpoSqliteXcode26(config) {
   return withDangerousMod(config, [
@@ -18,13 +54,35 @@ function withExpoSqliteXcode26(config) {
       const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
       const podfile = await fs.promises.readFile(podfilePath, 'utf8');
 
-      if (podfile.includes("build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'")) {
-        return config;
-      }
-
+      const clangSetting = "build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'";
+      const swiftSetting = "build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'";
       const marker = '    react_native_post_install(\n';
       if (!podfile.includes(marker)) {
         throw new Error('expo-sqlite-xcode26: could not locate the Podfile post_install hook');
+      }
+
+      if (podfile.includes(SWIFTUI_PRIVATE_AUTOLINK_FLAGS)) {
+        return config;
+      }
+
+      if (podfile.includes(clangSetting)) {
+        await fs.promises.writeFile(
+          podfilePath,
+          podfile.replace(marker, `${SWIFTUICORE_WORKAROUND}\n${marker}`),
+        );
+        return config;
+      }
+
+      if (podfile.includes(swiftSetting)) {
+        const migratedPodfile = podfile.replace(
+          swiftSetting,
+          `${clangSetting}\n        ${swiftSetting}`,
+        );
+        await fs.promises.writeFile(
+          podfilePath,
+          migratedPodfile.replace(marker, `${SWIFTUICORE_WORKAROUND}\n${marker}`),
+        );
+        return config;
       }
 
       await fs.promises.writeFile(


### PR DESCRIPTION
## Summary
- disable explicit Clang and Swift modules for ExpoSQLite under Xcode 26
- suppress SwiftUICore and UIUtilities private autolinks in generated iOS targets
- keep the Expo config plugin idempotent across prebuilds

## Verification
- `xcodebuild -workspace ios/GitNots.xcworkspace -scheme GitNots -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17" clean build`
- `codesign --verify --deep --strict` on the built simulator app