### PR TITLE
fix(sync): use local worktree paths for native pulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **PR:** TBD
 
+### fix(sync): pass local worktree paths to native pulls
+
+**What:** Repository pulls failed with `No such file or directory` after cloning because native fetch and pull received the logical `owner/repo` identifier instead of the on-disk clone path.
+
+**Fix:** Resolve the repository through `GitFsService.workingTreeUri` before calling the native Git engine.
+
+**PR:** TBD
+
 ### fix(sync): route repository pulls through the native Git engine
 
 **What:** Automatic foreground sync and pull-to-refresh reported success without fetching remote changes because the clone pull path used no-op JavaScript git adapter methods.

--- a/__tests__/services/git/GitFsService.test.ts
+++ b/__tests__/services/git/GitFsService.test.ts
@@ -6,6 +6,7 @@ jest.mock('expo-file-system/legacy', () => ({
 }));
 
 jest.mock('@/services/git/engine/GitEngine', () => ({
+  fetch: jest.fn(),
   pull: jest.fn(),
 }));
 
@@ -34,7 +35,7 @@ describe('GitFsService.pullWithFastForward', () => {
     });
 
     expect(result).toEqual({ ok: true });
-    expect(pull).toHaveBeenCalledWith('owner/repo', 'origin', 'repo-id');
+    expect(pull).toHaveBeenCalledWith('file:///documents/GitNotes/owner/repo', 'origin', 'repo-id');
   });
 
   it('surfaces native pull conflicts instead of reporting success', async () => {
@@ -52,5 +53,25 @@ describe('GitFsService.pullWithFastForward', () => {
       reason: 'diverged',
       error: 'merge conflict in notes/example.md',
     });
+  });
+});
+
+describe('GitFsService.fetch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes the absolute worktree path to the native GitEngine bridge', async () => {
+    const fetch = GitEngine.fetch as jest.MockedFunction<typeof GitEngine.fetch>;
+    fetch.mockResolvedValue(undefined);
+
+    await GitFsService.fetch({
+      repoPath: 'owner/repo',
+      branch: 'main',
+      token: 'token',
+      repoId: 'repo-id',
+    });
+
+    expect(fetch).toHaveBeenCalledWith('file:///documents/GitNotes/owner/repo', 'origin', 'repo-id');
   });
 });

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -442,7 +442,7 @@ export class GitFsService {
     if (!info) throw new Error(`Invalid repo path: ${opts.repoPath}`);
 
     try {
-      await GitEngine.fetch(opts.repoPath, 'origin', opts.repoId);
+      await GitEngine.fetch(GitFsService.workingTreeUri({ repoPath: opts.repoPath }), 'origin', opts.repoId);
     } catch (fetchError) {
       const msg = fetchError instanceof Error ? fetchError.message : String(fetchError);
       if (/Packfile trailer mismatch|Could not find object|not foundobject|NotFoundError/i.test(msg)) {
@@ -472,7 +472,11 @@ export class GitFsService {
 
     try {
       const startedAt = Date.now();
-      const result = await GitEngine.pull(opts.repoPath, 'origin', opts.repoId);
+      const result = await GitEngine.pull(
+        GitFsService.workingTreeUri({ repoPath: opts.repoPath }),
+        'origin',
+        opts.repoId,
+      );
       if (!result.ok) {
         const message = result.error ?? 'Native pull failed';
         if (/not.*fast.?forward|diverged|merge.?conflict|conflict/i.test(message)) {


### PR DESCRIPTION
## Summary
- pass the absolute local worktree URI to native fetch and pull operations
- add regression coverage for both GitEngine bridge calls
- document the fix in the changelog

## Root Cause
After cloning, `GitFsService` passed the logical `owner/repo` identifier to the native Git engine. The native bridge expects the on-disk worktree path, causing `ENOENT` during manual and foreground pulls.

## Verification
- `yarn jest __tests__/services/git/GitFsService.test.ts --no-coverage --forceExit`
- `yarn ts:check`
- `yarn eslint src/services/git/GitFsService.ts __tests__/services/git/GitFsService.test.ts`
- Full Jest was also run; 153 tests passed and 39 unrelated pre-existing failures remain in dynamic-import and checkout UI tests.

## Review
- Five-lane pre-PR review: all lanes passed.