### PR TITLE
fix(jest): mock expo-file-system modern API to enable tests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -252,6 +252,33 @@ jest.mock('expo-file-system/legacy', () => ({
   EncodingType: { UTF8: 'utf8', Base64: 'base64' },
 }));
 
+jest.mock('expo-file-system', () => {
+  const noop = () => {};
+  const mockDir = { uri: '', path: '', deleteAsync: jest.fn(), exists: jest.fn(() => false) };
+  const MockDirectory = jest.fn(() => mockDir);
+  const mockFile = { uri: '', path: '', deleteAsync: jest.fn(), exists: jest.fn(() => false), create: jest.fn() };
+  const MockFile = jest.fn(() => mockFile);
+  const MockPaths = jest.fn();
+  Object.defineProperties(MockPaths, {
+    cache: { get: jest.fn(() => mockDir) },
+    document: { get: jest.fn(() => mockDir) },
+    bundle: { get: jest.fn(() => mockDir) },
+    appleSharedContainers: { get: jest.fn(() => ({})) },
+  });
+  return {
+    __esModule: true,
+    File: MockFile,
+    Directory: MockDirectory,
+    Paths: MockPaths,
+    DownloadTask: jest.fn(),
+    UploadTask: jest.fn(),
+    EncodingType: { UTF8: 'utf8', Base64: 'base64' },
+    UploadType: {},
+    FileMode: {},
+    default: { File: MockFile, Directory: MockDirectory, Paths: MockPaths },
+  };
+});
+
 jest.mock('@expo/vector-icons', () => {
   const React = require('react');
   const { View } = require('react-native');


### PR DESCRIPTION
Fixes 809 test failures by adding a mock for the `expo-file-system` module (modern API with File/Directory/Paths exports). Only `expo-file-system/legacy` was mocked before; the modern API crashed in the Node.js jest environment.

CI still does not run Jest (see follow-up issue).

## Test results
- Before: 77 failed suites, 848 failed tests
- After: 3 failed suites, 39 failed tests (all pre-existing issues)