### PR TITLE
fix: stop github activity loader after push

### DIFF
--- a/__tests__/stores/gitActivityLifecycle.test.ts
+++ b/__tests__/stores/gitActivityLifecycle.test.ts
@@ -1,0 +1,14 @@
+import { operationActivityTransition } from '@/stores/gitActivityLifecycle';
+
+describe('git operation activity lifecycle', () => {
+  it('starts once and ends once across repeated active updates', () => {
+    const first = operationActivityTransition(false, 1);
+    const repeated = operationActivityTransition(first.active, 1);
+    const completed = operationActivityTransition(repeated.active, 0);
+
+    expect(first.action).toBe('begin');
+    expect(repeated.action).toBe('none');
+    expect(completed.action).toBe('end');
+    expect(completed.active).toBe(false);
+  });
+});

--- a/src/components/GitHubActivityIndicator.tsx
+++ b/src/components/GitHubActivityIndicator.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTokens } from '../contexts/ThemeContext';
 import { useGitHubActivityStore, githubActivity, SyncProgress } from '../stores/githubActivityStore';
 import { useGitOperationStore, pendingRunningCount } from '../stores/gitOperationStore';
+import { operationActivityTransition } from '../stores/gitActivityLifecycle';
 import { NoteSyncQueueService } from '../services/cloneSyncServiceImpl';
 
 function ProgressBar({ progress, color }: { progress: SyncProgress; color: string }) {
@@ -77,14 +78,15 @@ export function GitHubActivityIndicator() {
     refreshPending();
     const unsubscribeQueue = NoteSyncQueueService.subscribe(refreshPending);
 
-    const unsubscribeOps = useGitOperationStore.subscribe((state) => {
-      const running = pendingRunningCount(state.ops);
-      if (running > 0) {
-        githubActivity.begin('Syncing…');
-      } else {
-        githubActivity.end();
-      }
-    });
+    let operationsActive = false;
+    const syncOperationActivity = (state: { ops: Parameters<typeof pendingRunningCount>[0] }) => {
+      const transition = operationActivityTransition(operationsActive, pendingRunningCount(state.ops));
+      operationsActive = transition.active;
+      if (transition.action === 'begin') githubActivity.begin('Syncing…');
+      if (transition.action === 'end') githubActivity.end();
+    };
+    syncOperationActivity(useGitOperationStore.getState());
+    const unsubscribeOps = useGitOperationStore.subscribe(syncOperationActivity);
 
     return () => {
       unsubscribeQueue();

--- a/src/stores/gitActivityLifecycle.ts
+++ b/src/stores/gitActivityLifecycle.ts
@@ -1,0 +1,15 @@
+export type OperationActivityAction = 'begin' | 'end' | 'none';
+
+export interface OperationActivityTransition {
+  active: boolean;
+  action: OperationActivityAction;
+}
+
+export function operationActivityTransition(
+  wasActive: boolean,
+  runningCount: number,
+): OperationActivityTransition {
+  const active = runningCount > 0;
+  if (active === wasActive) return { active, action: 'none' };
+  return { active, action: active ? 'begin' : 'end' };
+}


### PR DESCRIPTION
## Summary
- make GitHub activity begin/end edge-triggered instead of repeating on every operation-store update
- stop the floating activity loader when operations complete
- add regression coverage for repeated active updates

## Verification
- `yarn ts:check`
- `yarn jest __tests__/stores/gitActivityLifecycle.test.ts --no-coverage --forceExit`
- `yarn eslint src/components/GitHubActivityIndicator.tsx src/stores/gitActivityLifecycle.ts __tests__/stores/gitActivityLifecycle.test.ts --ext .ts,.tsx`

The installed simulator app exited to the Home Screen before the authenticated push flow could be exercised manually.