### PR TITLE
fix(calendar): offset content below absolutely-positioned header

### DIFF
--- a/src/screens/CalendarScreen.tsx
+++ b/src/screens/CalendarScreen.tsx
@@ -20,7 +20,7 @@ import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../contexts/ThemeContext';
 import { useNotes } from '../contexts/NoteContext';
 import { SafeAreaView } from '../components/ui/SafeAreaView';
-import { ScreenHeader } from '../components/ui/ScreenHeader';
+import { ScreenHeader, useScreenHeaderHeight } from '../components/ui/ScreenHeader';
 import {
   getJournalEntries,
   findJournalEntry,
@@ -40,6 +40,7 @@ export default function CalendarScreen() {
   const route = useRoute<CalendarRouteProp>();
   const { colors } = useTheme();
   const { notes } = useNotes();
+  const headerHeight = useScreenHeaderHeight();
 
   const initialDate = route.params?.selectedDate
     ? new Date(route.params.selectedDate)
@@ -154,7 +155,7 @@ export default function CalendarScreen() {
         onBack={() => navigation.goBack()}
       />
 
-      <View style={{ paddingHorizontal: 16, paddingVertical: 12 }}>
+      <View style={{ paddingHorizontal: 16, paddingVertical: 12, paddingTop: headerHeight }}>
         {/* Month Navigation Header */}
         <View
           style={{


### PR DESCRIPTION
Fixes calendar content rendering under the header on iOS.

The ScreenHeader uses absolute positioning on iOS (via BlurView), but CalendarScreen was not accounting for the header height, causing the calendar grid and entries list to appear underneath the header.

Changes:
- Import useScreenHeaderHeight from ScreenHeader
- Add headerHeight hook call in component  
- Add paddingTop: headerHeight to content container

This follows the same pattern used by TodoListScreen, NotesListScreen, and other screens with absolutely-positioned headers.