### PR TITLE
fix(explore): prevent branch card button overflow when description is long

### DIFF
--- a/src/components/explore/BranchesSection.tsx
+++ b/src/components/explore/BranchesSection.tsx
@@ -197,8 +197,8 @@ export function BranchesSection({ repo, active, onChanged, chromeTopInset = 0, b
               </View>
             )}
           </View>
-          <View className="mt-1.5 flex-row items-center justify-between">
-            <Text className="text-[11px]" style={{ color: colors.textSecondary }}>
+          <View className="mt-1.5 flex-row flex-wrap items-center justify-between gap-2">
+            <Text className="min-w-0 flex-1 text-[11px]" style={{ color: colors.textSecondary }}>
               {item.upstream ? `upstream ${item.upstream} · ` : ''}
               {`ahead ${item.ahead} · behind ${item.behind}`}
             </Text>


### PR DESCRIPTION
## Summary

When a branch has a long upstream reference or description, the checkout/rename/delete buttons would overflow outside the card boundary.

## Fix

- Added `flex-wrap` to the button row container so buttons wrap to the next line when space is constrained
- Added `gap-2` for consistent spacing when wrapping occurs
- Added `min-w-0 flex-1` to the description text so it shrinks instead of pushing buttons off-screen

## Testing

Manual: verified buttons wrap correctly when description text is long.

