### PR TITLE
fix(pro): respect simulator override env flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,4 @@ GITHUB_TEST_TOKEN=<PLACEHOLDER>
 
 # Controls the iOS simulator Pro-bypass in dev mode (default: not set / true).
 # Set to 'false' to show paywalls even on iOS simulator in dev.
-# FORCE_ENABLE_PRO_ON_SIMULATOR=false
+# EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR=false

--- a/__tests__/stores/proStoreSimulatorOverride.test.ts
+++ b/__tests__/stores/proStoreSimulatorOverride.test.ts
@@ -1,0 +1,25 @@
+describe('DEV_FORCE_PRO simulator override', () => {
+  const originalOverride = process.env.EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR;
+
+  afterEach(() => {
+    if (originalOverride === undefined) {
+      delete process.env.EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR;
+    } else {
+      process.env.EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR = originalOverride;
+    }
+    jest.resetModules();
+    jest.unmock('expo-device');
+  });
+
+  it('disables the simulator Pro override when the public env var is false', () => {
+    process.env.EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR = 'false';
+    jest.doMock('expo-device', () => ({ isDevice: false }));
+
+    let devForcePro: boolean | undefined;
+    jest.isolateModules(() => {
+      devForcePro = jest.requireActual('@/stores/proStore').DEV_FORCE_PRO;
+    });
+
+    expect(devForcePro).toBe(false);
+  });
+});

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -230,7 +230,7 @@ GitNotēs Pro is powered by **RevenueCat** with **StoreKit 2** on iOS.
 - Entitlement ID: `GitNotēs Pro`
 - Packages: Monthly, Yearly, Lifetime (configurable in RevenueCat dashboard)
 - Feature gates: `useProGate()`, `useProScreenGuard()`
-- Simulator override: `FORCE_ENABLE_PRO_ON_SIMULATOR` env var
+- Simulator override: `EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR` env var
 
 See [Paywall & Pro Tier](./paywall.md) for full details.
 

--- a/docs/wiki/paywall.md
+++ b/docs/wiki/paywall.md
@@ -141,7 +141,7 @@ export const DEV_FORCE_PRO =
   __DEV__ &&
   Platform.OS === 'ios' &&
   isSimulator() &&
-  process.env.FORCE_ENABLE_PRO_ON_SIMULATOR !== 'false';
+  process.env.EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR !== 'false';
 ```
 
 The gate quad: `__DEV__ && iOS && simulator && env !== 'false'`

--- a/docs/wiki/setup.md
+++ b/docs/wiki/setup.md
@@ -38,7 +38,7 @@ cp .env.example .env
 Key variables:
 - `EXPO_PUBLIC_REVENUECAT_API_KEY_IOS` / `EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID` — RevenueCat SDK keys (required for Pro paywall)
 - `GITHUB_TEST_TOKEN` — PAT for E2E test suite (optional)
-- `FORCE_ENABLE_PRO_ON_SIMULATOR=false` — show paywalls even on iOS simulator in dev
+- `EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR=false` — show paywalls even on iOS simulator in dev
 
 ## Troubleshooting
 

--- a/docs/wiki/stores.md
+++ b/docs/wiki/stores.md
@@ -125,7 +125,7 @@
 - `markInterstitialShown`
 - `bindAccount`, `unbindAccount`
 
-**DEV_FORCE_PRO:** In `__DEV__` on iOS Simulator, Pro gate is forced open via `FORCE_ENABLE_PRO_ON_SIMULATOR` env var for QA testing without real IAP.
+**DEV_FORCE_PRO:** In `__DEV__` on iOS Simulator, Pro gate is forced open via `EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR` env var for QA testing without real IAP.
 
 ---
 

--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -30,17 +30,17 @@ function isSimulator(): boolean {
  * NOT a payment bypass — RevenueCat calls (initialize/refresh/purchase/restore) run unchanged.
  * Only the derived gate (`selectIsPro` + `status`) is forced to `true` / `'pro'` in this path.
  *
- * Gate quad: `__DEV__ && Platform.OS === 'ios' && !Device.isDevice && FORCE_ENABLE_PRO_ON_SIMULATOR !== 'false'`
+ * Gate quad: `__DEV__ && Platform.OS === 'ios' && !Device.isDevice && EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR !== 'false'`
  * - `__DEV__`: compiled out in production builds.
  * - `Platform.OS === 'ios'`: Android and web are unaffected.
  * - `!Device.isDevice`: only true in the iOS simulator (not on a real device).
- * - `FORCE_ENABLE_PRO_ON_SIMULATOR !== 'false'`: defaults true, set to 'false' to test paywalls on simulator.
+ * - `EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR !== 'false'`: defaults true, set to 'false' to test paywalls on simulator.
  */
 export const DEV_FORCE_PRO =
   __DEV__ &&
   Platform.OS === 'ios' &&
   isSimulator() &&
-  process.env.FORCE_ENABLE_PRO_ON_SIMULATOR !== 'false';
+  process.env.EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR !== 'false';
 
 const TRIAL_WAS_ACTIVE_KEY = '@gitnotes:trial_was_active';
 const TRIAL_EXPIRED_AT_KEY = '@gitnotes:trial_expired_at';


### PR DESCRIPTION
## Summary
- Fix the iOS simulator Pro override to read Expo's `EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR` variable.
- Add a regression test proving `'false'` keeps the simulator paywall enabled.
- Update `.env.example` and wiki references.

## Verification
- `yarn jest __tests__/stores/proStore.test.ts __tests__/stores/proStoreSimulatorOverride.test.ts --no-coverage --forceExit` (11 passed)
- `yarn ts:check` (passed)
- `yarn eslint src/stores/proStore.ts __tests__/stores/proStoreSimulatorOverride.test.ts` (passed)
- Full Jest: 243 passed, 12 pre-existing unrelated failures.

## Configuration
Use this in local `.env` files:

```env
EXPO_PUBLIC_FORCE_ENABLE_PRO_ON_SIMULATOR=false
```