### PR TITLE
fix(sync): alert on foreground failures

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -43,6 +43,7 @@ import { useRenderStyleStore } from './src/stores/renderStyleStore';
 import { useFloatingGitButtonStore } from './src/stores/floatingGitButtonStore';
 import { startForegroundWatcher } from './src/services/ForegroundSyncService';
 import { loadForegroundSyncConfig } from './src/hooks/useForegroundSyncSettings';
+import { useForegroundSyncAlert } from './src/hooks/useForegroundSyncAlert';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { reconcileThoughtDumps } from './src/services/ai/thoughtDumpIndexing';
 import { LastSelectionPreferenceService } from './src/services/LastSelectionPreferenceService';
@@ -67,6 +68,7 @@ if (__DEV__) {
 export default function App() {
   const [showOnboarding, setShowOnboarding] = useState<boolean | null>(null);
   const systemColorScheme = useColorScheme();
+  useForegroundSyncAlert();
 
   const checkOnboarding = useCallback(async () => {
     await bootstrapStorage();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-11
 
+### fix(sync): alert when foreground sync fails
+
+**What:** Foreground pull failures were only visible later in Settings as sync-health text, so users could miss failed automatic syncs.
+
+**Fix:** Show one alert for each foreground sync failure streak, including timeouts, and reset alerting after a successful sync.
+
+**PR:** TBD
+
 ### fix(sync): route repository pulls through the native Git engine
 
 **What:** Automatic foreground sync and pull-to-refresh reported success without fetching remote changes because the clone pull path used no-op JavaScript git adapter methods.

--- a/__tests__/hooks/useForegroundSyncAlert.test.ts
+++ b/__tests__/hooks/useForegroundSyncAlert.test.ts
@@ -66,4 +66,21 @@ describe('useForegroundSyncAlert', () => {
 
     expect(alert).toHaveBeenCalledWith('settings.autoSyncFailedTitle:', 'settings.autoSyncFailedBody:GitHub');
   });
+
+  it.each(['idle', 'syncing'] as const)('does not alert while sync is %s', (status) => {
+    setHealth(status, 0);
+    renderHook(() => useForegroundSyncAlert());
+
+    expect(alert).not.toHaveBeenCalled();
+  });
+
+  it('alerts again when remounted during a failed sync', () => {
+    setHealth('failed', 1, 100);
+    const rendered = renderHook(() => useForegroundSyncAlert());
+
+    rendered.unmount();
+    renderHook(() => useForegroundSyncAlert());
+
+    expect(alert).toHaveBeenCalledTimes(2);
+  });
 });

--- a/__tests__/hooks/useForegroundSyncAlert.test.ts
+++ b/__tests__/hooks/useForegroundSyncAlert.test.ts
@@ -1,0 +1,69 @@
+import { Alert } from 'react-native';
+import { act, renderHook } from '@testing-library/react-native';
+import { useForegroundSyncAlert } from '@/hooks/useForegroundSyncAlert';
+import { useForegroundSyncHealth } from '@/hooks/useForegroundSyncHealth';
+
+jest.mock('react-native', () => ({
+  Alert: { alert: jest.fn() },
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { name?: string }) => `${key}:${values?.name ?? ''}`,
+  }),
+}));
+
+jest.mock('@/hooks/useForegroundSyncHealth', () => ({
+  useForegroundSyncHealth: jest.fn(),
+}));
+
+const health = useForegroundSyncHealth as jest.MockedFunction<typeof useForegroundSyncHealth>;
+const alert = Alert.alert as jest.MockedFunction<typeof Alert.alert>;
+
+function setHealth(status: 'idle' | 'syncing' | 'ok' | 'failed' | 'timedout', consecutiveFailures: number, lastFailedAt = 0) {
+  health.mockReturnValue({
+    status,
+    lastRunAt: 1,
+    lastCompletedAt: status === 'ok' ? 2 : 0,
+    lastFailedAt,
+    consecutiveFailures,
+  });
+}
+
+describe('useForegroundSyncAlert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setHealth('idle', 0);
+  });
+
+  it('alerts once for a failed sync streak', () => {
+    setHealth('failed', 1, 100);
+    const rendered = renderHook(() => useForegroundSyncAlert());
+
+    expect(alert).toHaveBeenCalledTimes(1);
+
+    setHealth('failed', 2, 200);
+    act(() => rendered.rerender());
+
+    expect(alert).toHaveBeenCalledTimes(1);
+  });
+
+  it('alerts again after a successful sync resets the streak', () => {
+    setHealth('failed', 1, 100);
+    const rendered = renderHook(() => useForegroundSyncAlert());
+
+    setHealth('ok', 0);
+    act(() => rendered.rerender());
+    setHealth('failed', 1, 300);
+    act(() => rendered.rerender());
+
+    expect(alert).toHaveBeenCalledTimes(2);
+  });
+
+  it('alerts when a sync times out', () => {
+    setHealth('timedout', 1, 100);
+    renderHook(() => useForegroundSyncAlert());
+
+    expect(alert).toHaveBeenCalledWith('settings.autoSyncFailedTitle:', 'settings.autoSyncFailedBody:GitHub');
+  });
+});

--- a/src/hooks/useForegroundSyncAlert.ts
+++ b/src/hooks/useForegroundSyncAlert.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+import { Alert } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useForegroundSyncHealth } from './useForegroundSyncHealth';
+
+export function useForegroundSyncAlert(): void {
+  const health = useForegroundSyncHealth();
+  const { t } = useTranslation();
+  const alertedFailureStreak = useRef(false);
+
+  useEffect(() => {
+    if (health.status === 'ok') {
+      alertedFailureStreak.current = false;
+      return;
+    }
+
+    const failed = health.status === 'failed' || health.status === 'timedout';
+    if (!failed || alertedFailureStreak.current) return;
+
+    alertedFailureStreak.current = true;
+    Alert.alert(
+      t('settings.autoSyncFailedTitle'),
+      t('settings.autoSyncFailedBody', { name: 'GitHub' }),
+    );
+  }, [health.status, t]);
+}


### PR DESCRIPTION
## Summary
- Show a native alert when automatic foreground sync fails or times out
- Alert once per failure streak and reset after successful sync
- Add focused regression tests and changelog entry

## Verification
- `yarn jest __tests__/hooks/useForegroundSyncAlert.test.ts --no-coverage --forceExit`
- `yarn ts:check`
- ESLint: 0 errors; existing warning remains at `App.tsx:142` (`no-empty-function`)

## Notes
- Existing retry/backoff behavior is unchanged.
- LSP diagnostics were unavailable because the local LSP daemon socket did not start.