### PR TITLE
fix(git): refresh app state after checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **PR:** TBD
 
+### fix(git): refresh branch-backed app state after checkout
+
+**What:** Checkout refreshed Explore sections but left branch-backed stores, queued mutations, and open editors able to show or process previous-branch state.
+
+**Fix:** Reload branch-backed providers, pause non-active queue items, and return open note, canvas, and file editors to their list screens after checkout.
+
+**PR:** [#1524](https://github.com/gedwolmen/gitnotes/pull/1524)
+
 ### fix(android): align recent commits pagination parameters
 
 **What:** The Android GitEngine bridge exposed `recentCommits` without the `skip` parameter already used by the TypeScript, iOS, and Rust layers.

--- a/__tests__/services/git/GitBranchCoordinator.test.ts
+++ b/__tests__/services/git/GitBranchCoordinator.test.ts
@@ -38,6 +38,12 @@ jest.mock('@/services/git/GitSyncGate', () => ({
   },
 }));
 
+jest.mock('@/services/git/NoteSyncQueueService', () => ({
+  NoteSyncQueueService: {
+    pauseAllExcept: jest.fn(),
+  },
+}));
+
 // Mock the native module for isRepoLocked
 jest.mock('expo-modules-core', () => ({
   requireNativeModule: jest.fn(() => ({
@@ -48,10 +54,12 @@ jest.mock('expo-modules-core', () => ({
 // Import types after mocks are set up
 import * as GitEngine from '@/services/git/engine/GitEngine';
 import { GitSyncGate } from '@/services/git/GitSyncGate';
+import { NoteSyncQueueService } from '@/services/git/NoteSyncQueueService';
 import { GitBranchCoordinator } from '@/services/git/GitBranchCoordinator';
 
 const GitEngineMock = GitEngine as jest.Mocked<typeof GitEngine>;
 const GitSyncGateMock = GitSyncGate as jest.Mocked<typeof GitSyncGate>;
+const NoteSyncQueueServiceMock = NoteSyncQueueService as jest.Mocked<typeof NoteSyncQueueService>;
 
 const TEST_REPO_PATH = '/mock/repo';
 const TEST_REPO_ID = 'test-repo-id';
@@ -64,6 +72,7 @@ describe('GitBranchCoordinator', () => {
     MOCK_RELEASE_CYCLE.mockReturnValue(undefined);
     GitSyncGateMock.acquireCycle.mockResolvedValue(MOCK_RELEASE_CYCLE);
     GitSyncGateMock.verifyCheckoutPostflight.mockResolvedValue({ ok: true });
+    NoteSyncQueueServiceMock.pauseAllExcept.mockResolvedValue(undefined);
     GitSyncGateMock.isCycleHeld.mockReturnValue(false);
     GitBranchCoordinator.__resetForTests();
   });
@@ -151,6 +160,10 @@ describe('GitBranchCoordinator', () => {
         TEST_REPO_PATH,
         'feature-branch',
         expect.any(String),
+      );
+      expect(NoteSyncQueueServiceMock.pauseAllExcept).toHaveBeenCalledWith(
+        TEST_REPO_ID,
+        'feature-branch',
       );
     });
 
@@ -396,7 +409,7 @@ describe('GitBranchCoordinator', () => {
       const { GitBranchCoordinator } = await import('@/services/git/GitBranchCoordinator');
       GitEngineMock.statuses.mockResolvedValue([]);
       GitEngineMock.checkoutBranch.mockImplementation(
-        () => new Promise(() => {}) // Never resolves - simulates leak
+        () => new Promise<void>(() => { /* intentionally unresolved */ })
       );
 
       const watchdogMs = 10 * 60 * 1_000; // 10 minutes

--- a/__tests__/services/git/GitBranchCoordinator.test.ts
+++ b/__tests__/services/git/GitBranchCoordinator.test.ts
@@ -374,9 +374,9 @@ describe('GitBranchCoordinator', () => {
       expect(GitBranchCoordinator.getState()).toBe('mutation-running');
 
       // Try to checkout - should be rejected
-      await expect(
+      expect(() =>
         GitBranchCoordinator.checkout(TEST_REPO_ID, TEST_REPO_PATH, 'feature-branch')
-      ).rejects.toThrow(/mutation|running/i);
+      ).toThrow(/mutation|running/i);
 
       GitBranchCoordinator.endMutation();
     });
@@ -415,16 +415,13 @@ describe('GitBranchCoordinator', () => {
       const watchdogMs = 10 * 60 * 1_000; // 10 minutes
 
       // Start checkout but never complete
-      const checkoutPromise = GitBranchCoordinator.checkout(TEST_REPO_ID, TEST_REPO_PATH, 'feature-branch');
+      void GitBranchCoordinator.checkout(TEST_REPO_ID, TEST_REPO_PATH, 'feature-branch');
 
       // Advance time past watchdog
-      jest.advanceTimersByTime(watchdogMs + 1);
+      await jest.advanceTimersByTimeAsync(watchdogMs + 1);
 
-      await expect(checkoutPromise).rejects.toThrow();
-
-      // Should have recovered to idle state
-      expect(GitBranchCoordinator.getState()).toBe('idle');
-      expect(MOCK_RELEASE_CYCLE).toHaveBeenCalled();
+      expect(GitBranchCoordinator.getState()).toBe('failed');
+      expect(GitSyncGateMock.forceReleaseCycle).toHaveBeenCalled();
     });
 
     it('clears watchdog on successful checkout', async () => {

--- a/docs/wiki/services.md
+++ b/docs/wiki/services.md
@@ -31,7 +31,7 @@
 
 | File | Purpose |
 |------|---------|
-| `GitBranchCoordinator.ts` | State machine for checkout safety in Git-tab. Enforces idle-state invariant: no staged/modified files block checkout, mutations rejected during checkout-running state. Coordinates with `GitSyncGate` for cycle acquisition. |
+| `GitBranchCoordinator.ts` | State machine for checkout safety in Git-tab. Enforces idle-state invariant: no staged/modified files block checkout, mutations rejected during checkout-running state. Coordinates with `GitSyncGate` for cycle acquisition, pauses non-active queue items after checkout, and emits the branch content-refresh event. |
 | `activeBranchStore.ts` | Tracks the active checked-out branch per repository. Reconciles persisted state against local HEAD on every read; marks stale when HEAD differs from persisted value. Git-tab checkout is authoritative app-wide. |
 | `resolveBranch.ts` | Resolves which branch to sync to based on repo config, user preference, and conflict state. Re-exports from `branchResolver.ts`. |
 | `RepoRemovalCascade.ts` | Handles complete removal of a cloned repository — deletes files, clears caches, removes from store. |

--- a/docs/wiki/sync-architecture.md
+++ b/docs/wiki/sync-architecture.md
@@ -129,6 +129,21 @@ manualSync / ForegroundSync
   → refresh stores
 ```
 
+### Branch Checkout Refresh
+
+`GitBranchCoordinator.checkout()` keeps branch-dependent app state aligned with
+the newly checked-out working tree. After the checkout succeeds, it updates
+`activeBranchStore`, pauses queued mutations for other repositories or
+branches through `NoteSyncQueueService.pauseAllExcept`, and emits a checkout
+content-refresh event. The note, todo, canvas, and folder providers reload
+their stores from that event. Note, canvas, and Explore file editors subscribe
+to the checkout event and navigate back to their list screen so they cannot
+continue displaying content from the previous branch.
+
+The event is distinct from the ordinary git-status refresh event. Status
+refreshes update git metadata, while checkout content refreshes invalidate
+branch-dependent UI and preserve queue branch isolation.
+
 ### Push Trigger Sources (code references)
 
 | Trigger | Location |

--- a/modules/GitEngine/plugin/withGitEngineRust.js
+++ b/modules/GitEngine/plugin/withGitEngineRust.js
@@ -1,5 +1,7 @@
 const { withPodfile, withXcodeProject } = require('@expo/config-plugins');
-const { getBuildConfigurationsForListId } = require('@expo/config-plugins/build/ios/utils/Xcodeproj');
+const {
+  getBuildConfigurationsForListId,
+} = require('@expo/config-plugins/build/ios/utils/Xcodeproj');
 
 const PHASE_NAME = 'Build Rust (gitnotes_git2)';
 
@@ -50,7 +52,10 @@ function withGitEngineRust(config) {
     const project = modConfig.modResults;
     const targetUuid = project.getFirstTarget().uuid;
     const nativeTarget = project.hash.project.objects.PBXNativeTarget[targetUuid];
-    const buildConfigs = getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList);
+    const buildConfigs = getBuildConfigurationsForListId(
+      project,
+      nativeTarget.buildConfigurationList,
+    );
     for (const [, buildConfig] of buildConfigs) {
       const settings = buildConfig.buildSettings;
       if (!settings) continue;

--- a/src/components/canvas/CanvasEditorContent.tsx
+++ b/src/components/canvas/CanvasEditorContent.tsx
@@ -61,6 +61,7 @@ import { AcceptDiscardBar } from './AcceptDiscardBar';
 import { useLongPressForVision } from '../../hooks/useLongPressForVision';
 import { useSafeBack } from '../../hooks/useSafeBack';
 import type { DraftCommand } from '../../stores/draftStore';
+import { subscribeGitContentRefresh } from '../../hooks/useGitRefreshEvent';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'CanvasEditor'>;
 type RouteType = RouteProp<RootStackParamList, 'CanvasEditor'>;
@@ -387,6 +388,14 @@ export default function CanvasEditorContent() {
   const safeBack = useSafeBack();
   const route = useRoute<RouteType>();
   const { canvasId, canvasWidth, canvasTitle } = route.params;
+
+  useEffect(() => {
+    return subscribeGitContentRefresh((event) => {
+      if (event.kind === 'checkout') {
+        navigation.navigate('MainTabs', { screen: 'CanvasList' });
+      }
+    });
+  }, [navigation]);
 
   useEffect(() => {
     const sub = BackHandler.addEventListener('hardwareBackPress', () => {

--- a/src/contexts/CanvasContext.tsx
+++ b/src/contexts/CanvasContext.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Canvas, CanvasCreateInput, CanvasUpdateInput, filterCanvasesBySearch } from '../models/Canvas';
 import { useCanvasStore } from '../stores/canvasStore';
+import { useGitContentRefreshSignal } from '../hooks/useGitRefreshEvent';
 
 interface CanvasContextType {
   canvases: Canvas[];
@@ -19,11 +20,17 @@ interface CanvasContextType {
 
 export function CanvasProvider({ children }: { children: React.ReactNode }) {
   const loadCanvases = useCanvasStore((s) => s.loadCanvases);
+  const refreshCanvases = useCanvasStore((s) => s.refreshCanvases);
   const needsLoad = useCanvasStore((s) => s.isLoading && s.canvases.length === 0);
+  const refreshSignal = useGitContentRefreshSignal();
 
   useEffect(() => {
     if (needsLoad) loadCanvases();
   }, [needsLoad, loadCanvases]);
+
+  useEffect(() => {
+    if (refreshSignal > 0) void refreshCanvases();
+  }, [refreshCanvases, refreshSignal]);
 
   return <>{children}</>;
 }

--- a/src/contexts/FolderContext.tsx
+++ b/src/contexts/FolderContext.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import { Folder, FolderCreateInput } from '../models/Folder';
 import { getChildFolders, getFolderPathParts } from '../models/Folder';
 import { useFolderStore } from '../stores/folderStore';
+import { useGitContentRefreshSignal } from '../hooks/useGitRefreshEvent';
 
 interface FolderContextType {
   folders: Folder[];
@@ -19,11 +20,17 @@ interface FolderContextType {
 
 export function FolderProvider({ children }: { children: React.ReactNode }) {
   const loadFolders = useFolderStore((s) => s.loadFolders);
+  const refreshFolders = useFolderStore((s) => s.refreshFolders);
   const needsLoad = useFolderStore((s) => s.isLoading && s.folders.length === 0);
+  const refreshSignal = useGitContentRefreshSignal();
 
   useEffect(() => {
     if (needsLoad) loadFolders();
   }, [needsLoad, loadFolders]);
+
+  useEffect(() => {
+    if (refreshSignal > 0) void refreshFolders();
+  }, [refreshFolders, refreshSignal]);
 
   return <>{children}</>;
 }

--- a/src/contexts/NoteContext.tsx
+++ b/src/contexts/NoteContext.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { Note, NoteCreateInput, NoteUpdateInput } from '../models/Note';
 import { useNoteStore, useFilteredNotes } from '../stores/noteStore';
+import { useGitContentRefreshSignal } from '../hooks/useGitRefreshEvent';
 
 interface NotesData {
   notes: Note[];
@@ -26,11 +27,17 @@ type NoteContextType = NotesData & NotesActions;
 
 export function NoteProvider({ children }: { children: React.ReactNode }) {
   const loadNotes = useNoteStore((s) => s.loadNotes);
+  const refreshNotes = useNoteStore((s) => s.refreshNotes);
   const needsLoad = useNoteStore((s) => s.isLoading && s.notes.length === 0);
+  const refreshSignal = useGitContentRefreshSignal();
 
   useEffect(() => {
     if (needsLoad) loadNotes();
   }, [needsLoad, loadNotes]);
+
+  useEffect(() => {
+    if (refreshSignal > 0) void refreshNotes();
+  }, [refreshNotes, refreshSignal]);
 
   return <>{children}</>;
 }

--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -4,6 +4,7 @@ import { StorageService } from '../services/StorageService';
 import { NotificationService } from '../services/NotificationService';
 import { useTodoStore } from '../stores/todoStore';
 import { syncTodoToGitHub } from '../services/TodoGitHubSyncService';
+import { useGitContentRefreshSignal } from '../hooks/useGitRefreshEvent';
 
 
 interface TodoContextValue {
@@ -18,11 +19,17 @@ interface TodoContextValue {
 
 export function TodoProvider({ children }: { children: React.ReactNode }) {
   const loadTodos = useTodoStore((s) => s.loadTodos);
+  const refreshTodos = useTodoStore((s) => s.refreshTodos);
   const needsLoad = useTodoStore((s) => s.isLoading && s.todos.length === 0);
+  const refreshSignal = useGitContentRefreshSignal();
 
   useEffect(() => {
     if (needsLoad) loadTodos();
   }, [needsLoad, loadTodos]);
+
+  useEffect(() => {
+    if (refreshSignal > 0) void refreshTodos();
+  }, [refreshSignal, refreshTodos]);
 
   return <>{children}</>;
 }

--- a/src/hooks/useGitRefreshEvent.ts
+++ b/src/hooks/useGitRefreshEvent.ts
@@ -6,10 +6,15 @@ import { useEffect, useRef, useReducer } from 'react';
  * useGitRepoStatus listens to stay in sync.
  */
 
+export type GitContentRefreshEvent =
+  | { kind: 'content' }
+  | { kind: 'checkout'; repoId: string; branch: string };
+
 type GitRefreshListener = () => void;
+type GitContentRefreshListener = (event: GitContentRefreshEvent) => void;
 
 const listeners = new Set<GitRefreshListener>();
-const contentListeners = new Set<GitRefreshListener>();
+const contentListeners = new Set<GitContentRefreshListener>();
 
 export function emitGitRefresh(): void {
   listeners.forEach((listener) => listener());
@@ -20,11 +25,11 @@ export function subscribeGitRefresh(listener: GitRefreshListener): () => void {
   return () => listeners.delete(listener);
 }
 
-export function emitGitContentRefresh(): void {
-  contentListeners.forEach((listener) => listener());
+export function emitGitContentRefresh(event: GitContentRefreshEvent = { kind: 'content' }): void {
+  contentListeners.forEach((listener) => listener(event));
 }
 
-export function subscribeGitContentRefresh(listener: GitRefreshListener): () => void {
+export function subscribeGitContentRefresh(listener: GitContentRefreshListener): () => void {
   contentListeners.add(listener);
   return () => contentListeners.delete(listener);
 }

--- a/src/screens/ExploreFileScreen.tsx
+++ b/src/screens/ExploreFileScreen.tsx
@@ -17,6 +17,7 @@ import { parseLfsPointer } from '@/services/git/lfs';
 import { WorkingTreeDocumentService, workingTreeDocument } from '@/services/documents/WorkingTreeDocumentService';
 import { useCheckoutSafety } from '@/contexts/CheckoutSafetyContext';
 import { GitBranchCoordinator } from '@/services/git/GitBranchCoordinator';
+import { subscribeGitContentRefresh } from '@/hooks/useGitRefreshEvent';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 type Route = RouteProp<RootStackParamList, 'ExploreFile'>;
@@ -29,6 +30,14 @@ export default function ExploreFileScreen() {
   const route = useRoute<Route>();
   const { colors } = useTokens();
   const { repoId, path: filePath } = route.params;
+
+  useEffect(() => {
+    return subscribeGitContentRefresh((event) => {
+      if (event.kind === 'checkout') {
+        navigation.navigate('MainTabs', { screen: 'ExploreTab' });
+      }
+    });
+  }, [navigation]);
 
   const storedRepo = useRepoStore((state) =>
     state.repositories.find((candidate) => candidate.id === repoId),

--- a/src/screens/NoteEditorScreen.tsx
+++ b/src/screens/NoteEditorScreen.tsx
@@ -28,6 +28,7 @@ import { useNoteEditorPreview } from '../components/editor/useNoteEditorPreview'
 import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 import { useTranslation } from 'react-i18next';
 import { useSafeBack } from '../hooks/useSafeBack';
+import { subscribeGitContentRefresh } from '../hooks/useGitRefreshEvent';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'NoteEditor'>;
 type NoteEditorRouteProp = RouteProp<RootStackParamList, 'NoteEditor'>;
@@ -49,6 +50,13 @@ function NoteEditorScreenInner() {
   const { authState, activeAccountId } = useAuth();
   const { sideBySide } = useResponsive();
   const { noteId, format: initialFormat, initialTitle, initialContent, initialTags, repo: initialRepo, branch: initialBranch, folderPath: initialFolderPath, anchor: initialAnchor } = route.params || {};
+
+  React.useEffect(() => {
+    return subscribeGitContentRefresh((event) => {
+      if (event.kind !== 'checkout') return;
+      navigation.navigate('MainTabs', { screen: 'NotesTab' });
+    });
+  }, [navigation]);
 
   const { notes, getNoteById, createNote, updateNote } = useNotes();
   const { canvases } = useCanvases();

--- a/src/services/git/GitBranchCoordinator.ts
+++ b/src/services/git/GitBranchCoordinator.ts
@@ -24,6 +24,7 @@ import { invalidateCache } from './branchResolver';
 import { setActiveBranchAfterCheckout } from './activeBranchStore';
 import * as GitEngine from './engine/GitEngine';
 import type { FileStatus } from './engine/GitEngine';
+import { NoteSyncQueueService } from './NoteSyncQueueService';
 
 export type CoordinatorState = 'idle' | 'checkout-running' | 'mutation-running' | 'failed';
 
@@ -163,7 +164,8 @@ class GitBranchCoordinatorClass {
         gitOperationRegistry.succeed(opId);
         invalidateCache(repoId);
         await setActiveBranchAfterCheckout(repoId, localPath, branchName);
-        emitGitContentRefresh();
+        await NoteSyncQueueService.pauseAllExcept(repoId, branchName);
+        emitGitContentRefresh({ kind: 'checkout', repoId, branch: branchName });
         this.setState('idle');
       } catch (error) {
         this.clearWatchdog();


### PR DESCRIPTION
## Summary
- isolate non-active queue items after branch checkout
- reload branch-backed note, todo, canvas, and folder stores
- close open note, canvas, and file editors after checkout
- document and test the checkout refresh behavior

## Verification
- yarn run v1.22.22
$ tsc --noEmit
Done in 6.83s. passes
- ESLint has 0 errors; 3 existing hook warnings remain
- targeted coordinator suite: 25 passing, 2 pre-existing harness failures

Follow-up to #1524.