### PR TITLE
fix(pro): stable identity-first entitlement resolution across cold restarts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,7 +20,7 @@ import { ThemeProvider } from './src/contexts/ThemeContext';
 import { NativeWindThemeProvider } from './src/theme/nativewind';
 import { FolderProvider } from './src/contexts/FolderContext';
 import { ViewModeProvider } from './src/contexts/ViewModeContext';
-import { AccountsProvider, rebindRevenueCatToActiveAccount } from './src/contexts/AccountsContext';
+import { AccountsProvider } from './src/contexts/AccountsContext';
 import { HostAuthProvider } from './src/contexts/HostAuthContext';
 import { TodoProvider } from './src/contexts/TodoContext';
 import { CanvasProvider } from './src/contexts/CanvasContext';
@@ -47,9 +47,8 @@ import { useForegroundSyncAlert } from './src/hooks/useForegroundSyncAlert';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { reconcileThoughtDumps } from './src/services/ai/thoughtDumpIndexing';
 import { LastSelectionPreferenceService } from './src/services/LastSelectionPreferenceService';
-import { useProStore } from './src/stores/proStore';
-import { enforceTierLimits } from './src/services/TierLimits';
 import * as PushNotificationService from './src/services/PushNotificationService';
+import { bootstrapEntitlement } from './src/bootstrap/bootstrapEntitlement';
 import { hideDevMenuFloatingActionButton } from './src/utils/devMenuFab';
 
 const queryClient = new QueryClient({
@@ -83,9 +82,7 @@ export default function App() {
     // repo/account caps can be enforced on data brought back by Android backup
     // restore (#1233) — before the stores render it, not after.
     try {
-      await useProStore.getState().initialize();
-      await enforceTierLimits();
-      await rebindRevenueCatToActiveAccount();
+      await bootstrapEntitlement();
     } catch (error) {
       console.warn('[App] tier-limit enforcement failed:', error);
     }

--- a/__tests__/integration/entitlementRestart.account.test.ts
+++ b/__tests__/integration/entitlementRestart.account.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  useProStore,
+  PRO_ENTITLEMENT_ID,
+  resetAll,
+  getPurchasesMock,
+  mockAuthGetActiveSummary,
+} from './entitlementTestHelpers';
+
+describe('entitlement restart: account switching cannot leak entitlements', () => {
+  beforeEach(() => { resetAll(); });
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  describe('switching from Pro account to Free account transitions to free', () => {
+    it('bindAccount with Free entitlement updates state to free', async () => {
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+
+      mockAuthGetActiveSummary.mockResolvedValueOnce({
+        account: { id: 'acc1', name: 'Account 1', login: 'user1' },
+        activeHostId: 'host1',
+        hosts: [{ id: 'host1', provider: 'github', hostLogin: 'user1', hostUserId: '12345' }],
+      });
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({
+        entitlements: { active: { [PRO_ENTITLEMENT_ID]: { isActive: true, periodType: 'paid' } } },
+      });
+      (Purchases.logIn as jest.Mock).mockResolvedValueOnce({
+        customerInfo: { entitlements: { active: { [PRO_ENTITLEMENT_ID]: { isActive: true } } } },
+        created: false,
+      });
+
+      await useProStore.getState().initialize();
+      expect(useProStore.getState().status).toBe('pro');
+
+      (Purchases.getCustomerInfo as jest.Mock).mockReset();
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({ entitlements: { active: {} } });
+      (Purchases.logIn as jest.Mock).mockReset();
+      (Purchases.logIn as jest.Mock).mockResolvedValueOnce({
+        customerInfo: { entitlements: { active: {} } },
+        created: false,
+      });
+
+      await useProStore.getState().bindAccount('gitnotes:github:99999');
+
+      expect(useProStore.getState().status).toBe('free');
+      expect(useProStore.getState().entitlementActive).toBe(false);
+    });
+
+    it('unbindAccount resets entitlement to free', async () => {
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+
+      mockAuthGetActiveSummary.mockResolvedValueOnce({
+        account: { id: 'acc1', name: 'Account 1', login: 'user1' },
+        activeHostId: 'host1',
+        hosts: [{ id: 'host1', provider: 'github', hostLogin: 'user1', hostUserId: '12345' }],
+      });
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({
+        entitlements: { active: { [PRO_ENTITLEMENT_ID]: { isActive: true, periodType: 'paid' } } },
+      });
+      (Purchases.logIn as jest.Mock).mockResolvedValueOnce({
+        customerInfo: { entitlements: { active: { [PRO_ENTITLEMENT_ID]: { isActive: true } } } },
+        created: false,
+      });
+
+      await useProStore.getState().initialize();
+      expect(useProStore.getState().status).toBe('pro');
+
+      (Purchases.logOut as jest.Mock).mockResolvedValueOnce({ entitlements: { active: {} } });
+      await useProStore.getState().unbindAccount();
+
+      expect(useProStore.getState().status).toBe('free');
+      expect(useProStore.getState().entitlementActive).toBe(false);
+    });
+  });
+});

--- a/__tests__/integration/entitlementRestart.bootstrap.test.ts
+++ b/__tests__/integration/entitlementRestart.bootstrap.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  bootstrapEntitlement,
+  useProStore,
+  PRO_ENTITLEMENT_ID,
+  resetAll,
+  getPurchasesMock,
+  storeStateAtEnforceCall,
+  mockEnforceTierLimits,
+  mockSaveRepositories,
+  mockAuthGetActiveSummary,
+  getRebindCalls,
+} from './entitlementTestHelpers';
+
+describe('entitlement restart: bootstrap order + startup restore boundary', () => {
+  beforeEach(() => { resetAll(); });
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  describe('cold restart: Pro remains Pro, Free remains gated', () => {
+    it('entitlementActive=true persists through bootstrapEntitlement without truncation', async () => {
+      mockAuthGetActiveSummary.mockResolvedValueOnce({
+        account: { id: 'acc1', name: 'Account 1', login: 'user1' },
+        activeHostId: 'host1',
+        hosts: [{ id: 'host1', provider: 'github', hostLogin: 'user1', hostUserId: '12345' }],
+      });
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({
+        entitlements: { active: { [PRO_ENTITLEMENT_ID]: { isActive: true, periodType: 'paid' } } },
+      });
+
+      await bootstrapEntitlement();
+
+      expect(storeStateAtEnforceCall[0]?.entitlementActive).toBe(true);
+      expect(mockSaveRepositories).not.toHaveBeenCalled();
+      expect(useProStore.getState().status).toBe('pro');
+    });
+
+    it('entitlementActive=false results in free status after cold restart', async () => {
+      mockAuthGetActiveSummary.mockResolvedValueOnce(null);
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({
+        entitlements: { active: {} },
+      });
+
+      await bootstrapEntitlement();
+
+      expect(storeStateAtEnforceCall[0]?.entitlementActive).toBe(false);
+      expect(useProStore.getState().status).toBe('free');
+    });
+
+    it('bootstrapEntitlement runs rebind before enforce', async () => {
+      mockAuthGetActiveSummary.mockResolvedValueOnce(null);
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({ entitlements: { active: {} } });
+
+      await bootstrapEntitlement();
+
+      expect(getRebindCalls().length).toBe(1);
+      expect(mockEnforceTierLimits).toHaveBeenCalled();
+    });
+  });
+
+  describe('restorePurchases is never called at startup', () => {
+    it('bootstrapEntitlement does NOT call restorePurchases', async () => {
+      mockAuthGetActiveSummary.mockResolvedValueOnce({
+        account: { id: 'acc1', name: 'Account 1', login: 'user1' },
+        activeHostId: 'host1',
+        hosts: [{ id: 'host1', provider: 'github', hostLogin: 'user1', hostUserId: '12345' }],
+      });
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({
+        entitlements: { active: { [PRO_ENTITLEMENT_ID]: { isActive: true, periodType: 'paid' } } },
+      });
+
+      await bootstrapEntitlement();
+
+      expect((Purchases.restorePurchases as jest.Mock)).not.toHaveBeenCalled();
+    });
+
+    it('proStore.initialize does NOT call restorePurchases', async () => {
+      mockAuthGetActiveSummary.mockResolvedValueOnce(null);
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({ entitlements: { active: {} } });
+
+      await useProStore.getState().initialize();
+
+      expect((Purchases.restorePurchases as jest.Mock)).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/integration/entitlementRestart.restore.test.ts
+++ b/__tests__/integration/entitlementRestart.restore.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  useProStore,
+  resetAll,
+  getPurchasesMock,
+  mockAuthGetActiveSummary,
+} from './entitlementTestHelpers';
+
+describe('entitlement restart: proStore.restore() is the only path to restorePurchases', () => {
+  beforeEach(() => { resetAll(); });
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  describe('restore() behavior', () => {
+    it('restore() sets isRestoring=true and calls restorePurchases', async () => {
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.restorePurchases as jest.Mock).mockResolvedValueOnce({ entitlements: { active: {} } });
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({ entitlements: { active: {} } });
+
+      mockAuthGetActiveSummary.mockResolvedValueOnce(null);
+      await useProStore.getState().initialize();
+
+      (Purchases.restorePurchases as jest.Mock).mockClear();
+      (Purchases.getCustomerInfo as jest.Mock).mockClear();
+
+      const restorePromise = useProStore.getState().restore();
+
+      expect(useProStore.getState().isRestoring).toBe(true);
+      const outcome = await restorePromise;
+
+      expect((Purchases.restorePurchases as jest.Mock)).toHaveBeenCalledTimes(1);
+      expect(outcome).toBe('nothing');
+      expect(useProStore.getState().isRestoring).toBe(false);
+    });
+
+    it('restore() returns error when restorePurchases throws', async () => {
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.restorePurchases as jest.Mock).mockRejectedValueOnce(new Error('Restore failed'));
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({ entitlements: { active: {} } });
+
+      mockAuthGetActiveSummary.mockResolvedValueOnce(null);
+      await useProStore.getState().initialize();
+
+      (Purchases.restorePurchases as jest.Mock).mockClear();
+      const outcome = await useProStore.getState().restore();
+
+      expect(outcome).toBe('error');
+      expect(useProStore.getState().error).toMatch(/Restore failed/i);
+      expect(useProStore.getState().isRestoring).toBe(false);
+    });
+
+    it('restore() on unconfigured store calls restorePurchases and returns error', async () => {
+      const Purchases = getPurchasesMock();
+      (Purchases.restorePurchases as jest.Mock).mockRejectedValueOnce(
+        new Error('Purchases not configured'),
+      );
+
+      const outcome = await useProStore.getState().restore();
+
+      expect(outcome).toBe('error');
+      expect((Purchases.restorePurchases as jest.Mock)).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/__tests__/integration/entitlementRestart.transient.test.ts
+++ b/__tests__/integration/entitlementRestart.transient.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  bootstrapEntitlement,
+  useProStore,
+  PRO_ENTITLEMENT_ID,
+  __setDelayForTests,
+  resetAll,
+  getPurchasesMock,
+  mockAuthGetActiveSummary,
+} from './entitlementTestHelpers';
+
+describe('entitlement restart: transient failures with bounded retry', () => {
+  beforeEach(() => { resetAll(); });
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  describe('getCustomerInfo retries transient failures up to 3 times', () => {
+    it('succeeds after two transient failures and a third success', async () => {
+      mockAuthGetActiveSummary.mockResolvedValueOnce(null);
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock)
+        .mockRejectedValueOnce(new Error('network timeout'))
+        .mockRejectedValueOnce(new Error('network timeout'))
+        .mockResolvedValueOnce({
+          entitlements: { active: {} },
+          originalApplicationVersion: null,
+          originalPurchaseDate: null,
+        });
+
+      __setDelayForTests(() => Promise.resolve());
+      await bootstrapEntitlement();
+
+      expect((Purchases.getCustomerInfo as jest.Mock)).toHaveBeenCalledTimes(3);
+      expect(useProStore.getState().status).toBe('free');
+    });
+
+    it('throws after 3 failures with error stored in state', async () => {
+      mockAuthGetActiveSummary.mockResolvedValueOnce(null);
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockRejectedValue(new Error('network timeout'));
+
+      __setDelayForTests(() => Promise.resolve());
+      await bootstrapEntitlement();
+
+      expect((Purchases.getCustomerInfo as jest.Mock)).toHaveBeenCalledTimes(3);
+      expect(useProStore.getState().status).toBe('free');
+      expect(useProStore.getState().error).not.toBeNull();
+    });
+  });
+
+  describe('logInAppUser retries transient failures up to 3 times', () => {
+    it('succeeds after two transient failures and a third success', async () => {
+      mockAuthGetActiveSummary.mockResolvedValueOnce(null);
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({ entitlements: { active: {} } });
+      await bootstrapEntitlement();
+
+      (Purchases.logIn as jest.Mock).mockReset();
+      (Purchases.logIn as jest.Mock)
+        .mockRejectedValueOnce(new Error('network timeout'))
+        .mockRejectedValueOnce(new Error('network timeout'))
+        .mockResolvedValueOnce({
+          customerInfo: { entitlements: { active: { [PRO_ENTITLEMENT_ID]: { isActive: true } } } },
+          created: false,
+        });
+
+      __setDelayForTests(() => Promise.resolve());
+      await useProStore.getState().bindAccount('gitnotes:github:99999');
+
+      expect((Purchases.logIn as jest.Mock)).toHaveBeenCalledTimes(3);
+      expect(useProStore.getState().status).toBe('pro');
+    });
+
+    it('logs warning after 3 failures and does not update state', async () => {
+      mockAuthGetActiveSummary.mockResolvedValueOnce(null);
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValueOnce({ entitlements: { active: {} } });
+      await bootstrapEntitlement();
+
+      (Purchases.logIn as jest.Mock).mockReset();
+      (Purchases.logIn as jest.Mock).mockRejectedValue(new Error('network timeout'));
+
+      __setDelayForTests(() => Promise.resolve());
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => { /* noop */ });
+      await useProStore.getState().bindAccount('gitnotes:github:99999');
+
+      expect((Purchases.logIn as jest.Mock)).toHaveBeenCalledTimes(3);
+      expect(useProStore.getState().status).toBe('free');
+      const warnCall = consoleWarnSpy.mock.calls.find(
+        (call) => call[0] && String(call[0]).includes('logInAppUser failed after retries'),
+      );
+      expect(warnCall).toBeDefined();
+      consoleWarnSpy.mockRestore(); /* noop */
+    });
+  });
+});

--- a/__tests__/integration/entitlementTestHelpers.ts
+++ b/__tests__/integration/entitlementTestHelpers.ts
@@ -1,0 +1,157 @@
+/**
+ * Shared mock utilities for entitlement integration tests.
+ * All entitlement E2E tests import from this file to ensure consistent mock setup.
+ */
+import { jest as _jest } from '@jest/globals';
+
+export const TEST_API_KEY = 'test-revenecat-api-key-12345';
+
+export const mockAuthGetActiveSummary = jest.fn();
+jest.mock('@/services/AuthService', () => ({
+  AuthService: {
+    getActiveSummary: mockAuthGetActiveSummary,
+    listAccountSummaries: jest.fn().mockResolvedValue([]),
+  },
+  HostConnectionSummary: {},
+}));
+
+export const mockSaveRepositories = jest.fn();
+jest.mock('@/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn().mockResolvedValue([]),
+    saveRepositories: mockSaveRepositories,
+  },
+}));
+
+export const mockRemoveAccount = jest.fn();
+jest.mock('@/services/AccountStorage', () => ({
+  AccountStorage: {
+    listAccounts: jest.fn().mockResolvedValue([]),
+    removeAccount: mockRemoveAccount,
+  },
+}));
+
+let rebindCalls: unknown[][] = [];
+export const getRebindCalls = () => rebindCalls;
+jest.mock('@/contexts/AccountsContext', () => ({
+  rebindRevenueCatToActiveAccount: jest.fn(async (...args: unknown[]) => {
+    getRebindCalls().push(args);
+  }),
+  syncRevenueCatIdentity: jest.fn(async () => {
+    /* noop */
+  }),
+}));
+
+jest.unmock('@/stores/proStore');
+jest.unmock('@/services/TierLimits');
+jest.unmock('@/bootstrap/bootstrapEntitlement');
+
+export const { useProStore, PRO_ENTITLEMENT_ID } = jest.requireActual('@/stores/proStore');
+
+export const {
+  __resetConfiguredFlagForTests,
+  __setDelayForTests,
+} = jest.requireActual('@/services/RevenueCatService') as {
+  __resetConfiguredFlagForTests: () => void;
+  __setDelayForTests: (fn: ((ms: number) => Promise<void>) | null) => void;
+};
+
+export const realTierLimits = jest.requireActual('@/services/TierLimits') as {
+  enforceTierLimits: () => Promise<void>;
+  FREE_TIER_MAX_REPOS: number;
+  FREE_TIER_MAX_ACCOUNTS: number;
+};
+
+export const storeStateAtEnforceCall: Array<{ status: string; entitlementActive: boolean }> = [];
+export const mockEnforceTierLimits = jest.fn(async () => {
+  const { useProStore: realUseProStore } = jest.requireActual('@/stores/proStore') as {
+    useProStore: typeof useProStore;
+  };
+  const state = realUseProStore.getState();
+  storeStateAtEnforceCall.push({
+    status: state.status,
+    entitlementActive: state.entitlementActive,
+  });
+  await realTierLimits.enforceTierLimits();
+});
+
+jest.mock('@/services/TierLimits', () => ({
+  enforceTierLimits: mockEnforceTierLimits,
+  FREE_TIER_MAX_REPOS: 1,
+  FREE_TIER_MAX_ACCOUNTS: 1,
+}));
+
+export const { bootstrapEntitlement } = jest.requireActual('@/bootstrap/bootstrapEntitlement');
+
+jest.mock('react-native-purchases', () => {
+  const Purchases = {
+    setLogLevel: jest.fn(),
+    configure: jest.fn(async () => undefined),
+    getOfferings: jest.fn(async () => ({ current: null })),
+    purchasePackage: jest.fn(async () => ({
+      customerInfo: { entitlements: { active: { 'GitNotēs Pro': { isActive: true, periodType: 'NORMAL' } } } },
+    })),
+    restorePurchases: jest.fn(async () => ({ entitlements: { active: {} } })),
+    getCustomerInfo: jest.fn(async () => ({
+      entitlements: { active: {} },
+      originalApplicationVersion: null,
+      originalPurchaseDate: null,
+    })),
+    logIn: jest.fn(async () => ({
+      customerInfo: { entitlements: { active: { 'GitNotēs Pro': { isActive: true } } } },
+      created: false,
+    })),
+    logOut: jest.fn(async () => ({ entitlements: { active: {} } })),
+    addCustomerInfoUpdateListener: jest.fn(() => (() => undefined)),
+    removeCustomerInfoUpdateListener: jest.fn(),
+    checkTrialOrIntroductoryPriceEligibility: jest.fn(async () => ({})),
+    trackCustomPaywallImpression: jest.fn(async () => undefined),
+    LOG_LEVEL: { WARN: 'WARN', DEBUG: 'DEBUG', VERBOSE: 'VERBOSE' },
+    INTRO_ELIGIBILITY_STATUS: {
+      INTRO_ELIGIBILITY_STATUS_UNKNOWN: 0,
+      INTRO_ELIGIBILITY_STATUS_INELIGIBLE: 1,
+      INTRO_ELIGIBILITY_STATUS_ELIGIBLE: 2,
+      INTRO_ELIGIBILITY_STATUS_NO_INTRO_OFFER_EXISTS: 3,
+    },
+    PURCHASES_ERROR_CODE: { PURCHASE_CANCELLED_ERROR: '1' },
+  };
+  return {
+    __esModule: true,
+    default: Purchases,
+    STOREKIT_VERSION: { STOREKIT_1: 'STOREKIT_1', STOREKIT_2: 'STOREKIT_2' },
+    __resetPurchasesMocks: () => {
+      for (const fn of Object.values(Purchases)) {
+        if (typeof fn === 'function' && 'mockClear' in fn) (fn as jest.Mock).mockClear();
+      }
+    },
+  };
+});
+
+process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS = TEST_API_KEY;
+process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID = TEST_API_KEY;
+
+export function getPurchasesMock(): typeof import('react-native-purchases')['default'] {
+  const mock = _jest.requireMock('react-native-purchases');
+  return (mock as { default: typeof import('react-native-purchases')['default'] }).default;
+}
+
+export function resetAll(): void {
+  __resetConfiguredFlagForTests();
+  __setDelayForTests(null);
+  const Purchases = getPurchasesMock();
+  const mock = _jest.requireMock('react-native-purchases') as {
+    __resetPurchasesMocks?: () => void;
+  };
+  mock.__resetPurchasesMocks?.();
+  (Purchases.configure as _jest.Mock).mockResolvedValue(undefined);
+  (Purchases.getCustomerInfo as _jest.Mock).mockReset();
+  (Purchases.restorePurchases as _jest.Mock).mockReset();
+  (Purchases.logIn as _jest.Mock).mockReset();
+  (Purchases.addCustomerInfoUpdateListener as _jest.Mock).mockReset();
+  storeStateAtEnforceCall.length = 0;
+  rebindCalls = [];
+  mockEnforceTierLimits.mockClear();
+  mockSaveRepositories.mockClear();
+  mockRemoveAccount.mockClear();
+  mockAuthGetActiveSummary.mockReset();
+}

--- a/__tests__/screens/PaywallScreen.test.tsx
+++ b/__tests__/screens/PaywallScreen.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * PaywallScreen restore button tap test.
+ *
+ * Verifies:
+ * - render PaywallScreen with @testing-library/react-native
+ * - press testID="paywall.restore"
+ * - restore is called exactly once from that tap interaction
+ * - restore is NOT called on mount (before any tap)
+ */
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+const mockRestore = jest.fn();
+
+jest.mock('@/stores/proStore', () => {
+  const mockLoadOfferingsIfNeeded = jest.fn();
+  const MockedStore = (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      status: 'free',
+      entitlementActive: false,
+      trialActive: false,
+      trialEndsAt: null,
+      entitlementExpiresAt: null,
+      offeringsReady: true,
+      monthlyPackage: null,
+      yearlyPackage: null,
+      lifetimePackage: null,
+      currentOffering: null,
+      isPurchasing: false,
+      isRestoring: false,
+      error: null,
+      interstitialEligible: false,
+      configured: true,
+      loadOfferingsIfNeeded: mockLoadOfferingsIfNeeded,
+      restore: mockRestore,
+    });
+  Object.assign(MockedStore, {
+    getState: () => ({
+      status: 'free',
+      entitlementActive: false,
+      trialActive: false,
+      trialEndsAt: null,
+      entitlementExpiresAt: null,
+      offeringsReady: true,
+      monthlyPackage: null,
+      yearlyPackage: null,
+      lifetimePackage: null,
+      currentOffering: null,
+      isPurchasing: false,
+      isRestoring: false,
+      error: null,
+      interstitialEligible: false,
+      configured: true,
+      restore: mockRestore,
+      loadOfferingsIfNeeded: mockLoadOfferingsIfNeeded,
+    }),
+    setState: jest.fn(),
+    subscribe: () => (() => { /* noop */ }),
+    getInitialState: () => ({}),
+  });
+  return { useProStore: MockedStore };
+});
+
+jest.mock('@/services/RevenueCatService', () => ({
+  getIntroEligibilities: jest.fn().mockResolvedValue({}),
+  trackPaywallImpression: jest.fn(),
+}));
+
+jest.mock('@/services/PaywallAnalytics', () => ({
+  trackPaywallOpen: jest.fn(),
+  trackPaywallClose: jest.fn(),
+  trackCtaTap: jest.fn(),
+  trackRestoreTap: jest.fn(),
+  trackRestoreOutcome: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: jest.fn() }),
+}));
+
+jest.mock('@/contexts/ThemeContext', () => {
+  const mockColors = {
+    background: '#ffffff',
+    text: '#000000',
+    textSecondary: '#666666',
+    accent: '#0066ff',
+    error: '#ff0000',
+    surface: '#ffffff',
+    border: '#dddddd',
+    card: '#eeeeee',
+    success: '#00aa00',
+    warning: '#ffaa00',
+  };
+  return {
+    useTheme: () => ({ colors: mockColors, style: {}, isDark: false }),
+    useTokens: () => ({
+      colors: mockColors,
+      spacing: { xs: 4, sm: 8, md: 16, lg: 24, xl: 32 },
+      radii: { sm: 4, md: 8, lg: 16, full: 9999 },
+      type: 'light' as const,
+    }),
+  };
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: 'SafeAreaView',
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: jest.fn() },
+  }),
+  initReactI18next: { type: '3rdParty', init: jest.fn() },
+}));
+
+import PaywallScreen from '@/screens/PaywallScreen';
+
+describe('PaywallScreen restore button', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRestore.mockResolvedValue('nothing');
+  });
+
+  it('does NOT call restore on mount', async () => {
+    const { getByTestId } = render(<PaywallScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('paywall.restore')).toBeTruthy();
+    });
+
+    expect(mockRestore).not.toHaveBeenCalled();
+  });
+
+  it('calls restore exactly once when user taps paywall.restore', async () => {
+    const { getByTestId } = render(<PaywallScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('paywall.restore')).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('paywall.restore'));
+
+    await waitFor(() => {
+      expect(mockRestore).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/__tests__/services/RevenueCatService.test.ts
+++ b/__tests__/services/RevenueCatService.test.ts
@@ -1,0 +1,230 @@
+/**
+ * RevenueCatService tests.
+ *
+ * These tests verify:
+ * - configureRevenueCat accepts an optional appUserID and passes it to Purchases.configure
+ * - Anonymous configuration (no appUserID) still works
+ * - Placeholder keys result in configured=false
+ * - Configure can only happen once (idempotent)
+ * - logInAppUser / logOutAppUser work correctly
+ */
+import Purchases from 'react-native-purchases';
+import {
+  configureRevenueCat,
+  isConfigured,
+  getCustomerInfo,
+  logInAppUser,
+  logOutAppUser,
+  __resetConfiguredFlagForTests,
+  __setDelayForTests,
+} from '../../src/services/RevenueCatService';
+
+// Mock react-native-purchases for these specific tests
+jest.mock('react-native-purchases', () => {
+  const Purchases = {
+    setLogLevel: jest.fn(),
+    configure: jest.fn(async () => undefined),
+    getOfferings: jest.fn(async () => ({ current: null })),
+    purchasePackage: jest.fn(async () => ({
+      customerInfo: { entitlements: { active: { 'GitNotēs Pro': { isActive: true, periodType: 'NORMAL' } } } },
+    })),
+    restorePurchases: jest.fn(async () => ({ entitlements: { active: {} } })),
+    getCustomerInfo: jest.fn(async () => ({
+      entitlements: { active: {} },
+      originalApplicationVersion: null,
+      originalPurchaseDate: null,
+    })),
+    logIn: jest.fn(async () => ({
+      customerInfo: { entitlements: { active: { 'GitNotēs Pro': { isActive: true } } } },
+      created: false,
+    })),
+    logOut: jest.fn(async () => ({
+      entitlements: { active: {} },
+    })),
+    addCustomerInfoUpdateListener: jest.fn(() => () => {}),
+    removeCustomerInfoUpdateListener: jest.fn(),
+    checkTrialOrIntroductoryPriceEligibility: jest.fn(async () => ({})),
+    trackCustomPaywallImpression: jest.fn(async () => undefined),
+    LOG_LEVEL: { WARN: 'WARN', DEBUG: 'DEBUG', VERBOSE: 'VERBOSE' },
+    INTRO_ELIGIBILITY_STATUS: {
+      INTRO_ELIGIBILITY_STATUS_UNKNOWN: 0,
+      INTRO_ELIGIBILITY_STATUS_INELIGIBLE: 1,
+      INTRO_ELIGIBILITY_STATUS_ELIGIBLE: 2,
+      INTRO_ELIGIBILITY_STATUS_NO_INTRO_OFFER_EXISTS: 3,
+    },
+    PURCHASES_ERROR_CODE: { PURCHASE_CANCELLED_ERROR: '1' },
+  };
+  return {
+    __esModule: true,
+    default: Purchases,
+    STOREKIT_VERSION: { STOREKIT_1: 'STOREKIT_1', STOREKIT_2: 'STOREKIT_2' },
+    __resetPurchasesMocks: () => {
+      for (const fn of Object.values(Purchases)) {
+        if (typeof fn === 'function' && 'mockClear' in fn) (fn as jest.Mock).mockClear();
+      }
+    },
+  };
+});
+
+const MockPurchases = Purchases as jest.Mocked<typeof Purchases>;
+
+beforeAll(() => {
+  process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS = 'test-ios-api-key';
+  process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID = 'test-android-api-key';
+});
+
+describe('RevenueCatService', () => {
+  beforeEach(() => {
+    __resetConfiguredFlagForTests();
+    __setDelayForTests(null);
+    MockPurchases.configure.mockClear();
+    MockPurchases.logIn.mockClear();
+    MockPurchases.logOut.mockClear();
+    MockPurchases.getCustomerInfo.mockClear();
+  });
+
+  describe('configureRevenueCat', () => {
+    it('configures anonymously when no appUserID is provided', async () => {
+      const result = await configureRevenueCat();
+      expect(result.configured).toBe(true);
+      expect(result.appUserID).toBeNull();
+      const configureCall = MockPurchases.configure.mock.calls[0][0];
+      expect(configureCall.apiKey).toBeTruthy();
+      expect(configureCall).not.toHaveProperty('appUserID');
+    });
+
+    it('passes appUserID to Purchases.configure when provided', async () => {
+      const appUserID = 'gitnotes:github:12345';
+      const result = await configureRevenueCat(appUserID);
+      expect(result.configured).toBe(true);
+      expect(result.appUserID).toBe(appUserID);
+      expect(MockPurchases.configure).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: expect.any(String), appUserID }),
+      );
+    });
+
+    it('idempotent: second configure returns configured=true without calling Purchases.configure again', async () => {
+      await configureRevenueCat('gitnotes:github:12345');
+      await configureRevenueCat('gitnotes:github:99999');
+      // Only called once (the first time)
+      expect(MockPurchases.configure).toHaveBeenCalledTimes(1);
+      expect(MockPurchases.configure).toHaveBeenCalledWith(
+        expect.objectContaining({ appUserID: 'gitnotes:github:12345' }),
+      );
+    });
+
+    it('returns configured=false when API key is placeholder', async () => {
+      const originalKey = process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS;
+      process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS = '<PLACEHOLDER>';
+      try {
+        const result = await configureRevenueCat('gitnotes:github:12345');
+        expect(result.configured).toBe(false);
+        expect(result.appUserID).toBeNull();
+        expect(MockPurchases.configure).not.toHaveBeenCalled();
+      } finally {
+        if (originalKey !== undefined) {
+          process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS = originalKey;
+        }
+      }
+    });
+
+    it('returns configured=false when API key is empty', async () => {
+      const originalKey = process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS;
+      process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS = '';
+      try {
+        const result = await configureRevenueCat();
+        expect(result.configured).toBe(false);
+      } finally {
+        if (originalKey !== undefined) {
+          process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS = originalKey;
+        }
+      }
+    });
+
+    it('returns configured=false when API key is undefined', async () => {
+      const originalKey = process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS;
+      delete process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS;
+      try {
+        const result = await configureRevenueCat();
+        expect(result.configured).toBe(false);
+      } finally {
+        if (originalKey !== undefined) {
+          process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS = originalKey;
+        }
+      }
+    });
+  });
+
+  describe('isConfigured', () => {
+    it('returns false before first configure', () => {
+      expect(isConfigured()).toBe(false);
+    });
+
+    it('returns true after successful configure', async () => {
+      await configureRevenueCat();
+      expect(isConfigured()).toBe(true);
+    });
+  });
+
+  describe('logInAppUser', () => {
+    it('returns null when not configured', async () => {
+      const result = await logInAppUser('gitnotes:github:12345');
+      expect(result).toBeNull();
+    });
+
+    it('calls Purchases.logIn with the provided appUserID', async () => {
+      await configureRevenueCat();
+      const result = await logInAppUser('gitnotes:github:12345');
+      expect(MockPurchases.logIn).toHaveBeenCalledWith('gitnotes:github:12345');
+      expect(result).not.toBeNull();
+    });
+
+    it('returns null when logIn throws', async () => {
+      __setDelayForTests(() => Promise.resolve());
+      await configureRevenueCat();
+      MockPurchases.logIn.mockRejectedValue(new Error('Network error'));
+      const result = await logInAppUser('gitnotes:github:12345');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('logOutAppUser', () => {
+    it('is no-op when not configured', async () => {
+      await logOutAppUser();
+      expect(MockPurchases.logOut).not.toHaveBeenCalled();
+    });
+
+    it('calls Purchases.logOut when configured', async () => {
+      await configureRevenueCat();
+      await logOutAppUser();
+      expect(MockPurchases.logOut).toHaveBeenCalled();
+    });
+  });
+
+  describe('getCustomerInfo', () => {
+    it('calls Purchases.getCustomerInfo', async () => {
+      await configureRevenueCat();
+      await getCustomerInfo();
+      expect(MockPurchases.getCustomerInfo).toHaveBeenCalled();
+    });
+  });
+
+  describe('configure-before-customer-info contract', () => {
+    it('configure must precede getCustomerInfo in the call order', async () => {
+      __resetConfiguredFlagForTests();
+      MockPurchases.getCustomerInfo.mockClear();
+
+      // This test documents the expected behavior:
+      // 1. configure first (with appUserID if available)
+      // 2. then call getCustomerInfo
+      await configureRevenueCat('gitnotes:github:12345');
+      await getCustomerInfo();
+
+      // Verify configure was called with appUserID before getCustomerInfo was called
+      const configureCall = MockPurchases.configure.mock.calls[0][0];
+      const getCustomerInfoCall = MockPurchases.getCustomerInfo.mock.calls.length;
+      expect(configureCall.appUserID).toBe('gitnotes:github:12345');
+      expect(getCustomerInfoCall).toBeGreaterThan(0);
+    });
+  });
+});

--- a/__tests__/stores/proStore.test.ts
+++ b/__tests__/stores/proStore.test.ts
@@ -1,0 +1,260 @@
+/**
+ * proStore integration tests — real module, isolated RevenueCat mocks.
+ *
+ * These tests exercise proStore + RevenueCatService without the global forced-Pro
+ * mock (`mockProStoreState`).  Each test case controls the RevenueCat mock so
+ * the full entitlement-derivation logic can be verified:
+ *
+ * - active:   getCustomerInfo returns an active Pro entitlement
+ * - free:     getCustomerInfo returns empty entitlements
+ * - no-account: configureRevenueCat returns { configured: false } (placeholder key)
+ * - sdk-error: configureRevenueCat throws
+ *
+ * Setup/teardown guarantees:
+ * - RevenueCat module-level `configured` flag is reset via __resetConfiguredFlagForTests()
+ * - proStore module-level `_customerInfoCleanup` is called after each test
+ *
+ * @regression-target: global mock forces status=pro/entitlementActive=true and masks
+ *   regressions in initialize/refresh/deriveTrialInfo for startup identity states.
+ */
+
+const TEST_API_KEY = 'test-revenecat-api-key-12345';
+const PLACEHOLDER_KEY = '<PLACEHOLDER>';
+
+process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS = TEST_API_KEY;
+process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID = TEST_API_KEY;
+
+const realProStore = jest.requireActual('@/stores/proStore') as typeof import('@/stores/proStore');
+
+const {
+  useProStore,
+  selectIsPro,
+  PRO_ENTITLEMENT_ID,
+} = realProStore;
+
+import { __resetConfiguredFlagForTests, __setDelayForTests } from '@/services/RevenueCatService';
+
+function getPurchasesMock(): typeof import('react-native-purchases')['default'] {
+  const mock = jest.requireMock('react-native-purchases');
+  return (mock as { default: typeof import('react-native-purchases')['default'] }).default;
+}
+
+function resetRevenueCatState(): void {
+  __resetConfiguredFlagForTests();
+  __setDelayForTests(null);
+  const Purchases = getPurchasesMock();
+  const mock = jest.requireMock('react-native-purchases') as {
+    __resetPurchasesMocks?: () => void;
+  };
+  mock.__resetPurchasesMocks?.();
+  (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+  (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+    entitlements: { active: {} },
+    originalApplicationVersion: null,
+    originalPurchaseDate: null,
+  });
+}
+
+function resetProStoreState(): void {
+  useProStore.setState({
+    status: 'loading',
+    entitlementActive: false,
+    trialActive: false,
+    trialEndsAt: null,
+    entitlementExpiresAt: null,
+    offeringsReady: false,
+    monthlyPackage: null,
+    yearlyPackage: null,
+    lifetimePackage: null,
+    currentOffering: null,
+    isPurchasing: false,
+    isRestoring: false,
+    error: null,
+    interstitialEligible: false,
+    configured: false,
+  });
+  const clearCleanup = (realProStore as Record<string, unknown>)
+    .__clearCustomerInfoCleanupForTests as (() => void) | undefined;
+  clearCleanup?.();
+}
+
+describe('proStore — isolated entitlement states (real module)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetRevenueCatState();
+    resetProStoreState();
+  });
+
+  afterEach(() => {
+    resetRevenueCatState();
+    resetProStoreState();
+    jest.useRealTimers();
+  });
+
+  describe('when RevenueCat returns an active Pro entitlement', () => {
+    it('initializes with status=pro and entitlementActive=true', async () => {
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+        entitlements: {
+          active: { [PRO_ENTITLEMENT_ID]: { isActive: true, periodType: 'NORMAL' } },
+        },
+        originalApplicationVersion: null,
+        originalPurchaseDate: null,
+      });
+
+      await useProStore.getState().initialize();
+
+      const state = useProStore.getState();
+      expect(state.status).toBe('pro');
+      expect(state.entitlementActive).toBe(true);
+      expect(selectIsPro(state)).toBe(true);
+      expect(state.configured).toBe(true);
+      expect(state.error).toBeNull();
+    });
+
+    it('refresh reflects updated entitlementActive=true', async () => {
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+        entitlements: { active: {} },
+        originalApplicationVersion: null,
+        originalPurchaseDate: null,
+      });
+      await useProStore.getState().initialize();
+      expect(useProStore.getState().status).toBe('free');
+
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+        entitlements: {
+          active: { [PRO_ENTITLEMENT_ID]: { isActive: true, periodType: 'NORMAL' } },
+        },
+        originalApplicationVersion: null,
+        originalPurchaseDate: null,
+      });
+      await useProStore.getState().refresh();
+
+      const state = useProStore.getState();
+      expect(state.status).toBe('pro');
+      expect(state.entitlementActive).toBe(true);
+    });
+  });
+
+  describe('when RevenueCat returns empty entitlements (free user)', () => {
+    it('initializes with status=free and entitlementActive=false', async () => {
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+        entitlements: { active: {} },
+        originalApplicationVersion: null,
+        originalPurchaseDate: null,
+      });
+
+      await useProStore.getState().initialize();
+
+      const state = useProStore.getState();
+      expect(state.status).toBe('free');
+      expect(state.entitlementActive).toBe(false);
+      expect(selectIsPro(state)).toBe(false);
+      expect(state.configured).toBe(true);
+      expect(state.error).toBeNull();
+    });
+
+    it('refresh on a free user remains free', async () => {
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+        entitlements: { active: {} },
+        originalApplicationVersion: null,
+        originalPurchaseDate: null,
+      });
+      await useProStore.getState().initialize();
+      expect(useProStore.getState().status).toBe('free');
+
+      await useProStore.getState().refresh();
+
+      expect(useProStore.getState().status).toBe('free');
+      expect(useProStore.getState().entitlementActive).toBe(false);
+    });
+  });
+
+  describe('when RevenueCat API key is a placeholder (no-account)', () => {
+    it('initializes with configured=false and status=free', async () => {
+      process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS = PLACEHOLDER_KEY;
+      process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID = PLACEHOLDER_KEY;
+      __resetConfiguredFlagForTests();
+      const Purchases = getPurchasesMock();
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+        entitlements: { active: {} },
+        originalApplicationVersion: null,
+        originalPurchaseDate: null,
+      });
+
+      await useProStore.getState().initialize();
+
+      const state = useProStore.getState();
+      expect(state.configured).toBe(false);
+      expect(state.status).toBe('free');
+      expect(state.entitlementActive).toBe(false);
+
+      process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS = TEST_API_KEY;
+      process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID = TEST_API_KEY;
+    });
+  });
+
+  describe('when RevenueCat SDK throws during initialize', () => {
+    it('sets an error message and remains in a safe free state', async () => {
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockRejectedValue(new Error('SDK rejected'));
+
+      await useProStore.getState().initialize();
+
+      const state = useProStore.getState();
+      expect(state.error).not.toBeNull();
+      expect(state.status).toBe('free');
+      expect(state.entitlementActive).toBe(false);
+    });
+
+    it('refresh also propagates errors from RevenueCat', async () => {
+      __setDelayForTests(() => Promise.resolve());
+      const Purchases = getPurchasesMock();
+      (Purchases.configure as jest.Mock).mockResolvedValue(undefined);
+      (Purchases.getCustomerInfo as jest.Mock).mockRejectedValue(
+        new Error('Network error'),
+      );
+
+      await useProStore.getState().initialize();
+      await useProStore.getState().refresh();
+
+      const state = useProStore.getState();
+      expect(state.error).toMatch(/Network error|Failed to refresh/i);
+    });
+  });
+
+  describe('selectIsPro — entitlement-gated', () => {
+    it('returns true only when entitlementActive=true', () => {
+      useProStore.setState({ entitlementActive: false });
+      expect(selectIsPro(useProStore.getState())).toBe(false);
+
+      useProStore.setState({ entitlementActive: true });
+      expect(selectIsPro(useProStore.getState())).toBe(true);
+    });
+  });
+
+  describe('initial state', () => {
+    it('is loading/false before initialize', () => {
+      const state = useProStore.getState();
+      expect(state.status).toBe('loading');
+      expect(state.entitlementActive).toBe(false);
+      expect(state.configured).toBe(false);
+      expect(state.offeringsReady).toBe(false);
+    });
+  });
+
+  describe('restore() does not call initialize', () => {
+    it('restore on uninitialized store returns error without crashing', async () => {
+      const outcome = await useProStore.getState().restore();
+      expect(outcome).toMatch(/error|nothing/);
+      expect(useProStore.getState().configured).toBe(false);
+    });
+  });
+});

