### PR TITLE
fix(todos): extend kanban to screen edges

### DIFF
--- a/src/screens/TodoListScreen.tsx
+++ b/src/screens/TodoListScreen.tsx
@@ -500,7 +500,7 @@ export default function TodoListScreen() {
       />
 
       {viewMode === 'kanban' ? (
-        <View style={{ paddingTop: headerBlurHeight, paddingHorizontal: 16, flex: 1 }}>
+        <View style={{ paddingTop: headerBlurHeight, flex: 1 }}>
           <KanbanBoard onSelect={openEditModal} />
         </View>
       ) : (


### PR DESCRIPTION
Extends the todo kanban board to screen edges horizontally.

Previously the kanban had 16px horizontal padding. This change removes the padding so the columns stretch edge-to-edge, giving an infinite/edge-to-edge appearance.