### PR TITLE
fix(sync): recover missing Git objects and stabilize activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **Fix:** Preserve the active label through the hide delay and centralize corruption matching for the native missing-object error.
 
-**PR:** #1533
+**PR:** Follow-up to #1533
 
 ### fix(sync): alert when foreground sync fails
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-11
 
+### fix(sync): stabilize activity labels and recover missing Git objects
+
+**What:** Sync activity briefly switched to a generic label while hiding, and native `object not found` pull failures were not recognized by the corruption recovery path.
+
+**Fix:** Preserve the active label through the hide delay and centralize corruption matching for the native missing-object error.
+
+**PR:** #1533
+
 ### fix(sync): alert when foreground sync fails
 
 **What:** Foreground pull failures were only visible later in Settings as sync-health text, so users could miss failed automatic syncs.

--- a/__tests__/services/git/corruptionErrors.test.ts
+++ b/__tests__/services/git/corruptionErrors.test.ts
@@ -1,0 +1,12 @@
+import { isGitCorruptionError } from '@/services/git/corruptionErrors';
+
+describe('isGitCorruptionError', () => {
+  it('recognizes the native missing-object error', () => {
+    expect(isGitCorruptionError('object not found - no match for id (abc123)')).toBe(true);
+  });
+
+  it('preserves existing corruption matches without matching unrelated errors', () => {
+    expect(isGitCorruptionError('Packfile trailer mismatch')).toBe(true);
+    expect(isGitCorruptionError('Bad credentials')).toBe(false);
+  });
+});

--- a/__tests__/stores/githubActivityStore.test.ts
+++ b/__tests__/stores/githubActivityStore.test.ts
@@ -1,0 +1,32 @@
+import { githubActivity, useGitHubActivityStore } from '@/stores/githubActivityStore';
+
+describe('github activity store', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    useGitHubActivityStore.getState().reset();
+  });
+
+  afterEach(() => {
+    useGitHubActivityStore.getState().reset();
+    jest.useRealTimers();
+  });
+
+  it('keeps the active label while the indicator waits to hide', () => {
+    githubActivity.begin('Syncing…');
+    jest.advanceTimersByTime(300);
+
+    githubActivity.end();
+
+    expect(useGitHubActivityStore.getState()).toEqual(expect.objectContaining({
+      visible: true,
+      label: 'Syncing…',
+    }));
+
+    jest.advanceTimersByTime(300);
+
+    expect(useGitHubActivityStore.getState()).toEqual(expect.objectContaining({
+      visible: false,
+      label: null,
+    }));
+  });
+});

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -17,6 +17,7 @@ import type { GitHostProvider } from './git/GitHost';
 import type { CloneProgressCallback } from './RepoImportService';
 import { getActiveBranch } from './git/activeBranchStore';
 import { useRepoStore } from '../stores/repoStore';
+import { isGitCorruptionError } from './git/corruptionErrors';
 
 // Paths of todo files already reported as unparseable, per repo. Without this
 // cache the same malformed remote files re-warn on every pull (#1161); a file
