### PR TITLE
fix(folder-selector): allow creating nested folders via parent pill selector

### DIFF
--- a/__tests__/components/FolderSelectionDialog.test.tsx
+++ b/__tests__/components/FolderSelectionDialog.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import FolderSelectionDialog from '@/components/FolderSelectionDialog';
+
+const mockCreateFolder = jest.fn();
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f5f5f5',
+      surfaceSecondary: '#eee',
+      primary: '#07f',
+      text: '#000',
+      textSecondary: '#666',
+      border: '#ccc',
+      error: '#f00',
+    },
+  }),
+}));
+
+jest.mock('@/contexts/FolderContext', () => ({
+  useFolders: () => ({
+    folders: [
+      {
+        id: 'projects',
+        name: 'Projects',
+        path: '/Projects',
+        parentId: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ],
+    createFolder: mockCreateFolder,
+  }),
+}));
+
+jest.mock('@/utils/haptics', () => ({
+  HapticService: {
+    light: jest.fn(),
+    medium: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/ui', () => ({
+  Modal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+describe('FolderSelectionDialog nested folder creation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateFolder.mockResolvedValue({
+      id: 'frontend',
+      name: 'Frontend',
+      path: '/Projects/Frontend',
+      parentId: 'projects',
+      createdAt: 2,
+      updatedAt: 2,
+    });
+  });
+
+  it('creates a folder inside the selected parent folder', async () => {
+    const { getByTestId, getByPlaceholderText, getByText } = render(
+      <FolderSelectionDialog
+        visible
+        selectedFolderId={null}
+        onSelect={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(getByTestId('folder-selection.button.create'));
+    fireEvent.press(getByTestId('folder-selection.button.parent.projects'));
+    fireEvent.changeText(getByPlaceholderText('Folder name'), 'Frontend');
+    fireEvent.press(getByText('Create'));
+
+    await waitFor(() => {
+      expect(mockCreateFolder).toHaveBeenCalledWith({
+        name: 'Frontend',
+        parentId: 'projects',
+      });
+    });
+  });
+});

--- a/src/components/FolderSelectionDialog.tsx
+++ b/src/components/FolderSelectionDialog.tsx
@@ -262,7 +262,12 @@ export default function FolderSelectionDialog({
             Select Folder
           </Text>
           <View style={styles.headerSideRight}>
-            <TouchableOpacity onPress={toggleCreateMode} hitSlop={8} style={styles.headerActionButton}>
+             <TouchableOpacity
+               testID="folder-selection.button.create"
+               onPress={toggleCreateMode}
+               hitSlop={8}
+               style={styles.headerActionButton}
+             >
             <Ionicons
               name={isCreateMode ? 'close' : 'add'}
               size={24}
@@ -272,9 +277,43 @@ export default function FolderSelectionDialog({
           </View>
         </View>
 
-        {isCreateMode && (
-          <View style={[styles.createContainer, { backgroundColor: colors.surface }]}>
-            <TextInput
+         {isCreateMode && (
+           <View style={[styles.createContainer, { backgroundColor: colors.surface }]}>
+             <Text style={[styles.parentLabel, { color: colors.textSecondary }]}>Create inside</Text>
+             <ScrollView
+               horizontal
+               showsHorizontalScrollIndicator={false}
+               contentContainerStyle={styles.parentList}
+             >
+               <TouchableOpacity
+                 testID="folder-selection.button.parent.root"
+                 style={[
+                   styles.parentButton,
+                   { borderColor: selectedParentId === null ? colors.primary : colors.border },
+                 ]}
+                 onPress={() => setSelectedParentId(null)}
+               >
+                 <Text style={{ color: selectedParentId === null ? colors.primary : colors.text }}>
+                   Root
+                 </Text>
+               </TouchableOpacity>
+               {folders.map((folder) => (
+                 <TouchableOpacity
+                   key={folder.id}
+                   testID={`folder-selection.button.parent.${folder.id}`}
+                   style={[
+                     styles.parentButton,
+                     { borderColor: selectedParentId === folder.id ? colors.primary : colors.border },
+                   ]}
+                   onPress={() => setSelectedParentId(folder.id)}
+                 >
+                   <Text style={{ color: selectedParentId === folder.id ? colors.primary : colors.text }}>
+                     {folder.path}
+                   </Text>
+                 </TouchableOpacity>
+               ))}
+             </ScrollView>
+             <TextInput
               style={[styles.input, { backgroundColor: colors.surfaceSecondary, color: colors.text }]}
               placeholder="Folder name"
               placeholderTextColor={colors.textSecondary}
@@ -401,13 +440,24 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
   createContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
     padding: 16,
     gap: 12,
   },
+  parentLabel: {
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  parentList: {
+    gap: 8,
+    paddingBottom: 4,
+  },
+  parentButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+  },
   input: {
-    flex: 1,
     paddingHorizontal: 12,
     paddingVertical: 10,
     borderRadius: 8,


### PR DESCRIPTION
## Summary

FolderSelectionDialog could create folders but always at root because `selectedParentId` was never updated by any UI control — the state existed but no UI wrote to it.

## Root Cause

- `selectedParentId` initialized at line 43 of FolderSelectionDialog.tsx
- `handleCreateFolder` already passed it to `createFolder` correctly
- No UI control ever called `setSelectedParentId` — it was always `null`

## Fix

Add a horizontal pill selector above the folder name input in create mode:
- **Root** pill (deselects parent, keeps `null`)
- **Per-folder** pills (one per existing folder, set `selectedParentId` on tap)
- Selected pill gets primary color border
- `handleCreateFolder` → `createFolder(name, selectedParentId)` → nested folder

## Files Changed

- `src/components/FolderSelectionDialog.tsx` — UI + styles only
- `__tests__/components/FolderSelectionDialog.test.tsx` — new regression test

## Verification

- `yarn ts:check` → clean
- `yarn eslint` → 0 errors on changed files
- `yarn jest` → full suite passes (43 tests)