### PR TITLE
fix(sync): preserve repo identity during clone recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **Fix:** Thread `repoId` through push, pull, lazy-reader, and direct clone-repair recovery paths, resolving it from saved repository metadata when needed.
 
-**PR:** TBD
+**PR:** #1545
 
 ### fix(notes): preserve repository modification dates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-11
 
+### fix(sync): preserve repository identity during clone recovery
+
+**What:** Corruption recovery re-clones could omit the repository ID, so the native Git engine could not recover the registered HTTPS or SSH credential and libgit2 reported authentication replay failures.
+
+**Fix:** Thread `repoId` through push, pull, lazy-reader, and direct clone-repair recovery paths, resolving it from saved repository metadata when needed.
+
+**PR:** TBD
+
 ### fix(notes): preserve repository modification dates
 
 **What:** Imported Notes and other supported repository files displayed the import date instead of their historical last-modified date, which also made date sorting inaccurate.

--- a/__tests__/services/git/recovery.test.ts
+++ b/__tests__/services/git/recovery.test.ts
@@ -1,0 +1,51 @@
+import { GitFsService } from '@/services/git/GitFsService';
+import { repairCloneAfterCorruption } from '@/services/git/recovery';
+
+jest.mock('expo-file-system/legacy', () => ({
+  documentDirectory: 'file:///documents/',
+}));
+
+jest.mock('@/services/git/gitFs', () => ({
+  makeGitFs: jest.fn(() => ({ promises: { readFile: jest.fn(), unlink: jest.fn() } })),
+}));
+
+jest.mock('@/services/git/GitFsService', () => ({
+  GitFsService: {
+    clone: jest.fn(),
+    removeRepo: jest.fn(),
+    getCommitOid: jest.fn(),
+    findMergeBase: jest.fn(),
+  },
+  repairHeadRef: jest.fn(),
+}));
+
+const clone = GitFsService.clone as jest.MockedFunction<typeof GitFsService.clone>;
+const removeRepo = GitFsService.removeRepo as jest.MockedFunction<typeof GitFsService.removeRepo>;
+const getCommitOid = GitFsService.getCommitOid as jest.MockedFunction<typeof GitFsService.getCommitOid>;
+const findMergeBase = GitFsService.findMergeBase as jest.MockedFunction<typeof GitFsService.findMergeBase>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clone.mockResolvedValue(undefined);
+  removeRepo.mockResolvedValue(undefined);
+  getCommitOid.mockResolvedValue(null);
+  findMergeBase.mockResolvedValue(null);
+});
+
+describe('clone recovery credential identity', () => {
+  it('passes repoId when repairing a corrupted clone', async () => {
+    await repairCloneAfterCorruption({
+      repoPath: 'owner/repo',
+      branch: 'main',
+      repoId: 'repo-id',
+      token: 'token',
+    });
+
+    expect(clone).toHaveBeenCalledWith({
+      repoPath: 'owner/repo',
+      branch: 'main',
+      repoId: 'repo-id',
+      token: 'token',
+    });
+  });
+});

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -57,7 +57,7 @@ async function hasUnpushedCommits(repoPath: string, branch: string): Promise<boo
   }
 }
 
