### PR TITLE
fix(ios): keep GitEngine module maps out of Sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable fixes and feature changes to GitNotēs are documented here.
 >
 > **History**: prior fixes (pre-2026-08) lived in single-PR wiki pages. Those pages were retired in [#1047](https://github.com/gedwolmen/gitnotes/pull/1047); their full diagnostic content is preserved in git history via `git log -p -- docs/wiki/<file>.md`.
 
+## 2026-09-10
+
+### fix(ios): keep GitEngine module maps out of Sources
+
+**What:** Xcode 26 treated the UniFFI `GitNotesGit2FFI` module map as a source file, failing the iOS build before linking native modules.
+
+**fix(ios):** Declare only the generated Swift and C header as sources, then pass the module map explicitly through the GitEngine pod target settings.
+
+**PR:** TBD
+
 ## 2026-09-09
 
 ### fix(ios): disable explicit modules for ExpoSQLite on Xcode 26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **fix(ios):** Declare only the generated Swift and C header as sources, then pass the module map explicitly through the GitEngine pod target settings.
 
-**PR:** TBD
+**PR:** [#1510](https://github.com/gedwolmen/gitnotes/pull/1510)
 
 ## 2026-09-09
 

--- a/modules/GitEngine/ios-local/GitEngine.podspec
+++ b/modules/GitEngine/ios-local/GitEngine.podspec
@@ -8,8 +8,12 @@ Pod::Spec.new do |s|
   s.source       = { :path => '.' }
   s.platform     = :ios, '16.4'
 
-  # Expo native module + UniFFI generated Swift FFI + FFI headers
-  s.source_files = '*.swift', 'generated/*.swift', 'generated/GitNotesGit2FFI/**/*'
+  # Expo native module + UniFFI generated Swift FFI + FFI header
+  s.source_files = '*.swift', 'generated/*.swift', 'generated/GitNotesGit2FFI/GitNotesGit2FFI.h'
+  s.pod_target_xcconfig = {
+    'MODULEMAP_FILE' => '../../modules/GitEngine/ios-local/generated/GitNotesGit2FFI/module.modulemap',
+    'SWIFT_INCLUDE_PATHS' => '$(inherited) ${PODS_TARGET_SRCROOT}/generated',
+  }
 
   # Rust staticlib (vendored)
   s.vendored_libraries = 'rust/*.a'


### PR DESCRIPTION
## Summary
- Prevent CocoaPods from treating the UniFFI `GitNotesGit2FFI/module.modulemap` as an Xcode source file.
- Configure the module map and Swift include path explicitly for the GitEngine pod.
- Document the Xcode 26 build fix.

## Verification
- `yarn build:rust`
- `xcodebuild -workspace GitNots.xcworkspace -scheme GitEngine -sdk iphonesimulator -configuration Debug build -quiet`
- Full `GitNots` arm64 iPhone 17 simulator build
- `yarn ts:check`
- `yarn eslint . --ext .ts,.tsx` (0 errors; existing warnings remain)

## Known unrelated issue
- `yarn jest --runInBand`: 14 suites passed; 4 existing suites fail in unrelated areas.