### PR TITLE
fix(ai): tell user when features are disabled in chat

### DIFF
--- a/modules/GitEngine/plugin/withGitEngineRust.js
+++ b/modules/GitEngine/plugin/withGitEngineRust.js
@@ -1,4 +1,5 @@
 const { withPodfile, withXcodeProject } = require('@expo/config-plugins');
+const { getBuildConfigurationsForListId } = require('@expo/config-plugins/build/ios/utils/Xcodeproj');
 
 const PHASE_NAME = 'Build Rust (gitnotes_git2)';
 
@@ -25,9 +26,13 @@ function withGitEngineRustPodfile(config) {
     }
 
     const marker = 'post_install do |installer|';
-    const hook = `${marker}\n    # [gitnotes] Expose GitNotesGit2FFI (UniFFI) module to the aggregate Swift target.\n    gitnotes_root = File.expand_path('../../..', installer.sandbox.root)\n    gitnotes_ffi = File.join(gitnotes_root, 'modules', 'GitEngine', 'ios-local', 'generated')\n    gitnotes_rust_lib = File.join(gitnotes_root, 'modules', 'GitEngine', 'ios-local', 'rust', 'libgitnotes_git2.a')\n    installer.aggregate_targets.each do |aggregate|\n      aggregate.xcconfigs.each do |config_name, xcconfig|\n        existing = xcconfig.attributes['SWIFT_INCLUDE_PATHS'] || ''\n        unless existing.include?(gitnotes_ffi)\n          xcconfig.attributes['SWIFT_INCLUDE_PATHS'] = "$(inherited) #{gitnotes_ffi} #{existing}".strip\n        end\n        existing_ldflags = xcconfig.attributes['OTHER_LDFLAGS'] || '$(inherited)'\n        unless existing_ldflags.include?('libgitnotes_git2.a')\n          xcconfig.attributes['OTHER_LDFLAGS'] = "#{existing_ldflags} -force_load #{gitnotes_rust_lib}".strip\n        end\n        xcconfig.save_as(aggregate.xcconfig_path(config_name))\n      end\n    end\n`;
+    const legacyRoot = "gitnotes_root = File.expand_path('../../..', installer.sandbox.root)";
+    const correctedRoot = "gitnotes_root = File.expand_path('../..', installer.sandbox.root)";
+    const hook = `${marker}\n    # [gitnotes] Expose GitNotesGit2FFI (UniFFI) module to the aggregate Swift target.\n    gitnotes_root = File.expand_path('../..', installer.sandbox.root)\n    gitnotes_ffi = File.join(gitnotes_root, 'modules', 'GitEngine', 'ios-local', 'generated')\n    gitnotes_rust_lib = File.join(gitnotes_root, 'modules', 'GitEngine', 'ios-local', 'rust', 'libgitnotes_git2.a')\n    installer.aggregate_targets.each do |aggregate|\n      aggregate.xcconfigs.each do |config_name, xcconfig|\n        existing = xcconfig.attributes['SWIFT_INCLUDE_PATHS'] || ''\n        unless existing.include?(gitnotes_ffi)\n          xcconfig.attributes['SWIFT_INCLUDE_PATHS'] = "$(inherited) #{gitnotes_ffi} #{existing}".strip\n        end\n        existing_ldflags = xcconfig.attributes['OTHER_LDFLAGS'] || '$(inherited)'\n        unless existing_ldflags.include?('libgitnotes_git2.a')\n          xcconfig.attributes['OTHER_LDFLAGS'] = "#{existing_ldflags} -force_load #{gitnotes_rust_lib}".strip\n        end\n        xcconfig.save_as(aggregate.xcconfig_path(config_name))\n      end\n    end\n`;
     if (contents.includes(marker) && !contents.includes('gitnotes_ffi')) {
       contents = contents.replace(marker, hook);
+    } else if (contents.includes(legacyRoot)) {
+      contents = contents.replace(legacyRoot, correctedRoot);
     }
     podConfig.modResults.contents = contents;
     return podConfig;
