### PR TITLE
fix(splash): preserve iOS dark-mode launch appearance

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -160,7 +160,7 @@ export default function App() {
   if (showOnboarding === null) {
     const isDark = systemColorScheme === 'dark';
     return (
-      <View style={[styles.loadingContainer, { backgroundColor: isDark ? '#000000' : '#ffffff' }]}>
+      <View style={[styles.loadingContainer, { backgroundColor: isDark ? '#0E0E0E' : '#ffffff' }]}>
         <StatusBar style={isDark ? 'light' : 'dark'} />
       </View>
     );

--- a/__tests__/plugins/withSplashScreenDarkMode.test.ts
+++ b/__tests__/plugins/withSplashScreenDarkMode.test.ts
@@ -1,0 +1,111 @@
+import { removeAppearanceLight } from '../../plugins/withSplashScreenDarkMode';
+
+describe('removeAppearanceLight', () => {
+  describe('should remove appearance="light" from device element', () => {
+    test('removes appearance="light" from retina6_12 device', () => {
+      const input = `<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <resources/>
+</document>`;
+      const result = removeAppearanceLight(input);
+      expect(result).not.toContain('appearance="light"');
+      expect(result).not.toContain("appearance='light'");
+      // Other device attributes must be preserved
+      expect(result).toContain('id="retina6_12"');
+      expect(result).toContain('orientation="portrait"');
+    });
+
+    test('removes appearance="light" with double quotes', () => {
+      const input = `<device id="retina6_12" orientation="portrait" appearance="light"/>`;
+      const result = removeAppearanceLight(input);
+      expect(result).toBe('<device id="retina6_12" orientation="portrait"/>');
+    });
+
+    test('removes appearance=\'light\' with single quotes', () => {
+      const input = `<device id="retina6_12" orientation="portrait" appearance='light'/>`;
+      const result = removeAppearanceLight(input);
+      expect(result).toBe('<device id="retina6_12" orientation="portrait"/>');
+    });
+  });
+
+  describe('should preserve unrelated XML structure', () => {
+    test('preserves other appearance values (e.g., dark) when light also present', () => {
+      // When both appearance="light" and appearance="dark" exist in the same document,
+      // only appearance="light" should be removed
+      const input = `<document><device id="retina6_12" appearance="light"/><device id="another" appearance="dark"/></document>`;
+      const result = removeAppearanceLight(input);
+      expect(result).not.toContain('appearance="light"');
+      expect(result).toContain('appearance="dark"');
+    });
+
+    test('preserves other attributes on device when removing appearance="light"', () => {
+      const input = `<device id="retina6_12" orientation="portrait" appearance="light" other="value"/>`;
+      const result = removeAppearanceLight(input);
+      expect(result).toContain('id="retina6_12"');
+      expect(result).toContain('orientation="portrait"');
+      expect(result).toContain('other="value"');
+      expect(result).not.toContain('appearance="light"');
+    });
+
+    test('preserves namedColor and backgroundColor references', () => {
+      const input = `<?xml version="1.0"?>
+<document>
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <color key="backgroundColor" name="SplashScreenBackground"/>
+</document>`;
+      const result = removeAppearanceLight(input);
+      expect(result).toContain('name="SplashScreenBackground"');
+      expect(result).toContain('backgroundColor');
+    });
+
+    test('preserves full storyboard structure with all scenes', () => {
+      const input = `<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="EXPO-VIEWCONTROLLER-1">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <scenes>
+        <scene sceneID="EXPO-SCENE-1"/>
+    </scenes>
+    <resources>
+        <namedColor name="SplashScreenBackground"/>
+    </resources>
+</document>`;
+      const result = removeAppearanceLight(input);
+      expect(result).not.toContain('appearance="light"');
+      expect(result).toContain('initialViewController="EXPO-VIEWCONTROLLER-1"');
+      expect(result).toContain('namedColor name="SplashScreenBackground"');
+      expect(result).toContain('<scenes>');
+    });
+  });
+
+  describe('should reject invalid inputs', () => {
+    test('throws when input is not a string', () => {
+      // @ts-expect-error - intentionally passing wrong type to test runtime guard
+      expect(() => removeAppearanceLight(null)).toThrow('xmlString must be a string');
+      // @ts-expect-error - undefined is not a string and must be rejected
+      expect(() => removeAppearanceLight(undefined)).toThrow('xmlString must be a string');
+      // @ts-expect-error - number is not a string and must be rejected
+      expect(() => removeAppearanceLight(123)).toThrow('xmlString must be a string');
+    });
+
+    test('throws when no appearance="light" marker is present', () => {
+      const input = `<device id="retina6_12" orientation="portrait"/>`;
+      expect(() => removeAppearanceLight(input)).toThrow(
+        'No appearance="light" marker found'
+      );
+    });
+
+    test('throws when XML is already cleaned (second call)', () => {
+      const input = `<device id="retina6_12" orientation="portrait" appearance="light"/>`;
+      // First call removes it
+      removeAppearanceLight(input);
+      // Second call on same string has no marker (string was not mutated)
+      // But since we're passing the same string, it will find it again
+      // So test with an already-clean string
+      const cleanInput = `<device id="retina6_12" orientation="portrait"/>`;
+      expect(() => removeAppearanceLight(cleanInput)).toThrow(
+        'No appearance="light" marker found'
+      );
+    });
+  });
+});

--- a/app.json
+++ b/app.json
@@ -103,12 +103,11 @@
           "backgroundColor": "#ffffff",
           "dark": {
             "image": "./assets/generated/splash-icon.png",
-            "imageWidth": 300,
-            "resizeMode": "contain",
             "backgroundColor": "#0E0E0E"
           }
         }
       ],
