### PR TITLE
fix: show custom templates in picker and sync to GitHub on CRUD

### DIFF
--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -14,6 +14,7 @@ import { ActivityIndicator } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { NoteTemplate, TemplateService } from '../services/TemplateService';
+import { useTemplateStore } from '../stores/templateStore';
 import { useTheme } from '../contexts/ThemeContext';
 import { useProGate } from '../hooks/useProGate';
 import { Modal } from './ui';
@@ -75,14 +76,34 @@ export default function TemplateSelector({ visible, onClose, onSelect }: Templat
     navigation.navigate('TemplateManager');
   }, [onClose, navigation, isPro, openPaywall]);
 
+  const customTemplates = useTemplateStore((s) => s.customTemplates);
+  const loadTemplatesFromStore = useTemplateStore((s) => s.loadTemplates);
+
   const loadTemplates = useCallback(async () => {
     setIsLoading(true);
-    const results = searchQuery
+
+    if (customTemplates.length === 0) {
+      await loadTemplatesFromStore();
+    }
+
+    const builtIns = searchQuery
       ? await TemplateService.searchTemplates(searchQuery)
       : await TemplateService.getAllTemplates();
-    setTemplates(results);
+
+    const lowerQuery = searchQuery.toLowerCase();
+    const filteredCustom = searchQuery
+      ? customTemplates.filter(
+          (t) =>
+            t.name.toLowerCase().includes(lowerQuery) ||
+            t.description.toLowerCase().includes(lowerQuery) ||
+            t.tags.some((tag) => tag.toLowerCase().includes(lowerQuery)),
+        )
+      : customTemplates;
+
+    const allTemplates = [...builtIns, ...filteredCustom];
+    setTemplates(allTemplates);
     setIsLoading(false);
-  }, [searchQuery]);
+  }, [searchQuery, customTemplates, loadTemplatesFromStore]);
 
   useEffect(() => {
     if (visible) {

--- a/src/screens/TemplateManagerScreen.tsx
+++ b/src/screens/TemplateManagerScreen.tsx
@@ -14,13 +14,10 @@ import { useResponsive } from '../hooks/useResponsive';
 import { ScreenHeader, IconButton, useScreenHeaderHeight } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { useTemplateStore } from '../stores/templateStore';
-import { useRepoStore } from '../stores/repoStore';
-import { getActiveBranch } from '../services/git/activeBranchStore';
 import { NoteTemplate, NoteTemplateIcon } from '../services/TemplateService';
 import { HapticService } from '../utils/haptics';
 import { TemplateRepoPreferenceService, TemplateRepoPreference } from '../services/TemplateRepoPreferenceService';
 import { pullTemplatesFromConfiguredRepo } from '../services/RepoPullService';
-import { syncTemplateToGitHub } from '../services/TemplateGitHubSyncService';
 import {
   commitPendingTag,
   parseTagInput,
@@ -48,7 +45,6 @@ export default function TemplateManagerScreen() {
   const deleteTemplate = useTemplateStore((s) => s.deleteTemplate);
   const togglePin = useTemplateStore((s) => s.togglePin);
   const getAllTemplates = useTemplateStore((s) => s.getAllTemplates);
-  const repositories = useRepoStore((s) => s.repositories);
 
   const [showEditor, setShowEditor] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -170,7 +166,6 @@ export default function TemplateManagerScreen() {
     const finalTags = commitPendingTag(tagDraft, draftTags);
 
     try {
-      let savedTemplate: NoteTemplate | null = null;
       if (editingId) {
         await updateTemplate(editingId, {
           name,
@@ -180,26 +175,14 @@ export default function TemplateManagerScreen() {
           content: draftContent,
           tags: finalTags,
         });
-        savedTemplate = getAllTemplates().find((t) => t.id === editingId) ?? null;
       } else {
-        savedTemplate = await createTemplate({
+        await createTemplate({
           name,
           icon: draftIcon,
           description,
           title: title || undefined,
           content: draftContent,
           tags: finalTags,
-        });
-      }
-
-      if (savedTemplate && templatesRepoPref) {
-        const repoId = repositories.find((r) => r.path === templatesRepoPref.repoPath)?.id;
-        const activeBranchState = repoId ? await getActiveBranch(repoId) : null;
-        const branch = activeBranchState?.activeBranch ?? 'main';
-        await syncTemplateToGitHub({
-          repoPath: templatesRepoPref.repoPath,
-          branch,
-          template: savedTemplate,
         });
       }
 
@@ -221,8 +204,6 @@ export default function TemplateManagerScreen() {
     editingId,
     createTemplate,
     updateTemplate,
-    templatesRepoPref,
-    getAllTemplates,
     t,
   ]);
 

--- a/src/stores/templateStore.ts
+++ b/src/stores/templateStore.ts
@@ -2,6 +2,46 @@ import { create } from 'zustand';
 import { NoteTemplate, NOTE_TEMPLATES } from '../services/TemplateService';
 import { StorageService } from '../services/StorageService';
 import { generateId } from '../utils/ids';
+import { syncTemplateToGitHub, deleteTemplateFromGitHub } from '../services/TemplateGitHubSyncService';
+import { TemplateRepoPreferenceService } from '../services/TemplateRepoPreferenceService';
+import { getActiveBranch } from '../services/git/activeBranchStore';
+import { useRepoStore } from './repoStore';
+
+async function syncTemplateToGitHubIfConfigured(template: NoteTemplate): Promise<void> {
+  try {
+    const templatesRepoPref = await TemplateRepoPreferenceService.get();
+    if (!templatesRepoPref) return;
+
+    const repositories = useRepoStore.getState().repositories;
+    const repoId = repositories.find((r) => r.path === templatesRepoPref.repoPath)?.id;
+    if (!repoId) return;
+
+    const activeBranchState = await getActiveBranch(repoId);
+    const branch = activeBranchState?.activeBranch ?? 'main';
+
+    await syncTemplateToGitHub({ repoPath: templatesRepoPref.repoPath, branch, template });
+  } catch (error) {
+    console.warn('[templateStore] GitHub sync failed:', error);
+  }
+}
+
+async function deleteTemplateFromGitHubIfConfigured(filePath: string, name: string): Promise<void> {
+  try {
+    const templatesRepoPref = await TemplateRepoPreferenceService.get();
+    if (!templatesRepoPref) return;
+
+    const repositories = useRepoStore.getState().repositories;
+    const repoId = repositories.find((r) => r.path === templatesRepoPref.repoPath)?.id;
+    if (!repoId) return;
+
+    const activeBranchState = await getActiveBranch(repoId);
+    const branch = activeBranchState?.activeBranch ?? 'main';
+
+    await deleteTemplateFromGitHub({ repoPath: templatesRepoPref.repoPath, branch, filePath, name });
+  } catch (error) {
+    console.warn('[templateStore] GitHub template deletion sync failed:', error);
+  }
+}
 
 interface TemplateState {
   customTemplates: NoteTemplate[];
@@ -38,12 +78,13 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
       updatedAt: Date.now(),
     };
 
-    const synced = template;
-
-    const next = [...get().customTemplates, synced];
+    const next = [...get().customTemplates, template];
     await StorageService.saveCustomTemplates(next);
     set({ customTemplates: next });
-    return synced;
+
+    await syncTemplateToGitHubIfConfigured(template);
+
+    return template;
   },
 
   updateTemplate: async (id, updates) => {
@@ -55,6 +96,8 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
     const next = get().customTemplates.map((t) => (t.id === id ? merged : t));
     await StorageService.saveCustomTemplates(next);
     set({ customTemplates: next });
+
+    await syncTemplateToGitHubIfConfigured(merged);
   },
 
   deleteTemplate: async (id) => {
@@ -64,6 +107,10 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
     const next = get().customTemplates.filter((t) => t.id !== id);
     await StorageService.saveCustomTemplates(next);
     set({ customTemplates: next });
+
+    if (template.filePath) {
+      await deleteTemplateFromGitHubIfConfigured(template.filePath, template.name);
+    }
   },
 
   togglePin: async (id) => {


### PR DESCRIPTION
- TemplateSelector: merge built-in + custom templates, search both sets
- templateStore: auto-sync templates to GitHub on create/update/delete
- TemplateManagerScreen: remove redundant sync (now handled by store)
- delete also removes from GitHub if template has filePath

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Add screenshots to help demonstrate your changes for UI-related changes.
