### PR TITLE
fix(explore): responsive Repository/Repo tab label

### DIFF
--- a/src/components/explore/exploreShared.tsx
+++ b/src/components/explore/exploreShared.tsx
@@ -31,7 +31,7 @@ export const EXPLORE_SECTIONS = [
   { id: 'conflicts', label: 'Conflicts' },
   { id: 'pulls', label: 'Pull Requests' },
   { id: 'issues', label: 'Issues' },
-  { id: 'info', label: 'Repo Info' },
+  { id: 'info', label: 'Repository', shortLabel: 'Repo' },
 ] as const;
 
 export type ExploreSection = (typeof EXPLORE_SECTIONS)[number]['id'];

--- a/src/components/ui/SectionTabs.tsx
+++ b/src/components/ui/SectionTabs.tsx
@@ -6,6 +6,7 @@ import type { SectionTabColor } from '../explore/exploreShared';
 export interface SectionTab {
   id: string;
   label: string;
+  shortLabel?: string;
   color?: SectionTabColor;
 }
 
@@ -14,6 +15,7 @@ interface SectionTabsProps {
   value: string;
   onChange: (id: string) => void;
   testID?: string;
+  renderLabel?: (tab: SectionTab, isActive: boolean) => React.ReactNode;
 }
 
 const COLOR_MAP: Record<SectionTabColor, keyof ReturnType<typeof useTokens>['colors']> = {
@@ -23,7 +25,7 @@ const COLOR_MAP: Record<SectionTabColor, keyof ReturnType<typeof useTokens>['col
   accent: 'accent',
 };
 
-export function SectionTabs({ tabs, value, onChange, testID }: SectionTabsProps) {
+export function SectionTabs({ tabs, value, onChange, testID, renderLabel }: SectionTabsProps) {
   const { colors } = useTokens();
 
   return (
@@ -56,7 +58,7 @@ export function SectionTabs({ tabs, value, onChange, testID }: SectionTabsProps)
                 color: isActive ? activeColor : colors.textSecondary,
               }}
             >
-              {tab.label}
+              {renderLabel ? renderLabel(tab, isActive) : tab.label}
             </Text>
           </Pressable>
         );

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AppState,
   AppStateStatus,
+  Dimensions,
   FlatList,
   Pressable,
   ScrollView,
@@ -341,6 +342,12 @@ export default function ExploreScreen() {
               value={section}
               onChange={(id) => setSection(id as ExploreSection)}
               testID="explore.tabs"
+              renderLabel={(tab) => {
+                if (tab.shortLabel && Dimensions.get('window').width < 400) {
+                  return tab.shortLabel;
+                }
+                return tab.label;
+              }}
             />
             </View>
         </BlurView>


### PR DESCRIPTION
Changes:\n- Explore tab bar: "Repository" on wide screens (≥400pt), "Repo" on narrow screens\n- Removed "..." from the tab label (was "Repo Info")\n- Added  field to  type\n- Added  prop to  for custom label rendering\n\nPattern is now reusable — add  to any tab in  and handle it in .