### PR TITLE
fix(documents): repair FTS5 indexing

### DIFF
--- a/__tests__/services/documents/DocumentIndexFts.test.ts
+++ b/__tests__/services/documents/DocumentIndexFts.test.ts
@@ -18,6 +18,12 @@ jest.mock('expo-sqlite', () => ({
   openDatabaseAsync: jest.fn(),
 }));
 
+jest.mock('expo-file-system', () => ({
+  File: jest.fn(),
+  Directory: jest.fn(),
+  Paths: { document: '/mock/documents' },
+}));
+
 const mockDb = {
   execAsync: jest.fn(),
   runAsync: jest.fn(),
@@ -37,7 +43,12 @@ describe('DocumentIndex FTS5', () => {
     mockDb.execAsync.mockResolvedValue(undefined);
     mockDb.runAsync.mockResolvedValue({ lastInsertRowId: 1 });
     mockDb.getFirstAsync.mockResolvedValue({ rowid: 1 });
-    mockDb.getAllAsync.mockResolvedValue([]);
+    mockDb.getAllAsync.mockReset();
+    mockDb.getAllAsync.mockImplementation((query: string) =>
+      query.includes('PRAGMA user_version')
+        ? Promise.resolve([{ user_version: 0 }])
+        : Promise.resolve([]),
+    );
     index = new DocumentIndex();
     // Initialize the database
     await getDocumentDb();
@@ -46,36 +57,55 @@ describe('DocumentIndex FTS5', () => {
   describe('FTS5 table creation', () => {
     it('creates FTS5 virtual table after main schema', async () => {
       // Verify the execAsync calls
-      expect(mockDb.execAsync).toHaveBeenCalledTimes(2);
-      // Second call should be the FTS5 creation
-      expect(mockDb.execAsync).toHaveBeenLastCalledWith(
-        `CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, body, tags, content=documents, content_rowid=rowid)`,
+      expect(mockDb.execAsync).toHaveBeenCalledWith(
+        `CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, body, tags, content='', contentless_delete=1)`,
       );
     });
   });
 
   describe('upsertFts', () => {
-    it('inserts FTS row with ON CONFLICT handling', async () => {
+    it('reindexes an existing FTS row without SQLite UPSERT', async () => {
+      await index.upsertFts(1, 'Updated Title', 'Updated body', '["tag2"]');
+
+      expect(mockDb.runAsync).toHaveBeenNthCalledWith(
+        1,
+        'DELETE FROM documents_fts WHERE rowid = ?',
+        1,
+      );
+      expect(mockDb.runAsync).toHaveBeenNthCalledWith(
+        2,
+        'INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)',
+        [1, 'Updated Title', 'Updated body', '["tag2"]'],
+      );
+    });
+
+    it('inserts a new FTS row', async () => {
       await index.upsertFts(1, 'Test Title', 'Test body content', '["tag1"]');
 
       expect(mockDb.runAsync).toHaveBeenCalledWith(
-        `INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)
-         ON CONFLICT(rowid) DO UPDATE SET title=excluded.title, body=excluded.body, tags=excluded.tags`,
+        'INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)',
         [1, 'Test Title', 'Test body content', '["tag1"]'],
       );
     });
 
-    it('updates existing FTS row on conflict', async () => {
-      // First insert
+    it('deletes old indexed values before inserting an updated FTS row', async () => {
       await index.upsertFts(1, 'Original Title', 'Original body', '["tag1"]');
-      // Second insert with same rowid should update
       await index.upsertFts(1, 'Updated Title', 'Updated body', '["tag2"]');
 
-      expect(mockDb.runAsync).toHaveBeenCalledTimes(2);
+      expect(mockDb.runAsync).toHaveBeenCalledTimes(4);
       expect(mockDb.runAsync).toHaveBeenLastCalledWith(
-        `INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)
-         ON CONFLICT(rowid) DO UPDATE SET title=excluded.title, body=excluded.body, tags=excluded.tags`,
+        'INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)',
         [1, 'Updated Title', 'Updated body', '["tag2"]'],
+      );
+      expect(mockDb.runAsync).toHaveBeenNthCalledWith(
+        2,
+        'INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)',
+        [1, 'Original Title', 'Original body', '["tag1"]'],
+      );
+      expect(mockDb.runAsync).toHaveBeenNthCalledWith(
+        3,
+        'DELETE FROM documents_fts WHERE rowid = ?',
+        1,
       );
     });
   });
@@ -143,12 +173,9 @@ describe('DocumentIndex FTS5', () => {
     it('indexes body content when body is provided', async () => {
       await index.upsertDocument(mockMeta, 'This is the note body content');
 
-      // Should have called runAsync twice: once for documents table, once for FTS
-      expect(mockDb.runAsync).toHaveBeenCalledTimes(2);
-      // Second call should be the FTS upsert
+      expect(mockDb.runAsync).toHaveBeenCalledTimes(3);
       expect(mockDb.runAsync).toHaveBeenLastCalledWith(
-        `INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)
-         ON CONFLICT(rowid) DO UPDATE SET title=excluded.title, body=excluded.body, tags=excluded.tags`,
+        'INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)',
         [99, 'Test Note', 'This is the note body content', '["test"]'],
       );
     });

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -71,7 +71,7 @@ GitNotēs is a mobile notes/todos/canvases app backed by a **Git repository** (G
 | AsyncStorage | Local key-value storage |
 | Expo Secure Store | Auth tokens |
 | Expo File System | Working tree files |
-| Expo SQLite | (reserved for future use) |
+| Expo SQLite | Local document metadata and FTS5 body index |
 
 ### Platform Services
 

--- a/docs/wiki/note-file-format.md
+++ b/docs/wiki/note-file-format.md
@@ -76,16 +76,17 @@ Example: `DocumentService` writes to `documents/note/my-first-note.md` relative 
 Reading every file from disk for listing/search would be slow. `DocumentIndex` maintains a **SQLite mirror** of frontmatter metadata:
 
 - `documents` table: `id, type, path, title, slug, folder, tags, createdAt, updatedAt, isPinned, deleted`
+- `documents_fts` FTS5 virtual table: `title, body, tags`
 - `folders` table: `path, type, repo`
 - `tags` table: `name, repo`
 
-**Rule:** No document body is ever stored in SQLite. Only metadata. The file is always the source of truth.
+`documents_fts` stores document body text in an FTS5 virtual table for full-text search. The file is always the source of truth for document content.
 
 `DocumentIndex` is used for:
 - Fast note listing (without reading file bodies)
 - Folder tree building
 - Tag autocomplete
-- Search (title, tags — not full-text)
+- Full-text search via FTS5, plus metadata search via SQLite `LIKE`
 
 ## Note Formats
 

--- a/docs/wiki/services.md
+++ b/docs/wiki/services.md
@@ -85,13 +85,13 @@ GitNotēs uses a **centralized branch model** for clone-mode repositories:
 
 ## Documents (`src/services/documents/`)
 
-> **Local-first architecture:** Files are the source of truth. `DocumentIndex` is a SQLite mirror of frontmatter metadata for fast listing/search — no document bodies are stored in SQLite.
+> **Local-first architecture:** Files are the source of truth. `DocumentIndex` mirrors frontmatter metadata in SQLite for fast listing/search and indexes document bodies in the `documents_fts` FTS5 virtual table for full-text search.
 
 | File | Purpose |
 |------|---------|
 | `DocumentService.ts` | Core local-first document service. Creates/reads/updates/deletes files with YAML-ish frontmatter (`---` delimiter). All note content is a plain file on disk. |
 | `WorkingTreeDocumentService.ts` | Document operations scoped to the current git working tree. |
-| `DocumentIndex.ts` | SQLite index of document metadata (id, title, folder, tags, timestamps). Used for fast listing, folder tree, tag autocomplete, and search without reading file bodies. |
+| `DocumentIndex.ts` | SQLite index of document metadata (id, title, folder, tags, timestamps) plus an FTS5 body index. Used for fast listing, folder tree, tag autocomplete, and full-text search. |
 
 ## Sync (`src/services/`)
 

--- a/src/services/documents/DocumentIndex.ts
+++ b/src/services/documents/DocumentIndex.ts
@@ -22,7 +22,9 @@ import type {
 
 const DB_NAME = 'gitnotes.db';
 const MAX_LIMIT = 500;
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
+const FTS_SCHEMA =
+  `CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, body, tags, content='', contentless_delete=1)`;
 
 const SCHEMA = `
   PRAGMA journal_mode = WAL;
@@ -247,14 +249,13 @@ export function getDocumentDb(): Promise<SQLiteDatabase> {
   if (!dbPromise) {
     dbPromise = openDatabaseAsync(DB_NAME).then(async (db) => {
       await db.execAsync(SCHEMA);
-      await db.execAsync(
-        `CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(title, body, tags, content=documents, content_rowid=rowid)`,
-      );
       const [{ 'user_version': version }] = await db.getAllAsync<{ 'user_version': number }>(
         `PRAGMA user_version`,
       );
       if (version < SCHEMA_VERSION) {
-        migrateBodyColumn(db).catch((err) => console.error('[DocumentIndex] body column migration failed:', err));
+        await db.execAsync(`DROP TABLE IF EXISTS documents_fts`);
+        await db.execAsync(FTS_SCHEMA);
+        await migrateBodyColumn(db);
         await db.execAsync(`PRAGMA user_version = ${SCHEMA_VERSION}`);
       }
       return db;
@@ -282,8 +283,7 @@ async function migrateBodyColumn(db: SQLiteDatabase): Promise<void> {
         const raw = await file.text();
         const body = parseFrontmatter(raw).body ?? '';
         await db.runAsync(
-          `INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)
-           ON CONFLICT(rowid) DO UPDATE SET title=excluded.title, body=excluded.body, tags=excluded.tags`,
+          'INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)',
           [doc.rowid, doc.title, body, doc.tags],
         );
       } catch (err) {
@@ -301,7 +301,7 @@ export class DocumentIndex {
 
   // ------------------------------------------------------------------ upsert
 
-  async upsertDocument(meta: DocumentMeta, body?: string): Promise<void> {
+  async upsertDocument(meta: DocumentMeta, body?: string | null): Promise<void> {
     await this.withDb(async (db) => {
       await db.runAsync(
         `INSERT INTO documents
@@ -320,7 +320,7 @@ export class DocumentIndex {
            deleted = excluded.deleted`,
         metaToParams(meta),
       );
-      if (body !== undefined) {
+      if (body != null) {
         const row = await db.getFirstAsync<{ rowid: number }>(
           'SELECT rowid FROM documents WHERE id = ? LIMIT 1',
           meta.id,
@@ -334,9 +334,9 @@ export class DocumentIndex {
 
   async upsertFts(rowid: number, title: string, body: string, tags: string): Promise<void> {
     await this.withDb(async (db) => {
+      await db.runAsync('DELETE FROM documents_fts WHERE rowid = ?', rowid);
       await db.runAsync(
-        `INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)
-         ON CONFLICT(rowid) DO UPDATE SET title=excluded.title, body=excluded.body, tags=excluded.tags`,
+        'INSERT INTO documents_fts(rowid, title, body, tags) VALUES (?, ?, ?, ?)',
         [rowid, title, body, tags],
       );
     });

--- a/src/services/documents/DocumentService.ts
+++ b/src/services/documents/DocumentService.ts
@@ -4,8 +4,9 @@
  * Documents are plain files under `Paths.document/documents/<type>/<slug>.<ext>`
  * with a YAML-ish frontmatter block (see `src/utils/frontmatterParser.ts`).
  * The file is the source of truth; `DocumentIndex` mirrors metadata in sqlite
- * for fast listing/search/folders/tags/backlinks. No document body is ever
- * stored in sqlite, and no legacy `expo-file-system` API is used.
+ * for fast listing/search/folders/tags/backlinks. Document bodies are also
+ * indexed in SQLite FTS5 for full-text search, and no legacy `expo-file-system`
+ * API is used.
  */
 
 import { File, Directory, Paths } from 'expo-file-system';
@@ -280,7 +281,7 @@ export class DocumentService {
       );
     }
     writeFileContent(fileFor(type, slug, ext), raw);
-    await this.index.upsertDocument(meta);
+    await this.index.upsertDocument(meta, body);
     await this.index.syncTags(tags);
     const created: Document = { ...meta, body, raw };
     await reindexDocumentBacklinks(this, created);
@@ -371,7 +372,7 @@ export class DocumentService {
     const raw = buildFileContent(next, body, extra);
     writeFileContent(file, raw);
 
-    await this.index.upsertDocument(next);
+    await this.index.upsertDocument(next, body);
     await this.index.syncTags(tags);
     const updated: Document = { ...next, body, raw };
     await reindexDocumentBacklinks(this, updated);
@@ -481,11 +482,11 @@ export class DocumentService {
         continue;
       }
       for (const file of collectFiles(dir)) {
-        const meta = await this.metaFromFile(file);
-        if (meta === null) {
+        const document = await this.documentFromFile(file);
+        if (document === null) {
           continue;
         }
-        await this.index.upsertDocument(meta);
+        await this.index.upsertDocument(document.meta, document.body);
         count += 1;
       }
     }
@@ -567,7 +568,7 @@ export class DocumentService {
     if (raw === null) {
       return null;
     }
-    const { frontmatter } = parseFrontmatter(raw);
+    const { frontmatter, body } = parseFrontmatter(raw);
     const fm = frontmatter as DocumentFrontmatter;
     const id = typeof fm.id === 'string' ? fm.id : meta.id;
     const title = typeof fm.title === 'string' ? fm.title : meta.title;
@@ -588,12 +589,14 @@ export class DocumentService {
       isPinned,
       createdAt,
       updatedAt,
-      body: parseFrontmatter(raw).body,
+      body,
       raw,
     };
   }
 
-  private async metaFromFile(file: File): Promise<DocumentMeta | null> {
+  private async documentFromFile(
+    file: File,
+  ): Promise<{ meta: DocumentMeta; body: string } | null> {
     const type = typeFromDirectoryName(file.parentDirectory.name);
     if (type === null) {
       return null;
@@ -602,7 +605,7 @@ export class DocumentService {
     if (raw === null) {
       return null;
     }
-    const { frontmatter } = parseFrontmatter(raw);
+    const { frontmatter, body } = parseFrontmatter(raw);
     const fm = frontmatter as DocumentFrontmatter;
     const slug = file.name.replace(/\.[^.]*$/, '');
     const ext = extensionFromPath(file.name);
@@ -610,19 +613,22 @@ export class DocumentService {
     const createdAt = toMs(fm.createdAt) ?? now;
     const updatedAt = toMs(fm.updatedAt) ?? (file.lastModified ?? now);
     return {
-      id: typeof fm.id === 'string' ? fm.id : generateId(),
-      type,
-      path: relativePathFor(type, slug, ext),
-      title: typeof fm.title === 'string' ? fm.title : slug,
-      slug,
-      folder: typeof fm.folder === 'string' ? fm.folder : null,
-      tags: Array.isArray(fm.tags)
-        ? fm.tags.filter((tag): tag is string => typeof tag === 'string')
-        : [],
-      createdAt,
-      updatedAt,
-      isPinned: fm.isPinned === true,
-      deleted: false,
+      meta: {
+        id: typeof fm.id === 'string' ? fm.id : generateId(),
+        type,
+        path: relativePathFor(type, slug, ext),
+        title: typeof fm.title === 'string' ? fm.title : slug,
+        slug,
+        folder: typeof fm.folder === 'string' ? fm.folder : null,
+        tags: Array.isArray(fm.tags)
+          ? fm.tags.filter((tag): tag is string => typeof tag === 'string')
+          : [],
+        createdAt,
+        updatedAt,
+        isPinned: fm.isPinned === true,
+        deleted: false,
+      },
+      body,
     };
   }
 }


### PR DESCRIPTION
## Summary
- Replace unsupported FTS5 UPSERTs with DELETE + INSERT indexing.
- Rebuild legacy FTS tables through schema version 2 using contentless delete semantics.
- Pass document bodies through create, update, and reconcile indexing paths.
- Correct wiki documentation for SQLite and FTS5 body storage.

## Verification
- yarn test DocumentIndexFts.test.ts WorkingTreeDocumentService.test.ts: 26 tests passed
- yarn ts:check: passed
- yarn lint on changed TypeScript files: 0 errors; existing warnings remain
- SQLite DELETE + INSERT contentless FTS5 repro: passed

Full Jest still has unrelated pre-existing failures in GitBranchCoordinator.test.ts (dynamic import VM setup) and noteSyncQueueService.test.ts (branch count expectation).