+      "./plugins/withSplashScreenDarkMode",
       [
         "expo-speech-recognition",
         {

--- a/plugins/withSplashScreenDarkMode.js
+++ b/plugins/withSplashScreenDarkMode.js
@@ -1,0 +1,72 @@
+const { withDangerousMod } = require('@expo/config-plugins');
+const { Parser } = require('xml2js');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Removes appearance="light" from <device ...> elements in an iOS SplashScreen storyboard.
+ * This allows the storyboard to respect the system appearance (light/dark) instead of
+ * being locked to light mode by expo-splash-screen SDK 56's generator template.
+ *
+ * @param {string} xmlString - Raw XML string of the storyboard
+ * @returns {string} - XML with appearance="light" removed from <device> elements
+ */
+function removeAppearanceLight(xmlString) {
+  if (typeof xmlString !== 'string') {
+    throw new Error('removeAppearanceLight: xmlString must be a string');
+  }
+  // Match appearance="light" or appearance='light' as a standalone attribute on any element
+  // We target the <device> element specifically since that's what expo-splash-screen generates
+  const lightPattern = /\s+appearance=["']light["']/g;
+  if (!lightPattern.test(xmlString)) {
+    throw new Error(
+      'removeAppearanceLight: No appearance="light" marker found in storyboard XML. ' +
+        'The generated storyboard structure may have changed.',
+    );
+  }
+  return xmlString.replace(lightPattern, '');
+}
+
+/**
+ * Expo Config Plugin: Post-processes the generated iOS SplashScreen.storyboard
+ * to remove the forced appearance="light" attribute after expo-splash-screen runs.
+ * Registered after expo-splash-screen in app.json, this runs on every expo prebuild
+ * and keeps the fix durable across native regeneration.
+ */
+const withSplashScreenDarkMode = (config) => {
+  return withDangerousMod(config, [
+    'ios',
+    async (config) => {
+      const storyboardPath = path.join(
+        config.modRequest.platformProjectRoot,
+        config.modRequest.projectName || 'GitNotes',
+        'SplashScreen.storyboard',
+      );
+
+      const raw = await fs.promises.readFile(storyboardPath, 'utf8');
+      const updated = removeAppearanceLight(raw);
+
+      // Sanity check: ensure we actually changed something
+      if (raw === updated) {
+        throw new Error(
+          'withSplashScreenDarkMode: Storyboard was not modified. ' +
+            'Expected appearance="light" was not found.',
+        );
+      }
+
+      // Verify the result is valid XML (basic parse check)
+      const parser = new Parser();
+      try {
+        await parser.parseStringPromise(updated);
+      } catch {
+        throw new Error('withSplashScreenDarkMode: Modified storyboard is not valid XML.');
+      }
+
+      await fs.promises.writeFile(storyboardPath, updated, 'utf8');
+      return config;
+    },
+  ]);
+};
+
+module.exports = withSplashScreenDarkMode;
+module.exports.removeAppearanceLight = removeAppearanceLight;


### PR DESCRIPTION
## Summary

Fixes the iOS launch splash screen being forced to light appearance regardless of system dark mode setting.

## Root cause

expo-splash-screen SDK 56 plugin generates iOS SplashScreen.storyboard with appearance="light" hardcoded on the device element, bypassing the dark colorset. This was causing a white flash on launch for dark-mode users.

## Changes

### plugins/withSplashScreenDarkMode.js
Repository-owned local Expo config plugin that runs after expo-splash-screen in app.json and post-processes the generated SplashScreen.storyboard, removing the forced appearance="light" attribute. Exports removeAppearanceLight(xmlString) as a pure function for testability.

### __tests__/plugins/withSplashScreenDarkMode.test.ts
10 unit tests covering: correct removal, XML structure preservation, invalid input rejection, and missing-marker detection.

### app.json
Registered the local plugin after expo-splash-screen in the plugins array. Removed undocumented dark.imageWidth and dark.resizeMode fields (Expo SDK 56 documents only dark.image and dark.backgroundColor).

### App.tsx line 163
Changed dark-mode loading background from #000000 to #0E0E0E to match the native splash dark background color.

## Verification

- grep -c appearance="light" ios/GitNots/SplashScreen.storyboard → 0 (plugin successfully removes the forced light attribute)
- Dark colorset RGB: #0E0E0E (0.0549, 0.0549, 0.0549)
- yarn ts:check → pass
- yarn eslint on changed files → 0 errors
- yarn jest __tests__/plugins/withSplashScreenDarkMode.test.ts → 10/10 pass

## Scope

- iOS splash only — Android had correct #0E0E0E in values-night/colors.xml already
- No splash artwork changed
- No dark logo variant added
- No theme architecture changes

Closes #1538