### PR TITLE
feat(canvas): redesign canvases list with proper cards and grid/list toggle

### DIFF
--- a/src/components/CanvasCard.tsx
+++ b/src/components/CanvasCard.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { format } from 'date-fns';
+import { Canvas } from '../models/Canvas';
+import { useTheme } from '../contexts/ThemeContext';
+import { TagChips } from './TagChips';
+import CanvasThumbnail from './CanvasThumbnail';
+
+interface CanvasCardProps {
+  canvas: Canvas;
+  onPress: (canvas: Canvas) => void;
+  onLongPress?: (canvas: Canvas) => void;
+  onTagPress?: (tag: string) => void;
+  compact?: boolean;
+}
+
+function CanvasCardImpl({
+  canvas,
+  onPress,
+  onLongPress,
+  onTagPress,
+  compact = false,
+}: CanvasCardProps) {
+  const { colors, isDark } = useTheme();
+  const elementCount = canvas.scene?.elements?.length ?? 0;
+  const sceneWidth = canvas.scene?.width ?? 800;
+  const sceneHeight = canvas.scene?.height ?? 600;
+  const title = canvas.title || 'Untitled Canvas';
+  const formattedDate = format(new Date(canvas.updatedAt), compact ? 'MMM d' : 'MMM d, yyyy');
+
+  return (
+    <TouchableOpacity
+      testID={`canvas-card-${canvas.id}`}
+      accessibilityLabel={`${title}, ${sceneWidth} by ${sceneHeight}, ${elementCount} elements, ${formattedDate}`}
+      accessibilityRole="button"
+      style={[
+        styles.card,
+        {
+          backgroundColor: colors.card,
+          shadowColor: colors.shadow,
+          shadowOpacity: isDark ? 0 : 0.1,
+        },
+        compact && styles.cardCompact,
+      ]}
+      onPress={() => onPress(canvas)}
+      onLongPress={() => onLongPress?.(canvas)}
+      activeOpacity={0.7}
+    >
+      <View style={styles.contentRow}>
+        {/* Thumbnail */}
+        <View style={[styles.thumbnailContainer, compact && styles.thumbnailCompact]}>
+          <CanvasThumbnail
+            scene={canvas.scene}
+            width={compact ? 80 : 120}
+            height={compact ? 80 : 120}
+          />
+        </View>
+
+        {/* Main content */}
+        <View style={styles.mainContent}>
+          {/* Header */}
+          <View style={styles.header}>
+            <View style={styles.titleRow}>
+              <Ionicons name="easel-outline" size={18} color={colors.primary} />
+              <Text
+                style={[styles.title, { color: colors.text }]}
+                numberOfLines={compact ? 1 : 2}
+              >
+                {title}
+              </Text>
+            </View>
+
+            {/* Dimensions badge */}
+            <View style={[styles.dimensionsBadge, { backgroundColor: colors.primary + '18' }]}>
+              <Text style={[styles.dimensionsText, { color: colors.primary }]}>
+                {sceneWidth} × {sceneHeight}
+              </Text>
+            </View>
+          </View>
+
+          {/* Element count */}
+          <View style={styles.elementCountRow}>
+            <Ionicons name="layers-outline" size={14} color={colors.textSecondary} />
+            <Text style={[styles.elementCountText, { color: colors.textSecondary }]}>
+              {elementCount} element{elementCount !== 1 ? 's' : ''}
+            </Text>
+          </View>
+
+          {/* Tags */}
+          {!compact && canvas.tags.length > 0 && (
+            <View style={styles.tagsRow}>
+              <TagChips tags={canvas.tags} onTagPress={onTagPress} />
+            </View>
+          )}
+
+          {/* Repo/Branch info */}
+          {!compact && (canvas.repo || canvas.folderPath) && (
+            <View style={[styles.repoContainer, { borderTopColor: colors.border }]}>
+              {canvas.folderPath && canvas.folderPath !== '/' && (
+                <View style={styles.repoItem}>
+                  <Ionicons name="folder" size={14} color={colors.textSecondary} />
+                  <Text style={[styles.repoText, { color: colors.textSecondary }]}>
+                    {canvas.folderPath.split('/').pop()}
+                  </Text>
+                </View>
+              )}
+              {canvas.repo && (
+                <View style={styles.repoItem}>
+                  <Ionicons name="cube-outline" size={14} color={colors.textSecondary} />
+                  <Text style={[styles.repoText, { color: colors.textSecondary }]}>
+                    {canvas.repo}
+                  </Text>
+                </View>
+              )}
+              {canvas.branch && (
+                <View style={styles.repoItem}>
+                  <Ionicons name="git-branch-outline" size={14} color={colors.primary} />
+                  <Text style={[styles.branchText, { color: colors.primary }]}>
+                    {canvas.branch}
+                  </Text>
+                </View>
+              )}
+            </View>
+          )}
+        </View>
+      </View>
+
+      {/* Footer with date */}
+      <View style={styles.footer}>
+        <Text style={[styles.date, { color: colors.textSecondary }]}>
+          {formattedDate}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const CanvasCard = React.memo(CanvasCardImpl);
+export default CanvasCard;
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+    padding: 16,
+    marginVertical: 8,
+    marginHorizontal: 16,
+    ...Platform.select({
+      ios: {
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.1,
+        shadowRadius: 4,
+      },
+      android: {
+        elevation: 3,
+      },
+    }),
+  },
+  cardCompact: {
+    padding: 12,
+    marginVertical: 4,
+    marginHorizontal: 0,
+  },
+  contentRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  thumbnailContainer: {
+    borderRadius: 8,
+    overflow: 'hidden',
+    flexShrink: 0,
+  },
+  thumbnailCompact: {
+    borderRadius: 6,
+  },
+  mainContent: {
+    flex: 1,
+    minWidth: 0,
+  },
+  header: {
+    marginBottom: 8,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 6,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    flex: 1,
+    minWidth: 0,
+  },
+  dimensionsBadge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+  },
+  dimensionsText: {
+    fontSize: 11,
+    fontWeight: '600',
+    fontFamily: 'monospace',
+  },
+  elementCountRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    marginBottom: 8,
+  },
+  elementCountText: {
+    fontSize: 12,
+  },
+  tagsRow: {
+    marginTop: 4,
+  },
+  repoContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 8,
+    paddingTop: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    flexWrap: 'wrap',
+  },
+  repoItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: 12,
+    marginBottom: 2,
+    gap: 4,
+  },
+  repoText: {
+    fontSize: 12,
+  },
+  branchText: {
+    fontSize: 12,
+  },
+  footer: {
+    marginTop: 8,
+    paddingTop: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: 'rgba(0,0,0,0.05)',
+  },
+  date: {
+    fontSize: 12,
+  },
+});

