### PR TITLE
fix(sync): preserve repository host during clone recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **Fix:** Resolve the repository's stored host connection first and preserve its provider and instance URL through add-time clones, lazy pulls, and recovery re-clones.
 
-**PR:** TBD
+**PR:** [#1555](https://github.com/gedwolmen/gitnotes/pull/1555)
 
 ### fix(auth): clarify provider token failures
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-11
 
+### fix(sync): preserve repository host during clone recovery
+
+**What:** Repository clones and corruption recovery could fall back to the active host or GitHub defaults, breaking GitLab and self-hosted repositories when their saved host context differed.
+
+**Fix:** Resolve the repository's stored host connection first and preserve its provider and instance URL through add-time clones, lazy pulls, and recovery re-clones.
+
+**PR:** TBD
+
 ### fix(auth): clarify provider token failures
 
 **What:** GitLab and other non-GitHub token failures could show GitHub-specific wording, while sync errors gave too little guidance to recover.

--- a/__tests__/services/RepoImportService.cloneContext.test.ts
+++ b/__tests__/services/RepoImportService.cloneContext.test.ts
@@ -1,0 +1,94 @@
+import { importRepoAtAdd } from '@/services/RepoImportService';
+import { AccountStorage } from '@/services/AccountStorage';
+import { AuthService } from '@/services/AuthService';
+import { StorageService } from '@/services/StorageService';
+import { GitFsService } from '@/services/git/GitFsService';
+import { resolveBranch } from '@/services/git/branchResolver';
+
+jest.mock('@/services/AccountStorage', () => ({
+  AccountStorage: {
+    getActiveHostConnection: jest.fn(),
+    getHostConnection: jest.fn(),
+    getHostUseSsh: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/AuthService', () => ({
+  AuthService: {
+    getToken: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/git/GitFsService', () => ({
+  GitFsService: {
+    isCloned: jest.fn(),
+    cloneExclusive: jest.fn(),
+    getCommitOid: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/git/branchResolver', () => ({
+  resolveBranch: jest.fn(),
+}));
+
+jest.mock('@/services/git/engine/GitEngine', () => ({
+  setCredential: jest.fn(),
+}));
+
+jest.mock('@/services/RepoPullService', () => ({
+  pullFromSingleRepo: jest.fn(),
+}));
+
+describe('importRepoAtAdd clone context', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(AuthService.getToken).mockResolvedValue('gitlab-token');
+    jest.mocked(StorageService.getSavedRepositories).mockResolvedValue([
+      {
+        id: 'gitlab:repo-123',
+        path: 'group/project',
+        name: 'project',
+        provider: 'gitlab',
+        hostId: 'account-1:gitlab:default',
+        branch: 'main',
+      },
+    ]);
+    jest.mocked(resolveBranch).mockResolvedValue('main');
+    jest.mocked(AccountStorage.getActiveHostConnection).mockResolvedValue(null);
+    jest.mocked(AccountStorage.getHostConnection).mockResolvedValue({
+      id: 'account-1:gitlab:default',
+      accountId: 'account-1',
+      provider: 'gitlab',
+      instanceBaseUrl: 'https://gitlab.example.com',
+      hostLogin: 'alice',
+      hostUserId: 42,
+      name: 'Work GitLab',
+      email: 'alice@example.com',
+      avatarUrl: null,
+      addedAt: 1,
+    });
+    jest.mocked(AccountStorage.getHostUseSsh).mockResolvedValue(false);
+    jest.mocked(GitFsService.isCloned).mockResolvedValue(false);
+    jest.mocked(GitFsService.cloneExclusive).mockResolvedValue(undefined);
+    jest.mocked(GitFsService.getCommitOid).mockResolvedValue(null);
+  });
+
+  it('uses the repository host metadata when no active host is selected', async () => {
+    await importRepoAtAdd('group/project', 'project');
+
+    expect(AccountStorage.getHostConnection).toHaveBeenCalledWith('account-1:gitlab:default');
+    expect(GitFsService.cloneExclusive).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoId: 'gitlab:repo-123',
+        provider: 'gitlab',
+        instanceBaseUrl: 'https://gitlab.example.com',
+      }),
+    );
+  });
+});

