### PR TITLE
feat: edit text files from Explore - plain multiline editor

### DIFF
--- a/__tests__/ExploreFileScreen.test.tsx
+++ b/__tests__/ExploreFileScreen.test.tsx
@@ -1,0 +1,448 @@
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: jest.fn(),
+}));
+
+jest.mock('react-native-marked', () => ({
+  useMarkdown: jest.fn(() => []),
+}));
+
+const mockAlert = jest.fn();
+const mockFileText = jest.fn();
+const mockFileExists = jest.fn().mockReturnValue(true);
+const mockFileWrite = jest.fn();
+
+jest.mock('expo-file-system', () => ({
+  File: function MockFile(_path: string) {
+    return {
+      exists: mockFileExists(),
+      text: () => mockFileText(),
+      write: () => mockFileWrite(),
+    };
+  },
+}));
+
+jest.mock('react-native', () => {
+  const fn = jest.fn();
+  const React = require('react');
+  return {
+    __esModule: true,
+    View: 'View',
+    Text: 'Text',
+    TextInput: ({ testID, ...rest }: { testID?: string; [key: string]: unknown }) =>
+      React.createElement('TextInput', { testID, ...rest }),
+    ScrollView: 'ScrollView',
+    Pressable: 'Pressable',
+    ActivityIndicator: 'ActivityIndicator',
+    SafeAreaView: 'SafeAreaView',
+    Alert: { alert: mockAlert },
+    Platform: { OS: 'ios', select: (obj: Record<string, unknown>) => (obj.ios ?? obj.default) },
+    StyleSheet: { create: (style: unknown) => style, flatten: fn },
+    AppState: { addEventListener: fn, removeEventListener: fn, currentState: 'active' },
+    Keyboard: { dismiss: fn, addListener: fn, removeListener: fn },
+    KeyboardAvoidingView: 'KeyboardAvoidingView',
+    TouchableOpacity: 'TouchableOpacity',
+    Image: 'Image',
+    FlatList: 'FlatList',
+    SectionList: 'SectionList',
+    RefreshControl: 'RefreshControl',
+    Modal: 'Modal',
+    StatusBar: 'StatusBar',
+    Switch: 'Switch',
+    Dimensions: { get: () => ({ width: 375, height: 812 }), addEventListener: fn, removeEventListener: fn },
+    PixelRatio: { get: () => 2, getFontScale: () => 1 },
+    NativeModules: {},
+    DevMenu: {},
+    DevSettings: {},
+  };
+});
+
+function getFileMock() {
+  return { mockFileText, mockFileExists, mockFileWrite };
+}
+
+import React from 'react';
+import { fireEvent, render, waitFor, act } from '@testing-library/react-native';
+import { TextInput } from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+
+import ExploreFileScreen from '@/screens/ExploreFileScreen';
+import { GitFsService } from '@/services/git/GitFsService';
+import { WorkingTreeDocumentService } from '@/services/documents/WorkingTreeDocumentService';
+import { GitBranchCoordinator } from '@/services/git/GitBranchCoordinator';
+
+// ─── mock external dependencies ────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate, goBack: mockGoBack }),
+  useRoute: jest.fn(),
+}));
+
+let mockRepositories: { id: string; path: string; name: string; localPath: string; branch: string }[] = [];
+jest.mock('@/stores/repoStore', () => ({
+  useRepoStore: (selector: (state: { repositories: { id: string; path: string; name: string; localPath: string; branch: string }[] }) => unknown) =>
+    selector({ repositories: mockRepositories }),
+}));
+
+const mockWorkingTreeUri = 'file:///repo/owner/repo';
+jest.mock('@/services/git/GitFsService', () => ({
+  GitFsService: { workingTreeUri: jest.fn(() => mockWorkingTreeUri) },
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTokens: () => ({
+    colors: {
+      background: '#fff',
+      border: '#ddd',
+      text: '#111',
+      textSecondary: '#666',
+      accent: '#007AFF',
+      error: '#FF3B30',
+      surface: '#fff',
+    },
+    type: { xs: 12, sm: 14, md: 16 },
+  }),
+  useTheme: () => ({ isDark: false, style: {} }),
+}));
+
+jest.mock('@/contexts/CheckoutSafetyContext', () => ({
+  useCheckoutSafety: jest.fn(() => ({ isCheckingOut: false })),
+}));
+
+jest.mock('@/services/git/lfs', () => ({
+  parseLfsPointer: jest.fn((content: string) => {
+    if (content.includes('git-lfs.github.com/spec/v1')) {
+      return { oid: 'abc123'.padEnd(64, '0'), size: 123456 };
+    }
+    return null;
+  }),
+}));
+
+const mockServiceUpdate = jest.fn();
+jest.mock('@/services/documents/WorkingTreeDocumentService', () => ({
+  WorkingTreeDocumentService: jest.fn().mockImplementation(() => ({
+    update: mockServiceUpdate,
+  })),
+  workingTreeDocument: jest.fn((path: string, body: string, tag: string) => ({
+    id: `working-tree:${path}`,
+    type: 'note',
+    path,
+    title: path.split('/').pop() ?? path,
+    slug: path.split('/').pop() ?? path,
+    folder: null,
+    tags: [tag],
+    createdAt: 1000,
+    updatedAt: 1000,
+    isPinned: false,
+    deleted: false,
+    body,
+    raw: body,
+  })),
+}));
+
+jest.spyOn(GitBranchCoordinator, 'getState').mockReturnValue('idle');
+jest.spyOn(GitBranchCoordinator, 'onStateChange').mockReturnValue(jest.fn());
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: 'Ionicons' }));
+
+jest.mock('@/components/ui/text', () => {
+  const React = require('react');
+  return {
+    Text: ({ children, testID }: { children?: React.ReactNode; testID?: string }) => {
+      if (testID) {
+        return React.createElement('Text', { testID }, children ?? '');
+      }
+      return children != null ? React.createElement('Text', null, children) : null;
+    },
+  };
+});
+
+jest.mock('@/components/ui/heading', () => {
+  const React = require('react');
+  return {
+    Heading: ({ children, testID }: { children?: React.ReactNode; testID?: string }) => {
+      if (testID) {
+        return React.createElement('Text', { testID }, children ?? '');
+      }
+      return children != null ? React.createElement('Text', null, children) : null;
+    },
+  };
+});
+
+// ─── helpers ───────────────────────────────────────────────────────────────────
+
+function setupRoute(repoId: string, path: string) {
+  (useRoute as jest.Mock).mockReturnValue({ params: { repoId, path } });
+}
+
+const mockRepo = {
+  id: 'repo-1',
+  path: 'owner/repo',
+  name: 'repo',
+  localPath: '/repo/owner/repo',
+  branch: 'main',
+};
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('ExploreFileScreen', () => {
+  beforeEach(() => {
+    mockRepositories = [mockRepo];
+    mockFileExists.mockReturnValue(true);
+    mockFileText.mockResolvedValue('Hello world');
+    mockServiceUpdate.mockResolvedValue(undefined);
+  });
+
+  describe('happy path', () => {
+    it('renders editor with correct initial content', async () => {
+      setupRoute('repo-1', 'notes/hello.md');
+
+      const { getByTestId } = render(<ExploreFileScreen />);
+
+      const editor = await waitFor(
+        () => getByTestId('explore-file.editor'),
+        { timeout: 3000 },
+      );
+      expect(editor).toBeTruthy();
+    });
+
+    it('calls writer with exact new value when save is pressed', async () => {
+      setupRoute('repo-1', 'notes/hello.md');
+
+      const { getByTestId } = render(<ExploreFileScreen />);
+
+      const editor = await waitFor(
+        () => getByTestId('explore-file.editor'),
+        { timeout: 3000 },
+      );
+
+      const textInput = editor as unknown as TextInput;
+
+      fireEvent(textInput, 'changeText', 'Modified content');
+
+      const saveButton = getByTestId('explore-file.save');
+      await act(async () => {
+        fireEvent.press(saveButton);
+      });
+
+      expect(mockServiceUpdate).toHaveBeenCalledWith(
+        expect.any(String),
+        { body: 'Modified content' },
+      );
+    });
+
+    it('screen stays visible after save', async () => {
+      setupRoute('repo-1', 'notes/hello.md');
+
+      const { getByTestId } = render(<ExploreFileScreen />);
+
+      const editor = await waitFor(
+        () => getByTestId('explore-file.editor'),
+        { timeout: 3000 },
+      );
+
+      const textInput = editor as unknown as TextInput;
+
+      fireEvent(textInput, 'changeText', 'New content');
+
+      const saveButton = getByTestId('explore-file.save');
+      await act(async () => {
+        fireEvent.press(saveButton);
+      });
+
+      expect(getByTestId('explore-file.root')).toBeTruthy();
+    });
+  });
+
+  describe('binary file', () => {
+    it('shows binary-message and no editor', async () => {
+      setupRoute('repo-1', 'image.png');
+
+      const { getByTestId, queryByTestId } = render(<ExploreFileScreen />);
+
+      const binaryMessage = await waitFor(
+        () => getByTestId('explore-file.binary-message'),
+        { timeout: 3000 },
+      );
+      expect(binaryMessage).toBeTruthy();
+
+      expect(queryByTestId('explore-file.editor')).toBeNull();
+      expect(queryByTestId('explore-file.save')).toBeNull();
+    });
+  });
+
+  describe('LFS pointer', () => {
+    it('shows lfs-pointer-message when content is an LFS pointer', async () => {
+      setupRoute('repo-1', 'large.txt');
+
+      mockFileText.mockResolvedValue(
+        'version https://git-lfs.github.com/spec/v1\noid sha256:abc123\nsize 123456\n',
+      );
+
+      const { getByTestId, queryByTestId } = render(<ExploreFileScreen />);
+
+      const lfsMessage = await waitFor(
+        () => getByTestId('explore-file.lfs-pointer-message'),
+        { timeout: 3000 },
+      );
+      expect(lfsMessage).toBeTruthy();
+
+      expect(queryByTestId('explore-file.editor')).toBeNull();
+      expect(queryByTestId('explore-file.save')).toBeNull();
+    });
+  });
+
+  describe('writer rejection', () => {
+    it('shows save-error when writer throws', async () => {
+      setupRoute('repo-1', 'notes/hello.md');
+
+      mockServiceUpdate.mockRejectedValue(new Error('disk full'));
+
+      const { getByTestId } = render(<ExploreFileScreen />);
+
+      const editor = await waitFor(
+        () => getByTestId('explore-file.editor'),
+        { timeout: 3000 },
+      );
+
+      const textInput = editor as unknown as TextInput;
+
+      fireEvent(textInput, 'changeText', 'New content');
+
+      const saveButton = getByTestId('explore-file.save');
+      await act(async () => {
+        fireEvent.press(saveButton);
+      });
+
+      const saveError = await waitFor(
+        () => getByTestId('explore-file.save-error'),
+        { timeout: 3000 },
+      );
+      expect(saveError).toBeTruthy();
+    });
+
+    it('retains edited text after writer rejection', async () => {
+      setupRoute('repo-1', 'notes/hello.md');
+
+      mockServiceUpdate.mockRejectedValue(new Error('write failed'));
+
+      const { getByTestId } = render(<ExploreFileScreen />);
+
+      const editor = await waitFor(
+        () => getByTestId('explore-file.editor'),
+        { timeout: 3000 },
+      );
+
+      const textInput = editor as unknown as TextInput;
+
+      fireEvent(textInput, 'changeText', 'Should be retained');
+
+      const saveButton = getByTestId('explore-file.save');
+      await act(async () => {
+        fireEvent.press(saveButton);
+      });
+
+      await waitFor(
+        () => getByTestId('explore-file.save-error'),
+        { timeout: 3000 },
+      );
+
+      expect(textInput.props.value).toBe('Should be retained');
+    });
+  });
+
+  describe('missing repo', () => {
+    it('shows "Repository not found" without crashing', async () => {
+      mockRepositories = [];
+      setupRoute('nonexistent-repo', 'notes/hello.md');
+
+      const { getAllByText } = render(<ExploreFileScreen />);
+      const allMatching = getAllByText('Repository not found.');
+      expect(allMatching.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('missing file', () => {
+    it('shows error message when file does not exist', async () => {
+      mockFileExists.mockReturnValue(false);
+      setupRoute('repo-1', 'notes/doesnotexist.md');
+
+      const { getByTestId } = render(<ExploreFileScreen />);
+
+      const errorEl = await waitFor(
+        () => getByTestId('explore-file.error'),
+        { timeout: 3000 },
+      );
+      expect(errorEl).toBeTruthy();
+    });
+  });
+
+  describe('cancel dirty state', () => {
+    it('shows Alert when cancel is pressed with dirty state', async () => {
+      const ReactNative = require('react-native');
+      ReactNative.Alert.alert = mockAlert;
+
+      setupRoute('repo-1', 'notes/hello.md');
+
+      const { getByTestId } = render(<ExploreFileScreen />);
+
+      const editor = await waitFor(
+        () => getByTestId('explore-file.editor'),
+        { timeout: 3000 },
+      );
+
+      const textInput = editor as unknown as TextInput;
+
+      fireEvent(textInput, 'changeText', 'Dirty content');
+
+      const cancelButton = getByTestId('explore-file.cancel');
+      await act(async () => {
+        fireEvent.press(cancelButton);
+      });
+
+      expect(mockAlert).toHaveBeenCalledWith(
+        'Discard changes?',
+        'You have unsaved changes that will be lost.',
+        expect.arrayContaining([
+          expect.objectContaining({ text: 'Keep Editing' }),
+          expect.objectContaining({ text: 'Discard' }),
+        ]),
+      );
+    });
+  });
+
+  describe('checkout blocking', () => {
+    it('disables Save button when isCheckingOut is true', async () => {
+      jest.clearAllMocks();
+      mockRepositories = [mockRepo];
+      mockFileExists.mockReturnValue(true);
+      mockFileText.mockResolvedValue('Hello world');
+      mockServiceUpdate.mockResolvedValue(undefined);
+
+      // Override CheckoutSafetyContext mock to simulate isCheckingOut = true
+      const { useCheckoutSafety } = require('@/contexts/CheckoutSafetyContext');
+      (useCheckoutSafety as jest.Mock).mockReturnValue({ isCheckingOut: true });
+
+      setupRoute('repo-1', 'notes/hello.md');
+
+      const { getByTestId } = render(<ExploreFileScreen />);
+
+      const editor = await waitFor(
+        () => getByTestId('explore-file.editor'),
+        { timeout: 3000 },
+      );
+
+      const textInput = editor as unknown as TextInput;
+
+      fireEvent(textInput, 'changeText', 'Dirty content');
+
+      const saveButton = getByTestId('explore-file.save');
+      await act(async () => {
+        fireEvent.press(saveButton);
+      });
+      expect(mockServiceUpdate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/components/explore/FilesSection.test.tsx
+++ b/__tests__/components/explore/FilesSection.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+
+jest.mock('expo-file-system', () => ({}));
+
+const TEST_FILES = [
+  'readme.md',
+  'test.txt',
+  'index.ts',
+  'util.ts',
+  'guide.txt',
+  'screenshot.jpg',
+  'logo.png',
+  'archive.tar.gz',
+  'icon.woff2',
+  'Makefile',
+  'package.json',
+];
+
+jest.mock('@/components/explore/exploreShared', () => {
+  const actual = jest.requireActual('@/components/explore/exploreShared');
+  return {
+    ...actual,
+    walkWorkingTree: jest.fn(() => ({ files: TEST_FILES, truncated: false })),
+  };
+});
+
+jest.mock('@/services/git/engine/GitEngine', () => {
+  const actual = jest.requireActual('@/services/git/engine/GitEngine');
+  return { ...actual, statuses: jest.fn(), stage: jest.fn() };
+});
+
+jest.mock('@/services/git/GitFsService', () => ({
+  GitFsService: { isCloned: jest.fn() },
+}));
+
+jest.mock('@/services/GitHubService', () => {
+  const mockGetTreeRecursiveOrThrow = jest.fn();
+  return {
+    getTreeRecursiveOrThrow: mockGetTreeRecursiveOrThrow,
+    GitHubService: { getTreeRecursiveOrThrow: mockGetTreeRecursiveOrThrow },
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useFocusEffect: jest.fn((cb: () => void) => cb()),
+}));
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTokens: () => ({
+    colors: {
+      background: '#ffffff', card: '#f0f0f0', border: '#cccccc',
+      text: '#000000', textSecondary: '#666666', accent: '#007AFF',
+      success: '#34C759', error: '#FF3B30', warning: '#FF9500',
+      surface: '#e5e5ea', surfaceSecondary: '#e5e5ea',
+    },
+  }),
+}));
+
+import { FilesSection } from '@/components/explore/FilesSection';
+import * as GitEngine from '@/services/git/engine/GitEngine';
+import { GitFsService } from '@/services/git/GitFsService';
+import { GitHubService } from '@/services/GitHubService';
+import { isBinaryPath } from '@/components/explore/exploreShared';
+
+const mockRepo = {
+  id: 'test-repo-id', path: 'owner/test-repo', name: 'test-repo',
+  localPath: '/mock/repos/test-repo', branch: 'main',
+};
+
+describe('FilesSection row navigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (GitFsService.isCloned as jest.Mock).mockResolvedValue(true);
+    (GitEngine.statuses as jest.Mock).mockResolvedValue([]);
+  });
+
+  describe('non-binary file rows', () => {
+    const cases = [
+      { path: 'readme.md', desc: 'markdown' },
+      { path: 'index.ts', desc: 'typescript' },
+      { path: 'guide.txt', desc: 'text' },
+      { path: 'Makefile', desc: 'extensionless' },
+      { path: 'package.json', desc: 'json' },
+    ];
+
+    it.each(cases)('navigates to ExploreFile for $desc ($path)', async ({ path }) => {
+      expect(isBinaryPath(path)).toBe(false);
+      const { getByTestId } = render(
+        <FilesSection repo={mockRepo} active={true} onChanged={jest.fn()} status={null} />
+      );
+      await waitFor(() => expect(getByTestId(`explore.file.${path}`)).toBeTruthy());
+      fireEvent.press(getByTestId(`explore.file.${path}`));
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('ExploreFile', { repoId: mockRepo.id, path });
+    });
+  });
+
+  describe('binary file rows', () => {
+    const cases = [
+      { path: 'screenshot.jpg', desc: 'JPEG' },
+      { path: 'logo.png', desc: 'PNG' },
+      { path: 'archive.tar.gz', desc: 'archive' },
+      { path: 'icon.woff2', desc: 'font' },
+    ];
+
+    it.each(cases)('navigates to ExploreFile for $desc ($path) with binary badge', async ({ path }) => {
+      expect(isBinaryPath(path)).toBe(true);
+      const { getByTestId, getAllByText } = render(
+        <FilesSection repo={mockRepo} active={true} onChanged={jest.fn()} status={null} />
+      );
+      await waitFor(() => expect(getByTestId(`explore.file.${path}`)).toBeTruthy());
+      const badges = getAllByText('binary');
+      expect(badges.length).toBeGreaterThan(0);
+      fireEvent.press(getByTestId(`explore.file.${path}`));
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('ExploreFile', { repoId: mockRepo.id, path });
+    });
+  });
+
+  describe('no mutation on row tap', () => {
+    it('does not call GitHubService on file row tap', async () => {
+      const { getByTestId } = render(
+        <FilesSection repo={mockRepo} active={true} onChanged={jest.fn()} status={null} />
+      );
+      await waitFor(() => expect(getByTestId('explore.file.readme.md')).toBeTruthy());
+      fireEvent.press(getByTestId('explore.file.readme.md'));
+      expect(GitHubService.getTreeRecursiveOrThrow).not.toHaveBeenCalled();
+    });
+
+    it('does not call GitEngine.stage on file row tap', async () => {
+      const { getByTestId } = render(
+        <FilesSection repo={mockRepo} active={true} onChanged={jest.fn()} status={null} />
+      );
+      await waitFor(() => expect(getByTestId('explore.file.readme.md')).toBeTruthy());
+      fireEvent.press(getByTestId('explore.file.readme.md'));
+      expect(GitEngine.stage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('directory rows', () => {
+    it('toggling a directory does not navigate to ExploreFile', async () => {
+      const { getByTestId } = render(
+        <FilesSection repo={mockRepo} active={true} onChanged={jest.fn()} status={null} />
+      );
+      await waitFor(() => expect(getByTestId('explore.file.readme.md')).toBeTruthy());
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/services/documents/WorkingTreeDocumentService.test.ts
+++ b/__tests__/services/documents/WorkingTreeDocumentService.test.ts
@@ -1,0 +1,224 @@
+const mockFileWrite = jest.fn();
+const mockFileExists = jest.fn();
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: jest.fn(),
+}));
+
+jest.mock('@/services/git/GitFsService', () => ({
+  normalizeWorktreeRelPath: jest.fn((filepath: string) => {
+    if (!filepath || filepath.includes('..') || filepath.startsWith('/')) {
+      throw Object.assign(new Error(`Invalid worktree filepath: ${filepath}`), { code: 'NotFoundError' });
+    }
+    return filepath;
+  }),
+}));
+
+jest.mock('expo-file-system', () => ({
+  File: jest.fn().mockImplementation(() => ({
+    exists: mockFileExists(),
+    write: mockFileWrite,
+  })),
+}));
+
+jest.mock('@/services/git/engine/GitEngine', () => ({
+  stage: jest.fn(),
+  remove: jest.fn(),
+  commit: jest.fn(),
+  push: jest.fn(),
+  isRepoOnBranch: jest.fn(),
+}));
+
+import * as GitEngine from '@/services/git/engine/GitEngine';
+import type { Document } from '@/models/Document';
+
+const { WorkingTreeDocumentService, workingTreeDocument, WriteError } = jest.requireActual('@/services/documents/WorkingTreeDocumentService');
+
+// Override normalizeWorktreeRelPath to throw for invalid paths
+const actualGitFs = jest.requireActual('@/services/git/GitFsService');
+jest.spyOn(actualGitFs, 'normalizeWorktreeRelPath').mockImplementation((path: string) => {
+  if (!path || path.includes('..') || path.startsWith('/')) {
+    throw Object.assign(new Error(`Invalid worktree filepath: ${path}`), { code: 'NotFoundError' });
+  }
+  return path;
+});
+
+// Patch it onto the GitFsService module so WorkingTreeDocumentService uses it
+jest.doMock('@/services/git/GitFsService', () => actualGitFs);
+
+describe('WorkingTreeDocumentService', () => {
+  const baseDoc: Document = {
+    id: 'working-tree:notes/test.md',
+    type: 'note',
+    path: 'notes/test.md',
+    title: 'test.md',
+    slug: 'test.md',
+    folder: null,
+    tags: ['explore'],
+    createdAt: 1000,
+    updatedAt: 1000,
+    isPinned: false,
+    deleted: false,
+    body: 'original content',
+    raw: 'original content',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFileExists.mockReturnValue(true);
+    mockFileWrite.mockReturnValue(undefined);
+  });
+
+  describe('update - happy path', () => {
+    it('writes Unicode content exactly to File.write', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      const content = 'Hello 世界 🌍\t\r\n';
+      await service.update(baseDoc.id, { body: content });
+
+      expect(mockFileWrite).toHaveBeenCalledWith(content);
+    });
+
+    it('writes tabs and CRLF unchanged', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      const content = 'line1\t\ttab\r\nline2\r\nline3\r\n';
+      await service.update(baseDoc.id, { body: content });
+
+      expect(mockFileWrite).toHaveBeenCalledWith(content);
+    });
+
+    it('writes empty string without error', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      await service.update(baseDoc.id, { body: '' });
+
+      expect(mockFileWrite).toHaveBeenCalledWith('');
+    });
+
+    it('returns Document with correct body and updatedAt', async () => {
+      const before = Date.now();
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      const result = await service.update(baseDoc.id, { body: 'new content' });
+      const after = Date.now();
+
+      expect(result.body).toBe('new content');
+      expect(result.raw).toBe('new content');
+      expect(result.updatedAt).toBeGreaterThanOrEqual(before);
+      expect(result.updatedAt).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('update - path guards', () => {
+    it('does not call File.write for ../traversal.txt path', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', '../traversal.txt', baseDoc);
+      try {
+        await service.update(baseDoc.id, { body: 'content' });
+      } catch {
+        // expected to throw
+      }
+      expect(mockFileWrite).not.toHaveBeenCalled();
+    });
+
+    it('does not call File.write for .. path segment', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/../notes/../etc/passwd', baseDoc);
+      try {
+        await service.update(baseDoc.id, { body: 'content' });
+      } catch {
+        // expected to throw
+      }
+      expect(mockFileWrite).not.toHaveBeenCalled();
+    });
+
+    it('does not call File.write for empty string path', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', '', baseDoc);
+      try {
+        await service.update(baseDoc.id, { body: 'content' });
+      } catch {
+        // expected to throw
+      }
+      expect(mockFileWrite).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update - size guard', () => {
+    it('does not call File.write when content exceeds 5 MiB', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      const largeContent = 'x'.repeat(5 * 1024 * 1024 + 1);
+
+      try {
+        await service.update(baseDoc.id, { body: largeContent });
+      } catch {
+        // expected to throw
+      }
+      expect(mockFileWrite).not.toHaveBeenCalled();
+    });
+
+    it('does not throw for content exactly at 5 MiB', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      const exactContent = 'x'.repeat(5 * 1024 * 1024);
+      mockFileWrite.mockReturnValue(undefined);
+
+      await expect(service.update(baseDoc.id, { body: exactContent })).resolves.toBeDefined();
+      expect(mockFileWrite).toHaveBeenCalledWith(exactContent);
+    });
+  });
+
+  describe('update - write rejection', () => {
+    it('surfaces WriteError when File.write throws', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      mockFileWrite.mockImplementation(() => {
+        throw new Error('disk full');
+      });
+
+      await expect(service.update(baseDoc.id, { body: 'new content' })).rejects.toThrow(WriteError);
+    });
+
+    it('WriteError message includes the underlying error', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      mockFileWrite.mockImplementation(() => {
+        throw new Error('permission denied');
+      });
+
+      await expect(service.update(baseDoc.id, { body: 'new content' })).rejects.toThrow('permission denied');
+    });
+  });
+
+  describe('no Git side effects', () => {
+    it('does not call GitEngine.stage', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      await service.update(baseDoc.id, { body: 'content' });
+
+      expect(GitEngine.stage).not.toHaveBeenCalled();
+    });
+
+    it('does not call GitEngine.remove', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      await service.update(baseDoc.id, { body: 'content' });
+
+      expect(GitEngine.remove).not.toHaveBeenCalled();
+    });
+
+    it('does not call GitEngine.commit', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      await service.update(baseDoc.id, { body: 'content' });
+
+      expect(GitEngine.commit).not.toHaveBeenCalled();
+    });
+
+    it('does not call GitEngine.push', async () => {
+      const service = new WorkingTreeDocumentService('/repo/path', 'notes/test.md', baseDoc);
+      await service.update(baseDoc.id, { body: 'content' });
+
+      expect(GitEngine.push).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('workingTreeDocument', () => {
+    it('creates a Document with working-tree id prefix', () => {
+      const doc = workingTreeDocument('notes/hello.md', 'body content', 'explore');
+
+      expect(doc.id).toBe('working-tree:notes/hello.md');
+      expect(doc.body).toBe('body content');
+      expect(doc.raw).toBe('body content');
+      expect(doc.tags).toContain('explore');
+    });
+  });
+});

--- a/docs/wiki/screens.md
+++ b/docs/wiki/screens.md
@@ -229,9 +229,11 @@ The canonical route param types are in `src/navigation/types.ts`:
 
 ### ExploreFileScreen
 
-**Purpose:** View a file at a specific commit or branch state.
+**Purpose:** View and edit a text file from the local working tree. Binary files and LFS pointer files are read-only. Text files are editable as plain text via a multiline editor.
 
 **Route params:** `{ repoId: string; path: string }`
+
+**Save behavior:** Save writes raw UTF-8 content directly to the working tree without staging, committing, or pushing. The file appears as an unstaged modification in the Git workspace. User reviews, stages, commits, and pushes from the existing Git workspace.
 
 **Navigation:** Tapped from `ExploreScreen` file tree.
 

--- a/docs/wiki/sync-architecture.md
+++ b/docs/wiki/sync-architecture.md
@@ -21,6 +21,15 @@ User edits note
 
 Delete operations remove the working-tree file without staging the deletion, so the user can review, stage, and commit it from the Git workspace.
 
+### Explore File Editing (Raw Working-Tree Write)
+
+When editing a file from the Git → Files tab:
+- `ExploreFileScreen` loads the file content from the local working tree
+- Save writes the exact UTF-8 content back to the working tree via `WorkingTreeDocumentService`
+- No staging, committing, pushing, queue enqueue, or branch checkout occurs
+- The file appears as an unstaged modification in the Git workspace
+- User reviews, stages, commits, and pushes from the existing Git workspace
+
 ### Push Triggers
 
 After a local commit, push is triggered automatically by any of:

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '^.+\\.tsx$': 'babel-jest',
   },
   testEnvironment: 'node',
+  roots: ['<rootDir>'],
   testMatch: [
     '**/__tests__/**/*.test.{ts,tsx}',
     '**/?(*.)+(spec|test).{ts,tsx}',
@@ -24,7 +25,7 @@ module.exports = {
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: [
     '/node_modules/',
-    '/.worktrees/',
+    '/.worktrees/(?!git-files-text-edit)/',
   ],
   transformIgnorePatterns: [
     'node_modules/(?!(react-native|@react-native|@react-navigation|expo|expo-[^/]+|@expo|react-native-reanimated|@shopify|nativewind|react-native-css|@rn-primitives|class-variance-authority|tailwind-merge|tailwindcss-animate)/)',

--- a/src/screens/ExploreFileScreen.tsx
+++ b/src/screens/ExploreFileScreen.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Alert, Pressable, ScrollView, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
-import { useMarkdown } from 'react-native-marked';
 import { File } from 'expo-file-system';
 
 import { Text } from '@/components/ui/text';
@@ -12,49 +11,24 @@ import { Heading } from '@/components/ui/heading';
 import { GitFsService } from '@/services/git/GitFsService';
 import { isBinaryPath } from '@/components/explore/exploreShared';
 import { useRepoStore } from '@/stores/repoStore';
-import { useTokens, useTheme } from '@/contexts/ThemeContext';
+import { useTokens } from '@/contexts/ThemeContext';
 import type { RootStackParamList } from '@/navigation/types';
-import { getMarkdownStyles } from '@/utils/preview';
-import { useRenderStyle } from '@/stores/renderStyleStore';
+import { parseLfsPointer } from '@/services/git/lfs';
+import { WorkingTreeDocumentService, workingTreeDocument } from '@/services/documents/WorkingTreeDocumentService';
+import { useCheckoutSafety } from '@/contexts/CheckoutSafetyContext';
+import { GitBranchCoordinator } from '@/services/git/GitBranchCoordinator';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 type Route = RouteProp<RootStackParamList, 'ExploreFile'>;
 
-type Mode = 'markdown' | 'code' | 'binary' | 'plain';
-
-const CODE_EXTS = new Set([
-  'ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs',
-  'py', 'rb', 'go', 'rs', 'java', 'kt', 'swift',
-  'c', 'cpp', 'cc', 'h', 'hpp',
-  'cs', 'php', 'scala', 'lua', 'sh', 'bash', 'zsh',
-  'css', 'scss', 'less', 'html', 'htm', 'xml', 'svg',
-  'json', 'yaml', 'yml', 'toml', 'ini', 'conf', 'env',
-  'sql', 'graphql', 'proto', 'dockerfile', 'gitignore',
-]);
-
-function detectMode(filename: string): Mode {
-  const lower = filename.toLowerCase();
-  const ext = lower.split('.').pop() ?? '';
-  if (ext === 'md' || ext === 'markdown') return 'markdown';
-  if (isBinaryPath(lower)) return 'binary';
-  if (CODE_EXTS.has(ext)) return 'code';
-  return 'plain';
-}
-
-function MarkdownBody({ value, styles: mdStyles }: { value: string; styles: ReturnType<typeof getMarkdownStyles> }) {
-  const nodes = useMarkdown(value, { styles: mdStyles });
-  return <>{React.Children.toArray(nodes)}</>;
-}
-
-/** View a single file from the local working tree.
- * Supports markdown rendering, syntax-highlighted code, and plain text.
- * Binary files show a placeholder. */
+/** View and edit a single file from the local working tree.
+ * Plain-text editor for non-binary, non-LFS-pointer files.
+ * Binary and LFS pointer files are shown as read-only placeholders. */
 export default function ExploreFileScreen() {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<Route>();
   const { colors } = useTokens();
-  const { isDark } = useTheme();
-  const { repoId, path } = route.params;
+  const { repoId, path: filePath } = route.params;
 
   const storedRepo = useRepoStore((state) =>
     state.repositories.find((candidate) => candidate.id === repoId),
@@ -64,8 +38,25 @@ export default function ExploreFileScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fileName = useMemo(() => path.split('/').pop() ?? path, [path]);
-  const mode: Mode = useMemo(() => detectMode(fileName), [fileName]);
+  const [editorText, setEditorText] = useState<string>('');
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  const checkoutSafety = useCheckoutSafetySafe();
+  const isCheckingOut = checkoutSafety?.isCheckingOut ?? false;
+
+  const fileName = useMemo(() => filePath.split('/').pop() ?? filePath, [filePath]);
+
+  const isBinary = useMemo(() => isBinaryPath(filePath), [filePath]);
+
+  const isLfsPointer = useMemo(
+    () => (content != null ? parseLfsPointer(content) !== null : false),
+    [content],
+  );
+
+  const isReadOnly = isBinary || isLfsPointer;
 
   useEffect(() => {
     if (!storedRepo) return;
@@ -73,11 +64,14 @@ export default function ExploreFileScreen() {
     setContent(null);
     setError(null);
     setLoading(true);
+    setIsDirty(false);
+    setSaveError(null);
+    setSavedAt(null);
     (async () => {
       try {
         const workingTreeUri = GitFsService.workingTreeUri({ repoPath: storedRepo.path });
-        const filePath = `${workingTreeUri}/${path}`;
-        const file = new File(filePath);
+        const fullPath = `${workingTreeUri}/${filePath}`;
+        const file = new File(fullPath);
         if (!file.exists) {
           if (!cancelled) setError('File not found in working tree.');
           return;
@@ -85,6 +79,7 @@ export default function ExploreFileScreen() {
         const result = await file.text();
         if (cancelled) return;
         setContent(result);
+        setEditorText(result);
       } catch (caught) {
         if (cancelled) return;
         setError(caught instanceof Error ? caught.message : String(caught));
@@ -95,13 +90,63 @@ export default function ExploreFileScreen() {
     return () => {
       cancelled = true;
     };
-  }, [storedRepo, path]);
+  }, [storedRepo, filePath]);
 
-  const markdownOverrides = useRenderStyle('markdown');
-  const markdownStyles = useMemo(
-    () => getMarkdownStyles(colors, isDark, markdownOverrides),
-    [colors, isDark, markdownOverrides],
-  );
+  const handleSave = useCallback(async () => {
+    if (isSaving || isCheckingOut || !isDirty || !storedRepo) return;
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      const workingTreeUri = GitFsService.workingTreeUri({ repoPath: storedRepo.path });
+      const doc = workingTreeDocument(filePath, editorText, 'explore');
+      const service = new WorkingTreeDocumentService(workingTreeUri, filePath, doc);
+      await service.update(doc.id, { body: editorText });
+      setIsDirty(false);
+      setSavedAt(Date.now());
+    } catch (caught) {
+      setSaveError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setIsSaving(false);
+    }
+  }, [isSaving, isCheckingOut, isDirty, storedRepo, editorText, filePath]);
+
+  const handleCancel = useCallback(() => {
+    if (!isDirty) {
+      navigation.goBack();
+      return;
+    }
+    Alert.alert(
+      'Discard changes?',
+      'You have unsaved changes that will be lost.',
+      [
+        { text: 'Keep Editing', style: 'cancel' },
+        {
+          text: 'Discard',
+          style: 'destructive',
+          onPress: () => navigation.goBack(),
+        },
+      ],
+    );
+  }, [isDirty, navigation]);
+
+  const handleBack = useCallback(() => {
+    if (isDirty) {
+      Alert.alert(
+        'Discard changes?',
+        'You have unsaved changes that will be lost.',
+        [
+          { text: 'Keep Editing', style: 'cancel' },
+          {
+            text: 'Discard',
+            style: 'destructive',
+            onPress: () => navigation.goBack(),
+          },
+        ],
+      );
+    } else {
+      navigation.goBack();
+    }
+  }, [isDirty, navigation]);
 
   if (!storedRepo) {
     return (
@@ -120,7 +165,7 @@ export default function ExploreFileScreen() {
         style={{ borderBottomWidth: 1, borderBottomColor: colors.border }}
       >
         <Pressable
-          onPress={() => navigation.goBack()}
+          onPress={handleBack}
           hitSlop={8}
           accessibilityRole="button"
           accessibilityLabel="Go back"
@@ -133,20 +178,57 @@ export default function ExploreFileScreen() {
             {fileName}
           </Heading>
           <Text className="text-xs font-mono" style={{ color: colors.textSecondary }} numberOfLines={1}>
-            {path}
+            {filePath}
           </Text>
         </View>
+
+        {!loading && !error && content != null && !isReadOnly && (
+          <>
+            <Pressable
+              onPress={handleCancel}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="Cancel editing"
+              testID="explore-file.cancel"
+              disabled={isSaving}
+            >
+              <Text style={{ color: isSaving ? colors.textSecondary : colors.error }}>
+                Cancel
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={handleSave}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="Save changes"
+              testID="explore-file.save"
+              disabled={isSaving || !isDirty || isCheckingOut}
+            >
+              <Text
+                style={{
+                  color:
+                    isSaving || !isDirty || isCheckingOut
+                      ? colors.textSecondary
+                      : colors.accent,
+                  fontWeight: '600',
+                }}
+              >
+                {isSaving ? 'Saving…' : savedAt ? 'Saved' : 'Save'}
+              </Text>
+            </Pressable>
+          </>
+        )}
       </View>
 
-      {loading ? (
+      {error ? (
+        <View className="flex-1 items-center justify-center px-8" style={{ flex: 1 }}>
+          <Ionicons name="alert-circle-outline" size={40} color={colors.error} />
+          <Text className="mt-2 text-center text-sm" style={{ color: colors.error }} testID="explore-file.error">{error}</Text>
+        </View>
+      ) : loading ? (
         <View className="flex-1 items-center justify-center gap-2" style={{ flex: 1 }}>
           <ActivityIndicator size="small" color={colors.accent} />
           <Text style={{ color: colors.textSecondary }}>Reading file…</Text>
-        </View>
-      ) : error ? (
-        <View className="flex-1 items-center justify-center px-8" style={{ flex: 1 }}>
-          <Ionicons name="alert-circle-outline" size={40} color={colors.error} />
-          <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
         </View>
       ) : content == null ? (
         <View className="flex-1 items-center justify-center px-8" style={{ flex: 1 }}>
@@ -155,32 +237,79 @@ export default function ExploreFileScreen() {
             Empty file.
           </Text>
         </View>
-      ) : mode === 'binary' ? (
+      ) : isBinary ? (
         <View className="flex-1 items-center justify-center px-8" style={{ flex: 1 }}>
           <Ionicons name="cube-outline" size={44} color={colors.textSecondary} />
-          <Text className="mt-2 text-center" style={{ color: colors.textSecondary }}>
+          <Text className="mt-2 text-center" style={{ color: colors.textSecondary }} testID="explore-file.binary-message">
             Binary file — no textual preview available.
           </Text>
         </View>
+      ) : isLfsPointer ? (
+        <View className="flex-1 items-center justify-center px-8" style={{ flex: 1 }}>
+          <Ionicons name="git-branch-outline" size={44} color={colors.textSecondary} />
+          <Text className="mt-2 text-center" style={{ color: colors.textSecondary }} testID="explore-file.lfs-pointer-message">
+            LFS pointer file — content is stored in Git LFS.
+          </Text>
+        </View>
       ) : (
-        <ScrollView
-          className="flex-1"
-          contentContainerClassName="p-4 pb-10"
-          showsVerticalScrollIndicator
-        >
-          {mode === 'markdown' ? (
-            <MarkdownBody value={content} styles={markdownStyles} />
-          ) : (
-            <Text
-              className={mode === 'code' ? 'text-[13px] leading-[18px] font-mono' : 'text-sm leading-5'}
-              style={{ color: colors.text }}
-              selectable
-            >
-              {content}
-            </Text>
-          )}
+        <ScrollView className="flex-1" keyboardDismissMode="interactive">
+          <TextInput
+            testID="explore-file.editor"
+            style={{
+              flex: 1,
+              color: colors.text,
+              fontSize: 14,
+              lineHeight: 20,
+              paddingHorizontal: 16,
+              paddingVertical: 12,
+              fontFamily: 'monospace',
+            }}
+            value={editorText}
+            onChangeText={(text) => {
+              setEditorText(text);
+              setIsDirty(text !== content);
+              setSavedAt(null);
+            }}
+            multiline
+            scrollEnabled={false}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="default"
+            placeholder="Empty file"
+            placeholderTextColor={colors.textSecondary}
+            editable={!isSaving && !isCheckingOut}
+          />
         </ScrollView>
+      )}
+
+      {saveError && (
+        <View
+          className="px-4 py-3"
+          style={{ borderTopWidth: 1, borderTopColor: colors.error }}
+        >
+          <Text style={{ color: colors.error }} testID="explore-file.save-error">
+            {saveError}
+          </Text>
+        </View>
       )}
     </SafeAreaView>
   );
+}
+
+/** Fallback checkout safety using GitBranchCoordinator when outside provider context. */
+function useCheckoutSafetySafe(): { isCheckingOut: boolean } | null {
+  try {
+    return useCheckoutSafety();
+  } catch {
+    const [isCheckingOut, setIsCheckingOut] = useState(
+      GitBranchCoordinator.getState() === 'checkout-running',
+    );
+    useEffect(() => {
+      const unsubscribe = GitBranchCoordinator.onStateChange((state) => {
+        setIsCheckingOut(state === 'checkout-running');
+      });
+      return unsubscribe;
+    }, []);
+    return isCheckingOut ? { isCheckingOut } : null;
+  }
 }

--- a/src/services/documents/WorkingTreeDocumentService.ts
+++ b/src/services/documents/WorkingTreeDocumentService.ts
@@ -1,7 +1,24 @@
 import { File } from 'expo-file-system';
 
+import { normalizeWorktreeRelPath } from '@/services/git/GitFsService';
 import { DocumentService } from './DocumentService';
+import { DocumentError } from '@/models/Document';
 import type { Document, DocumentCreateInput, DocumentUpdateInput } from '@/models/Document';
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class WriteError extends DocumentError {
+  constructor(message: string, cause?: unknown) {
+    super('IO_ERROR', message);
+    if (cause instanceof Error) {
+      this.cause = cause;
+    }
+  }
+}
 
 /**
  * DocumentService adapter that writes the editor's saved body straight into
@@ -11,6 +28,7 @@ import type { Document, DocumentCreateInput, DocumentUpdateInput } from '@/model
  */
 export class WorkingTreeDocumentService extends DocumentService {
   private current: Document;
+  public writeError: WriteError | null = null;
 
   constructor(
     private readonly repoPath: string,
@@ -21,9 +39,24 @@ export class WorkingTreeDocumentService extends DocumentService {
     this.current = document;
   }
 
+  private async write(body: string): Promise<void> {
+    normalizeWorktreeRelPath(this.relativePath);
+    if (body.length > MAX_FILE_SIZE) {
+      throw new WriteError(
+        `Content (${body.length} bytes) exceeds maximum file size of ${MAX_FILE_SIZE} bytes`,
+      );
+    }
+    const file = new File(this.repoPath, this.relativePath);
+    try {
+      file.write(body);
+    } catch (error) {
+      throw new WriteError(`Failed to write ${this.relativePath}: ${errorMessage(error)}`, error);
+    }
+  }
+
   override async update(_id: string, input: DocumentUpdateInput): Promise<Document> {
     const body = input.body ?? '';
-    new File(this.repoPath, this.relativePath).write(body);
+    await this.write(body);
     this.current = { ...this.current, body, raw: body, updatedAt: Date.now() };
     return this.current;
   }

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -148,7 +148,7 @@ async function walkWorktree(
 }
 
 /** Normalize a repo-relative filepath and reject escapes from the worktree. */
-function normalizeWorktreeRelPath(filepath: string): string {
+export function normalizeWorktreeRelPath(filepath: string): string {
   const segments = filepath.replace(/^\/+/, '').split('/').filter((s) => s.length > 0);
   if (segments.length === 0 || segments.includes('..')) {
     throw Object.assign(new Error(`Invalid worktree filepath: ${filepath}`), {


### PR DESCRIPTION
## Summary

Adds plain-text editing to the Git Files tab in GitNotēs:

- Tapping a text file opens a multiline  editor showing the exact raw content
- Save writes raw UTF-8 to the local working tree only — no staging, commit, or push
- Binary files and Git LFS pointer files remain read-only
- Invalid paths, oversized content, and write failures are handled with friendly error messages
- Checkout safety blocks Save during branch checkout operations

## Changes

- ****: hardened writer with  path guards, 5 MiB size guard,  class, no Git side effects
- ****: replaced markdown/code viewer with plain  editor, dirty tracking, Save/Cancel, binary/LFS read-only states
- ****: exported  for use by the writer
- ****: worktree test config enabling  and excluding other worktrees' mocks

## Tests

39 tests across 3 suites, all passing:
-  — 16 tests (Unicode round-trip, path guards, size guard, write errors, zero Git side effects)
-  — 11 tests (happy-path edit/save, binary/LFS/missing-file states, Alert on cancel, checkout blocking)
-  — 12 tests (file-row navigation, binary badge, no GitHub mutation)

## Docs

- : ExploreFileScreen now documented as editable text viewer with save behavior note
- : Added "Explore File Editing" section documenting raw working-tree write contract

## Notes

- No markdown rendering, formatting toolbar, syntax highlighting, or preview pane
- No automatic stage/commit/push — user reviews and commits from existing Git workspace
- No remote GitHub API editing or file management UI

Closes [issue #1504]