### PR TITLE
fix(ios): correct Swift flags generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-11
 
+### fix(ios): generate valid Swift flags in CocoaPods Podfile
+
+**What:** Production iOS archives failed because the Expo config plugin emitted escaped Ruby interpolation, leaving `#{swift_flags}` as a literal input path for Swift pod targets.
+
+**Fix:** Preserve Ruby interpolation when generating `OTHER_SWIFT_FLAGS` and remove the temporary Podfile sanitizer workaround.
+
+**PR:** TBD
+
 ### fix(sync): preserve repository host during clone recovery
 
 **What:** Repository clones and corruption recovery could fall back to the active host or GitHub defaults, breaking GitLab and self-hosted repositories when their saved host context differed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **Fix:** Preserve Ruby interpolation when generating `OTHER_SWIFT_FLAGS` and remove the temporary Podfile sanitizer workaround.
 
-**PR:** TBD
+**PR:** [#1563](https://github.com/gedwolmen/gitnotes/pull/1563)
 
 ### fix(sync): preserve repository host during clone recovery
 

--- a/__tests__/plugins/withExpoSqliteXcode26.test.ts
+++ b/__tests__/plugins/withExpoSqliteXcode26.test.ts
@@ -1,0 +1,12 @@
+const { SWIFTUICORE_WORKAROUND } = require('../../plugins/withExpoSqliteXcode26');
+
+describe('withExpoSqliteXcode26', () => {
+  test('does not escape Ruby swift_flags interpolation', () => {
+    expect(SWIFTUICORE_WORKAROUND).toContain(
+      '"#{swift_flags} -Xfrontend -disable-autolink-framework',
+    );
+    expect(SWIFTUICORE_WORKAROUND).not.toContain(
+      '"\\#{swift_flags} -Xfrontend -disable-autolink-framework',
+    );
+  });
+});

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,9 +1,6 @@
 require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 
-# Disable input/output paths to work around Ruby 3.x #{swift_flags} interpolation bug in CocoaPods
-install! 'cocoapods', :disable_input_output_paths => true
-
 require 'json'
 podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
 
@@ -132,18 +129,6 @@ target 'GitNots' do
           build_configuration.build_settings['SWIFT_INCLUDE_PATHS'] =
             "#{existing_swift_include_paths} $(PODS_TARGET_SRCROOT)".strip
         end
-      end
-    end
-
-    # Workaround: Remove any Ruby interpolation literals (#{...}) from the Pods.xcodeproj
-    # that may have been generated due to Ruby 3.x + CocoaPods 1.17 interpolation bugs
-    pods_pbxproj = installer.sandbox.root.join('Pods.xcodeproj', 'project.pbxproj')
-    if File.exist?(pods_pbxproj)
-      content = File.read(pods_pbxproj)
-      sanitized = content.gsub(/#\{[^}]+\}/, '')
-      if content != sanitized
-        File.write(pods_pbxproj, sanitized)
-        puts "CocoaPods workaround: removed Ruby interpolation literals from #{pods_pbxproj}"
       end
     end
   end

--- a/plugins/withExpoSqliteXcode26.js
+++ b/plugins/withExpoSqliteXcode26.js
@@ -25,7 +25,7 @@ const SWIFTUICORE_WORKAROUND = `    installer.aggregate_targets.each do |aggrega
           swift_flags = build_configuration.build_settings['OTHER_SWIFT_FLAGS'] || '$(inherited)'
           swift_flags = swift_flags.join(' ') if swift_flags.is_a?(Array)
           unless swift_flags.include?('${SWIFTUI_PRIVATE_AUTOLINK_FLAGS}')
-            build_configuration.build_settings['OTHER_SWIFT_FLAGS'] = "\\#{swift_flags} ${SWIFTUI_PRIVATE_AUTOLINK_FLAGS}"
+            build_configuration.build_settings['OTHER_SWIFT_FLAGS'] = "#{swift_flags} ${SWIFTUI_PRIVATE_AUTOLINK_FLAGS}"
           end
         end
       end
@@ -38,7 +38,7 @@ const SWIFTUICORE_WORKAROUND = `    installer.aggregate_targets.each do |aggrega
         swift_flags = build_configuration.build_settings['OTHER_SWIFT_FLAGS'] || '$(inherited)'
         swift_flags = swift_flags.join(' ') if swift_flags.is_a?(Array)
         unless swift_flags.include?('${SWIFTUI_PRIVATE_AUTOLINK_FLAGS}')
-          build_configuration.build_settings['OTHER_SWIFT_FLAGS'] = "\\#{swift_flags} ${SWIFTUI_PRIVATE_AUTOLINK_FLAGS}"
+          build_configuration.build_settings['OTHER_SWIFT_FLAGS'] = "#{swift_flags} ${SWIFTUI_PRIVATE_AUTOLINK_FLAGS}"
         end
       end
     end
@@ -51,7 +51,7 @@ const INCLUDE_PATH_WORKAROUND = `    installer.pods_project.targets.each do |tar
         existing_swift_include_paths = build_configuration.build_settings['SWIFT_INCLUDE_PATHS'] || '$(inherited)'
         unless existing_swift_include_paths.include?('$(PODS_TARGET_SRCROOT)')
           build_configuration.build_settings['SWIFT_INCLUDE_PATHS'] =
-            "\\#{existing_swift_include_paths} $(PODS_TARGET_SRCROOT)".strip
+            "#{existing_swift_include_paths} $(PODS_TARGET_SRCROOT)".strip
         end
       end
     end
@@ -110,3 +110,4 @@ function withExpoSqliteXcode26(config) {
 }
 
 module.exports = withExpoSqliteXcode26;
+module.exports.SWIFTUICORE_WORKAROUND = SWIFTUICORE_WORKAROUND;


### PR DESCRIPTION
## Root cause

`plugins/withExpoSqliteXcode26.js` emitted `\#{swift_flags}` into the generated Ruby Podfile. The backslash disabled Ruby interpolation, so CocoaPods wrote the literal `#{swift_flags}` into Swift pod build inputs.

## Fix

- Preserve Ruby interpolation in both `OTHER_SWIFT_FLAGS` assignments.
- Preserve interpolation in the Swift include path assignment.
- Remove the broad Podfile sanitizer and input/output-path workaround.
- Add a regression test for the generated workaround text.

## Verification

- Regression test passes.
- `expo prebuild --platform ios --no-install` followed by `pod install --repo-update` succeeds.
- Local Xcode archive no longer reports `Unexpected input file` or `#{swift_flags}`; it reaches a separate final linker failure with signing disabled.
