### PR TITLE
fix(notes): preserve repository modification dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **Fix:** Read each file's GitHub commit history during import and preserve its oldest and newest commit dates through note creation.
 
-**PR:** TBD
+**PR:** #1543
 
 ### fix(sync): stabilize activity labels and recover missing Git objects
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-11
 
+### fix(notes): preserve repository modification dates
+
+**What:** Imported Notes and other supported repository files displayed the import date instead of their historical last-modified date, which also made date sorting inaccurate.
+
+**Fix:** Read each file's GitHub commit history during import and preserve its oldest and newest commit dates through note creation.
+
+**PR:** TBD
+
 ### fix(sync): stabilize activity labels and recover missing Git objects
 
 **What:** Sync activity briefly switched to a generic label while hiding, and native `object not found` pull failures were not recognized by the corruption recovery path.

--- a/__tests__/models/Note.test.ts
+++ b/__tests__/models/Note.test.ts
@@ -1,0 +1,25 @@
+import { createNote, sortNotesByUpdated } from '../../src/models/Note';
+
+describe('Note timestamps', () => {
+  it('preserves timestamps supplied by an import', () => {
+    const createdAt = Date.parse('2024-01-15T10:00:00.000Z');
+    const updatedAt = Date.parse('2025-02-20T12:00:00.000Z');
+
+    const note = createNote({
+      title: 'Imported note',
+      content: 'content',
+      createdAt,
+      updatedAt,
+    });
+
+    expect(note.createdAt).toBe(createdAt);
+    expect(note.updatedAt).toBe(updatedAt);
+  });
+
+  it('sorts notes by last-modified timestamp', () => {
+    const older = createNote({ title: 'Older', content: '', updatedAt: 100 });
+    const newer = createNote({ title: 'Newer', content: '', updatedAt: 200 });
+
+    expect(sortNotesByUpdated([older, newer]).map((note) => note.title)).toEqual(['Newer', 'Older']);
+  });
+});

--- a/src/models/Note.ts
+++ b/src/models/Note.ts
@@ -62,6 +62,8 @@ export interface NoteCreateInput {
   format?: NoteFormat;
   attachments?: Attachment[];
   accountId?: string;
+  createdAt?: number;
+  updatedAt?: number;
   /** When true, skip the immediate clone-mode commit so the note goes through normal sync flow. */
   isAiCreated?: boolean;
 }
@@ -89,8 +91,8 @@ export function createNote(input: NoteCreateInput): Note {
     id: generateId(),
     title: input.title,
     content: input.content,
-    createdAt: now,
-    updatedAt: now,
+    createdAt: input.createdAt ?? now,
+    updatedAt: input.updatedAt ?? input.createdAt ?? now,
     tags: input.tags || [],
     color: input.color === null ? undefined : input.color,
     repo: input.repo,

--- a/src/services/RepoFileSyncService.ts
+++ b/src/services/RepoFileSyncService.ts
@@ -111,6 +111,12 @@ class RepoFileSyncServiceClass {
           const title = item.name.replace(/\.[^.]+$/, '');
           const lastSlash = item.path.lastIndexOf('/');
           const folderPath = lastSlash > 0 ? item.path.substring(0, lastSlash) : undefined;
+          const commitDates = await GitHubService.getPathCommitDates(
+            owner,
+            repo,
+            item.path,
+            branch,
+          );
           await StorageService.createNote({
             title,
             content,
@@ -120,6 +126,8 @@ class RepoFileSyncServiceClass {
             tags: [],
             filePath: item.path,
             folderPath,
+            createdAt: commitDates.createdAt,
+            updatedAt: commitDates.updatedAt,
           });
 
           result.created++;

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -382,6 +382,7 @@ async function pullNotesFromRepo(
       const format = noteFormatFromExt(ext);
       const tags = extractTagsFromContent(item.content, format);
       const color = extractColorFromContent(item.content, format);
+      const commitDates = await GitHubService.getPathCommitDates(owner, repo, item.path, branch);
       const titleFromPath = item.path
         .replace(/^notes\//, '')
         .replace(/\.[^.]+$/, '')
@@ -404,7 +405,7 @@ async function pullNotesFromRepo(
             content: item.content,
             tags,
             color: color ?? existing.color,
-            updatedAt: Date.now(),
+            updatedAt: commitDates.updatedAt ?? Date.now(),
           };
           pulled++;
         } else if (color && color !== existing.color) {
@@ -422,6 +423,8 @@ async function pullNotesFromRepo(
             format,
             tags,
             color,
+            createdAt: commitDates.createdAt,
+            updatedAt: commitDates.updatedAt,
           }),
         );
         pulled++;


### PR DESCRIPTION
## Summary

Imported Notes displayed the import date instead of their historical last-modified date, which also made date sorting inaccurate. This fix reads each file's GitHub commit history during import and preserves its oldest and newest commit dates.

## Changes

- **Note.ts**: Added `createdAt`/`updatedAt` optional fields to `NoteCreateInput` and use them in `createNote()` when provided
- **RepoFileSyncService.ts**: Fetch commit dates via `GitHubService.getPathCommitDates()` and pass to `createNote()`
- **RepoPullService.ts**: Fetch commit dates for new and updated notes, preserving historical timestamps
- **Note.test.ts**: Unit tests for `createNote()` with provided `createdAt`/`updatedAt`

## Testing

- `yarn ts:check` — TypeScript compilation: **PASS**
- `yarn jest __tests__/models/Note.test.ts --no-coverage` — Focused Note model tests: **PASS**
- `yarn eslint src --ext .ts,.tsx` — Linting: **PASS**

### Known unrelated failures (pre-existing)

`yarn jest` with dynamic imports reports failures in unrelated test suites due to Jest environment issues. These are not introduced by this change and are tracked separately.