### PR TITLE
fix: custom templates not appearing in picker or git changes

### DIFF
--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -14,6 +14,7 @@ import { ActivityIndicator } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { NoteTemplate, TemplateService } from '../services/TemplateService';
+import { useTemplateStore } from '../stores/templateStore';
 import { useTheme } from '../contexts/ThemeContext';
 import { useProGate } from '../hooks/useProGate';
 import { Modal } from './ui';
@@ -75,14 +76,34 @@ export default function TemplateSelector({ visible, onClose, onSelect }: Templat
     navigation.navigate('TemplateManager');
   }, [onClose, navigation, isPro, openPaywall]);
 
+  const customTemplates = useTemplateStore((s) => s.customTemplates);
+  const loadTemplatesFromStore = useTemplateStore((s) => s.loadTemplates);
+
   const loadTemplates = useCallback(async () => {
     setIsLoading(true);
-    const results = searchQuery
+
+    if (customTemplates.length === 0) {
+      await loadTemplatesFromStore();
+    }
+
+    const builtIns = searchQuery
       ? await TemplateService.searchTemplates(searchQuery)
       : await TemplateService.getAllTemplates();
-    setTemplates(results);
+
+    const lowerQuery = searchQuery.toLowerCase();
+    const filteredCustom = searchQuery
+      ? customTemplates.filter(
+          (t) =>
+            t.name.toLowerCase().includes(lowerQuery) ||
+            t.description.toLowerCase().includes(lowerQuery) ||
+            t.tags.some((tag) => tag.toLowerCase().includes(lowerQuery)),
+        )
+      : customTemplates;
+
+    const allTemplates = [...builtIns, ...filteredCustom];
+    setTemplates(allTemplates);
     setIsLoading(false);
-  }, [searchQuery]);
+  }, [searchQuery, customTemplates, loadTemplatesFromStore]);
 
   useEffect(() => {
     if (visible) {

--- a/src/screens/TemplateManagerScreen.tsx
+++ b/src/screens/TemplateManagerScreen.tsx
@@ -14,13 +14,10 @@ import { useResponsive } from '../hooks/useResponsive';
 import { ScreenHeader, IconButton, useScreenHeaderHeight } from '../components/ui';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
 import { useTemplateStore } from '../stores/templateStore';
-import { useRepoStore } from '../stores/repoStore';
-import { getActiveBranch } from '../services/git/activeBranchStore';
 import { NoteTemplate, NoteTemplateIcon } from '../services/TemplateService';
 import { HapticService } from '../utils/haptics';
 import { TemplateRepoPreferenceService, TemplateRepoPreference } from '../services/TemplateRepoPreferenceService';
 import { pullTemplatesFromConfiguredRepo } from '../services/RepoPullService';
-import { syncTemplateToGitHub } from '../services/TemplateGitHubSyncService';
 import {
   commitPendingTag,
   parseTagInput,
@@ -48,7 +45,6 @@ export default function TemplateManagerScreen() {
   const deleteTemplate = useTemplateStore((s) => s.deleteTemplate);
   const togglePin = useTemplateStore((s) => s.togglePin);
   const getAllTemplates = useTemplateStore((s) => s.getAllTemplates);
-  const repositories = useRepoStore((s) => s.repositories);
 
   const [showEditor, setShowEditor] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -170,7 +166,6 @@ export default function TemplateManagerScreen() {
     const finalTags = commitPendingTag(tagDraft, draftTags);
 
     try {
-      let savedTemplate: NoteTemplate | null = null;
       if (editingId) {
         await updateTemplate(editingId, {
           name,
@@ -180,26 +175,14 @@ export default function TemplateManagerScreen() {
           content: draftContent,
           tags: finalTags,
         });
-        savedTemplate = getAllTemplates().find((t) => t.id === editingId) ?? null;
       } else {
-        savedTemplate = await createTemplate({
+        await createTemplate({
           name,
           icon: draftIcon,
           description,
           title: title || undefined,
           content: draftContent,
           tags: finalTags,
-        });
-      }
-
-      if (savedTemplate && templatesRepoPref) {
-        const repoId = repositories.find((r) => r.path === templatesRepoPref.repoPath)?.id;
-        const activeBranchState = repoId ? await getActiveBranch(repoId) : null;
-        const branch = activeBranchState?.activeBranch ?? 'main';
-        await syncTemplateToGitHub({
-          repoPath: templatesRepoPref.repoPath,
-          branch,
-          template: savedTemplate,
         });
       }
 
@@ -221,8 +204,6 @@ export default function TemplateManagerScreen() {
     editingId,
     createTemplate,
     updateTemplate,
-    templatesRepoPref,
-    getAllTemplates,
     t,
   ]);
 

--- a/src/services/TemplateGitHubSyncService.ts
+++ b/src/services/TemplateGitHubSyncService.ts
@@ -1,7 +1,7 @@
 import { GitHubService } from './GitHubService';
 import { serializeTemplate, templateSlug } from './TemplateMarkdownService';
 import type { NoteTemplate } from './TemplateService';
-import { CloneSyncService } from './cloneSyncServiceImpl';
+import { CommitService } from './git/CommitService';
 import { resolveDefaultFolder } from './git/defaultsPolicy';
 import { resolveDefaultRepo } from './git/defaultsPolicy';
 
@@ -33,16 +33,15 @@ export async function syncTemplateToGitHub(params: {
   const message = `${isUpdate ? 'Update' : 'Add'} template ${template.name}`;
   const body = serializeTemplate({ ...template, filePath: undefined });
 
-  const saveResult = await CloneSyncService.save({
-    repoPath,
+  const commitResult = await CommitService.commit({
+    repo: repoPath,
     branch,
     filePath: targetPath,
     content: body,
     message,
-    intent: 'upsert',
   });
-  if (saveResult.success) return { success: true, filePath: targetPath };
-  return { success: false, error: saveResult.error };
+  if (commitResult.success) return { success: true, filePath: targetPath };
+  return { success: false, error: commitResult.error };
 }
 
 export async function deleteTemplateFromGitHub(params: {
@@ -58,13 +57,13 @@ export async function deleteTemplateFromGitHub(params: {
     return { success: false, error: 'GitHub not authenticated' };
   }
 
-  const saveResult = await CloneSyncService.save({
-    repoPath,
+  const commitResult = await CommitService.commit({
+    repo: repoPath,
     branch,
     filePath,
     message: `Delete template ${name}`,
-    intent: 'delete',
+    delete: true,
   });
-  if (saveResult.success) return { success: true, filePath };
-  return { success: false, error: saveResult.error };
+  if (commitResult.success) return { success: true, filePath };
+  return { success: false, error: commitResult.error };
 }

--- a/src/stores/templateStore.ts
+++ b/src/stores/templateStore.ts
@@ -2,6 +2,46 @@ import { create } from 'zustand';
 import { NoteTemplate, NOTE_TEMPLATES } from '../services/TemplateService';
 import { StorageService } from '../services/StorageService';
 import { generateId } from '../utils/ids';
+import { syncTemplateToGitHub, deleteTemplateFromGitHub } from '../services/TemplateGitHubSyncService';
+import { TemplateRepoPreferenceService } from '../services/TemplateRepoPreferenceService';
+import { getActiveBranch } from '../services/git/activeBranchStore';
+import { useRepoStore } from './repoStore';
+
+async function syncTemplateToGitHubIfConfigured(template: NoteTemplate): Promise<void> {
+  try {
+    const templatesRepoPref = await TemplateRepoPreferenceService.get();
+    if (!templatesRepoPref) return;
+
+    const repositories = useRepoStore.getState().repositories;
+    const repoId = repositories.find((r) => r.path === templatesRepoPref.repoPath)?.id;
+    if (!repoId) return;
+
+    const activeBranchState = await getActiveBranch(repoId);
+    const branch = activeBranchState?.activeBranch ?? 'main';
+
+    await syncTemplateToGitHub({ repoPath: templatesRepoPref.repoPath, branch, template });
+  } catch (error) {
+    console.warn('[templateStore] GitHub sync failed:', error);
+  }
+}
+
+async function deleteTemplateFromGitHubIfConfigured(filePath: string, name: string): Promise<void> {
+  try {
+    const templatesRepoPref = await TemplateRepoPreferenceService.get();
+    if (!templatesRepoPref) return;
+
+    const repositories = useRepoStore.getState().repositories;
+    const repoId = repositories.find((r) => r.path === templatesRepoPref.repoPath)?.id;
+    if (!repoId) return;
+
+    const activeBranchState = await getActiveBranch(repoId);
+    const branch = activeBranchState?.activeBranch ?? 'main';
+
+    await deleteTemplateFromGitHub({ repoPath: templatesRepoPref.repoPath, branch, filePath, name });
+  } catch (error) {
+    console.warn('[templateStore] GitHub template deletion sync failed:', error);
+  }
+}
 
 interface TemplateState {
   customTemplates: NoteTemplate[];
@@ -38,12 +78,13 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
       updatedAt: Date.now(),
     };
 
-    const synced = template;
-
-    const next = [...get().customTemplates, synced];
+    const next = [...get().customTemplates, template];
     await StorageService.saveCustomTemplates(next);
     set({ customTemplates: next });
-    return synced;
+
+    await syncTemplateToGitHubIfConfigured(template);
+
+    return template;
   },
 
   updateTemplate: async (id, updates) => {
@@ -55,6 +96,8 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
     const next = get().customTemplates.map((t) => (t.id === id ? merged : t));
     await StorageService.saveCustomTemplates(next);
     set({ customTemplates: next });
+
+    await syncTemplateToGitHubIfConfigured(merged);
   },
 
   deleteTemplate: async (id) => {
@@ -64,6 +107,10 @@ export const useTemplateStore = create<TemplateState>()((set, get) => ({
     const next = get().customTemplates.filter((t) => t.id !== id);
     await StorageService.saveCustomTemplates(next);
     set({ customTemplates: next });
+
+    if (template.filePath) {
+      await deleteTemplateFromGitHubIfConfigured(template.filePath, template.name);
+    }
   },
 
   togglePin: async (id) => {


### PR DESCRIPTION
## Summary

Fixed two bugs where custom templates weren't appearing in the template picker and weren't being git-tracked.

### Bugs Fixed

1. **Template picker only showed built-in templates**
   - The picker only queried TemplateService.getAllTemplates() which returns built-in templates
   - Now merges built-in + custom templates and searches both sets

2. **Templates not synced to GitHub on CRUD**
   - createTemplate/updateTemplate/deleteTemplate only saved to AsyncStorage, not GitHub
   - Sync only happened in TemplateManagerScreen and only when saving
   - Moved sync into the store so it happens automatically on every create/update/delete

3. **Templates written but never committed** (root cause)
   - Was using CloneSyncService.save() which only writes files to disk
   - Does NOT commit to git
   - Now uses CommitService.commit() which writes AND commits (like notes do)

### Changes

- TemplateSelector.tsx - Merge built-in + custom templates
- templateStore.ts - Auto-sync on create/update/delete
- TemplateGitHubSyncService.ts - Use CommitService.commit() not CloneSyncService.save()
- TemplateManagerScreen.tsx - Removed redundant sync (now in store)