@@ -61,8 +62,7 @@ async function handleCorruptionErrors<T>(fn: () => Promise<T>, repoPath: string,
     return await fn();
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
-    const isMissingObject = /Could not find object|not foundobject|NotFoundError|Packfile trailer mismatch/i.test(errorMsg);
-    if (isMissingObject) {
+    if (isGitCorruptionError(errorMsg)) {
       console.warn(`[RepoPullService] corruption detected during operation, re-cloning...`);
       const hasLocalCommits = await hasUnpushedCommits(repoPath, branch);
       if (hasLocalCommits) {
@@ -113,8 +113,7 @@ async function getRepoReader(
         };
       }
       const errorMsg = result.error ?? '';
-      const isMissingObject = /Could not find object|not foundobject|NotFoundError|Packfile trailer mismatch/i.test(errorMsg);
-      if (isMissingObject) {
+      if (isGitCorruptionError(errorMsg)) {
         console.warn(`[RepoPullService] clone appears corrupted (${errorMsg}), re-cloning...`);
         const hasLocalCommits = await hasUnpushedCommits(repoPath, branch);
         if (hasLocalCommits) {

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -5,6 +5,7 @@ import * as GitEngine from './engine/GitEngine';
 import { makeGitFs, type PromiseFsClient } from './gitFs';
 import { gitHttp } from './gitHttp';
 import { LfsService } from './lfs';
+import { isGitCorruptionError } from './corruptionErrors';
 
 const CLONES_SUBDIR = 'GitNotes/';
 
@@ -383,7 +384,7 @@ export class GitFsService {
         lastError = cloneError;
         await GitFsService.removeRepo({ repoPath: opts.repoPath }).catch(() => undefined);
         const msg = cloneError instanceof Error ? cloneError.message : String(cloneError);
-        const isCorruption = /Packfile trailer mismatch|Could not find object|not foundobject|NotFoundError|internal error caused this command to fail/i.test(msg);
+        const isCorruption = isGitCorruptionError(msg) || /internal error caused this command to fail/i.test(msg);
         if (looksLikeOutOfMemory(cloneError)) {
           throw new CloneOutOfMemoryError(
             `Out of memory while cloning ${opts.repoPath}. The repo is too large for this device — try a shallow clone or free up storage.`,
@@ -445,7 +446,7 @@ export class GitFsService {
       await GitEngine.fetch(GitFsService.workingTreeUri({ repoPath: opts.repoPath }), 'origin', opts.repoId);
     } catch (fetchError) {
       const msg = fetchError instanceof Error ? fetchError.message : String(fetchError);
-      if (/Packfile trailer mismatch|Could not find object|not foundobject|NotFoundError/i.test(msg)) {
+      if (isGitCorruptionError(msg)) {
         await cleanCorruptedPackfiles(opts.repoPath);
       }
       throw fetchError;
@@ -637,7 +638,7 @@ export class GitFsService {
       const code = (e as { code?: string }).code;
       const msg = e instanceof Error ? e.message : String(e);
       if (code === 'NotFoundError' || code === 'ENOENT') {
-        if (/Could not find object|not foundobject|NotFoundError/i.test(msg)) {
+        if (isGitCorruptionError(msg)) {
           throw e;
         }
         return null;

--- a/src/services/git/corruptionErrors.ts
+++ b/src/services/git/corruptionErrors.ts
@@ -1,0 +1,5 @@
+const CORRUPTION_ERROR_PATTERN = /Could not find object|not foundobject|object not found|NotFoundError|Packfile trailer mismatch/i;
+
+export function isGitCorruptionError(message: string): boolean {
+  return CORRUPTION_ERROR_PATTERN.test(message);
+}

--- a/src/services/git/recovery.ts
+++ b/src/services/git/recovery.ts
@@ -17,6 +17,7 @@ import { parseRepoPath } from '../../utils/gitPathParser';
 import { makeGitFs as buildGitFs } from './gitFs';
 import { GitFsService, repairHeadRef } from './GitFsService';
 import * as GitEngine from './engine/GitEngine';
+import { isGitCorruptionError } from './corruptionErrors';
 
 const CLONES_SUBDIR = 'GitNotes/';
 
@@ -89,7 +90,7 @@ export function classifyPushError(raw: string): string {
 
 /** Returns true when the error message indicates git object / packfile corruption. */
 export function isCorruptionError(errorMsg: string): boolean {
-  return /Could not find|NotFoundError|Packfile trailer mismatch/i.test(errorMsg);
+  return isGitCorruptionError(errorMsg) || /Could not find/i.test(errorMsg);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/stores/githubActivityStore.ts
+++ b/src/stores/githubActivityStore.ts
@@ -71,7 +71,7 @@ export const useGitHubActivityStore = create<GitHubActivityState & GitHubActivit
       const timer = setTimeout(() => {
         set({ inflight: 0, label: null, hideTimer: null, visible: false, pendingVisibilityChange: false, progress: null });
       }, MINIMUM_DISPLAY_MS);
-      set({ inflight: 0, label: null, hideTimer: timer, visibilityChangeTimer: null, progress: null });
+      set({ inflight: 0, label: get().label, hideTimer: timer, visibilityChangeTimer: null, progress: null });
     }
   },
 


### PR DESCRIPTION
## Summary
- Recognize native missing-object errors across clone, fetch, read, pull, and push recovery paths.
- Preserve the active sync activity label through the delayed hide window.
- Add focused regression tests and document the follow-up to #1533.

## Verification
- `yarn jest __tests__/services/git/corruptionErrors.test.ts __tests__/stores/githubActivityStore.test.ts --no-coverage --forceExit`
- `yarn ts:check`
- Targeted ESLint: 0 errors; 4 pre-existing warnings in `RepoPullService.ts`.

Follow-up to #1533.