### PR TITLE
fix(explore): remove misleading commit count from commits tab header

### DIFF
--- a/src/components/explore/CommitsSection.tsx
+++ b/src/components/explore/CommitsSection.tsx
@@ -204,10 +204,7 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
         <RefreshControl refreshing={loading} onRefresh={() => void loadInitial()} tintColor={colors.accent} />
       }
       ListHeaderComponent={
-        <View className="flex-row items-center justify-between px-4 pb-2">
-          <Text className="text-xs" style={{ color: colors.textSecondary }} testID="explore.commits.count">
-            {loading ? 'Reading history…' : `${commits.length} commit${commits.length !== 1 ? 's' : ''}`}
-          </Text>
+        <View className="flex-row items-center justify-end px-4 pb-2">
           <View className="flex-row items-center gap-2">
             {loading || pushing ? (
               <ActivityIndicator size="small" color={colors.accent} />


### PR DESCRIPTION
The commits tab shows a `X commits` count in the header, but since it's an infinite-scrolling list, the count only reflects loaded commits (grows as you scroll) rather than the actual total. This is misleading.

Removed the count display from the header — the Push button remains.

**Before:** Header shows `50 commits` (or whatever was loaded), which keeps growing as you scroll
**After:** Header only shows Push button with loading indicator when active