--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -28,7 +28,7 @@ import { useEntityFilter } from '../hooks/useEntityFilter';
 import { useResponsive } from '../hooks/useResponsive';
 import { useTranslation } from 'react-i18next';
 import { useProGate } from '../hooks/useProGate';
-import CanvasThumbnail from '../components/CanvasThumbnail';
+import CanvasCard from '../components/CanvasCard';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -41,71 +41,27 @@ const CANVAS_PRESET_DIMS: Record<(typeof CANVAS_PRESET_KEYS)[number], { w: numbe
   'canvases.presets.a4': { w: 794, h: 1123, desc: '794 × 1123' },
 };
 
-interface CanvasRowProps {
-  item: Canvas;
+interface CanvasCardContainerProps {
+  canvas: Canvas;
   onOpen: (id: string) => void;
   onDelete: (canvas: Canvas) => void;
 }
 
-function CanvasRow({ item, onOpen, onDelete }: CanvasRowProps) {
-  const { t } = useTranslation();
-  const { colors } = useTheme();
-  const elementCount = item.scene?.elements?.length ?? 0;
-  const date = new Date(item.updatedAt);
-  const dateStr = date.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+function CanvasCardContainer({ canvas, onOpen, onDelete }: CanvasCardContainerProps) {
+  const handlePress = useCallback(() => {
+    onOpen(canvas.id);
+  }, [canvas.id, onOpen]);
+
+  const handleLongPress = useCallback(() => {
+    onDelete(canvas);
+  }, [canvas, onDelete]);
 
   return (
-    <TouchableOpacity
-      testID="canvas-list.button.open"
-      className="flex-row items-center p-3.5 rounded-md border mb-2.5"
-      style={{ backgroundColor: colors.surface, borderColor: colors.border }}
-      onPress={() => onOpen(item.id)}
-      activeOpacity={0.7}
-    >
-      <View className="mr-3 rounded overflow-hidden" style={{ width: 60, height: 60 }}>
-        <CanvasThumbnail scene={item.scene} width={60} height={60} />
-      </View>
-      <View className="flex-1">
-        <View className="flex-row items-center gap-2 mb-1">
-          <Ionicons name="easel-outline" size={18} color={colors.primary} />
-          <Text className="text-base font-semibold flex-1" style={{ color: colors.text }} numberOfLines={1}>
-            {item.title || t('canvases.untitled')}
-          </Text>
-        </View>
-        <Text className="text-xs mb-1" style={{ color: colors.textSecondary }}>
-          {elementCount} element{elementCount !== 1 ? 's' : ''} · {dateStr}
-        </Text>
-        {item.repo && (
-          <View className="flex-row items-center gap-1 mt-1">
-            <Ionicons name="git-branch-outline" size={12} color={colors.primary} />
-            <Text className="text-xs font-medium" style={{ color: colors.primary }} numberOfLines={1}>
-              {item.repo.split('/').pop()}{item.branch ? ` · ${item.branch}` : ''}
-            </Text>
-          </View>
-        )}
-        {item.tags.length > 0 && (
-          <View className="flex-row gap-1.5 flex-wrap">
-            {item.tags.slice(0, 3).map((tag) => (
-              <View key={tag} className="px-2 py-0.5 rounded-sm" style={{ backgroundColor: colors.primary + '18' }}>
-                <Text className="text-xs font-medium" style={{ color: colors.primary }}>{tag}</Text>
-              </View>
-            ))}
-          </View>
-        )}
-      </View>
-      <TouchableOpacity
-        testID="canvas-list.button.delete"
-        className="p-3"
-        onPress={() => onDelete(item)}
-      >
-        <Ionicons name="trash-outline" size={20} color={colors.textSecondary} />
-      </TouchableOpacity>
-    </TouchableOpacity>
+    <CanvasCard
+      canvas={canvas}
+      onPress={handlePress}
+      onLongPress={handleLongPress}
+    />
   );
 }
 
@@ -189,7 +145,7 @@ export default function CanvasListScreen() {
 
   const renderCanvas = useCallback(
     ({ item }: { item: Canvas }) => (
-      <CanvasRow item={item} onOpen={handleOpen} onDelete={handleDelete} />
+      <CanvasCardContainer canvas={item} onOpen={handleOpen} onDelete={handleDelete} />
     ),
     [handleOpen, handleDelete],
   );

--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
+  StyleSheet,
 } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -25,10 +26,11 @@ import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { EntityFilterModal } from '../components/EntityFilterModal';
 import { ActiveFilterStrip } from '../components/ActiveFilterStrip';
 import { useEntityFilter } from '../hooks/useEntityFilter';
-import { useResponsive } from '../hooks/useResponsive';
 import { useTranslation } from 'react-i18next';
 import { useProGate } from '../hooks/useProGate';
 import CanvasCard from '../components/CanvasCard';
+
+type CanvasViewMode = 'list' | 'grid';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -76,12 +78,13 @@ export default function CanvasListScreen() {
   const { repositories } = useRepos();
   const filter = useEntityFilter<Canvas>(canvases);
   const displayCanvases = useMemo(() => filter.applyFilters(filteredCanvases), [filter, filteredCanvases]);
-  const { columnCount } = useResponsive('list');
   const [showSizePicker, setShowSizePicker] = useState(false);
   const [showFilterModal, setShowFilterModal] = useState(false);
+  const [showViewModePicker, setShowViewModePicker] = useState(false);
   const [customW, setCustomW] = useState('800');
   const [customH, setCustomH] = useState('600');
   const [canvasTitle, setCanvasTitle] = useState('');
+  const [viewMode, setViewMode] = useState<CanvasViewMode>('list');
 
   useFocusEffect(
     useCallback(() => {
@@ -143,6 +146,11 @@ export default function CanvasListScreen() {
     [deleteCanvas, t],
   );
 
+  const handleViewModeChange = useCallback((mode: CanvasViewMode) => {
+    setViewMode(mode);
+    setShowViewModePicker(false);
+  }, []);
+
   const renderCanvas = useCallback(
     ({ item }: { item: Canvas }) => (
       <CanvasCardContainer canvas={item} onOpen={handleOpen} onDelete={handleDelete} />
@@ -174,10 +182,10 @@ export default function CanvasListScreen() {
         data={displayCanvases}
         keyExtractor={(item) => item.id}
         renderItem={renderCanvas}
-        numColumns={columnCount}
-        key={`canvases-${columnCount}`}
+        numColumns={viewMode === 'grid' ? 2 : 1}
+        key={`canvases-${viewMode}`}
         contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 16, paddingBottom: tabBarHeight + 24 }}
-        columnWrapperStyle={columnCount > 1 ? { gap: 8 } : undefined}
+        columnWrapperStyle={viewMode === 'grid' ? { gap: 12 } : undefined}
         ListEmptyComponent={
           <View className="items-center justify-center pt-15 px-6">
             <Ionicons name="easel-outline" size={48} color={colors.textSecondary} />
@@ -196,6 +204,58 @@ export default function CanvasListScreen() {
           </View>
         }
       />
+
+      <Modal
+        visible={showViewModePicker}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowViewModePicker(false)}
+      >
+        <TouchableOpacity
+          style={styles.viewModeBackdrop}
+          activeOpacity={1}
+          onPress={() => setShowViewModePicker(false)}
+        >
+          <View style={[styles.viewModeSheet, { backgroundColor: colors.surface }]}>
+            <View style={[styles.viewModeHandle, { backgroundColor: colors.border + '40' }]} />
+            <Text style={[styles.viewModeTitle, { color: colors.textSecondary }]}>View Mode</Text>
+            <View style={styles.viewModeOptions}>
+              <TouchableOpacity
+                testID="canvas-view-mode.button.change-list"
+                style={[styles.viewModeOption, viewMode === 'list' && { backgroundColor: colors.primary + '15' }]}
+                onPress={() => handleViewModeChange('list')}
+                activeOpacity={0.7}
+              >
+                <Ionicons
+                  name="list"
+                  size={22}
+                  color={viewMode === 'list' ? colors.primary : colors.textSecondary}
+                />
+                <Text style={[styles.viewModeLabel, { color: viewMode === 'list' ? colors.primary : colors.text }]}>
+                  List
+                </Text>
+                {viewMode === 'list' && <Ionicons name="checkmark" size={18} color={colors.primary} />}
+              </TouchableOpacity>
+              <TouchableOpacity
+                testID="canvas-view-mode.button.change-grid"
+                style={[styles.viewModeOption, viewMode === 'grid' && { backgroundColor: colors.primary + '15' }]}
+                onPress={() => handleViewModeChange('grid')}
+                activeOpacity={0.7}
+              >
+                <Ionicons
+                  name="grid"
+                  size={22}
+                  color={viewMode === 'grid' ? colors.primary : colors.textSecondary}
+                />
+                <Text style={[styles.viewModeLabel, { color: viewMode === 'grid' ? colors.primary : colors.text }]}>
+                  Grid
+                </Text>
+                {viewMode === 'grid' && <Ionicons name="checkmark" size={18} color={colors.primary} />}
+              </TouchableOpacity>
+            </View>
+          </View>
+        </TouchableOpacity>
+      </Modal>
 
       <Modal
         visible={showSizePicker}
@@ -303,6 +363,18 @@ export default function CanvasListScreen() {
           <>
             <IconButton
               size="sm"
+              testID="canvas-list.icon-button.view-mode"
+              onPress={() => setShowViewModePicker(true)}
+              accessibilityLabel={t('common.viewMode')}
+            >
+              <Ionicons
+                name={viewMode === 'list' ? 'list' : 'grid'}
+                size={18}
+                color={colors.textSecondary}
+              />
+            </IconButton>
+            <IconButton
+              size="sm"
               testID="canvas-list.icon-button.filters"
               active={filter.activeCount > 0}
               onPress={() => setShowFilterModal(true)}
@@ -323,4 +395,48 @@ export default function CanvasListScreen() {
     </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  viewModeBackdrop: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  viewModeSheet: {
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingBottom: 32,
+  },
+  viewModeHandle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    alignSelf: 'center',
+    marginTop: 10,
+    marginBottom: 8,
+  },
+  viewModeTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  viewModeOptions: {
+    paddingHorizontal: 12,
+  },
+  viewModeOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderRadius: 10,
+    gap: 12,
+  },
+  viewModeLabel: {
+    fontSize: 16,
+    flex: 1,
+  },
+});
 


### PR DESCRIPTION
## Summary

Redesigned the canvases list to match the quality and patterns of the notes list.

### Changes

**New CanvasCard component** (src/components/CanvasCard.tsx):
- Larger 120x120 thumbnail (doubled from old 60x60)
- Proper card styling: shadows, border-radius 12px, using colors.card background
- Dimensions badge showing canvas size prominently
- Element count with layers icon
- Tags rendered via TagChips component
- Repo/branch info with icons
- Delete via long-press instead of tiny trash button

**CanvasListScreen updates**:
- Replaced inline CanvasRow with CanvasCardContainer wrapper
- NEW: Grid/List view toggle
- Grid mode shows 2-column layout
- View mode picker modal matching NotesListScreen pattern

### Testing

- ESLint 0 errors
- TypeScript compiles