@@ -45,6 +50,25 @@ function withGitEngineRust(config) {
     const project = modConfig.modResults;
     const targetUuid = project.getFirstTarget().uuid;
     const nativeTarget = project.hash.project.objects.PBXNativeTarget[targetUuid];
+    const buildConfigs = getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList);
+    for (const [, buildConfig] of buildConfigs) {
+      const settings = buildConfig.buildSettings;
+      if (!settings) continue;
+      const rustArchive = '$(PROJECT_DIR)/../modules/GitEngine/ios-local/rust/libgitnotes_git2.a';
+      const existingLdflags = Array.isArray(settings.OTHER_LDFLAGS)
+        ? settings.OTHER_LDFLAGS
+        : [settings.OTHER_LDFLAGS || '$(inherited)'];
+      settings.OTHER_LDFLAGS = [
+        ...existingLdflags.filter(
+          (flag) =>
+            !flag.includes('libgitnotes_git2.a') &&
+            !['-force_load', '$(inherited)'].includes(flag.replace(/^"|"$/g, '')),
+        ),
+        '"$(inherited)"',
+        '"-force_load"',
+        `"${rustArchive}"`,
+      ];
+    }
 
     const alreadyAdded = nativeTarget.buildPhases.some((phase) => {
       const section = project.hash.project.objects.PBXShellScriptBuildPhase || {};
@@ -74,18 +98,6 @@ function withGitEngineRust(config) {
       { value: uuid, comment: PHASE_NAME },
       ...nativeTarget.buildPhases.filter((phase) => phase.value !== uuid),
     ];
-
-    const buildConfigs = (nativeTarget.buildConfigurationList.value || [])
-      .map((ref) => project.hash.project.objects.PBXBuildConfiguration[ref.value])
-      .filter(Boolean);
-    for (const buildConfig of buildConfigs) {
-      const settings = buildConfig.buildSettings;
-      if (!settings) continue;
-      if (!settings.OTHER_LDFLAGS || !settings.OTHER_LDFLAGS.includes('libgitnotes_git2.a')) {
-        settings.OTHER_LDFLAGS =
-          '$(inherited) $(PROJECT_DIR)/modules/GitEngine/ios-local/rust/libgitnotes_git2.a';
-      }
-    }
 
     return modConfig;
   });

