### PR TITLE
fix(command-palette): prevent keyboard from covering modal and enable result tap interactions

### DIFF
--- a/__tests__/components/CommandPaletteModal.test.tsx
+++ b/__tests__/components/CommandPaletteModal.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { FlatList } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+import CommandPaletteModal from '../../src/components/CommandPaletteModal';
+
+jest.mock('../../src/components/ui/Modal', () => ({
+  Modal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('../../src/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      border: '#cccccc',
+      surface: '#f5f5f5',
+      text: '#000000',
+      textSecondary: '#666666',
+    },
+  }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+describe('CommandPaletteModal', () => {
+  it('keeps result taps active while the search keyboard is open', () => {
+    const { UNSAFE_getByType } = render(
+      <CommandPaletteModal visible onClose={jest.fn()} />,
+    );
+
+    expect(UNSAFE_getByType(FlatList).props.keyboardShouldPersistTaps).toBe('handled');
+  });
+
+  it('updates visible commands when the query changes', () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <CommandPaletteModal visible onClose={jest.fn()} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Search commands...'), 'home');
+
+    expect(getByText('Go Home')).toBeTruthy();
+    expect(queryByText('New Note')).toBeNull();
+  });
+});

--- a/src/components/CommandPaletteModal.tsx
+++ b/src/components/CommandPaletteModal.tsx
@@ -93,6 +93,7 @@ export default function CommandPaletteModal({ visible, onClose }: CommandPalette
         data={results}
         keyExtractor={(item) => item.id}
         style={{ flex: 1 }}
+        keyboardShouldPersistTaps="handled"
         ListEmptyComponent={
           <Text style={{ color: colors.textSecondary, textAlign: 'center', paddingVertical: 20 }}>
             No commands found

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -123,7 +123,7 @@ export function Modal(props: ModalProps) {
         >
           {bottomSheet ? (
             <KeyboardAvoidingView
-              behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+              behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
               style={{
                 position: 'absolute',
                 top: 0,


### PR DESCRIPTION
## What

Two issues when the Command Palette is open with the keyboard:

1. **Android: keyboard covers the modal** — `Modal.tsx` bottom-sheet used `behavior={undefined}` for Android's `KeyboardAvoidingView`, which is a no-op. Changed to `behavior='height'` (the same pattern already used in `NoteEditorScreen` and `GitHubPicker`).

2. **Result list ignores taps while keyboard is open** — `CommandPaletteModal.tsx` FlatList lacked `keyboardShouldPersistTaps='handled'`, so tappable command rows did not respond until the keyboard was dismissed. Added the prop so taps execute commands immediately.

## Search

`searchCommands()` was not broken — it filters correctly by label/description. The observed "search not working" symptom was a consequence of the keyboard covering results and the list not accepting taps.

## Testing

Added `__tests__/components/CommandPaletteModal.test.tsx` with two component tests:
- `keeps result taps active while the search keyboard is open` — verifies `keyboardShouldPersistTaps='handled'` is set (was red, now green)
- `updates visible commands when the query changes` — verifies typed filtering works (was already passing)

## Files changed

| File | Change |
|------|--------|
| `src/components/ui/Modal.tsx` | `behavior='height'` on Android bottom-sheet KAV |
| `src/components/CommandPaletteModal.tsx` | `keyboardShouldPersistTaps='handled'` on FlatList |
| `__tests__/components/CommandPaletteModal.test.tsx` | regression tests |