### PR TITLE
fix: use provider-aware URL for Git clone instead of hardcoded GitHub

### DIFF
--- a/src/services/RepoImportService.ts
+++ b/src/services/RepoImportService.ts
@@ -120,7 +120,14 @@ async function runImport(
         }
       }
       await GitFsService.cloneExclusive({
-        repoPath, branch, token, onProgress, repoId: repo?.id, remoteUrlOverride,
+        repoPath,
+        branch,
+        token,
+        onProgress,
+        repoId: repo?.id,
+        remoteUrlOverride,
+        provider: hostConnection?.provider,
+        instanceBaseUrl: hostConnection?.instanceBaseUrl,
       });
     }
 

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -57,7 +57,7 @@ async function hasUnpushedCommits(repoPath: string, branch: string): Promise<boo
   }
 }
 
-async function handleCorruptionErrors<T>(fn: () => Promise<T>, repoPath: string, branch: string, token?: string, repoId?: string): Promise<T> {
+async function handleCorruptionErrors<T>(fn: () => Promise<T>, repoPath: string, branch: string, token?: string, repoId?: string, provider?: GitHostProvider): Promise<T> {
   try {
     return await fn();
   } catch (error) {
@@ -72,7 +72,9 @@ async function handleCorruptionErrors<T>(fn: () => Promise<T>, repoPath: string,
         );
       }
       await GitFsService.removeRepo({ repoPath });
-      await GitFsService.cloneExclusive({ repoPath, branch, token: token ?? undefined, repoId });
+      const savedRepos = await StorageService.getSavedRepositories();
+      const savedRepo = savedRepos.find((r) => r.path === repoPath);
+      await GitFsService.cloneExclusive({ repoPath, branch, token: token ?? undefined, repoId, provider: provider ?? savedRepo?.provider });
       return fn();
     }
     throw error;
@@ -93,23 +95,25 @@ async function getRepoReader(
   owner: string,
   repo: string,
   branch: string,
-  _provider?: GitHostProvider,
+  provider?: GitHostProvider,
 ): Promise<RepoReader> {
   const token = (await AuthService.getToken()) ?? undefined;
   const savedRepos = await StorageService.getSavedRepositories();
-  const repoId = savedRepos.find((r) => r.path === repoPath)?.id;
+  const savedRepo = savedRepos.find((r) => r.path === repoPath);
+  const repoId = savedRepo?.id;
+  const resolvedProvider = provider ?? savedRepo?.provider;
   const cloned = await GitFsService.isCloned({ repoPath });
   if (!cloned) {
-    await GitFsService.cloneExclusive({ repoPath, branch, token, repoId });
+    await GitFsService.cloneExclusive({ repoPath, branch, token, repoId, provider: resolvedProvider });
   } else {
     const result = await GitFsService.pullWithFastForward({ repoPath, branch, token, repoId });
     if (!result.ok) {
       if (result.reason === 'diverged') {
         const remoteRefName = `refs/remotes/origin/${branch}`;
         return {
-          listTree: () => handleCorruptionErrors(() => GitFsService.listTree({ repoPath, ref: remoteRefName }), repoPath, branch, token, repoId),
+          listTree: () => handleCorruptionErrors(() => GitFsService.listTree({ repoPath, ref: remoteRefName }), repoPath, branch, token, repoId, resolvedProvider),
           readFile: (path: string) =>
-            handleCorruptionErrors(() => GitFsService.readFile({ repoPath, ref: remoteRefName, filepath: path }), repoPath, branch, token, repoId),
+            handleCorruptionErrors(() => GitFsService.readFile({ repoPath, ref: remoteRefName, filepath: path }), repoPath, branch, token, repoId, resolvedProvider),
         };
       }
       const errorMsg = result.error ?? '';
@@ -123,7 +127,7 @@ async function getRepoReader(
           );
         }
         await GitFsService.removeRepo({ repoPath });
-        await GitFsService.cloneExclusive({ repoPath, branch, token, repoId });
+        await GitFsService.cloneExclusive({ repoPath, branch, token, repoId, provider: resolvedProvider });
         return {
           listTree: () => GitFsService.listTree({ repoPath, ref: branch }),
           readFile: (path: string) =>

--- a/src/services/git/GitFsService.ts
+++ b/src/services/git/GitFsService.ts
@@ -31,10 +31,10 @@ interface CloneOpts extends RepoLocator {
   token?: string;
   depth?: number;
   onProgress?: (phase: string, loaded: number, total: number | null) => void;
-  /** Passed to native engine for credential lookup. Omit to skip credential auth (public repos). */
   repoId?: string;
-  /** Override the remote URL (e.g., SSH URL when SSH is enabled). Defaults to HTTPS. */
   remoteUrlOverride?: string;
+  provider?: string;
+  instanceBaseUrl?: string | null;
 }
 
 interface FetchOpts extends RepoLocator {
@@ -294,10 +294,6 @@ export function remoteUrlForHost(
   return `https://github.com/${owner}/${repo}.git`;
 }
 
-function authedRemote(owner: string, repo: string): string {
-  return `https://github.com/${owner}/${repo}.git`;
-}
-
 /**
  * Remove corrupted packfiles from a repo's .git/objects/pack directory.
  * When a fetch times out, partial packfile data may be left on disk, causing
@@ -374,7 +370,11 @@ export class GitFsService {
     for (let attempt = 0; attempt <= MAX_CLONE_RETRIES; attempt++) {
       try {
         await nativeClone(
-          opts.remoteUrlOverride ?? authedRemote(info.owner, info.repo),
+          opts.remoteUrlOverride ?? remoteUrlForHost(info.owner, info.repo, {
+            useSsh: false,
+            provider: opts.provider ?? 'github',
+            instanceBaseUrl: opts.instanceBaseUrl ?? null,
+          }),
           `${fsRoot}${info.owner}/${info.repo}`,
           opts.repoId ?? null,
         );

--- a/src/services/git/activeHost.ts
+++ b/src/services/git/activeHost.ts
@@ -21,6 +21,8 @@ export interface ActiveGitHost {
   host: GitHostFullService;
   /** Host connection id this active host was resolved from. */
   hostId: string;
+  /** Self-hosted instance base URL. `null` for SaaS defaults (github.com / gitlab.com / gitea.com / codeberg.org). */
+  instanceBaseUrl: string | null;
 }
 
 /** Scratch cache so two callers in the same tick don't re-instantiate services. */
@@ -69,6 +71,7 @@ export async function getActiveGitHost(): Promise<ActiveGitHost | null> {
     token,
     host,
     hostId: hostSummary.id,
+    instanceBaseUrl: hostSummary.instanceBaseUrl,
   };
   cache = { key, value };
   return value;

--- a/src/stores/repoStore.ts
+++ b/src/stores/repoStore.ts
@@ -104,6 +104,8 @@ export const useRepoStore = create<RepoState & RepoActions>()((set, get) => ({
         branch: repo.branch ?? 'main',
         token: activeHost.token,
         repoId: repo?.id,
+        provider: repo.provider,
+        instanceBaseUrl: activeHost.instanceBaseUrl,
       });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Fixes the "too many redirects or authentication replays" error when cloning a GitLab (or other non-GitHub) repository via HTTPS.

### Root Cause

`GitFsService.clone()` used `authedRemote()` as fallback for HTTPS clones, which was **hardcoded to GitHub URLs**. When cloning a GitLab repo via HTTPS (without SSH), it would try to clone from `https://github.com/owner/repo.git` instead of `https://gitlab.com/owner/repo.git`, causing the libgit2 error.

### Changes

| File | Change |
|------|--------|
| `src/services/git/GitFsService.ts` | Replaced `authedRemote()` with `remoteUrlForHost()` using provider-aware URL construction. Added `provider` and `instanceBaseUrl` to `CloneOpts`. Removed dead `authedRemote()` function. |
| `src/services/RepoImportService.ts` | Pass `provider` and `instanceBaseUrl` from `hostConnection` to `cloneExclusive` |
| `src/services/RepoPullService.ts` | Pass `provider` from `savedRepo` to `cloneExclusive` and `handleCorruptionErrors` |
| `src/stores/repoStore.ts` | Pass `provider` and `instanceBaseUrl` to `cloneExclusive` |
| `src/services/git/activeHost.ts` | Added `instanceBaseUrl` field to `ActiveGitHost` interface |

### Testing

- TypeScript compiles clean
- ESLint passes (0 errors)
- GitFsService tests pass