### PR TITLE
fix(sync): show 'Syncing…' instead of 'Syncing with GitHub' for non-GitHub providers

### DIFF
--- a/src/components/GitHubActivityIndicator.tsx
+++ b/src/components/GitHubActivityIndicator.tsx
@@ -66,7 +66,7 @@ export function GitHubActivityIndicator() {
   const progress = useGitHubActivityStore((s) => s.progress);
   const [pendingCount, setPendingCount] = useState(0);
 
-  const safeLabel = (label ?? 'Syncing with GitHub').replace(/…+$/, '');
+  const safeLabel = (label ?? 'Syncing…').replace(/…+$/, '');
 
   const opacity = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(-12)).current;

--- a/src/stores/githubActivityStore.ts
+++ b/src/stores/githubActivityStore.ts
@@ -48,7 +48,7 @@ export const useGitHubActivityStore = create<GitHubActivityState & GitHubActivit
     const timer = get().hideTimer;
     if (timer !== null) clearTimeout(timer);
     const newInflight = get().inflight + 1;
-    const newLabel = label ?? get().label ?? 'Syncing with GitHub';
+    const newLabel = label ?? get().label ?? 'Syncing…';
     if (!get().visible) {
       const existing = get().visibilityChangeTimer;
       if (existing !== null) clearTimeout(existing);


### PR DESCRIPTION
## Root Cause

The `GitHubActivityIndicator` and `githubActivityStore` had hardcoded `'Syncing with GitHub'` as fallback labels in two places:

1. `src/stores/githubActivityStore.ts` line 51 — fallback when `begin()` is called without a label
2. `src/components/GitHubActivityIndicator.tsx` line 69 — fallback when store label is null

When any code path called `githubActivity.begin()` without a provider-specific label (e.g., edge cases in the HTTP interceptor), the indicator would incorrectly show "Syncing with GitHub" regardless of the actual provider (GitLab, Gitea, Forgejo).

## Fix

Changed the hardcoded fallback from `'Syncing with GitHub'` to `'Syncing…'` in both locations.

## Testing

- TypeScript check: ✅
- `githubActivityStore` tests: ✅ passing