### PR TITLE
fix(android): align recent commits pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **Fix:** Forward both `skip` and `limit` so Android matches the shared native contract.
 
-**PR:** TBD
+**PR:** [#1511](https://github.com/gedwolmen/gitnotes/pull/1511)
 
 ### fix(ios): keep GitEngine module maps out of Sources
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-10
 
+### fix(android): align recent commits pagination parameters
+
+**What:** The Android GitEngine bridge exposed `recentCommits` without the `skip` parameter already used by the TypeScript, iOS, and Rust layers.
+
+**Fix:** Forward both `skip` and `limit` so Android matches the shared native contract.
+
+**PR:** TBD
+
 ### fix(ios): keep GitEngine module maps out of Sources
 
 **What:** Xcode 26 treated the UniFFI `GitNotesGit2FFI` module map as a source file, failing the iOS build before linking native modules.

--- a/modules/GitEngine/android/src/main/java/expo/modules/gitengine/GitEngineModule.kt
+++ b/modules/GitEngine/android/src/main/java/expo/modules/gitengine/GitEngineModule.kt
@@ -195,8 +195,8 @@ class GitEngineModule : Module() {
       engineOp { commitDict(commitChanges(fsPath(path), message, Author(authorName, authorEmail))) }
     }
 
-    AsyncFunction("recentCommits") Coroutine { path: String, limit: Int ->
-      engineOp { recentCommits(fsPath(path), 0u, limit.toUInt()).map(::commitDict) }
+    AsyncFunction("recentCommits") Coroutine { path: String, skip: Int, limit: Int ->
+      engineOp { recentCommits(fsPath(path), skip.toUInt(), limit.toUInt()).map(::commitDict) }
     }
 
     AsyncFunction("commitDiff") Coroutine { path: String, commitId: String ->


### PR DESCRIPTION
## Summary
- Add the missing `skip` parameter to the Android GitEngine `recentCommits` bridge.
- Forward `skip` and `limit` to the generated native binding, matching TypeScript, iOS, Rust, and generated Android contracts.
- Document the fix in the changelog.

## Verification
- Clean `:gitnotes-git-engine:compileDebugKotlin`: passed
- Full Android `app:assembleDebug` for `arm64-v8a`: passed
- `yarn ts:check`: passed
- Android contract assertion: passed
- `yarn eslint src --ext .ts,.tsx`: 0 errors; 138 existing warnings

The original tmux failure also required regenerating the ignored Expo Android project; the full build passes from a fresh prebuild.