--- a/src/bootstrap/bootstrapEntitlement.ts
+++ b/src/bootstrap/bootstrapEntitlement.ts
@@ -1,0 +1,21 @@
+/**
+ * Bootstrap entitlement sequence.
+ *
+ * Exposes the cold-start entitlement bootstrap as an isolated function so it can be
+ * tested without running the full App component. The correct order is:
+ *   1. useProStore.initialize()  — resolve stable identity + entitlement
+ *   2. rebindRevenueCatToActiveAccount()  — confirm account binding (safety net)
+ *   3. enforceTierLimits()  — enforce free-tier caps AFTER identity confirmed
+ *
+ * App.tsx calls this function from checkOnboarding(). The sequence must not change
+ * without a corresponding test update.
+ */
+import { useProStore } from '../stores/proStore';
+import { enforceTierLimits } from '../services/TierLimits';
+import { rebindRevenueCatToActiveAccount } from '../contexts/AccountsContext';
+
+export async function bootstrapEntitlement(): Promise<void> {
+  await useProStore.getState().initialize();
+  await rebindRevenueCatToActiveAccount();
+  await enforceTierLimits();
+}

--- a/src/services/RevenueCatService.ts
+++ b/src/services/RevenueCatService.ts
@@ -9,6 +9,8 @@ import type {
 
 export interface ConfigureResult {
   configured: boolean;
+  /** The appUserID that was used during configure, or null if anonymous. */
+  appUserID: string | null;
 }
 
 export interface Packages {
@@ -28,34 +30,40 @@ function isPlaceholderKey(apiKey: string | undefined): boolean {
 }
 
 let configured = false;
+let configuredAppUserID: string | null = null;
 
-export async function configureRevenueCat(): Promise<ConfigureResult> {
+export async function configureRevenueCat(appUserID?: string | null): Promise<ConfigureResult> {
   if (configured) {
-    return { configured: true };
+    return { configured: true, appUserID: configuredAppUserID };
   }
   const apiKey =
     Platform.OS === 'ios'
       ? process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_IOS
       : process.env.EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID;
   if (isPlaceholderKey(apiKey)) {
-    return { configured: false };
+    return { configured: false, appUserID: null };
   }
   Purchases.setLogLevel(Purchases.LOG_LEVEL.WARN);
-  await Purchases.configure({
-    apiKey,
+  const finalAppUserID = appUserID ?? null;
+  const configureOptions: Parameters<typeof Purchases.configure>[0] = {
+    apiKey: apiKey!,
     ...(Platform.OS === 'ios' ? { storeKitVersion: STOREKIT_VERSION.STOREKIT_2 } : {}),
-  });
+    ...(finalAppUserID !== null ? { appUserID: finalAppUserID } : {}),
+  };
+  await Purchases.configure(configureOptions);
   configured = true;
-  return { configured: true };
+  configuredAppUserID = finalAppUserID;
+  return { configured: true, appUserID: finalAppUserID };
 }
 
 export function isConfigured(): boolean {
   return configured;
 }
 
-/** Test-only seam: clear the module-level configured flag (#1162). */
+/** Test-only seam: clear the module-level configured flag and appUserID (#1162). */
 export function __resetConfiguredFlagForTests(): void {
   configured = false;
+  configuredAppUserID = null;
 }
 
 const matchIdentifier =
@@ -111,9 +119,37 @@ export async function restorePurchases(): Promise<PurchaseResult> {
   });
 }
 
-export function getCustomerInfo(): Promise<CustomerInfo> {
-  return Purchases.getCustomerInfo();
+const CUSTOMER_INFO_MAX_RETRIES = 3;
+const CUSTOMER_INFO_BASE_DELAY_MS = 100;
+
+async function delay(ms: number): Promise<void> {
+  if (_delayForTests) return _delayForTests(ms);
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+let _delayForTests: ((ms: number) => Promise<void>) | null = null;
+export function __setDelayForTests(fn: ((ms: number) => Promise<void>) | null): void {
+  _delayForTests = fn;
+}
+
+export async function getCustomerInfo(): Promise<CustomerInfo> {
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt < CUSTOMER_INFO_MAX_RETRIES; attempt++) {
+    try {
+      return await Purchases.getCustomerInfo();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt < CUSTOMER_INFO_MAX_RETRIES - 1) {
+        const backoffMs = CUSTOMER_INFO_BASE_DELAY_MS * Math.pow(2, attempt);
+        await delay(backoffMs);
+      }
+    }
+  }
+  throw lastError ?? new Error('Failed to get customer info after retries');
+}
+
+const LOGIN_MAX_RETRIES = 3;
+const LOGIN_BASE_DELAY_MS = 100;
 
 /**
  * Bind the current (anonymous) RevenueCat identity to a stable app user ID so
@@ -122,12 +158,21 @@ export function getCustomerInfo(): Promise<CustomerInfo> {
  */
 export async function logInAppUser(appUserID: string): Promise<CustomerInfo | null> {
   if (!configured) return null;
-  try {
-    const result = await Purchases.logIn(appUserID);
-    return result.customerInfo;
-  } catch {
-    return null;
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt < LOGIN_MAX_RETRIES; attempt++) {
+    try {
+      const result = await Purchases.logIn(appUserID);
+      return result.customerInfo;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt < LOGIN_MAX_RETRIES - 1) {
+        const backoffMs = LOGIN_BASE_DELAY_MS * Math.pow(2, attempt);
+        await delay(backoffMs);
+      }
+    }
   }
+  console.warn('[RevenueCat] logInAppUser failed after retries:', lastError?.message);
+  return null;
 }
 
 /** Detach the current RevenueCat identity back to anonymous. */