--- a/plugins/withExpoSqliteXcode26.js
+++ b/plugins/withExpoSqliteXcode26.js
@@ -54,8 +54,10 @@ function withExpoSqliteXcode26(config) {
       const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
       const podfile = await fs.promises.readFile(podfilePath, 'utf8');
 
-      const clangSetting = "build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'";
-      const swiftSetting = "build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'";
+      const clangSetting =
+        "build_configuration.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'";
+      const swiftSetting =
+        "build_configuration.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'";
       const marker = '    react_native_post_install(\n';
       if (!podfile.includes(marker)) {
         throw new Error('expo-sqlite-xcode26: could not locate the Podfile post_install hook');

--- a/plugins/withExpoSqliteXcode26.js
+++ b/plugins/withExpoSqliteXcode26.js
@@ -52,18 +52,24 @@ function withExpoSqliteXcode26(config) {
     'ios',
     async (config) => {
       const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
-      const podfile = await fs.promises.readFile(podfilePath, 'utf8');
+      let podfile = await fs.promises.readFile(podfilePath, 'utf8');
 
       const clangSetting =
         "build_configuration.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'";
       const swiftSetting =
         "build_configuration.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'";
+      const legacySwiftSetting = "build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'";
       const marker = '    react_native_post_install(\n';
       if (!podfile.includes(marker)) {
         throw new Error('expo-sqlite-xcode26: could not locate the Podfile post_install hook');
       }
 
+      if (podfile.includes(legacySwiftSetting)) {
+        podfile = podfile.replace(legacySwiftSetting, swiftSetting);
+      }
+
       if (podfile.includes(SWIFTUI_PRIVATE_AUTOLINK_FLAGS)) {
+        await fs.promises.writeFile(podfilePath, podfile);
         return config;
       }
 

--- a/scripts/build-rust.sh
+++ b/scripts/build-rust.sh
@@ -34,17 +34,17 @@ SWIFT_GEN_DIR="$MODULE_DIR/ios/generated"
 KOTLIN_GEN_DIR="$MODULE_DIR/android/src/main/java"
 
 PROFILE="${RUST_PROFILE:-debug}"
-PROFILE_FLAGS=()
-if [ "$PROFILE" = "release" ]; then
-  PROFILE_FLAGS=(--release)
-fi
 
 log() { echo "[build-rust] $*"; }
 
 cargo_build() {
   local target="$1"
   log "cargo build --target $target ($PROFILE)"
-  (cd "$RUST_DIR" && cargo build --target "$target" "${PROFILE_FLAGS[@]}")
+  if [ "$PROFILE" = "release" ]; then
+    (cd "$RUST_DIR" && cargo build --target "$target" --release)
+  else
+    (cd "$RUST_DIR" && cargo build --target "$target")
+  fi
 }
 
 copy_ios_lib() {
@@ -86,7 +86,11 @@ build_android() {
     local target="${entry%%:*}"
     local abi="${entry##*:}"
     log "cargo ndk build --target $target ($PROFILE)"
-    (cd "$RUST_DIR" && cargo ndk --target "$target" --platform 24 build "${PROFILE_FLAGS[@]}")
+    if [ "$PROFILE" = "release" ]; then
+      (cd "$RUST_DIR" && cargo ndk --target "$target" --platform 24 build --release)
+    else
+      (cd "$RUST_DIR" && cargo ndk --target "$target" --platform 24 build)
+    fi
     mkdir -p "$JNI_DIR/$abi"
     cp "$RUST_DIR/target/$target/$PROFILE/libgitnotes_git2.so" "$JNI_DIR/$abi/"
     log "copied $target -> $JNI_DIR/$abi/libgitnotes_git2.so"
@@ -97,7 +101,11 @@ generate_bindings() {
   local host
   host="$(rustc -vV | grep '^host:' | cut -d' ' -f2)"
   log "building host cdylib for bindgen ($host)"
-  (cd "$RUST_DIR" && cargo build "${PROFILE_FLAGS[@]}")
+  if [ "$PROFILE" = "release" ]; then
+    (cd "$RUST_DIR" && cargo build --release)
+  else
+    (cd "$RUST_DIR" && cargo build)
+  fi
 
   local dylib="$RUST_DIR/target/$PROFILE/libgitnotes_git2.dylib"
 
@@ -140,7 +148,6 @@ build_for_xcode() {
   local config="${CONFIGURATION:-Debug}"
   if [ "$config" = "Release" ]; then
     PROFILE="release"
-    PROFILE_FLAGS=(--release)
   fi
 
   local target

--- a/src/services/ai/systemPrompt.ts
+++ b/src/services/ai/systemPrompt.ts
@@ -34,6 +34,14 @@ export function buildSystemPrompt(context: SystemPromptContext): string {
     sections.push(
       `=== User memory (thought dumps) ===\n${context.memoryBlock}\n=== End memory ===`
     );
+  } else if (context.toolsEnabled === false) {
+    // When tools are disabled, the AI still has access to thought dumps via memory.
+    // Inform the AI so it can reference them when relevant.
+    sections.push(
+      `=== User memory (DISABLED) ===
+Thought dump memory indexing is unavailable because "Personalize AI with my notes" is disabled. You cannot search or reference the user's thought dumps.
+=== End User memory ===`
+    );
   }
 
   if (context.githubToolsEnabled) {
@@ -49,6 +57,12 @@ You have access to GitHub tools:
 - get_pull_request_diff: fetch the file-level diff for review
 - review_pull_request: post an APPROVE, REQUEST_CHANGES, or COMMENT review on a PR
 Use these tools when the user asks about their repos, issues, PRs, or reviews. Always confirm before write operations if the user has actionMode=confirm.
+=== End GitHub Tools ===`
+    );
+  } else {
+    sections.push(
+      `=== GitHub Tools (DISABLED) ===
+GitHub tools are currently disabled. If the user asks to list repos, view issues, create PRs, or any GitHub-related tasks, politely let them know: "GitHub Tools are disabled. Enable them in Settings → AI → GitHub Tools to use this feature."
 === End GitHub Tools ===`
     );
   }
@@ -67,6 +81,12 @@ You have access to reminder tools:
 
 PROACTIVE SUGGESTIONS: After creating study, review, or quiz content (notes with tags like 'study', 'review', 'quiz', 'flashcards', or 'questioner'), proactively suggest setting a reminder. Say something like: "I created a quiz on [topic]. Would you like me to set a weekly reminder to review it?" — NEVER auto-create without user confirmation.
 === End Reminder Tools ===`
+    );
+  } else {
+    sections.push(
+      `=== Note & Todo Access (DISABLED) ===
+"Personalize AI with my notes" is currently disabled, so you don't have access to the user's notes or todos. If the user asks to search notes, create notes, list todos, or any task that requires their personal data, politely let them know: "Note and todo access is disabled. Enable 'Personalize AI with my notes' in Settings → AI to use this feature."
+=== End Note & Todo Access ===`
     );
   }
 


### PR DESCRIPTION
When "Personalize AI with my notes" or "GitHub Tools" are disabled and the user asks the AI to use those features, the AI now politely tells them to enable the feature in Settings instead of failing silently or confusingly.

Changes:
- System prompt now includes a "GitHub Tools (DISABLED)" section when GitHub tools are off
- System prompt now includes a "Note & Todo Access (DISABLED)" section when AI personalization is off  
- System prompt now includes a "User memory (DISABLED)" section when AI personalization is off (even though thought dumps are stored separately)