### PR TITLE
fix(git): accept intentional checkout state changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-10
 
+### fix(git): accept intentional branch changes during checkout
+
+**What:** Branch checkout was rejected because postflight validation compared the requested checkout's new branch and HEAD against the pre-checkout state.
+
+**Fix:** Validate checkout postflight against the requested branch while retaining strict branch/HEAD stability checks for push operations.
+
+**PR:** TBD
+
 ### fix(android): align recent commits pagination parameters
 
 **What:** The Android GitEngine bridge exposed `recentCommits` without the `skip` parameter already used by the TypeScript, iOS, and Rust layers.

--- a/__tests__/services/git/GitBranchCoordinator.test.ts
+++ b/__tests__/services/git/GitBranchCoordinator.test.ts
@@ -31,6 +31,7 @@ jest.mock('@/services/git/engine/GitEngine', () => ({
 jest.mock('@/services/git/GitSyncGate', () => ({
   GitSyncGate: {
     acquireCycle: jest.fn(),
+    verifyCheckoutPostflight: jest.fn(),
     isCycleHeld: jest.fn(),
     forceReleaseCycle: jest.fn(),
     __resetForTest: jest.fn(),
@@ -62,6 +63,7 @@ describe('GitBranchCoordinator', () => {
     jest.clearAllMocks();
     MOCK_RELEASE_CYCLE.mockReturnValue(undefined);
     GitSyncGateMock.acquireCycle.mockResolvedValue(MOCK_RELEASE_CYCLE);
+    GitSyncGateMock.verifyCheckoutPostflight.mockResolvedValue({ ok: true });
     GitSyncGateMock.isCycleHeld.mockReturnValue(false);
     GitBranchCoordinator.__resetForTests();
   });
@@ -136,6 +138,37 @@ describe('GitBranchCoordinator', () => {
   });
 
   describe('working tree safety checks', () => {
+    it('accepts the requested branch after checkout changes HEAD', async () => {
+      const { GitBranchCoordinator } = await import('@/services/git/GitBranchCoordinator');
+      GitEngineMock.statuses.mockResolvedValue([]);
+      GitEngineMock.checkoutBranch.mockResolvedValue(undefined);
+
+      await expect(
+        GitBranchCoordinator.checkout(TEST_REPO_ID, TEST_REPO_PATH, 'feature-branch')
+      ).resolves.not.toThrow();
+
+      expect(GitSyncGateMock.verifyCheckoutPostflight).toHaveBeenCalledWith(
+        TEST_REPO_PATH,
+        'feature-branch',
+        expect.any(String),
+      );
+    });
+
+    it('fails when checkout postflight finds a different branch', async () => {
+      const { GitBranchCoordinator } = await import('@/services/git/GitBranchCoordinator');
+      GitEngineMock.statuses.mockResolvedValue([]);
+      GitEngineMock.checkoutBranch.mockResolvedValue(undefined);
+      GitSyncGateMock.verifyCheckoutPostflight.mockResolvedValue({
+        ok: false,
+        reason: 'branch-changed',
+      });
+
+      await expect(
+        GitBranchCoordinator.checkout(TEST_REPO_ID, TEST_REPO_PATH, 'feature-branch')
+      ).rejects.toThrow(/branch state changed/i);
+      expect(GitBranchCoordinator.getState()).toBe('failed');
+    });
+
     it('allows checkout when all files are Unmodified (clean tree)', async () => {
       const { GitBranchCoordinator } = await import('@/services/git/GitBranchCoordinator');
       GitEngineMock.statuses.mockResolvedValue([

--- a/src/services/git/GitBranchCoordinator.ts
+++ b/src/services/git/GitBranchCoordinator.ts
@@ -18,7 +18,7 @@
  */
 
 import { gitOperationRegistry, type GitOpKind } from '@/stores/gitOperationStore';
-import { GitSyncGate, type PreflightState } from './GitSyncGate';
+import { GitSyncGate } from './GitSyncGate';
 import { emitGitContentRefresh } from '@/hooks/useGitRefreshEvent';
 import { invalidateCache } from './branchResolver';
 import { setActiveBranchAfterCheckout } from './activeBranchStore';
@@ -123,13 +123,9 @@ class GitBranchCoordinatorClass {
     });
 
     let releaseCycle: (() => void) | null = null;
-    let preflight: PreflightState | null = null;
-
     return (async () => {
       try {
         releaseCycle = await GitSyncGate.acquireCycle('manual');
-
-        preflight = await GitSyncGate.capturePreflight(repoId, localPath);
 
         this.armWatchdog();
 
@@ -156,23 +152,8 @@ class GitBranchCoordinatorClass {
           throw checkoutError;
         }
 
-        const postflightResult = await GitSyncGate.verifyPostflight(preflight!, opId);
-
-        if (!postflightResult.ok && postflightResult.reason === 'head-changed') {
-          preflight = await GitSyncGate.capturePreflight(repoId, localPath);
-          try {
-            await GitEngine.checkoutBranch(localPath, branchName, remoteName);
-          } catch (retryError) {
-            checkoutError = retryError instanceof Error ? retryError : new Error(String(retryError));
-            throw checkoutError;
-          }
-          const retryResult = await GitSyncGate.verifyPostflight(preflight!, opId);
-          if (!retryResult.ok) {
-            gitOperationRegistry.fail(opId, `Postflight failed after retry: ${retryResult.reason}`);
-            this.setState('failed');
-            throw new Error('Checkout aborted: branch state changed during operation');
-          }
-        } else if (!postflightResult.ok) {
+        const postflightResult = await GitSyncGate.verifyCheckoutPostflight(localPath, branchName, opId);
+        if (!postflightResult.ok) {
           gitOperationRegistry.fail(opId, `Postflight: ${postflightResult.reason}`);
           this.setState('failed');
           throw new Error('Checkout aborted: branch state changed during operation');
@@ -190,7 +171,6 @@ class GitBranchCoordinatorClass {
         this.setState('failed');
         throw error;
       } finally {
-        if (preflight) GitSyncGate.clearPreflight(repoId);
         if (releaseCycle) {
           releaseCycle();
         }

--- a/src/services/git/GitSyncGate.ts
+++ b/src/services/git/GitSyncGate.ts
@@ -185,6 +185,28 @@ class GitSyncGateClass {
     }
   }
 
+  async verifyCheckoutPostflight(
+    repoPath: string,
+    expectedBranch: string,
+    registryOpId?: string,
+  ): Promise<PostflightResult> {
+    try {
+      const repoInfo = await GitEngine.repoInfo(repoPath);
+      if (repoInfo.currentBranch !== expectedBranch) {
+        if (registryOpId) {
+          gitOperationRegistry.fail(registryOpId, 'Branch changed during checkout (stale)');
+        }
+        return { ok: false, reason: 'branch-changed' };
+      }
+      return { ok: true };
+    } catch {
+      if (registryOpId) {
+        gitOperationRegistry.fail(registryOpId, 'Checkout postflight verification error');
+      }
+      return { ok: false, reason: 'error' };
+    }
+  }
+
   clearPreflight(repoId: string): void {
     this.preflightStates.delete(repoId);
   }


### PR DESCRIPTION
## Summary
- Fix checkout postflight validation to accept the requested branch and its intentional HEAD transition.
- Keep strict branch/HEAD stability validation for push operations.
- Add regression coverage for successful and failed checkout postflight states.

## Verification
- `yarn ts:check` passes.
- ESLint on changed files: 0 errors; one pre-existing watchdog-test warning.
- Targeted coordinator Jest: 25 passed, 2 pre-existing test-harness failures.
- Full Jest baseline: 166 passed; 14 pre-existing failures, including the same coordinator harness failures.

## Root Cause
Checkout previously reused push-style preflight validation, so the branch/HEAD transition caused by checkout itself could be reported as stale.