### PR TITLE
fix(git): refresh note/todo/canvas content after branch checkout

### DIFF
--- a/src/services/git/GitBranchCoordinator.ts
+++ b/src/services/git/GitBranchCoordinator.ts
@@ -25,6 +25,7 @@ import { setActiveBranchAfterCheckout } from './activeBranchStore';
 import * as GitEngine from './engine/GitEngine';
 import type { FileStatus } from './engine/GitEngine';
 import { NoteSyncQueueService } from './NoteSyncQueueService';
+import { pullFromSingleRepo } from '../RepoPullService';
 
 export type CoordinatorState = 'idle' | 'checkout-running' | 'mutation-running' | 'failed';
 
@@ -166,6 +167,9 @@ class GitBranchCoordinatorClass {
         await setActiveBranchAfterCheckout(repoId, localPath, branchName);
         await NoteSyncQueueService.pauseAllExcept(repoId, branchName);
         emitGitContentRefresh({ kind: 'checkout', repoId, branch: branchName });
+        // Sync the new branch's working tree files into AsyncStorage so
+        // note/todo/canvas providers reload the correct content on refresh.
+        void pullFromSingleRepo(localPath);
         this.setState('idle');
       } catch (error) {
         this.clearWatchdog();


### PR DESCRIPTION
## Summary

After checking out a branch, the note/todo/canvas list screens still showed stale content from the previous branch — users had to manually pull-to-refresh.

## Root Cause

GitBranchCoordinator.checkout() correctly emits a GitContentRefreshEvent after checkout, and the context providers do listen for it and call their refreshNotes() / refreshTodos() etc. However, those refresh methods only re-read from AsyncStorage, which still holds the cached content from the previous branch.

The working tree files ARE correct after checkout, but the AsyncStorage cache was never updated to reflect the new branch files.

## Fix

After emitting the checkout refresh event, call pullFromSingleRepo to read the new branch working tree files and sync them into AsyncStorage. This ensures context providers get fresh data from the newly checked-out branch.

## Testing

Manual: checked out between branches in the Explore tab and verified notes/todos/canvases lists update immediately without pull-to-refresh.