### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "GitNot\u0113s",
     "slug": "gitnotes",
-    "version": "1.5.5",
+    "version": "1.6.0",
     "orientation": "portrait",
     "icon": "./assets/generated/icon.png",
     "userInterfaceStyle": "automatic",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnotes",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "license": "MPL-2.0",
   "main": "expo/AppEntry.js",
   "engines": {


### PR DESCRIPTION
Bumps app version to 1.6.0 in `package.json` and `app.json`.