### PR TITLE
fix: align quick access cards and template modal sizing

### DIFF
--- a/src/components/home/BentoRecent.tsx
+++ b/src/components/home/BentoRecent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
-import { BentoTile } from './BentoTile';
+import { BentoTile, getBentoMediumTileWidth } from './BentoTile';
 import type { RecentItem } from '../../utils/recentItems';
 import { useResponsive } from '../../hooks/useResponsive';
 
@@ -13,7 +13,8 @@ interface Props {
 
 export function BentoRecent({ items, onOpen, onLongPress }: Props) {
   const { colors } = useTheme();
-  const { columnCount } = useResponsive('bento');
+  const { screenWidth, columnCount } = useResponsive('bento');
+  const tileWidth = getBentoMediumTileWidth(screenWidth, columnCount);
 
   if (items.length === 0) return null;
 
@@ -35,6 +36,7 @@ export function BentoRecent({ items, onOpen, onLongPress }: Props) {
                   <BentoTile
                     item={item}
                     size="medium"
+                    widthOverride={tileWidth}
                     onPress={() => onOpen(item)}
                     onLongPress={onLongPress ? () => onLongPress(item) : undefined}
                     testIDSlot={`recent-${flatIdx}`}

--- a/src/components/home/BentoTile.tsx
+++ b/src/components/home/BentoTile.tsx
@@ -133,6 +133,10 @@ const TILE_WIDTH_HINT: Record<BentoSize, number> = { large: 320, medium: 160, sm
 const SNIPPET_LINES: Record<BentoSize, number> = { large: 3, medium: 2, small: 1, pinned: 2 };
 const COLOR_STRIPE_WIDTH = 4;
 
+export function getBentoMediumTileWidth(screenWidth: number, columnCount: number): number {
+  return (screenWidth - 40 - 12 * (columnCount - 1)) / columnCount;
+}
+
 export function BentoTile({ item, size, onPress, onLongPress, widthOverride, hidePinGlyph, testIDSlot }: Props) {
   const { colors } = useTheme();
   const isLarge = size === 'large';

--- a/src/components/home/QuickAccessShelf.tsx
+++ b/src/components/home/QuickAccessShelf.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../../contexts/ThemeContext';
+import { useResponsive } from '../../hooks/useResponsive';
 import type { RecentItem } from '../../utils/recentItems';
-import { BentoTile } from './BentoTile';
+import { BentoTile, getBentoMediumTileWidth } from './BentoTile';
 
 interface Props {
   items: RecentItem[];
@@ -15,6 +16,8 @@ const EDGE_INSET = 20;
 
 export function QuickAccessShelf({ items, onOpen, onLongPress }: Props) {
   const { colors } = useTheme();
+  const { screenWidth, columnCount } = useResponsive('bento');
+  const tileWidth = getBentoMediumTileWidth(screenWidth, columnCount);
   if (items.length === 0) return null;
 
   return (
@@ -33,7 +36,7 @@ export function QuickAccessShelf({ items, onOpen, onLongPress }: Props) {
             key={`${item.kind}-${item.data.id}`}
             item={item}
             size="medium"
-            widthOverride={160}
+            widthOverride={tileWidth}
             hidePinGlyph
             onPress={() => onOpen(item)}
             onLongPress={onLongPress ? () => onLongPress(item) : undefined}

--- a/src/components/templates/TemplateEditorModal.tsx
+++ b/src/components/templates/TemplateEditorModal.tsx
@@ -5,7 +5,6 @@ import { Ionicons } from '@expo/vector-icons';
 import { Modal } from '../ui';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useTranslation } from 'react-i18next';
-import { useResponsive } from '../../hooks/useResponsive';
 import { NoteTemplateIcon } from '../../services/TemplateService';
 import { TEMPLATE_MAX_TAGS, TEMPLATE_MAX_TAG_LENGTH } from '../../utils/templateTags';
 import { ICON_OPTIONS } from './templateManagerShared';
@@ -55,13 +54,12 @@ export function TemplateEditorModal({
 }: TemplateEditorModalProps) {
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const { isTablet } = useResponsive();
   const previewName = draftName.trim() || (editingId ? t('templates.untitled') : t('templates.newTemplate'));
   const previewDescription = draftDescription.trim() || t('templates.noDescription');
   const tagLimitReached = draftTags.length >= TEMPLATE_MAX_TAGS;
 
   return (
-    <Modal visible={visible} onRequestClose={onClose} fullWidth contentStyle={{ width: '100%', maxWidth: isTablet ? 720 : 480 }}>
+    <Modal visible={visible} onRequestClose={onClose} fullWidth contentStyle={{ width: '100%', flex: 1 }}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} className="flex-1 pt-3 px-5 pb-3">
         <Text className="text-[22px] font-bold mb-[18px]" style={{ color: colors.text }}>{editingId ? t('templates.editTemplate') : t('templates.newTemplate')}</Text>
 


### PR DESCRIPTION
## Fixes

- Reuse the exact Recent grid-cell width calculation for Quick Access cards instead of a hard-coded 160px width.
- Give Recent cards the same explicit calculated width so both sections stay pixel-aligned across phone and tablet layouts.
- Make the template editor modal full-width and full-height through `flex: 1`, preventing the content Surface from collapsing into a black bar.
- Remove the previous tablet max-width workaround.

## Verification

- `yarn ts:check --noEmit` passes.
- Targeted ESLint passes.
- `git diff --check` passes.
- Jest reports no runnable tests in this checkout.