-async function handleCorruptionErrors<T>(fn: () => Promise<T>, repoPath: string, branch: string, token?: string): Promise<T> {
+async function handleCorruptionErrors<T>(fn: () => Promise<T>, repoPath: string, branch: string, token?: string, repoId?: string): Promise<T> {
   try {
     return await fn();
   } catch (error) {
@@ -72,7 +72,7 @@ async function handleCorruptionErrors<T>(fn: () => Promise<T>, repoPath: string,
         );
       }
       await GitFsService.removeRepo({ repoPath });
-      await GitFsService.cloneExclusive({ repoPath, branch, token: token ?? undefined });
+      await GitFsService.cloneExclusive({ repoPath, branch, token: token ?? undefined, repoId });
       return fn();
     }
     throw error;
@@ -107,9 +107,9 @@ async function getRepoReader(
       if (result.reason === 'diverged') {
         const remoteRefName = `refs/remotes/origin/${branch}`;
         return {
-          listTree: () => handleCorruptionErrors(() => GitFsService.listTree({ repoPath, ref: remoteRefName }), repoPath, branch, token),
+          listTree: () => handleCorruptionErrors(() => GitFsService.listTree({ repoPath, ref: remoteRefName }), repoPath, branch, token, repoId),
           readFile: (path: string) =>
-            handleCorruptionErrors(() => GitFsService.readFile({ repoPath, ref: remoteRefName, filepath: path }), repoPath, branch, token),
+            handleCorruptionErrors(() => GitFsService.readFile({ repoPath, ref: remoteRefName, filepath: path }), repoPath, branch, token, repoId),
         };
       }
       const errorMsg = result.error ?? '';

--- a/src/services/git/LocalGitWriter.ts
+++ b/src/services/git/LocalGitWriter.ts
@@ -1,6 +1,7 @@
 /** Thin facade over commitOps.ts + recovery.ts. Public API unchanged. */
 import * as FileSystem from 'expo-file-system/legacy';
 import { parseRepoPath } from '../../utils/gitPathParser';
+import { StorageService } from '../StorageService';
 import { formatSyncError } from './formatSyncError';
 import { GitFsService } from './GitFsService';
 import { commitWrite, commitDelete, ensureOnBranch } from './commitOps';
@@ -12,8 +13,14 @@ export function summarizePushError(raw: string | undefined): string { return for
 export interface LocalGitWriterResult { success: boolean; filePath?: string; error?: string; }
 interface AuthorInfo { name: string; email: string; }
 interface BaseOpts { repoPath: string; branch: string; message: string; author: AuthorInfo; }
-interface WriteOpts extends BaseOpts { filePath: string; content: string; push?: boolean; token?: string; onProgress?: (p: { phase: string; loaded: number; total: number }) => void; }
-interface DeleteOpts extends BaseOpts { filePath: string; push?: boolean; token?: string; onProgress?: (p: { phase: string; loaded: number; total: number }) => void; }
+interface WriteOpts extends BaseOpts { filePath: string; content: string; push?: boolean; token?: string; repoId?: string; onProgress?: (p: { phase: string; loaded: number; total: number }) => void; }
+interface DeleteOpts extends BaseOpts { filePath: string; push?: boolean; token?: string; repoId?: string; onProgress?: (p: { phase: string; loaded: number; total: number }) => void; }
+
+async function resolveRepoId(repoPath: string, repoId?: string): Promise<string | undefined> {
+  if (repoId) return repoId;
+  const repositories = await StorageService.getSavedRepositories();
+  return repositories.find(repository => repository.path === repoPath)?.id;
+}
 
 function clonesRoot(): string {
   const docDir = FileSystem.documentDirectory;
@@ -38,7 +45,8 @@ export class LocalGitWriter {
       const cr = await commitWrite({ repo: opts.repoPath, branch: opts.branch, filePath: opts.filePath, content: opts.content, message: opts.message, author: opts.author });
       if (!cr.success) return { success: false, error: cr.error };
       if (opts.push !== false) {
-        const pr = await pushWithRecovery({ repoPath: opts.repoPath, branch: opts.branch, token: opts.token, onProgress: opts.onProgress });
+        const repoId = await resolveRepoId(opts.repoPath, opts.repoId);
+        const pr = await pushWithRecovery({ repoPath: opts.repoPath, branch: opts.branch, token: opts.token, repoId, onProgress: opts.onProgress });
         if (!pr.success) return { success: false, error: pr.error };
       }
       return { success: true, filePath: opts.filePath };
@@ -52,7 +60,8 @@ export class LocalGitWriter {
       const cr = await commitDelete({ repo: opts.repoPath, branch: opts.branch, filePath: opts.filePath, message: opts.message, author: opts.author });
       if (!cr.success) return { success: false, error: cr.error };
       if (opts.push !== false) {
-        const pr = await pushWithRecovery({ repoPath: opts.repoPath, branch: opts.branch, token: opts.token, onProgress: opts.onProgress });
+        const repoId = await resolveRepoId(opts.repoPath, opts.repoId);
+        const pr = await pushWithRecovery({ repoPath: opts.repoPath, branch: opts.branch, token: opts.token, repoId, onProgress: opts.onProgress });
         if (!pr.success) return { success: false, error: pr.error };
       }
       return { success: true, filePath: opts.filePath };
@@ -74,11 +83,12 @@ export class LocalGitWriter {
     } catch (e) { return { success: false, error: e instanceof Error ? e.message : String(e) }; }
   }
 
-  static async push(opts: { repoPath: string; branch: string; token?: string; onProgress?: (p: { phase: string; loaded: number; total: number }) => void }): Promise<LocalGitWriterResult> {
+  static async push(opts: { repoPath: string; branch: string; token?: string; repoId?: string; onProgress?: (p: { phase: string; loaded: number; total: number }) => void }): Promise<LocalGitWriterResult> {
     const info = parseRepoPath(opts.repoPath);
     if (!info) return { success: false, error: `Invalid repo path: ${opts.repoPath}` };
     try {
-      const r = await pushWithRecovery({ repoPath: opts.repoPath, branch: opts.branch, token: opts.token, onProgress: opts.onProgress });
+      const repoId = await resolveRepoId(opts.repoPath, opts.repoId);
+      const r = await pushWithRecovery({ repoPath: opts.repoPath, branch: opts.branch, token: opts.token, repoId, onProgress: opts.onProgress });
       return { success: r.success, error: r.error };
     } catch (e) { return { success: false, error: classifyPushError(e instanceof Error ? e.message : String(e)) }; }
   }

--- a/src/services/git/recovery.ts
+++ b/src/services/git/recovery.ts
@@ -185,6 +185,7 @@ export interface PushWithRecoveryOptions {
   repoPath: string;
   branch: string;
   token?: string;
+  repoId?: string;
   onProgress?: (progress: { phase: string; loaded: number; total: number }) => void;
 }
 
@@ -201,7 +202,7 @@ export interface PushWithRecoveryResult {
 export async function pushWithRecovery(
   opts: PushWithRecoveryOptions,
 ): Promise<PushWithRecoveryResult> {
-  const { repoPath, branch, token } = opts;
+  const { repoPath, branch, token, repoId } = opts;
   const info = parseRepoPath(repoPath);
   if (!info) return { success: false, error: `Invalid repo path: ${repoPath}` };
 
@@ -223,7 +224,7 @@ export async function pushWithRecovery(
         return { success: false, error: `Clone corruption with unpushed commits in ${repoPath}@${branch}. Please push or reset.` };
       }
       await GitFsService.removeRepo({ repoPath });
-      await GitFsService.clone({ repoPath, branch, token });
+      await GitFsService.clone({ repoPath, branch, token, repoId });
       try {
         const result = await GitEngine.pushWithIntegrate(repoDirFs(repoPath), 'origin', undefined);
         if (!result.ok) {
@@ -251,7 +252,7 @@ export async function pushWithRecovery(
             return { success: false, error: `Clone corruption with unpushed commits in ${repoPath}@${branch}. Please push or reset.` };
           }
           await GitFsService.removeRepo({ repoPath });
-          await GitFsService.clone({ repoPath, branch, token });
+          await GitFsService.clone({ repoPath, branch, token, repoId });
           try {
             const result = await GitEngine.pushWithIntegrate(repoDirFs(repoPath), 'origin', undefined);
             if (!result.ok) {
@@ -343,9 +344,10 @@ export async function repairCloneAfterCorruption(opts: {
   repoPath: string;
   branch: string;
   token?: string;
+  repoId?: string;
   filePathForRecoveryCheck?: string;
 }): Promise<void> {
-  const { repoPath, branch, token, filePathForRecoveryCheck } = opts;
+  const { repoPath, branch, token, repoId, filePathForRecoveryCheck } = opts;
 
   const fsPath = repoDirFs(repoPath);
 
@@ -378,5 +380,5 @@ export async function repairCloneAfterCorruption(opts: {
   }
 
   await GitFsService.removeRepo({ repoPath });
-  await GitFsService.clone({ repoPath, branch, token: token ?? undefined });
+  await GitFsService.clone({ repoPath, branch, token: token ?? undefined, repoId });
 }


### PR DESCRIPTION
## Summary
- preserve `repoId` through corruption recovery clone paths
- resolve missing repository IDs from saved repository metadata before write-through push recovery
- add a regression test for direct clone repair credential identity

## Verification
- `yarn jest __tests__/services/git/recovery.test.ts --no-coverage --forceExit` passes
- `yarn ts:check` passes
- changed-file ESLint: 0 errors, 4 pre-existing warnings
- full Jest remains blocked by 12 unrelated baseline failures in branch queue, checkout UI, and native-module mock suites

## Review notes
- no Swift/native error-wrapper changes
- no speculative retry behavior added
- main worktree changes were not included