--- a/__tests__/services/git/recovery.test.ts
+++ b/__tests__/services/git/recovery.test.ts
@@ -9,6 +9,19 @@ jest.mock('@/services/git/gitFs', () => ({
   makeGitFs: jest.fn(() => ({ promises: { readFile: jest.fn(), unlink: jest.fn() } })),
 }));
 
+jest.mock('@/services/StorageService', () => ({
+  StorageService: {
+    getSavedRepositories: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/AccountStorage', () => ({
+  AccountStorage: {
+    getHostConnection: jest.fn(),
+    getActiveHostConnection: jest.fn(),
+  },
+}));
+
 jest.mock('@/services/git/GitFsService', () => ({
   GitFsService: {
     clone: jest.fn(),
@@ -23,6 +36,12 @@ const clone = GitFsService.clone as jest.MockedFunction<typeof GitFsService.clon
 const removeRepo = GitFsService.removeRepo as jest.MockedFunction<typeof GitFsService.removeRepo>;
 const getCommitOid = GitFsService.getCommitOid as jest.MockedFunction<typeof GitFsService.getCommitOid>;
 const findMergeBase = GitFsService.findMergeBase as jest.MockedFunction<typeof GitFsService.findMergeBase>;
+const { StorageService } = jest.requireMock('@/services/StorageService') as {
+  StorageService: { getSavedRepositories: jest.Mock };
+};
+const { AccountStorage } = jest.requireMock('@/services/AccountStorage') as {
+  AccountStorage: { getHostConnection: jest.Mock; getActiveHostConnection: jest.Mock };
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -30,6 +49,20 @@ beforeEach(() => {
   removeRepo.mockResolvedValue(undefined);
   getCommitOid.mockResolvedValue(null);
   findMergeBase.mockResolvedValue(null);
+  StorageService.getSavedRepositories.mockResolvedValue([
+    {
+      id: 'repo-id',
+      path: 'owner/repo',
+      provider: 'gitlab',
+      hostId: 'host-id',
+    },
+  ]);
+  AccountStorage.getHostConnection.mockResolvedValue({
+    id: 'host-id',
+    provider: 'gitlab',
+    instanceBaseUrl: 'https://gitlab.example.com',
+  });
+  AccountStorage.getActiveHostConnection.mockResolvedValue(null);
 });
 
 describe('clone recovery credential identity', () => {
@@ -46,6 +79,8 @@ describe('clone recovery credential identity', () => {
       branch: 'main',
       repoId: 'repo-id',
       token: 'token',
+      provider: 'gitlab',
+      instanceBaseUrl: 'https://gitlab.example.com',
     });
   });
 });

--- a/src/services/RepoImportService.ts
+++ b/src/services/RepoImportService.ts
@@ -95,7 +95,9 @@ async function runImport(
 
     if (!(await GitFsService.isCloned({ repoPath }))) {
       let remoteUrlOverride: string | undefined;
-      const hostConnection = await AccountStorage.getActiveHostConnection();
+      const hostConnection =
+        (repo?.hostId ? await AccountStorage.getHostConnection(repo.hostId) : null) ??
+        (await AccountStorage.getActiveHostConnection());
       if (hostConnection) {
         const useSsh = await AccountStorage.getHostUseSsh(hostConnection.id);
         if (useSsh && repo?.id) {
@@ -126,7 +128,7 @@ async function runImport(
         onProgress,
         repoId: repo?.id,
         remoteUrlOverride,
-        provider: hostConnection?.provider,
+        provider: repo?.provider ?? hostConnection?.provider,
         instanceBaseUrl: hostConnection?.instanceBaseUrl,
       });
     }

--- a/src/services/RepoPullService.ts
+++ b/src/services/RepoPullService.ts
@@ -1,6 +1,7 @@
 import { GitHubService } from './GitHubService';
 import { GitService } from './GitService';
 import { StorageService } from './StorageService';
+import { AccountStorage } from './AccountStorage';
 import { createNote, isNoteColor, NoteColor } from '../models/Note';
 import { createCanvas, updateCanvas, CanvasScene } from '../models/Canvas';
 import { createTodoItem, applyTodoUpdate, reorderTodos } from '../models/Todo';
@@ -57,7 +58,7 @@ async function hasUnpushedCommits(repoPath: string, branch: string): Promise<boo
   }
 }
 
-async function handleCorruptionErrors<T>(fn: () => Promise<T>, repoPath: string, branch: string, token?: string, repoId?: string, provider?: GitHostProvider): Promise<T> {
+async function handleCorruptionErrors<T>(fn: () => Promise<T>, repoPath: string, branch: string, token?: string, repoId?: string, provider?: GitHostProvider, instanceBaseUrl?: string | null): Promise<T> {
   try {
     return await fn();
   } catch (error) {
@@ -74,7 +75,17 @@ async function handleCorruptionErrors<T>(fn: () => Promise<T>, repoPath: string,
       await GitFsService.removeRepo({ repoPath });
       const savedRepos = await StorageService.getSavedRepositories();
       const savedRepo = savedRepos.find((r) => r.path === repoPath);
-      await GitFsService.cloneExclusive({ repoPath, branch, token: token ?? undefined, repoId, provider: provider ?? savedRepo?.provider });
+      const hostConnection =
+        (savedRepo?.hostId ? await AccountStorage.getHostConnection(savedRepo.hostId) : null) ??
+        (await AccountStorage.getActiveHostConnection());
+      await GitFsService.cloneExclusive({
+        repoPath,
+        branch,
+        token: token ?? undefined,
+        repoId,
+        provider: provider ?? savedRepo?.provider ?? hostConnection?.provider,
+        instanceBaseUrl: instanceBaseUrl ?? hostConnection?.instanceBaseUrl,
+      });
       return fn();
     }
     throw error;
@@ -101,19 +112,23 @@ async function getRepoReader(
   const savedRepos = await StorageService.getSavedRepositories();
   const savedRepo = savedRepos.find((r) => r.path === repoPath);
   const repoId = savedRepo?.id;
-  const resolvedProvider = provider ?? savedRepo?.provider;
+  const hostConnection =
+    (savedRepo?.hostId ? await AccountStorage.getHostConnection(savedRepo.hostId) : null) ??
+    (await AccountStorage.getActiveHostConnection());
+  const resolvedProvider = provider ?? savedRepo?.provider ?? hostConnection?.provider;
+  const instanceBaseUrl = hostConnection?.instanceBaseUrl;
   const cloned = await GitFsService.isCloned({ repoPath });
   if (!cloned) {
-    await GitFsService.cloneExclusive({ repoPath, branch, token, repoId, provider: resolvedProvider });
+    await GitFsService.cloneExclusive({ repoPath, branch, token, repoId, provider: resolvedProvider, instanceBaseUrl });
   } else {
     const result = await GitFsService.pullWithFastForward({ repoPath, branch, token, repoId });
     if (!result.ok) {
       if (result.reason === 'diverged') {
         const remoteRefName = `refs/remotes/origin/${branch}`;
         return {
-          listTree: () => handleCorruptionErrors(() => GitFsService.listTree({ repoPath, ref: remoteRefName }), repoPath, branch, token, repoId, resolvedProvider),
+          listTree: () => handleCorruptionErrors(() => GitFsService.listTree({ repoPath, ref: remoteRefName }), repoPath, branch, token, repoId, resolvedProvider, instanceBaseUrl),
           readFile: (path: string) =>
-            handleCorruptionErrors(() => GitFsService.readFile({ repoPath, ref: remoteRefName, filepath: path }), repoPath, branch, token, repoId, resolvedProvider),
+            handleCorruptionErrors(() => GitFsService.readFile({ repoPath, ref: remoteRefName, filepath: path }), repoPath, branch, token, repoId, resolvedProvider, instanceBaseUrl),
         };
       }
       const errorMsg = result.error ?? '';
@@ -127,7 +142,7 @@ async function getRepoReader(
           );
         }
         await GitFsService.removeRepo({ repoPath });
-        await GitFsService.cloneExclusive({ repoPath, branch, token, repoId, provider: resolvedProvider });
+        await GitFsService.cloneExclusive({ repoPath, branch, token, repoId, provider: resolvedProvider, instanceBaseUrl });
         return {
           listTree: () => GitFsService.listTree({ repoPath, ref: branch }),
           readFile: (path: string) =>

--- a/src/services/git/recovery.ts
+++ b/src/services/git/recovery.ts
@@ -13,6 +13,8 @@
  */
 
 import * as FileSystem from 'expo-file-system/legacy';
+import { AccountStorage } from '../AccountStorage';
+import { StorageService } from '../StorageService';
 import { parseRepoPath } from '../../utils/gitPathParser';
 import { makeGitFs as buildGitFs } from './gitFs';
 import { GitFsService, repairHeadRef } from './GitFsService';
@@ -114,6 +116,25 @@ function repoDirFs(repoPath: string): string {
   if (!info) return repoPath;
   const root = clonesRoot();
   return `${root.replace(/\/$/, '')}/${info.owner}/${info.repo}`;
+}
+
+async function cloneWithRepositoryContext(opts: {
+  repoPath: string;
+  branch: string;
+  token?: string;
+  repoId?: string;
+}): Promise<void> {
+  const savedRepos = await StorageService.getSavedRepositories();
+  const savedRepo = savedRepos.find(repo => repo.id === opts.repoId || repo.path === opts.repoPath);
+  const hostConnection =
+    (savedRepo?.hostId ? await AccountStorage.getHostConnection(savedRepo.hostId) : null) ??
+    (await AccountStorage.getActiveHostConnection());
+
+  await GitFsService.clone({
+    ...opts,
+    provider: savedRepo?.provider ?? hostConnection?.provider,
+    instanceBaseUrl: hostConnection?.instanceBaseUrl,
+  });
 }
 
 async function ensureOnBranch(
@@ -224,7 +245,7 @@ export async function pushWithRecovery(
         return { success: false, error: `Clone corruption with unpushed commits in ${repoPath}@${branch}. Please push or reset.` };
       }
       await GitFsService.removeRepo({ repoPath });
-      await GitFsService.clone({ repoPath, branch, token, repoId });
+      await cloneWithRepositoryContext({ repoPath, branch, token, repoId });
       try {
         const result = await GitEngine.pushWithIntegrate(repoDirFs(repoPath), 'origin', undefined);
         if (!result.ok) {
@@ -252,7 +273,7 @@ export async function pushWithRecovery(
             return { success: false, error: `Clone corruption with unpushed commits in ${repoPath}@${branch}. Please push or reset.` };
           }
           await GitFsService.removeRepo({ repoPath });
-          await GitFsService.clone({ repoPath, branch, token, repoId });
+          await cloneWithRepositoryContext({ repoPath, branch, token, repoId });
           try {
             const result = await GitEngine.pushWithIntegrate(repoDirFs(repoPath), 'origin', undefined);
             if (!result.ok) {
@@ -380,5 +401,5 @@ export async function repairCloneAfterCorruption(opts: {
   }
 
   await GitFsService.removeRepo({ repoPath });
-  await GitFsService.clone({ repoPath, branch, token: token ?? undefined, repoId });
+  await cloneWithRepositoryContext({ repoPath, branch, token: token ?? undefined, repoId });
 }


### PR DESCRIPTION
## Summary
- resolve saved repository host metadata before the active host during add-time clones
- preserve provider and self-hosted instance URLs through lazy pulls and corruption recovery re-clones
- add regression coverage for GitLab/self-hosted clone context and document the fix

## Verification
- `yarn ts:check` passes
- targeted clone, recovery, and repository-picker Jest suites pass
- full Jest: 38 suites pass; 3 existing environment/component suites fail due unrelated native/Jest issues
- ESLint: 0 errors; existing warnings remain

## Review
- Goal, QA, code quality, and security review lanes passed
- Context-mining lane was inconclusive after repeated agent-service capacity/balance failures
