### PR TITLE
fix: prevent CocoaPods swift flags build failure

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,150 @@
+require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
+require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
+
+# Disable input/output paths to work around Ruby 3.x #{swift_flags} interpolation bug in CocoaPods
+install! 'cocoapods', :disable_input_output_paths => true
+
+require 'json'
+podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
+
+def ccache_enabled?(podfile_properties)
+  # Environment variable takes precedence
+  return ENV['USE_CCACHE'] == '1' if ENV['USE_CCACHE']
+
+  # Fall back to Podfile properties
+  podfile_properties['apple.ccacheEnabled'] == 'true'
+end
+
+ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
+ENV['RCT_USE_RN_DEP'] ||= podfile_properties['ios.buildReactNativeFromSource'] == 'true' ? '0' : '1'
+ENV['RCT_USE_PREBUILT_RNCORE'] ||= podfile_properties['ios.buildReactNativeFromSource'] == 'true' ? '0' : '1'
+ENV['RCT_HERMES_V1_ENABLED'] ||= '0' if podfile_properties['expo.useHermesV1'] == 'false'
+# An explicit `ios.usePrecompiledModules: false` must win even when the env var is already set
+# (e.g. EXPO_USE_PRECOMPILED_MODULES exported by EAS Build), so force-disable here before the default.
+ENV['EXPO_USE_PRECOMPILED_MODULES'] = '0' if podfile_properties['EXPO_USE_PRECOMPILED_MODULES'] == 'false'
+ENV['EXPO_USE_PRECOMPILED_MODULES'] ||= '1'
+platform :ios, podfile_properties['ios.deploymentTarget'] || '16.4'
+
+prepare_react_native_project!
+
+target 'GitNots' do
+  use_expo_modules!
+
+  if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'
+    config_command = ['node', '-e', "process.argv=['', '', 'config'];require('@react-native-community/cli').run()"];
+  else
+    config_command = [
+      'node',
+      '--no-warnings',
+      '--eval',
+      'require(\'expo/bin/autolinking\')',
+      'expo-modules-autolinking',
+      'react-native-config',
+      '--json',
+      '--platform',
+      'ios'
+    ]
+  end
+
+  config = use_native_modules!(config_command)
+  pod 'GitEngine', :path => '../modules/GitEngine/ios-local'
+
+
+  use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
+  use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']
+
+  use_react_native!(
+    :path => config[:reactNativePath],
+    :hermes_enabled => podfile_properties['expo.jsEngine'] == nil || podfile_properties['expo.jsEngine'] == 'hermes',
+    # An absolute path to your application root.
+    :app_path => "#{Pod::Config.instance.installation_root}/..",
+    :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
+  )
+
+  post_install do |installer|
+    # [gitnotes] Expose GitNotesGit2FFI (UniFFI) module to the aggregate Swift target.
+    gitnotes_root = File.expand_path('../..', installer.sandbox.root)
+    gitnotes_ffi = File.join(gitnotes_root, 'modules', 'GitEngine', 'ios-local', 'generated')
+    gitnotes_rust_lib = File.join(gitnotes_root, 'modules', 'GitEngine', 'ios-local', 'rust', 'libgitnotes_git2.a')
+    installer.aggregate_targets.each do |aggregate|
+      aggregate.xcconfigs.each do |config_name, xcconfig|
+        existing = xcconfig.attributes['SWIFT_INCLUDE_PATHS'] || ''
+        unless existing.include?(gitnotes_ffi)
+          xcconfig.attributes['SWIFT_INCLUDE_PATHS'] = "$(inherited) #{gitnotes_ffi} #{existing}".strip
+        end
+        existing_ldflags = xcconfig.attributes['OTHER_LDFLAGS'] || '$(inherited)'
+        unless existing_ldflags.include?('libgitnotes_git2.a')
+          xcconfig.attributes['OTHER_LDFLAGS'] = "#{existing_ldflags} -force_load #{gitnotes_rust_lib}".strip
+        end
+        xcconfig.save_as(aggregate.xcconfig_path(config_name))
+      end
+    end
+
+    installer.pods_project.targets.each do |target|
+      next unless target.name == 'ExpoSQLite'
+
+      target.build_configurations.each do |build_configuration|
+        build_configuration.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'
+        build_configuration.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'
+      end
+    end
+
+
+    installer.aggregate_targets.each do |aggregate_target|
+      next unless aggregate_target.user_project
+
+      aggregate_target.user_project.native_targets.each do |target|
+        target.build_configurations.each do |build_configuration|
+          swift_flags = build_configuration.build_settings['OTHER_SWIFT_FLAGS'] || '$(inherited)'
+          swift_flags = swift_flags.join(' ') if swift_flags.is_a?(Array)
+          unless swift_flags.include?('-Xfrontend -disable-autolink-framework -Xfrontend SwiftUICore -Xfrontend -disable-autolink-framework -Xfrontend UIUtilities')
+            build_configuration.build_settings['OTHER_SWIFT_FLAGS'] = "#{swift_flags} -Xfrontend -disable-autolink-framework -Xfrontend SwiftUICore -Xfrontend -disable-autolink-framework -Xfrontend UIUtilities"
+          end
+        end
+      end
+
+      aggregate_target.user_project.save
+    end
+
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |build_configuration|
+        swift_flags = build_configuration.build_settings['OTHER_SWIFT_FLAGS'] || '$(inherited)'
+        swift_flags = swift_flags.join(' ') if swift_flags.is_a?(Array)
+        unless swift_flags.include?('-Xfrontend -disable-autolink-framework -Xfrontend SwiftUICore -Xfrontend -disable-autolink-framework -Xfrontend UIUtilities')
+          build_configuration.build_settings['OTHER_SWIFT_FLAGS'] = "#{swift_flags} -Xfrontend -disable-autolink-framework -Xfrontend SwiftUICore -Xfrontend -disable-autolink-framework -Xfrontend UIUtilities"
+        end
+      end
+    end
+
+    react_native_post_install(
+      installer,
+      config[:reactNativePath],
+      :mac_catalyst_enabled => false,
+      :ccache_enabled => ccache_enabled?(podfile_properties),
+    )
+
+    installer.pods_project.targets.each do |target|
+      next unless target.name == 'ExpoSQLite'
+
+      target.build_configurations.each do |build_configuration|
+        existing_swift_include_paths = build_configuration.build_settings['SWIFT_INCLUDE_PATHS'] || '$(inherited)'
+        unless existing_swift_include_paths.include?('$(PODS_TARGET_SRCROOT)')
+          build_configuration.build_settings['SWIFT_INCLUDE_PATHS'] =
+            "#{existing_swift_include_paths} $(PODS_TARGET_SRCROOT)".strip
+        end
+      end
+    end
+
+    # Workaround: Remove any Ruby interpolation literals (#{...}) from the Pods.xcodeproj
+    # that may have been generated due to Ruby 3.x + CocoaPods 1.17 interpolation bugs
+    pods_pbxproj = installer.sandbox.root.join('Pods.xcodeproj', 'project.pbxproj')
+    if File.exist?(pods_pbxproj)
+      content = File.read(pods_pbxproj)
+      sanitized = content.gsub(/#\{[^}]+\}/, '')
+      if content != sanitized
+        File.write(pods_pbxproj, sanitized)
+        puts "CocoaPods workaround: removed Ruby interpolation literals from #{pods_pbxproj}"
+      end
+    end
+  end
+end

--- a/ios/Podfile.properties.json
+++ b/ios/Podfile.properties.json
@@ -1,0 +1,7 @@
+{
+  "expo.jsEngine": "hermes",
+  "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
+  "expo.inlineModules.watchedDirectories": "[]",
+  "expo.inlineModules.xcodeProjectTargets": "{\"mainTarget\":\"GitNots\",\"targets\":[]}",
+  "expo-image.disable-libdav1d": "false"
+}


### PR DESCRIPTION
## Summary\n- Track the iOS Podfile and Podfile properties used by Expo builds\n- Disable CocoaPods input/output paths to avoid literal #{swift_flags} paths in Swift pod targets\n- Sanitize any remaining Ruby interpolation literals after pod installation\n\n## Verification\n- Pods regeneration completed with the workaround; generated Pods.xcodeproj contained no #{...} interpolation literals.\n- Full archive was not run in the isolated worktree because the repository intentionally excludes the rest of the generated ios/ directory.