### PR TITLE
fix: template modal width and canvas list back button

### DIFF
--- a/src/components/templates/TemplateEditorModal.tsx
+++ b/src/components/templates/TemplateEditorModal.tsx
@@ -61,7 +61,7 @@ export function TemplateEditorModal({
   const tagLimitReached = draftTags.length >= TEMPLATE_MAX_TAGS;
 
   return (
-    <Modal visible={visible} onRequestClose={onClose} fullWidth contentStyle={{ maxWidth: isTablet ? 720 : 480 }}>
+    <Modal visible={visible} onRequestClose={onClose} contentStyle={{ maxWidth: isTablet ? 720 : 480 }}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} className="flex-1 pt-3 px-5 pb-3">
         <Text className="text-[22px] font-bold mb-[18px]" style={{ color: colors.text }}>{editingId ? t('templates.editTemplate') : t('templates.newTemplate')}</Text>
 

--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -359,6 +359,7 @@ export default function CanvasListScreen() {
       </Modal>
       <ScreenHeader
         title={t('canvases.title')}
+        onBack={() => navigation.goBack()}
         actions={
           <>
             <IconButton


### PR DESCRIPTION
## What

- **Template modal**: remove  prop that was making it stretch to full screen width on tablets; now respects the proper  (720px tablet / 480px phone)
- **Canvas list screen**: add back button to  so users arriving via deep link () can navigate back

## Testing

- `yarn ts:check` passes