### PR TITLE
feat(git): git-tab-only branch policy — clone defaults, git tab checkout, remove branch UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,15 @@ yarn eslint . --ext .ts,.tsx  # Linting
 - Worktrees are required — see the "Worktrees (ALWAYS)" section above. The old note that said "create git worktrees inside `.worktrees/`" was too soft; the requirement is unconditional.
 - `lint-staged` runs on pre-commit (ESLint + Prettier).
 
+## Git Tab Branch Ownership
+
+**Git → Branches.** The Explore tab (Git UI) is the sole authority for branch operations. No external UI (note editors, sync services, or other tabs) may trigger or control branch switches.
+
+- **No external branch UI.** Branch selection exists only in the Explore screen. Do not add branch selectors to note editors, settings screens, or other non-Git UI surfaces.
+- **Remote checkout via GitBranchCoordinator.** When checking out a remote tracking branch, `GitBranchCoordinator.checkout()` fetches the remote ref first if the local checkout fails with "ref not found", then retries. Do not implement separate fetch-and-retry logic elsewhere.
+- **Queue isolation on checkout.** When `GitBranchCoordinator.checkout()` succeeds, it calls `pauseAllExcept(activeRepoId, activeBranch)` to isolate the sync queue. Do not bypass this by calling `NoteSyncQueueService` directly for branch operations.
+- **Retained internal branch identity.** Every `QueueItem` stores `branch` as a required field. Do not allow mutations that strip or default this field.
+
 ## Sync Architecture (Git Services) — source of truth
 
 GitNotēs uses **clone mode** exclusively: local git commits with write-through push.

--- a/__tests__/services/git/activeBranchStore.test.ts
+++ b/__tests__/services/git/activeBranchStore.test.ts
@@ -234,7 +234,7 @@ describe('activeBranchStore', () => {
       });
     });
 
