### PR TITLE
fix: add missing skip param to recentCommits, widen template modal, add disabled AI feature prompts

### DIFF
--- a/modules/GitEngine/android/src/main/java/expo/modules/gitengine/GitEngineModule.kt
+++ b/modules/GitEngine/android/src/main/java/expo/modules/gitengine/GitEngineModule.kt
@@ -196,7 +196,7 @@ class GitEngineModule : Module() {
     }
 
     AsyncFunction("recentCommits") Coroutine { path: String, limit: Int ->
-      engineOp { recentCommits(fsPath(path), limit.toUInt()).map(::commitDict) }
+      engineOp { recentCommits(fsPath(path), 0u, limit.toUInt()).map(::commitDict) }
     }
 
     AsyncFunction("commitDiff") Coroutine { path: String, commitId: String ->

--- a/src/components/templates/TemplateEditorModal.tsx
+++ b/src/components/templates/TemplateEditorModal.tsx
@@ -61,7 +61,7 @@ export function TemplateEditorModal({
   const tagLimitReached = draftTags.length >= TEMPLATE_MAX_TAGS;
 
   return (
-    <Modal visible={visible} onRequestClose={onClose} contentStyle={{ width: '100%', maxWidth: isTablet ? undefined : 480, flex: 1 }}>
+    <Modal visible={visible} onRequestClose={onClose} fullWidth contentStyle={{ maxWidth: isTablet ? 720 : 480 }}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} className="flex-1 pt-3 px-5 pb-3">
         <Text className="text-[22px] font-bold mb-[18px]" style={{ color: colors.text }}>{editingId ? t('templates.editTemplate') : t('templates.newTemplate')}</Text>
 

--- a/src/services/ai/systemPrompt.ts
+++ b/src/services/ai/systemPrompt.ts
@@ -51,6 +51,12 @@ You have access to GitHub tools:
 Use these tools when the user asks about their repos, issues, PRs, or reviews. Always confirm before write operations if the user has actionMode=confirm.
 === End GitHub Tools ===`
     );
+  } else {
+    sections.push(
+      `=== GitHub Tools (DISABLED) ===
+GitHub tools are currently disabled. If the user asks to list repos, view issues, create PRs, or any GitHub-related tasks, politely let them know: "GitHub Tools are disabled. Enable them in Settings → AI → GitHub Tools to use this feature."
+=== End GitHub Tools ===`
+    );
   }
 
   if (context.toolsEnabled !== false) {
@@ -67,6 +73,12 @@ You have access to reminder tools:
 
 PROACTIVE SUGGESTIONS: After creating study, review, or quiz content (notes with tags like 'study', 'review', 'quiz', 'flashcards', or 'questioner'), proactively suggest setting a reminder. Say something like: "I created a quiz on [topic]. Would you like me to set a weekly reminder to review it?" — NEVER auto-create without user confirmation.
 === End Reminder Tools ===`
+    );
+  } else {
+    sections.push(
+      `=== Note & Todo Access (DISABLED) ===
+"Personalize AI with my notes" is currently disabled, so you don't have access to the user's notes or todos. If the user asks to search notes, create notes, list todos, or any task that requires their personal data, politely let them know: "Note and todo access is disabled. Enable 'Personalize AI with my notes' in Settings → AI to use this feature."
+=== End Note & Todo Access ===`
     );
   }
 


### PR DESCRIPTION
## What

- **Android build fix**:  UniFFI binding requires a `skip` param; Android was passing only `limit`
- **Template editor modal**: now takes full available width on tablets (720px max) instead of collapsing to content width
- **AI system prompt**: when GitHub Tools or Note/Todo access are disabled, the model now explains this gracefully instead of silently refusing

## Testing

- `yarn ts:check` passes
- Android build: `yarn android` compiles without `compileDebugKotlin` error