### PR TITLE
fix(todos): offset kanban view below absolutely-positioned header

### DIFF
--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { Alert, Platform, RefreshControl, LayoutChangeEvent } from 'react-native';
-import { FlatList } from 'react-native';
+import { FlatList, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -500,7 +500,9 @@ export default function TodoListScreen() {
       />
 
       {viewMode === 'kanban' ? (
-        <KanbanBoard onSelect={openEditModal} />
+        <View style={{ paddingTop: headerBlurHeight, paddingHorizontal: 16, flex: 1 }}>
+          <KanbanBoard onSelect={openEditModal} />
+        </View>
       ) : (
         <FlatList
           data={filteredTodos}


### PR DESCRIPTION
Fixes todo kanban grid rendering under the header on iOS.

The ScreenHeader uses absolute positioning on iOS (via BlurView), but the KanbanBoard was rendered directly without accounting for the header height, causing it to appear underneath the header.

Changes:
- Wrap KanbanBoard in a View with paddingTop: headerBlurHeight
- Add paddingHorizontal: 16 to match FlatList content container style
- Import View from react-native

This follows the same pattern used by the FlatList in the same screen which already correctly offsets content below the header.