-    it('uses null when no local HEAD and no remote default', async () => {
+    it('uses main as fallback when no local HEAD and no remote default', async () => {
       mockGetCurrentBranch.mockResolvedValue(null);
       mockAsyncStorageSetItem.mockResolvedValue(undefined);
 
@@ -243,7 +243,7 @@ describe('activeBranchStore', () => {
 
       expect(result).toMatchObject({
         repoId: 'repo-1',
-        activeBranch: null,
+        activeBranch: 'main',
         source: 'default',
         status: 'idle',
       });

--- a/__tests__/services/git/activeBranchStore.test.ts
+++ b/__tests__/services/git/activeBranchStore.test.ts
@@ -324,4 +324,157 @@ describe('activeBranchStore', () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe('existing-branch preservation', () => {
+    it('preserves existing branch state on re-initialization when HEAD matches', async () => {
+      const existingState: ActiveBranchState = {
+        repoId: 'repo-1',
+        repoPath: 'owner/repo',
+        activeBranch: 'feature-branch',
+        source: 'head',
+        status: 'idle',
+      };
+      mockAsyncStorageGetItem.mockResolvedValue(JSON.stringify(existingState));
+      mockGetCurrentBranch.mockResolvedValue('feature-branch');
+
+      const result = await getActiveBranch('repo-1');
+
+      expect(result).toMatchObject({
+        activeBranch: 'feature-branch',
+        source: 'head',
+        status: 'idle',
+      });
+    });
+
+    it('does not overwrite existing state when reconcile returns same values', async () => {
+      const existingState: ActiveBranchState = {
+        repoId: 'repo-1',
+        repoPath: 'owner/repo',
+        activeBranch: 'main',
+        source: 'head',
+        status: 'idle',
+      };
+      mockAsyncStorageGetItem.mockResolvedValue(JSON.stringify(existingState));
+      mockGetCurrentBranch.mockResolvedValue('main');
+
+      await getActiveBranch('repo-1');
+
+      expect(mockAsyncStorageSetItem.mock.calls.length).toBe(0);
+    });
+
+    it('handles multiple repos with different active branches independently', async () => {
+      const state1: ActiveBranchState = {
+        repoId: 'repo-1',
+        repoPath: 'owner/repo1',
+        activeBranch: 'main',
+        source: 'head',
+        status: 'idle',
+      };
+      const state2: ActiveBranchState = {
+        repoId: 'repo-2',
+        repoPath: 'owner/repo2',
+        activeBranch: 'develop',
+        source: 'head',
+        status: 'idle',
+      };
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(state1));
+      mockGetCurrentBranch.mockResolvedValueOnce('main');
+
+      const result1 = await getActiveBranch('repo-1');
+      expect(result1?.activeBranch).toBe('main');
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(state2));
+      mockGetCurrentBranch.mockResolvedValueOnce('develop');
+
+      const result2 = await getActiveBranch('repo-2');
+      expect(result2?.activeBranch).toBe('develop');
+    });
+  });
+
+  describe('memory cache consistency', () => {
+    it('returns cached state without re-reading from storage on second call', async () => {
+      const persistedState: ActiveBranchState = {
+        repoId: 'repo-1',
+        repoPath: 'owner/repo',
+        activeBranch: 'main',
+        source: 'head',
+        status: 'idle',
+      };
+      mockAsyncStorageGetItem.mockResolvedValue(JSON.stringify(persistedState));
+      mockGetCurrentBranch.mockResolvedValue('main');
+
+      await getActiveBranch('repo-1');
+      const result = await getActiveBranch('repo-1');
+
+      expect(result).toMatchObject({
+        activeBranch: 'main',
+        source: 'head',
+        status: 'idle',
+      });
+      expect(mockAsyncStorageGetItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('updates cache when reconciliation detects stale state', async () => {
+      const persistedState: ActiveBranchState = {
+        repoId: 'repo-1',
+        repoPath: 'owner/repo',
+        activeBranch: 'old-branch',
+        source: 'persisted',
+        status: 'idle',
+      };
+      mockAsyncStorageGetItem.mockResolvedValue(JSON.stringify(persistedState));
+      mockGetCurrentBranch.mockResolvedValue('new-branch');
+
+      const result = await getActiveBranch('repo-1');
+
+      expect(result).toMatchObject({
+        activeBranch: 'new-branch',
+        source: 'head',
+        status: 'stale',
+      });
+    });
+  });
+
+  describe('add/remove initialization', () => {
+    it('initializes for a new repo without existing state', async () => {
+      mockAsyncStorageGetItem.mockResolvedValue(null);
+      mockGetCurrentBranch.mockResolvedValue('main');
+      mockAsyncStorageSetItem.mockResolvedValue(undefined);
+
+      const repos = [
+        { id: 'new-repo', path: 'owner/newrepo', name: 'newrepo', branch: 'main' },
+      ];
+
+      await reconcileAllRepos(repos);
+
+      expect(mockAsyncStorageSetItem).toHaveBeenCalled();
+      const savedState = JSON.parse(mockAsyncStorageSetItem.mock.calls[0][1]);
+      expect(savedState.repoId).toBe('new-repo');
+      expect(savedState.activeBranch).toBe('main');
+    });
+
+    it('clears memory cache on removeForRepo', async () => {
+      const existingState: ActiveBranchState = {
+        repoId: 'repo-1',
+        repoPath: 'owner/repo',
+        activeBranch: 'main',
+        source: 'head',
+        status: 'idle',
+      };
+      mockAsyncStorageGetItem.mockResolvedValue(JSON.stringify(existingState));
+      mockGetCurrentBranch.mockResolvedValue('main');
+      mockAsyncStorageRemoveItem.mockResolvedValue(undefined);
+
+      await getActiveBranch('repo-1');
+
+      await removeForRepo('repo-1');
+
+      mockAsyncStorageGetItem.mockResolvedValue(null);
+      mockGetCurrentBranch.mockResolvedValue(null);
+
+      const result = await getActiveBranch('repo-1');
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/__tests__/services/git/noteSyncQueueService.test.ts
+++ b/__tests__/services/git/noteSyncQueueService.test.ts
@@ -1,0 +1,403 @@
+/**
+ * NoteSyncQueueService.test.ts
+ *
+ * Regression tests for NoteSyncQueueService queue isolation and branch payload preservation.
+ *
+ * Tests cover:
+ * 1. Queue isolation (pauseAllExcept)
+ * 2. Branch payload preservation
+ * 3. Stale-state reconciliation
+ * 4. Active-branch refresh
+ * 5. Automatic entity branch assignment
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { GitFsService } from '@/services/git/GitFsService';
+import { NoteSyncQueueService, type QueueItem, type EntityType } from '@/services/git/NoteSyncQueueService';
+
+// Mock AsyncStorage
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  getAllKeys: jest.fn(),
+  multiGet: jest.fn(),
+  multiSet: jest.fn(),
+  multiRemove: jest.fn(),
+}));
+
+// Mock GitFsService
+jest.mock('@/services/git/GitFsService', () => ({
+  GitFsService: {
+    getCurrentBranch: jest.fn(),
+  },
+}));
+
+const mockGetCurrentBranch = GitFsService.getCurrentBranch as jest.Mock;
+const mockAsyncStorageGetItem = AsyncStorage.getItem as jest.Mock;
+const mockAsyncStorageSetItem = AsyncStorage.setItem as jest.Mock;
+
+describe('NoteSyncQueueService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAsyncStorageGetItem.mockResolvedValue(null);
+    mockAsyncStorageSetItem.mockResolvedValue(undefined);
+    mockGetCurrentBranch.mockResolvedValue('main');
+  });
+
+  describe('enqueue with automatic branch assignment', () => {
+    it('preserves branch identity on every enqueued item', async () => {
+      const item: Omit<QueueItem, 'id' | 'createdAt' | 'attempts' | 'status'> = {
+        repoId: 'repo-1',
+        repoPath: 'owner/repo',
+        branch: 'feature-branch',
+        entityType: 'note',
+        entityId: 'note-123',
+        payload: { intent: 'upsert', content: 'test' },
+      };
+
+      const id = await NoteSyncQueueService.enqueue(item);
+
+      expect(id).toBeDefined();
+      const savedQueue = JSON.parse(mockAsyncStorageSetItem.mock.calls[0][1]);
+      expect(savedQueue).toHaveLength(1);
+      expect(savedQueue[0].branch).toBe('feature-branch');
+    });
+
+    it('accepts all entity types with branch assignment', async () => {
+      const entityTypes: EntityType[] = ['note', 'canvas', 'todo', 'journal'];
+
+      for (const entityType of entityTypes) {
+        mockAsyncStorageGetItem.mockResolvedValueOnce(null);
+        mockAsyncStorageSetItem.mockResolvedValueOnce(undefined);
+
+        const id = await NoteSyncQueueService.enqueue({
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'main',
+          entityType,
+          entityId: `${entityType}-123`,
+          payload: { intent: 'upsert' },
+        });
+
+        expect(id).toBeDefined();
+      }
+    });
+  });
+
+  describe('queue isolation on branch switch', () => {
+    it('pauses all non-active-branch items on pauseAllExcept', async () => {
+      const existingQueue: QueueItem[] = [
+        {
+          id: 'q1',
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'main',
+          entityType: 'note',
+          entityId: 'note-1',
+          payload: { intent: 'upsert' },
+          status: 'pending',
+          createdAt: Date.now(),
+          attempts: 0,
+        },
+        {
+          id: 'q2',
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'feature-branch',
+          entityType: 'note',
+          entityId: 'note-2',
+          payload: { intent: 'upsert' },
+          status: 'pending',
+          createdAt: Date.now(),
+          attempts: 0,
+        },
+        {
+          id: 'q3',
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'develop',
+          entityType: 'note',
+          entityId: 'note-3',
+          payload: { intent: 'upsert' },
+          status: 'pending',
+          createdAt: Date.now(),
+          attempts: 0,
+        },
+      ];
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(existingQueue));
+      mockAsyncStorageSetItem.mockResolvedValueOnce(undefined);
+
+      await NoteSyncQueueService.pauseAllExcept('repo-1', 'feature-branch');
+
+      const savedQueue = JSON.parse(mockAsyncStorageSetItem.mock.calls[0][1]);
+      const q1 = savedQueue.find((i: QueueItem) => i.id === 'q1');
+      const q2 = savedQueue.find((i: QueueItem) => i.id === 'q2');
+      const q3 = savedQueue.find((i: QueueItem) => i.id === 'q3');
+
+      expect(q1.status).toBe('paused');
+      expect(q2.status).toBe('pending'); // active branch stays pending
+      expect(q3.status).toBe('paused');
+    });
+
+    it('drains only active-branch items matching repoId + branch', async () => {
+      const existingQueue: QueueItem[] = [
+        {
+          id: 'q1',
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'main',
+          entityType: 'note',
+          entityId: 'note-1',
+          payload: { intent: 'upsert' },
+          status: 'pending',
+          createdAt: Date.now(),
+          attempts: 0,
+        },
+        {
+          id: 'q2',
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'feature-branch',
+          entityType: 'note',
+          entityId: 'note-2',
+          payload: { intent: 'upsert' },
+          status: 'pending',
+          createdAt: Date.now(),
+          attempts: 0,
+        },
+      ];
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(existingQueue));
+      mockGetCurrentBranch.mockResolvedValueOnce('feature-branch');
+      mockAsyncStorageSetItem.mockResolvedValueOnce(undefined);
+
+      const drained = await NoteSyncQueueService.drain('repo-1', 'feature-branch');
+
+      expect(drained).toHaveLength(1);
+      expect(drained[0].id).toBe('q2');
+      expect(drained[0].branch).toBe('feature-branch');
+    });
+
+    it('does not drain items when HEAD has switched away from branch', async () => {
+      const existingQueue: QueueItem[] = [
+        {
+          id: 'q1',
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'feature-branch',
+          entityType: 'note',
+          entityId: 'note-1',
+          payload: { intent: 'upsert' },
+          status: 'pending',
+          createdAt: Date.now(),
+          attempts: 0,
+        },
+      ];
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(existingQueue));
+      mockGetCurrentBranch.mockResolvedValueOnce('main'); // HEAD has switched!
+      mockAsyncStorageSetItem.mockResolvedValueOnce(undefined);
+
+      const drained = await NoteSyncQueueService.drain('repo-1', 'feature-branch');
+
+      expect(drained).toHaveLength(0);
+
+      // Verify the item was marked as paused
+      const savedQueue = JSON.parse(mockAsyncStorageSetItem.mock.calls[0][1]);
+      expect(savedQueue[0].status).toBe('paused');
+    });
+  });
+
+  describe('preserved internal branch payloads', () => {
+    it('preserves full payload structure including branch identity', async () => {
+      const item: Omit<QueueItem, 'id' | 'createdAt' | 'attempts' | 'status'> = {
+        repoId: 'repo-1',
+        repoPath: 'owner/repo',
+        branch: 'feature-branch',
+        entityType: 'note',
+        entityId: 'note-123',
+        payload: {
+          intent: 'upsert',
+          content: '# Test Note',
+          filePath: 'notes/test.md',
+          customField: 'preserved',
+        },
+      };
+
+      const id = await NoteSyncQueueService.enqueue(item);
+
+      const savedQueue = JSON.parse(mockAsyncStorageSetItem.mock.calls[0][1]);
+      const savedItem = savedQueue.find((i: QueueItem) => i.id === id);
+
+      expect(savedItem.branch).toBe('feature-branch');
+      expect(savedItem.payload.intent).toBe('upsert');
+      expect(savedItem.payload.customField).toBe('preserved');
+      expect(savedItem.entityType).toBe('note');
+      expect(savedItem.entityId).toBe('note-123');
+    });
+
+    it('preserves branch identity on pauseForBranchSwitch', async () => {
+      const existingQueue: QueueItem[] = [
+        {
+          id: 'q1',
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'feature-branch',
+          entityType: 'note',
+          entityId: 'note-1',
+          payload: { intent: 'upsert', customData: 'keep-me' },
+          status: 'pending',
+          createdAt: Date.now(),
+          attempts: 0,
+        },
+      ];
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(existingQueue));
+      mockAsyncStorageSetItem.mockResolvedValueOnce(undefined);
+
+      await NoteSyncQueueService.pauseForBranchSwitch('feature-branch');
+
+      const savedQueue = JSON.parse(mockAsyncStorageSetItem.mock.calls[0][1]);
+      expect(savedQueue[0].branch).toBe('feature-branch');
+      expect(savedQueue[0].payload.customData).toBe('keep-me');
+    });
+
+    it('preserves branch identity on resumeForBranch', async () => {
+      const existingQueue: QueueItem[] = [
+        {
+          id: 'q1',
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'feature-branch',
+          entityType: 'note',
+          entityId: 'note-1',
+          payload: { intent: 'upsert' },
+          status: 'paused',
+          createdAt: Date.now(),
+          attempts: 0,
+        },
+      ];
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(existingQueue));
+      mockGetCurrentBranch.mockResolvedValueOnce('feature-branch');
+      mockAsyncStorageSetItem.mockResolvedValueOnce(undefined);
+
+      await NoteSyncQueueService.resumeForBranch('feature-branch');
+
+      const savedQueue = JSON.parse(mockAsyncStorageSetItem.mock.calls[0][1]);
+      expect(savedQueue[0].status).toBe('pending');
+      expect(savedQueue[0].branch).toBe('feature-branch');
+    });
+  });
+
+  describe('stale-state reconciliation', () => {
+    it('marks items as paused when HEAD differs from expected branch', async () => {
+      const existingQueue: QueueItem[] = [
+        {
+          id: 'q1',
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'old-branch',
+          entityType: 'note',
+          entityId: 'note-1',
+          payload: { intent: 'upsert' },
+          status: 'pending',
+          createdAt: Date.now(),
+          attempts: 0,
+        },
+      ];
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(existingQueue));
+      mockGetCurrentBranch.mockResolvedValueOnce('new-branch'); // HEAD has switched
+      mockAsyncStorageSetItem.mockResolvedValueOnce(undefined);
+
+      const drained = await NoteSyncQueueService.drain('repo-1', 'old-branch');
+
+      expect(drained).toHaveLength(0);
+
+      const savedQueue = JSON.parse(mockAsyncStorageSetItem.mock.calls[0][1]);
+      expect(savedQueue[0].status).toBe('paused');
+    });
+
+    it('returns drained items only when HEAD matches expected branch', async () => {
+      const existingQueue: QueueItem[] = [
+        {
+          id: 'q1',
+          repoId: 'repo-1',
+          repoPath: 'owner/repo',
+          branch: 'main',
+          entityType: 'note',
+          entityId: 'note-1',
+          payload: { intent: 'upsert' },
+          status: 'pending',
+          createdAt: Date.now(),
+          attempts: 0,
+        },
+      ];
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(existingQueue));
+      mockGetCurrentBranch.mockResolvedValueOnce('main'); // HEAD matches
+      mockAsyncStorageSetItem.mockResolvedValueOnce(undefined);
+
+      const drained = await NoteSyncQueueService.drain('repo-1', 'main');
+
+      expect(drained).toHaveLength(1);
+      expect(drained[0].id).toBe('q1');
+    });
+  });
+
+  describe('active-branch refresh', () => {
+    it('pendingCount filters by branch correctly', async () => {
+      const existingQueue: QueueItem[] = [
+        { id: 'q1', repoId: 'repo-1', repoPath: 'owner/repo', branch: 'main', entityType: 'note', entityId: 'n1', payload: {}, status: 'pending', createdAt: 1, attempts: 0 },
+        { id: 'q2', repoId: 'repo-1', repoPath: 'owner/repo', branch: 'main', entityType: 'note', entityId: 'n2', payload: {}, status: 'pending', createdAt: 2, attempts: 0 },
+        { id: 'q3', repoId: 'repo-1', repoPath: 'owner/repo', branch: 'feature', entityType: 'note', entityId: 'n3', payload: {}, status: 'pending', createdAt: 3, attempts: 0 },
+        { id: 'q4', repoId: 'repo-1', repoPath: 'owner/repo', branch: 'main', entityType: 'note', entityId: 'n4', payload: {}, status: 'paused', createdAt: 4, attempts: 0 },
+      ];
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(existingQueue));
+
+      const mainPending = await NoteSyncQueueService.pendingCount('repo-1', 'main');
+      const featurePending = await NoteSyncQueueService.pendingCount('repo-1', 'feature');
+
+      expect(mainPending).toBe(2); // q1 and q2 (q4 is paused)
+      expect(featurePending).toBe(1); // q3
+    });
+
+    it('getAllForRepo returns all items with preserved branch identity', async () => {
+      const existingQueue: QueueItem[] = [
+        { id: 'q1', repoId: 'repo-1', repoPath: 'owner/repo', branch: 'main', entityType: 'note', entityId: 'n1', payload: {}, status: 'pending', createdAt: 1, attempts: 0 },
+        { id: 'q2', repoId: 'repo-1', repoPath: 'owner/repo', branch: 'feature', entityType: 'note', entityId: 'n2', payload: {}, status: 'pending', createdAt: 2, attempts: 0 },
+        { id: 'q3', repoId: 'repo-2', repoPath: 'other/repo', branch: 'main', entityType: 'note', entityId: 'n3', payload: {}, status: 'pending', createdAt: 3, attempts: 0 },
+      ];
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(existingQueue));
+
+      const items = await NoteSyncQueueService.getAllForRepo('repo-1');
+
+      expect(items).toHaveLength(2);
+      expect(items.map((i: QueueItem) => i.branch)).toEqual(['main', 'feature']);
+    });
+  });
+
+  describe('queue item removal', () => {
+    it('remove purges processed items and preserves other branches', async () => {
+      const existingQueue: QueueItem[] = [
+        { id: 'q1', repoId: 'repo-1', repoPath: 'owner/repo', branch: 'main', entityType: 'note', entityId: 'n1', payload: {}, status: 'pending', createdAt: 1, attempts: 0 },
+        { id: 'q2', repoId: 'repo-1', repoPath: 'owner/repo', branch: 'feature', entityType: 'note', entityId: 'n2', payload: {}, status: 'pending', createdAt: 2, attempts: 0 },
+      ];
+
+      mockAsyncStorageGetItem.mockResolvedValueOnce(JSON.stringify(existingQueue));
+      mockAsyncStorageSetItem.mockResolvedValueOnce(undefined);
+
+      await NoteSyncQueueService.remove('q1');
+
+      const savedQueue = JSON.parse(mockAsyncStorageSetItem.mock.calls[0][1]);
+      expect(savedQueue).toHaveLength(1);
+      expect(savedQueue[0].id).toBe('q2');
+      expect(savedQueue[0].branch).toBe('feature');
+    });
+  });
+});

--- a/docs/wiki/git-engine.md
+++ b/docs/wiki/git-engine.md
@@ -257,7 +257,9 @@ Creates a new branch.
 
 ### `GitEngine.checkoutBranch(repoPath: string, name: string, remoteName?: string): Promise<void>`
 
-Checks out a branch.
+Checks out a branch. If checkout fails because the remote tracking ref is missing, callers should fetch from the remote first and retry.
+
+> **Note:** For remote-to-local checkout, callers (e.g., `GitBranchCoordinator`) handle the fetch-and-retry logic. See `GitBranchCoordinator.checkout()` for the full remote branch checkout flow.
 
 ---
 

--- a/docs/wiki/screens.md
+++ b/docs/wiki/screens.md
@@ -189,6 +189,10 @@ The canonical route param types are in `src/navigation/types.ts`:
 
 **Wrapped by:** `CheckoutSafetyProvider` — gates mutation operations while checkout is running.
 
+**Git → Branches ownership:** The Explore tab (Git UI) is the sole authority for branch operations. The Git tab owns all branch state — no external UI (note editors, sync services, or other tabs) may trigger or control branch switches. Note editing never triggers implicit branch switches.
+
+**Branch UI:** Only the Explore screen exposes branch selection. No branch selector exists in the note editor or elsewhere. When checking out a remote branch, GitBranchCoordinator fetches the remote ref first and retries checkout locally.
+
 **Sections:**
 - `FilesSection` — repo file tree
 - `ChangesSection` — unstaged/staged changes in working tree

--- a/docs/wiki/services.md
+++ b/docs/wiki/services.md
@@ -41,10 +41,13 @@
 
 GitNotēs uses a **centralized branch model** for clone-mode repositories:
 
-- **One active checked-out branch per clone.** The Git tab owns branch state; only `GitBranchCoordinator.checkout()` transitions HEAD. All other services read branch state from `activeBranchStore`.
-- **Git-tab ownership.** The Explore tab (Git UI) is the sole authority for branch operations. Note editing never triggers implicit branch switches.
+- **Git → Branches ownership.** The Explore tab (Git UI) is the sole authority for branch operations. No external UI (note editors, sync services, or other tabs) may trigger or control branch switches. Only `GitBranchCoordinator.checkout()` transitions HEAD.
+- **One active checked-out branch per clone.** All other services read branch state from `activeBranchStore`.
+- **No external branch UI.** Branch selection exists only in the Explore screen. Note editors and sync services have no branch controls.
+- **Remote checkout behavior.** When checking out a remote tracking branch (e.g., `origin/feature`), `GitBranchCoordinator.checkout()` first fetches the remote ref if the local checkout fails with "ref not found", then retries. This enables seamless remote-to-local branch checkout.
+- **Retained internal branch identity.** Queue items preserve full `branch` identity in their payload. On branch switch, `pauseAllExcept(activeRepoId, activeBranch)` pauses all non-active-branch items, preventing cross-branch sync drift.
 - **Operation state/locking.** `GitBranchCoordinator` maintains a state machine (`idle | checkout-running | mutation-running | failed`). Mutations (stage, commit, discard) are rejected while `checkout-running`; checkout is rejected when files are staged/modified/conflicted.
-- **Queue pause semantics.** `NoteSyncQueueService` tracks `{ repoId, repoPath, branch }` on every queue item. On branch switch, all non-active-branch items are paused; only the active branch's pending items drain. This prevents cross-branch sync drift.
+- **Queue pause semantics.** `NoteSyncQueueService` tracks `{ repoId, repoPath, branch }` on every queue item. On branch switch, all non-active-branch items are paused; only the active branch's pending items drain.
 
 ### Sync & Recovery
 

--- a/docs/wiki/sync-architecture.md
+++ b/docs/wiki/sync-architecture.md
@@ -61,6 +61,12 @@ interface QueueItem {
 
 **Branch-aware drain:** `dequeue(repoId, branch)` returns only items matching both `repoId` AND `branch`. On checkout, all non-active-branch items are paused via `pauseAllExcept(activeRepoId, activeBranch)`. This prevents cross-branch sync drift.
 
+**Queue isolation:** When `GitBranchCoordinator.checkout()` succeeds, it calls `pauseAllExcept(activeRepoId, activeBranch)` to isolate the queue to the newly checked-out branch. Only items matching both the active `repoId` and `activeBranch` remain in `pending` status; all others are marked `paused`. Drained items are verified against local HEAD before processing.
+
+**Preserved internal branch payloads:** Every `QueueItem` stores `branch` as a required field. This branch identity is preserved across pause/resume cycles and is never stripped or defaulted. On `resumeForBranch`, items are only resumed if local HEAD still matches the expected branch.
+
+**Stale-state reconciliation:** If local HEAD has changed since an item was queued (e.g., user switched branches), the item is marked `paused` rather than processed, preventing mutations from being applied to the wrong branch.
+
 ```
 CloneSyncService.save (offline)
   → NoteSyncQueueService.enqueue({ repoId, repoPath, branch, ... })
@@ -68,7 +74,7 @@ CloneSyncService.save (offline)
 
 Network restored (NetInfo online-transition)
   → NoteSyncQueueService.drain(repoId, activeBranch)
-    → Only items matching active branch are returned
+    → Only items matching active branch are returned (and HEAD verified)
       → Push via tryPushNow
 ```
 

--- a/src/components/CanvasCard.tsx
+++ b/src/components/CanvasCard.tsx
@@ -113,14 +113,6 @@ function CanvasCardImpl({
                   </Text>
                 </View>
               )}
-              {canvas.branch && (
-                <View style={styles.repoItem}>
-                  <Ionicons name="git-branch-outline" size={14} color={colors.primary} />
-                  <Text style={[styles.branchText, { color: colors.primary }]}>
-                    {canvas.branch}
-                  </Text>
-                </View>
-              )}
             </View>
           )}
         </View>

--- a/src/components/GitContextPicker.tsx
+++ b/src/components/GitContextPicker.tsx
@@ -9,41 +9,30 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { GitService } from '../services/GitService';
 import { LastUsedRepoService } from '../services/LastUsedRepoService';
 import { LastSelectionPreferenceService, SelectionEntityType } from '../services/LastSelectionPreferenceService';
 import { useRepos } from '../contexts/RepoContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { HapticService } from '../utils/haptics';
 import { Modal } from './ui';
-import { getActiveBranch } from '../services/git/activeBranchStore';
 
 interface GitContextPickerProps {
   repo?: string;
-  branch?: string;
-  commit?: string;
   entityType?: SelectionEntityType;
   onRepoChange: (repo: string | undefined) => void;
-  onBranchChange: (branch: string | undefined) => void;
-  onCommitChange: (commit: string | undefined) => void;
 }
 
 type SheetView = 'main' | 'repo';
 
 export default function GitContextPicker({
   repo,
-  branch,
   entityType,
   onRepoChange,
-  onBranchChange,
-  onCommitChange,
 }: GitContextPickerProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [view, setView] = useState<SheetView>('main');
   const { repositories } = useRepos();
   const [repoSearch, setRepoSearch] = useState('');
-  const [activeBranch, setActiveBranch] = useState<string | null>(null);
-  const [activeBranchStatus, setActiveBranchStatus] = useState<'idle' | 'loading' | 'stale' | 'error' | null>(null);
 
   const { colors } = useTheme();
 
@@ -79,22 +68,19 @@ export default function GitContextPicker({
 
   const handleClearContext = useCallback(() => {
     onRepoChange(undefined);
-    onBranchChange(undefined);
-    onCommitChange(undefined);
-  }, [onRepoChange, onBranchChange, onCommitChange]);
+  }, [onRepoChange]);
 
   const handleRepoPick = useCallback(
     (path: string) => {
       HapticService.selection();
       onRepoChange(path);
-      onCommitChange(undefined);
       void LastUsedRepoService.set(path);
       if (entityType) {
         void LastSelectionPreferenceService.set(entityType, { repo: path });
       }
       setView('main');
     },
-    [onRepoChange, onCommitChange, entityType],
+    [onRepoChange, entityType],
   );
 
   // Auto-fill the repo when opening this picker for a new note/canvas/etc.
@@ -124,31 +110,6 @@ export default function GitContextPicker({
     });
   }, [repo, repositories, onRepoChange]);
 
-  // Fetch active branch from activeBranchStore whenever repo changes.
-  useEffect(() => {
-    if (!repo) {
-      setActiveBranch(null);
-      setActiveBranchStatus(null);
-      return;
-    }
-    const repoId = repositories.find((r) => r.path === repo)?.id;
-    if (!repoId) {
-      setActiveBranch(null);
-      setActiveBranchStatus('error');
-      return;
-    }
-    setActiveBranchStatus('loading');
-    void getActiveBranch(repoId).then((state) => {
-      if (!state) {
-        setActiveBranch(null);
-        setActiveBranchStatus('error');
-        return;
-      }
-      setActiveBranch(state.activeBranch);
-      setActiveBranchStatus(state.status);
-    });
-  }, [repo, repositories]);
-
   const isListView = view !== 'main';
   const headerTitle =
     view === 'repo' ? 'Select Repository' : 'Git Context';
@@ -171,7 +132,7 @@ export default function GitContextPicker({
           numberOfLines={1}
         >
           {repo
-            ? `${repo.split('/').pop()}${activeBranch ? ` · ${activeBranch}` : ''}`
+            ? repo.split('/').pop()
             : repositories.length === 0
             ? 'None'
             : 'Select repository'}
@@ -230,29 +191,8 @@ export default function GitContextPicker({
                   </View>
                 </TouchableOpacity>
 
-                <View testID="note-editor-form.picker.branch">
-                  {repo && (
-                    <View style={styles.selector}>
-                    <Text style={[styles.selectorLabel, { color: colors.textSecondary }]}>Branch</Text>
-                    <View style={[styles.selectorValue, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-                      {activeBranchStatus === 'loading' ? (
-                        <Text style={[styles.placeholderText, { color: colors.textSecondary }]}>Loading…</Text>
-                      ) : activeBranchStatus === 'error' ? (
-                        <Text style={[styles.placeholderText, { color: colors.error }]}>No active branch</Text>
-                      ) : activeBranchStatus === 'stale' ? (
-                        <Text style={[styles.placeholderText, { color: colors.warning }]}>{activeBranch} (stale)</Text>
-                      ) : !activeBranch ? (
-                        <Text style={[styles.valueText, { color: colors.text }]}>main</Text>
-                      ) : (
-                        <Text style={[styles.valueText, { color: colors.text }]}>{activeBranch}</Text>
-                      )}
-                    </View>
-                  </View>
-                  )}
-                </View>
-
                 <View testID="note-editor-form.picker.commit" />
-                {(repo || activeBranch) && (
+                {repo && (
                   <TouchableOpacity style={styles.clearButton} accessibilityRole="button" onPress={handleClearContext}>
                     <Ionicons name="trash-outline" size={16} color={colors.error} />
                     <Text style={[styles.clearButtonText, { color: colors.error }]}>Clear Git Context</Text>

--- a/src/components/GitContextPicker.tsx
+++ b/src/components/GitContextPicker.tsx
@@ -237,10 +237,12 @@ export default function GitContextPicker({
                     <View style={[styles.selectorValue, { backgroundColor: colors.surface, borderColor: colors.border }]}>
                       {activeBranchStatus === 'loading' ? (
                         <Text style={[styles.placeholderText, { color: colors.textSecondary }]}>Loading…</Text>
-                      ) : activeBranchStatus === 'error' || activeBranchStatus === 'stale' || !activeBranch ? (
-                        <Text style={[styles.placeholderText, { color: colors.error }]}>
-                          {activeBranchStatus === 'stale' ? `${activeBranch} (stale)` : 'No active branch'}
-                        </Text>
+                      ) : activeBranchStatus === 'error' ? (
+                        <Text style={[styles.placeholderText, { color: colors.error }]}>No active branch</Text>
+                      ) : activeBranchStatus === 'stale' ? (
+                        <Text style={[styles.placeholderText, { color: colors.warning }]}>{activeBranch} (stale)</Text>
+                      ) : !activeBranch ? (
+                        <Text style={[styles.valueText, { color: colors.text }]}>main</Text>
                       ) : (
                         <Text style={[styles.valueText, { color: colors.text }]}>{activeBranch}</Text>
                       )}

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -161,12 +161,6 @@ function NoteCardImpl({
               <Text style={[styles.repoText, { color: colors.textSecondary }]}>{note.repo}</Text>
             </View>
           )}
-          {note.branch && (
-            <View style={styles.repoItem}>
-              <Ionicons name="git-branch-outline" size={14} color={colors.primary} />
-              <Text style={[styles.branchText, { color: colors.primary }]}>{note.branch}</Text>
-            </View>
-          )}
         </View>
       )}
     </TouchableOpacity>

--- a/src/components/canvas/CanvasEditorContent.tsx
+++ b/src/components/canvas/CanvasEditorContent.tsx
@@ -488,7 +488,6 @@ export default function CanvasEditorContent() {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const { activeAccountId } = useAuth();
   const [repo, setRepo] = useState<string | undefined>(existingCanvas?.repo);
-  const [branch, setBranch] = useState<string | undefined>(existingCanvas?.branch);
   const accountId = existingCanvas?.accountId ?? activeAccountId ?? undefined;
   const dragStartRef = useRef<Point | null>(null);
   const resizeHandleRef = useRef<'tl' | 'tr' | 'bl' | 'br' | null>(null);
@@ -1264,15 +1263,14 @@ export default function CanvasEditorContent() {
       : undefined;
 
     if (canvasId) {
-      await updateCanvas({ id: canvasId, title, scene, repo, branch, filePath: canvasFilePath, accountId });
+      await updateCanvas({ id: canvasId, title, scene, repo, filePath: canvasFilePath, accountId });
     } else {
-      await createCanvas({ title, scene, repo, branch, filePath: canvasFilePath, accountId });
+      await createCanvas({ title, scene, repo, filePath: canvasFilePath, accountId });
     }
 
     if (repo) {
       const syncResult = await syncCanvasToGitHub({
         repo,
-        branch,
         filePath: canvasFilePath,
         title: title.trim(),
         scene,
@@ -1287,7 +1285,7 @@ export default function CanvasEditorContent() {
     }
 
     navigation.goBack();
-  }, [canvasId, title, elements, canvasSize, cw, repo, branch, existingCanvas, updateCanvas, createCanvas, navigation, accountId]);
+  }, [canvasId, title, elements, canvasSize, cw, repo, existingCanvas, updateCanvas, createCanvas, navigation, accountId]);
 
   const handleExportPng = useCallback(async () => {
     if (exporting) return;
@@ -1614,11 +1612,7 @@ export default function CanvasEditorContent() {
       <View style={styles.gitContextContainer}>
         <GitContextPicker
           repo={repo}
-          branch={branch}
-          commit={undefined}
           onRepoChange={setRepo}
-          onBranchChange={setBranch}
-          onCommitChange={() => undefined}
         />
       </View>
 

--- a/src/components/editor/NoteEditorForm.tsx
+++ b/src/components/editor/NoteEditorForm.tsx
@@ -14,8 +14,6 @@ import { FORMAT_OPTIONS } from './editorShared';
 
 interface NoteEditorFormProps {
   repo?: string;
-  branch?: string;
-  commit?: string;
   title: string;
   folderPath?: string;
   noteFormat: NoteFormat;
@@ -24,8 +22,6 @@ interface NoteEditorFormProps {
   content: string;
   placeholder: string;
   onRepoChange: (repo: string | undefined) => void;
-  onBranchChange: (branch: string | undefined) => void;
-  onCommitChange: (commit: string | undefined) => void;
   onTitleChange: (value: string) => void;
   onOpenFolderDialog: () => void;
   onNoteFormatChange: (format: NoteFormat) => void;
@@ -36,8 +32,6 @@ interface NoteEditorFormProps {
 
 export function NoteEditorForm({
   repo,
-  branch,
-  commit,
   title,
   folderPath,
   noteFormat,
@@ -46,8 +40,6 @@ export function NoteEditorForm({
   content,
   placeholder,
   onRepoChange,
-  onBranchChange,
-  onCommitChange,
   onTitleChange,
   onOpenFolderDialog,
   onNoteFormatChange,
@@ -72,12 +64,8 @@ export function NoteEditorForm({
       <View testID="note-editor-form.picker.repo" style={styles.gitContextContainer}>
         <GitContextPicker
           repo={repo}
-          branch={branch}
-          commit={commit}
           entityType="note"
           onRepoChange={onRepoChange}
-          onBranchChange={onBranchChange}
-          onCommitChange={onCommitChange}
         />
       </View>
 

--- a/src/components/explore/BranchesSection.tsx
+++ b/src/components/explore/BranchesSection.tsx
@@ -88,7 +88,7 @@ export function BranchesSection({ repo, active, onChanged, chromeTopInset = 0, b
       setBusy(`checkout:${name}`);
       try {
         const coordinator = GitBranchCoordinator;
-        await coordinator.checkout(repo.localPath, name, 'origin');
+        await coordinator.checkout(repo.id, repo.localPath, name);
         onChanged();
         setVersion((value) => value + 1);
       } catch (caught) {

--- a/src/components/explore/BranchesSection.tsx
+++ b/src/components/explore/BranchesSection.tsx
@@ -97,7 +97,7 @@ export function BranchesSection({ repo, active, onChanged, chromeTopInset = 0, b
         setBusy(null);
       }
     },
-    [repo.localPath, onChanged],
+    [repo.id, repo.localPath, onChanged],
   );
 
   const remove = useCallback(
@@ -250,11 +250,22 @@ export function BranchesSection({ repo, active, onChanged, chromeTopInset = 0, b
                 <ButtonText>Rename</ButtonText>
               </Button>
             )}
+            {item.isRemote && !branches?.some((b) => !b.isRemote && b.name === item.name) && (
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={busy !== null}
+                onPress={() => void checkout(item.name)}
+                testID={`explore.branch.checkout-locally.${item.name}`}
+              >
+                <ButtonText>Checkout locally</ButtonText>
+              </Button>
+            )}
           </View>
         </View>
       );
     },
-    [busy, checkout, remove, renaming, renameValue, saveRename],
+    [branches, busy, checkout, renaming, renameValue, saveRename],
   );
 
   const renderItem = useCallback(

--- a/src/components/notes/NotesActiveFilters.tsx
+++ b/src/components/notes/NotesActiveFilters.tsx
@@ -24,9 +24,9 @@ export function NotesActiveFilters({
 }: NotesActiveFiltersProps) {
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const { selectedFormat, selectedBranch, selectedFolder } = filters;
+  const { selectedFormat, selectedFolder } = filters;
 
-  if (!selectedFormat && !selectedBranch && !selectedFolder) return null;
+  if (!selectedFormat && !selectedFolder) return null;
 
   const renderChip = (
     key: string,
@@ -56,9 +56,6 @@ export function NotesActiveFilters({
               NOTE_FORMAT_LABELS[selectedFormat as Exclude<NoteFormat, 'json'>],
               onClearFormat,
             )
-          : null}
-        {selectedBranch
-          ? renderChip('branch', 'git-branch-outline', selectedBranch, onClearBranch)
           : null}
         {selectedFolder ? renderChip('folder', 'folder-outline', selectedFolder, onClearFolder) : null}
         <TouchableOpacity testID="notes-active-filters.button.clear-all" style={[styles.chip, { borderColor: colors.border + '60' }]} onPress={onClearAll}>

--- a/src/components/notes/NotesActiveFilters.tsx
+++ b/src/components/notes/NotesActiveFilters.tsx
@@ -10,7 +10,6 @@ import { NotesListFilters, NOTE_FORMAT_LABELS } from './notesShared';
 interface NotesActiveFiltersProps {
   filters: NotesListFilters;
   onClearFormat: () => void;
-  onClearBranch: () => void;
   onClearFolder: () => void;
   onClearAll: () => void;
 }
@@ -18,7 +17,6 @@ interface NotesActiveFiltersProps {
 export function NotesActiveFilters({
   filters,
   onClearFormat,
-  onClearBranch,
   onClearFolder,
   onClearAll,
 }: NotesActiveFiltersProps) {

--- a/src/components/repo/RepoTreeItem.tsx
+++ b/src/components/repo/RepoTreeItem.tsx
@@ -451,7 +451,6 @@ export function RepoTreeItem({ node, owner, repo, branch, provider, level, onFil
                       `Path: ${node.path}`,
                       !isDir ? `Size: ${formatBytes(node.size)}` : null,
                       node.sha ? `SHA: ${node.sha.slice(0, 10)}` : null,
-                      `Branch: ${branch || 'main'}`,
                     ].filter(Boolean).join('\n'),
                   );
                 },

--- a/src/components/todos/TodoEditorModal.tsx
+++ b/src/components/todos/TodoEditorModal.tsx
@@ -22,7 +22,6 @@ interface TodoEditorModalProps {
   showTimePicker: boolean;
   showReminderPicker: boolean;
   todoRepo?: string;
-  todoBranch?: string;
   isDark: boolean;
   onClose: () => void;
   onChangeText: (value: string) => void;
@@ -37,7 +36,6 @@ interface TodoEditorModalProps {
   onToggleReminderPicker: () => void;
   onSelectReminderMinutes: (minutes: number) => void;
   onRepoChange: (repo: string | undefined) => void;
-  onBranchChange: (branch: string | undefined) => void;
   onSubmit: () => void;
 }
 
@@ -53,7 +51,6 @@ export function TodoEditorModal({
   showTimePicker,
   showReminderPicker,
   todoRepo,
-  todoBranch,
   isDark,
   onClose,
   onChangeText,
@@ -68,7 +65,6 @@ export function TodoEditorModal({
   onToggleReminderPicker,
   onSelectReminderMinutes,
   onRepoChange,
-  onBranchChange,
   onSubmit,
 }: TodoEditorModalProps) {
   const { colors } = useTheme();
@@ -302,14 +298,8 @@ export function TodoEditorModal({
           <View style={styles.gitContextContainer}>
             <GitContextPicker
               repo={todoRepo}
-              branch={todoBranch}
-              commit={undefined}
               entityType="todo"
               onRepoChange={onRepoChange}
-              onBranchChange={onBranchChange}
-              onCommitChange={() => {
-                // noop
-              }}
             />
           </View>
 

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -188,7 +188,12 @@ export default function ExploreScreen() {
 
   const onChanged = useCallback(() => {
     void refreshStatus();
-  }, [refreshStatus]);
+    if (repo?.id) {
+      void getActiveBranch(repo.id).then((state) => {
+        if (state?.activeBranch) setActiveBranch(state.activeBranch);
+      });
+    }
+  }, [repo?.id, refreshStatus]);
 
   /**
    * The floating git button is rendered at the app level. When the user

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -187,8 +187,6 @@ function NoteEditorScreenInner() {
             <View className="flex-1">
               <NoteEditorForm
                 repo={document.repo}
-                branch={document.branch}
-                commit={document.commit}
                 title={document.title}
                 folderPath={document.folderPath}
                 noteFormat={document.noteFormat}
@@ -197,8 +195,6 @@ function NoteEditorScreenInner() {
                 content={document.content}
                 placeholder={document.editorPlaceholder}
                 onRepoChange={document.handleRepoChange}
-                onBranchChange={document.handleBranchChange}
-                onCommitChange={document.handleCommitChange}
                 onTitleChange={document.handleTitleChange}
                 onOpenFolderDialog={() => setShowFolderDialog(true)}
                 onNoteFormatChange={document.handleNoteFormatChange}
@@ -232,8 +228,6 @@ function NoteEditorScreenInner() {
         ) : (
           <NoteEditorForm
             repo={document.repo}
-            branch={document.branch}
-            commit={document.commit}
             title={document.title}
             folderPath={document.folderPath}
             noteFormat={document.noteFormat}
@@ -242,8 +236,6 @@ function NoteEditorScreenInner() {
             content={document.content}
             placeholder={document.editorPlaceholder}
             onRepoChange={document.handleRepoChange}
-            onBranchChange={document.handleBranchChange}
-            onCommitChange={document.handleCommitChange}
             onTitleChange={document.handleTitleChange}
             onOpenFolderDialog={() => setShowFolderDialog(true)}
             onNoteFormatChange={document.handleNoteFormatChange}

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -538,7 +538,6 @@ export default function TodoListScreen() {
         showTimePicker={showTimePicker}
         showReminderPicker={showReminderPicker}
         todoRepo={todoRepo}
-        todoBranch={todoBranch}
         isDark={isDark}
         onClose={closeModals}
         onChangeText={setTodoText}
@@ -565,7 +564,6 @@ export default function TodoListScreen() {
           setShowReminderPicker(false);
         }}
         onRepoChange={setTodoRepo}
-        onBranchChange={setTodoBranch}
         onSubmit={editingTodo ? handleUpdateTodo : handleAddTodo}
       />
 

--- a/src/services/CanvasGitHubSyncService.ts
+++ b/src/services/CanvasGitHubSyncService.ts
@@ -44,7 +44,8 @@ export async function syncCanvasToGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = await resolveBranch(repoPath, branch);
+  // Updates preserve stored branch; creates use HEAD.
+  const targetBranch = filePath && branch ? branch : await resolveBranch(repoPath);
 
   let targetPath = filePath;
   if (!targetPath) {
@@ -92,7 +93,7 @@ export async function deleteCanvasFromGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = await resolveBranch(repoPath, branch);
+  const targetBranch = branch ?? (await resolveBranch(repoPath));
   const saveResult = await CloneSyncService.save({
     repoPath,
     branch: targetBranch,

--- a/src/services/NoteGitHubSyncService.ts
+++ b/src/services/NoteGitHubSyncService.ts
@@ -328,7 +328,9 @@ export async function deleteNoteFromGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = await resolveBranch(repoPath, branch);
+  // Use the entity's stored branch for deletes (to target the correct branch
+  // where the file exists), falling back to HEAD only if not available.
+  const targetBranch = branch ?? (await resolveBranch(repoPath));
 
   const saveResult = await CloneSyncService.save({
     repoPath,
@@ -380,7 +382,12 @@ export async function syncNoteToGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = await resolveBranch(repoPath, branch);
+  // For updates (knownSha from conflict guard, or entity already has a filePath),
+  // use the entity's stored branch to preserve branch identity.
+  // For creates, resolve HEAD.
+  const isUpdate = !!(knownSha || filePath);
+  const targetBranch = isUpdate && branch ? branch : await resolveBranch(repoPath);
+
   const ext = getExtension(format);
   const opts = tokenOverride ? { tokenOverride } : undefined;
 

--- a/src/services/TodoGitHubSyncService.ts
+++ b/src/services/TodoGitHubSyncService.ts
@@ -59,7 +59,8 @@ export async function syncTodoToGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = await resolveBranch(repoPath, branch);
+  // Updates preserve stored branch; creates use HEAD.
+  const targetBranch = filePath && branch ? branch : await resolveBranch(repoPath);
 
   let targetPath = filePath;
   if (!targetPath) {
@@ -123,7 +124,8 @@ export async function deleteTodoFromGitHub(params: {
     return { success: false, error: `Invalid repo path: ${repoPath}` };
   }
 
-  const targetBranch = await resolveBranch(repoPath, branch);
+  // Use the entity's stored branch for deletes.
+  const targetBranch = branch ?? (await resolveBranch(repoPath));
   const saveResult = await CloneSyncService.save({
     repoPath,
     branch: targetBranch,

--- a/src/services/git/GitBranchCoordinator.ts
+++ b/src/services/git/GitBranchCoordinator.ts
@@ -136,7 +136,28 @@ class GitBranchCoordinatorClass {
         const statuses = await GitEngine.statuses(localPath);
         this.validateWorkingTree(statuses);
 
-        await GitEngine.checkoutBranch(localPath, branchName, remoteName);
+        let checkoutError: Error | null = null;
+        try {
+          await GitEngine.checkoutBranch(localPath, branchName, remoteName);
+        } catch (error) {
+          // If checkout fails because the remote tracking ref is missing,
+          // fetch from the remote and retry once.
+          const message = error instanceof Error ? error.message : String(error);
+          if (/ref.*not(found|exist)|couldn't find|not found/i.test(message)) {
+            try {
+              await GitEngine.fetch(localPath, remoteName, repoId);
+              await GitEngine.checkoutBranch(localPath, branchName, remoteName);
+              checkoutError = null;
+            } catch (retryError) {
+              checkoutError = retryError instanceof Error ? retryError : new Error(String(retryError));
+            }
+          } else {
+            checkoutError = error instanceof Error ? error : new Error(message);
+          }
+        }
+        if (checkoutError) {
+          throw checkoutError;
+        }
 
         const postflightOk = await GitSyncGate.verifyPostflight(preflight!, opId);
         if (!postflightOk) {

--- a/src/services/git/GitBranchCoordinator.ts
+++ b/src/services/git/GitBranchCoordinator.ts
@@ -21,6 +21,7 @@ import { gitOperationRegistry, type GitOpKind } from '@/stores/gitOperationStore
 import { GitSyncGate, type PreflightState } from './GitSyncGate';
 import { emitGitContentRefresh } from '@/hooks/useGitRefreshEvent';
 import { invalidateCache } from './branchResolver';
+import { setActiveBranchAfterCheckout } from './activeBranchStore';
 import * as GitEngine from './engine/GitEngine';
 import type { FileStatus } from './engine/GitEngine';
 
@@ -147,6 +148,7 @@ class GitBranchCoordinatorClass {
         this.clearWatchdog();
         gitOperationRegistry.succeed(opId);
         invalidateCache(repoId);
+        await setActiveBranchAfterCheckout(repoId, localPath, branchName);
         emitGitContentRefresh();
         this.setState('idle');
       } catch (error) {

--- a/src/services/git/activeBranchStore.ts
+++ b/src/services/git/activeBranchStore.ts
@@ -281,7 +281,7 @@ export async function initializeForRepo(repo: GitRepository): Promise<ActiveBran
     activeBranch = remoteDefault;
     source = 'default';
   } else {
-    activeBranch = null;
+    activeBranch = 'main';
     source = 'default';
   }
 

--- a/src/services/git/activeBranchStore.ts
+++ b/src/services/git/activeBranchStore.ts
@@ -244,6 +244,19 @@ async function __setActiveBranch(
 }
 
 /**
+ * Called by GitBranchCoordinator after a successful checkout to update the store
+ * with the newly checked-out branch. This ensures the active branch badge and
+ * all subscribers see the correct branch immediately without waiting for reconciliation.
+ */
+export async function setActiveBranchAfterCheckout(
+  repoId: string,
+  repoPath: string,
+  branchName: string,
+): Promise<ActiveBranchState> {
+  return __setActiveBranch(repoId, repoPath, branchName, 'head');
+}
+
+/**
  * Initialize branch state for a newly added repository.
  * Called when a repo is added via repoStore.
  *

--- a/src/services/git/branchResolver.ts
+++ b/src/services/git/branchResolver.ts
@@ -27,25 +27,21 @@ async function resolveActiveProvider(): Promise<'github' | 'gitlab' | null> {
 }
 
 /**
- * Best-effort resolution of the branch to use for a repo. Order:
- *   1. `hint` (caller-provided, usually `repo.branch` / `note.branch`)
- *   2. Local clone HEAD (clone-mode repos)
- *   3. GitHub API `default_branch`
- *   4. Hard fallback: 'main'
- *
- * Fixes #543: hardcoded `branch || 'main'` literals broke clone-mode
- * delete + write + pull on repos whose default branch is not `main`.
+ * Resolve the branch for a repo operation. Order:
+ *   1. Local clone HEAD (clone-mode repos) — verified against actual HEAD
+ *   2. GitHub API `default_branch`
+ *   3. Hard fallback: 'main'
  *
  * @param repoPath - The repository path
- * @param hint - Optional branch hint (e.g., from repo config)
+ * @param _hint - Deprecated and ignored. Internal operations bind to HEAD directly.
  * @param repoId - Optional repoId for cache key (preferred over repoPath)
  */
 export async function resolveBranch(
   repoPath: string,
-  hint?: string | null,
+  _hint?: string | null,
   repoId?: string,
 ): Promise<string> {
-  if (hint) return hint;
+  // Internal branch identity is bound to HEAD; hint is ignored.
 
   const cacheKey = repoId ?? repoPath;
   const cached = sessionCache.get(cacheKey);

--- a/src/stores/repoStore.ts
+++ b/src/stores/repoStore.ts
@@ -15,6 +15,7 @@ import {
   RepoAccessPreflightError,
 } from '../services/git/repoAccessPreflight';
 import { reposAffectedByRemovedHosts, type RemovedHostRef } from '../services/git/repoRemovalCascade';
+import { initializeForRepo, removeForRepo } from '../services/git/activeBranchStore';
 
 interface RepoState {
   repositories: GitRepository[];
@@ -109,12 +110,19 @@ export const useRepoStore = create<RepoState & RepoActions>()((set, get) => ({
       throw new Error(`Clone failed: ${msg}`);
     }
 
+    await initializeForRepo(repo);
+
     const updated = await StorageService.getSavedRepositories();
     set({ repositories: updated });
     return repo;
   },
 
   removeRepository: async (path, provider = 'github') => {
+    const repos = await StorageService.getSavedRepositories();
+    const repo = repos.find((r) => r.path === path && (r.provider ?? 'github') === provider);
+    if (repo) {
+      await removeForRepo(repo.id);
+    }
     await StorageService.removeRepository(path, provider);
     await StorageService.purgeRepoData(path);
 


### PR DESCRIPTION
## Summary

Implements the  policy: GitNotēs is clone-only for user data, so new repos default to  and branch changes happen exclusively in the Git → Branches tab.

## Changes

### Core
- **Default to ** —  initializes to  instead of ; wired into  lifecycle (/)
- **Checkout locally from remote** —  shows  button for remote-only branches; uses  with retry logic; refreshes  after checkout
- **Remove branch selectors from editors** — removes // from , , , 
- **Remove branch presentation from cards/lists** — removes branch badges from , ; removes branch chip from ; removes branch display from 
- **Bind internal ops to active branch** — , , ,  snapshot the active branch at operation initiation

### Docs & Tests
- Regression tests in  for  default and / lifecycle
- Wiki docs updated for git-tab-only branch ownership

## Verification
- F1 (Branch Audit): PASS ✅ — no user-facing branch matches outside /
- F2 (Quality Gates):  ✅,  ✅
- F3 (Simulator QA):  button present ✅
- F4 (Scope Hygiene): main worktree clean, feature branch pushed ✅

## Testing
```bash
yarn ts:check && yarn eslint . --ext .ts,.tsx && yarn jest
```

Closes #1407