### PR TITLE
fix(explore): use full repository wording

### DIFF
--- a/src/components/explore/RepoInfoSection.tsx
+++ b/src/components/explore/RepoInfoSection.tsx
@@ -44,8 +44,6 @@ function describeRepair(report: RepairReport): string {
   return `${report.isHealthy ? 'Healthy after repair.' : 'NOT healthy.'} ${parts.join(' ')}`.trim();
 }
 
-/** Repo Info section (todo 25): metadata + Sync now (push-with-integrate),
- * Repair repo, and Remove repo. */
 export function RepoInfoSection({ repo, status, active, onChanged, chromeTopInset = 0 }: SectionProps) {
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTokens();
@@ -131,7 +129,7 @@ export function RepoInfoSection({ repo, status, active, onChanged, chromeTopInse
       await removeRepo(repo.id);
       navigation.goBack();
     } catch (caught) {
-      Alert.alert('Could not remove repo', caught instanceof Error ? caught.message : String(caught));
+      Alert.alert('Could not remove repository', caught instanceof Error ? caught.message : String(caught));
       setBusy(null);
     }
   }, [removeRepo, repo.id, navigation]);
@@ -151,7 +149,7 @@ export function RepoInfoSection({ repo, status, active, onChanged, chromeTopInse
               [
                 { text: 'Cancel', style: 'cancel' },
                 {
-                  text: 'Remove repo',
+                  text: 'Remove repository',
                   style: 'destructive',
                   onPress: () => void removeNow(),
                 },
@@ -234,7 +232,7 @@ export function RepoInfoSection({ repo, status, active, onChanged, chromeTopInse
         testID="explore.info.repair"
       >
         {busy === 'repair' ? <ActivityIndicator size="small" color={colors.text} /> : null}
-        <ButtonText>Repair repo</ButtonText>
+        <ButtonText>Repair repository</ButtonText>
       </Button>
       {repairResult && (
         <Text className="mt-2 text-xs" style={{ color: colors.textSecondary }} testID="explore.info.repair-result">
@@ -250,7 +248,7 @@ export function RepoInfoSection({ repo, status, active, onChanged, chromeTopInse
         testID="explore.info.remove"
       >
         {busy === 'remove' ? <ActivityIndicator size="small" color={colors.error} /> : null}
-        <ButtonText style={{ color: colors.error }}>Remove repo…</ButtonText>
+        <ButtonText style={{ color: colors.error }}>Remove repository…</ButtonText>
       </Button>
       <Text className="mt-2 pb-24 text-center text-[11px]" style={{ color: colors.textSecondary }}>
         Repair rebuilds a damaged index and prunes corrupt objects. Remove deletes the local clone after two confirmations.

--- a/src/components/explore/exploreShared.tsx
+++ b/src/components/explore/exploreShared.tsx
@@ -31,7 +31,7 @@ export const EXPLORE_SECTIONS = [
   { id: 'conflicts', label: 'Conflicts' },
   { id: 'pulls', label: 'Pull Requests' },
   { id: 'issues', label: 'Issues' },
-  { id: 'info', label: 'Repo Info' },
+  { id: 'info', label: 'Repository', shortLabel: 'Repo' },
 ] as const;
 
 export type ExploreSection = (typeof EXPLORE_SECTIONS)[number]['id'];

--- a/src/components/ui/SectionTabs.tsx
+++ b/src/components/ui/SectionTabs.tsx
@@ -6,6 +6,7 @@ import type { SectionTabColor } from '../explore/exploreShared';
 export interface SectionTab {
   id: string;
   label: string;
+  shortLabel?: string;
   color?: SectionTabColor;
 }
 
@@ -14,6 +15,7 @@ interface SectionTabsProps {
   value: string;
   onChange: (id: string) => void;
   testID?: string;
+  renderLabel?: (tab: SectionTab, isActive: boolean) => React.ReactNode;
 }
 
 const COLOR_MAP: Record<SectionTabColor, keyof ReturnType<typeof useTokens>['colors']> = {
@@ -23,7 +25,7 @@ const COLOR_MAP: Record<SectionTabColor, keyof ReturnType<typeof useTokens>['col
   accent: 'accent',
 };
 
-export function SectionTabs({ tabs, value, onChange, testID }: SectionTabsProps) {
+export function SectionTabs({ tabs, value, onChange, testID, renderLabel }: SectionTabsProps) {
   const { colors } = useTokens();
 
   return (
@@ -56,7 +58,7 @@ export function SectionTabs({ tabs, value, onChange, testID }: SectionTabsProps)
                 color: isActive ? activeColor : colors.textSecondary,
               }}
             >
-              {tab.label}
+              {renderLabel ? renderLabel(tab, isActive) : tab.label}
             </Text>
           </Pressable>
         );

--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AppState,
   AppStateStatus,
+  Dimensions,
   FlatList,
   Pressable,
   ScrollView,
@@ -341,6 +342,12 @@ export default function ExploreScreen() {
               value={section}
               onChange={(id) => setSection(id as ExploreSection)}
               testID="explore.tabs"
+              renderLabel={(tab) => {
+                if (tab.shortLabel && Dimensions.get('window').width < 400) {
+                  return tab.shortLabel;
+                }
+                return tab.label;
+              }}
             />
             </View>
         </BlurView>


### PR DESCRIPTION
## Summary
- use “repository” instead of “repo” in Git tab repair and remove actions
- expand related confirmation and error text while retaining the compact tab label on narrow screens

## Validation
- `yarn ts:check`
- `yarn prettier --check src/components/explore/RepoInfoSection.tsx src/components/explore/exploreShared.tsx src/components/ui/SectionTabs.tsx src/screens/ExploreScreen.tsx`
- `yarn eslint . --ext .ts,.tsx` (0 errors; existing warnings remain)
- Jest could not run tests because the repository Jest configuration ignores `.worktrees` and found no runnable tests there