### PR TITLE
fix: keep Todo refresh control mounted

### DIFF
--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -520,17 +520,15 @@ export default function TodoListScreen() {
           ListEmptyComponent={<TodosEmptyState isFiltered={hasActiveFilters} />}
           showsVerticalScrollIndicator={false}
           refreshControl={
-            gitOperationActive ? undefined : (
-              <RefreshControl
-                testID="todo-list.swipe.pull-refresh"
-                refreshing={isRefreshing}
-                onRefresh={handlePullToRefresh}
-                enabled={!gateBusy}
-                tintColor="transparent"
-                colors={['transparent']}
-                progressViewOffset={headerBlurHeight}
-              />
-            )
+            <RefreshControl
+              testID="todo-list.swipe.pull-refresh"
+              refreshing={isRefreshing}
+              onRefresh={handlePullToRefresh}
+              enabled={!gateBusy && !gitOperationActive}
+              tintColor="transparent"
+              colors={['transparent']}
+              progressViewOffset={headerBlurHeight}
+            />
           }
         />
       )}


### PR DESCRIPTION
## Summary
- keep TodoListScreen RefreshControl mounted across git activity transitions
- disable the gesture through `enabled` instead of unmounting the native control
- preserve transparent native spinner colors and the global top activity indicator

## Verification
- `yarn ts:check` passes
- targeted CommitsSection Jest test passes
- ESLint reports 0 errors (4 pre-existing warnings)