--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -13,6 +13,8 @@ import {
   restorePurchases,
 } from '../services/RevenueCatService';
 import * as PaywallAnalytics from '../services/PaywallAnalytics';
+import { AuthService } from '../services/AuthService';
+import type { HostConnectionSummary } from '../services/AuthService';
 
 let _isDevice: boolean | null = null;
 let _customerInfoCleanup: (() => void) | null = null;
@@ -95,6 +97,11 @@ interface CustomerInfoLike {
   originalApplicationVersion?: string | null;
 }
 
+function rcAppUserIdFor(host: HostConnectionSummary | null): string | null {
+  if (!host) return null;
+  return `gitnotes:${host.provider}:${host.hostUserId}`;
+}
+
 function deriveTrialInfo(customerInfo: CustomerInfoLike | null): {
   entitlementActive: boolean;
   trialActive: boolean;
@@ -159,8 +166,20 @@ export const useProStore = create<ProState & ProActions>()((set, get) => ({
   initialize: async () => {
     let customerInfo: CustomerInfoLike | null = null;
     let rcError: string | null = null;
+
+    let appUserID: string | null = null;
     try {
-      const { configured } = await configureRevenueCat();
+      const activeSummary = await AuthService.getActiveSummary();
+      const activeHost = activeSummary?.hosts.find((h) => h.id === activeSummary.activeHostId)
+        ?? activeSummary?.hosts[0]
+        ?? null;
+      appUserID = rcAppUserIdFor(activeHost);
+    } catch {
+      // AuthService unavailable — configure anonymously
+    }
+
+    try {
+      const { configured } = await configureRevenueCat(appUserID);
       set({ configured });
       if (configured) {
         customerInfo = await getCustomerInfo();


### PR DESCRIPTION
## Summary

Stabilizes RevenueCat entitlement resolution so that the app identity (anonymous or signed-in) is resolved before entitlements are fetched, preventing race conditions on cold restarts.

## Changes

- **Bootstrap ordering**: ensure identity resolution completes before entitlement fetch
- **Retry behavior**: added retry logic with exponential backoff for transient entitlement fetch failures
- **Identity-first startup**: RevenueCat SDK is now initialized after app identity is confirmed stable

## Verification

- TypeScript compilation: ✅ passes
- Targeted entitlement tests: ✅ pass
- Full Jest suite: 39 pre-existing failures in 3 unrelated suites (sync, calendar, todos) — unrelated to this change

## Known Limitations

- **Manual simulator QA**: confirmed repeated cold relaunches without automatic restore; interactive taps and real RevenueCat credentials were unavailable during testing.

## Files

Single commit: `a163e06` — `fix(pro): stable identity-first entitlement resolution across cold restarts`

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>