### PR TITLE
fix: template modal full width, canvas back button, quick access card sizing

### DIFF
--- a/src/components/home/QuickAccessShelf.tsx
+++ b/src/components/home/QuickAccessShelf.tsx
@@ -33,6 +33,7 @@ export function QuickAccessShelf({ items, onOpen, onLongPress }: Props) {
             key={`${item.kind}-${item.data.id}`}
             item={item}
             size="medium"
+            widthOverride={160}
             hidePinGlyph
             onPress={() => onOpen(item)}
             onLongPress={onLongPress ? () => onLongPress(item) : undefined}

--- a/src/components/templates/TemplateEditorModal.tsx
+++ b/src/components/templates/TemplateEditorModal.tsx
@@ -61,7 +61,7 @@ export function TemplateEditorModal({
   const tagLimitReached = draftTags.length >= TEMPLATE_MAX_TAGS;
 
   return (
-    <Modal visible={visible} onRequestClose={onClose} contentStyle={{ maxWidth: isTablet ? 720 : 480 }}>
+    <Modal visible={visible} onRequestClose={onClose} fullWidth contentStyle={{ width: '100%', maxWidth: isTablet ? 720 : 480 }}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} className="flex-1 pt-3 px-5 pb-3">
         <Text className="text-[22px] font-bold mb-[18px]" style={{ color: colors.text }}>{editingId ? t('templates.editTemplate') : t('templates.newTemplate')}</Text>
 

--- a/src/components/templates/TemplateEditorModal.tsx
+++ b/src/components/templates/TemplateEditorModal.tsx
@@ -61,7 +61,7 @@ export function TemplateEditorModal({
   const tagLimitReached = draftTags.length >= TEMPLATE_MAX_TAGS;
 
   return (
-    <Modal visible={visible} onRequestClose={onClose} fullWidth contentStyle={{ maxWidth: isTablet ? 720 : 480 }}>
+    <Modal visible={visible} onRequestClose={onClose} contentStyle={{ maxWidth: isTablet ? 720 : 480 }}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} className="flex-1 pt-3 px-5 pb-3">
         <Text className="text-[22px] font-bold mb-[18px]" style={{ color: colors.text }}>{editingId ? t('templates.editTemplate') : t('templates.newTemplate')}</Text>
 

--- a/src/screens/CanvasListScreen.tsx
+++ b/src/screens/CanvasListScreen.tsx
@@ -359,6 +359,7 @@ export default function CanvasListScreen() {
       </Modal>
       <ScreenHeader
         title={t('canvases.title')}
+        onBack={() => navigation.goBack()}
         actions={
           <>
             <IconButton


### PR DESCRIPTION
## What

- **Template modal**: use `fullWidth` + `width: 100%` so the modal Surface actually fills available width instead of being a thin bar
- **Canvas list screen**: add back button to `ScreenHeader` for users arriving via deep link
- **Quick access cards**: add `widthOverride={160}` to match recent cards' `TILE_WIDTH_HINT[medium]` width

## Testing

- `yarn ts:check` passes