### PR TITLE
fix: use global activity indicator for list refresh

### DIFF
--- a/src/components/explore/BranchesSection.tsx
+++ b/src/components/explore/BranchesSection.tsx
@@ -312,7 +312,7 @@ export function BranchesSection({ repo, active, onChanged, chromeTopInset = 0, b
       renderItem={renderItem}
        contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 96, flexGrow: 1 }}
       refreshControl={
-        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
+        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor="transparent" colors={['transparent']} />
       }
       ListHeaderComponent={
         <View className="px-4 pb-1">

--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -206,7 +206,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0, on
       renderItem={renderItem}
         contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 96 }}
       refreshControl={
-        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
+        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor="transparent" colors={['transparent']} />
       }
       ListHeaderComponent={
         <View className="flex-row items-center justify-between px-4 pb-2">

--- a/src/components/explore/CommitsSection.tsx
+++ b/src/components/explore/CommitsSection.tsx
@@ -204,7 +204,7 @@ export function CommitsSection({ repo, active, chromeTopInset = 0, refreshStatus
       onEndReached={loadMore}
       onEndReachedThreshold={0.5}
       refreshControl={
-        <RefreshControl refreshing={loading} onRefresh={() => void loadInitial()} tintColor={colors.accent} />
+        <RefreshControl refreshing={loading} onRefresh={() => void loadInitial()} tintColor="transparent" colors={['transparent']} />
       }
       ListHeaderComponent={
         <View className="flex-row items-center justify-end px-4 pb-2">

--- a/src/components/explore/FilesSection.tsx
+++ b/src/components/explore/FilesSection.tsx
@@ -212,7 +212,7 @@ export function FilesSection({ repo, active, chromeTopInset = 0, branchInvalidat
       renderItem={renderItem}
       contentContainerStyle={listContentContainerStyle}
       refreshControl={
-        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
+        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor="transparent" colors={['transparent']} />
       }
       ListHeaderComponent={
         <View className="flex-row items-center justify-between px-4 pb-2">

--- a/src/components/explore/IssuesSection.tsx
+++ b/src/components/explore/IssuesSection.tsx
@@ -168,7 +168,7 @@ export function IssuesSection({ repo, active, chromeTopInset = 0 }: SectionProps
       renderItem={renderItem}
       contentContainerStyle={listContentContainerStyle}
       refreshControl={
-        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
+        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor="transparent" colors={['transparent']} />
       }
       ListHeaderComponent={
         <View>

--- a/src/components/explore/PullRequestsSection.tsx
+++ b/src/components/explore/PullRequestsSection.tsx
@@ -153,7 +153,7 @@ export function PullRequestsSection({ repo, active, chromeTopInset = 0 }: Sectio
         renderItem={renderItem}
         contentContainerStyle={listContentContainerStyle}
         refreshControl={
-          <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
+          <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor="transparent" colors={['transparent']} />
         }
         ListHeaderComponent={
           <View>

--- a/src/components/explore/RemotesSection.tsx
+++ b/src/components/explore/RemotesSection.tsx
@@ -213,7 +213,7 @@ export function RemotesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
       renderItem={renderItem}
        contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 96, flexGrow: 1 }}
       refreshControl={
-        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
+        <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor="transparent" colors={['transparent']} />
       }
       ListHeaderComponent={
         <View className="px-4 pb-3">

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -229,7 +229,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0, on
         renderItem={renderItem}
         contentContainerStyle={{ paddingTop: chromeTopInset, paddingBottom: 16 }}
         refreshControl={
-          <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor={colors.accent} />
+          <RefreshControl refreshing={loading} onRefresh={() => void load()} tintColor="transparent" colors={['transparent']} />
         }
         ListHeaderComponent={
           <View className="flex-row items-center justify-between px-4 pb-2">

--- a/src/screens/ChatThreadListScreen.tsx
+++ b/src/screens/ChatThreadListScreen.tsx
@@ -347,8 +347,8 @@ export default function ChatThreadListScreen() {
             <RefreshControl
               refreshing={isPullRefreshing}
               onRefresh={handleRefresh}
-              tintColor={colors.primary}
-              colors={[colors.primary]}
+              tintColor="transparent"
+              colors={['transparent']}
             />
           }
           ListEmptyComponent={renderEmptyState}

--- a/src/screens/NotesListScreen.tsx
+++ b/src/screens/NotesListScreen.tsx
@@ -485,8 +485,8 @@ export default function NotesListScreen() {
               refreshing={isPullRefreshing}
               onRefresh={handlePullToRefresh}
               enabled={!gateBusy}
-              tintColor={colors.primary}
-              colors={[colors.primary]}
+              tintColor="transparent"
+              colors={['transparent']}
               progressViewOffset={headerBlurHeight}
             />
           }

--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -526,8 +526,8 @@ export default function TodoListScreen() {
                 refreshing={isRefreshing}
                 onRefresh={handlePullToRefresh}
                 enabled={!gateBusy}
-                tintColor={colors.primary}
-                colors={[colors.primary]}
+                tintColor="transparent"
+                colors={['transparent']}
                 progressViewOffset={headerBlurHeight}
               />
             )


### PR DESCRIPTION
## Summary
- keep pull-to-refresh callbacks and controlled loading state on all git-backed lists
- hide duplicate native RefreshControl spinners with transparent iOS and Android colors
- preserve the global top GitHubActivityIndicator and existing translucent-header scroll behavior
- leave Template Manager unchanged because it uses a separate template pull flow

## Verification
- `yarn ts:check` passes
- targeted `CommitsSection` Jest test passes
- ESLint reports 0 errors (pre-existing warnings remain)
- full Jest has 3 unrelated existing failing suites: noteSyncQueueService, GitBranchCoordinator, and checkoutSafety