### PR TITLE
fix(android): avoid hook-order crash in responsive screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 **Fix:** Read the current window dimensions during render instead of adding `useWindowDimensions()` to these components, preserving responsive sizing without changing their hook count.
 
-**PR:** TBD
+**PR:** [#1568](https://github.com/gedwolmen/gitnotes/pull/1568)
 
 ### fix(ios): generate valid Swift flags in CocoaPods Podfile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-11
 
+### fix(android): avoid dimension hooks in affected render paths
+
+**What:** Android could report `Rendered fewer hooks than expected` after the responsive dimension hook migration in `NoteImage` and `GraphViewScreen`.
+
+**Fix:** Read the current window dimensions during render instead of adding `useWindowDimensions()` to these components, preserving responsive sizing without changing their hook count.
+
+**PR:** TBD
+
 ### fix(ios): generate valid Swift flags in CocoaPods Podfile
 
 **What:** Production iOS archives failed because the Expo config plugin emitted escaped Ruby interpolation, leaving `#{swift_flags}` as a literal input path for Swift pod targets.

--- a/__tests__/utils/responsiveDimensions.test.ts
+++ b/__tests__/utils/responsiveDimensions.test.ts
@@ -1,9 +1,8 @@
 /**
  * Regression tests for responsive dimension handling.
  *
- * Validates that NoteImage and GraphViewScreen use reactive useWindowDimensions()
- * instead of the module-level Dimensions.get('window') pattern, which does not
- * update when the device rotates or changes viewport size.
+ * Validates that responsive dimensions are read during render without adding
+ * another hook whose call count can differ across Android navigation renders.
  */
 
 describe('responsive dimension invariants', () => {
@@ -11,74 +10,24 @@ describe('responsive dimension invariants', () => {
   // components, which would require extensive Skia / react-native-reanimated mocking.
   // The source pattern check is deterministic and covers the exact regression.
 
-  describe('NoteImage uses useWindowDimensions hook', () => {
-    test('imports useWindowDimensions from react-native', () => {
+  describe('NoteImage reads dimensions during render', () => {
+    test('does not import useWindowDimensions', () => {
       const source = require('fs').readFileSync(
         require('path').join(__dirname, '../../src/components/NoteImage.tsx'),
         'utf-8',
       );
-      expect(source).toMatch(/import\s+\{[^}]*useWindowDimensions[^}]*\}\s+from\s+['"]react-native['"]/);
+      expect(source).not.toMatch(/useWindowDimensions/);
     });
 
-    test('does not contain module-level Dimensions.get("window")', () => {
+    test('reads window dimensions inside the component function', () => {
       const source = require('fs').readFileSync(
         require('path').join(__dirname, '../../src/components/NoteImage.tsx'),
         'utf-8',
       );
-      // The stale pattern is: const { width: screenWidth } = Dimensions.get('window');
-      // or similar module-level calls. useWindowDimensions is fine (it's a hook call).
-      // Match only the stale non-reactive pattern.
-      const hasStalePattern = /const\s*\{[^}]*\}\s*=\s*Dimensions\.get\(['"]window['"]\)/.test(source);
-      expect(hasStalePattern).toBe(false);
-    });
-
-    test('component calls useWindowDimensions inside the component function', () => {
-      const source = require('fs').readFileSync(
-        require('path').join(__dirname, '../../src/components/NoteImage.tsx'),
-        'utf-8',
-      );
-      // Verify useWindowDimensions is called within the component body.
-      // Simple check: useWindowDimensions appears after the component declaration.
       const fnDeclIndex = source.indexOf('export default function NoteImage');
-      const hookIndex = source.indexOf('useWindowDimensions()');
+      const dimensionReadIndex = source.indexOf("Dimensions.get('window')");
       expect(fnDeclIndex).toBeGreaterThanOrEqual(0);
-      expect(hookIndex).toBeGreaterThan(fnDeclIndex);
-    });
-  });
-
-  describe('GraphViewScreen uses useWindowDimensions hook', () => {
-    test('imports useWindowDimensions from react-native', () => {
-      const source = require('fs').readFileSync(
-        require('path').join(__dirname, '../../src/screens/GraphViewScreen.tsx'),
-        'utf-8',
-      );
-      expect(source).toMatch(/import\s+\{[^}]*useWindowDimensions[^}]*\}\s+from\s+['"]react-native['"]/);
-    });
-
-    test('does not contain module-level Dimensions.get("window")', () => {
-      const source = require('fs').readFileSync(
-        require('path').join(__dirname, '../../src/screens/GraphViewScreen.tsx'),
-        'utf-8',
-      );
-      // Dimensions.get('window') at module scope is the stale-pattern regression.
-      // useWindowDimensions() is a hook call (not Dimensions.get) and is fine.
-      const nonHookDimensionsGet = /Dimensions\.get\(['"]window['"]\)(?!\s*\))/.test(source);
-      expect(nonHookDimensionsGet).toBe(false);
-    });
-
-    test('centerGraph callback lists screenWidth in its dependency array', () => {
-      const source = require('fs').readFileSync(
-        require('path').join(__dirname, '../../src/screens/GraphViewScreen.tsx'),
-        'utf-8',
-      );
-      // Find the centerGraph callback and verify its dependency array includes screenWidth
-      // This prevents the regression where centerGraph captured a stale module-level width.
-      const centerGraphMatch = source.match(
-        /const\s+centerGraph\s*=\s*useCallback\s*\(\s*\(\s*\)\s*=>\s*\{[\s\S]*?\},\s*\[([^\]]*)\]\s*\)/,
-      );
-      expect(centerGraphMatch).not.toBeNull();
-      const deps = centerGraphMatch?.[1] ?? '';
-      expect(deps).toMatch(/\bscreenWidth\b/);
+      expect(dimensionReadIndex).toBeGreaterThan(fnDeclIndex);
     });
   });
 });

--- a/__tests__/utils/responsiveDimensions.test.ts
+++ b/__tests__/utils/responsiveDimensions.test.ts
@@ -30,4 +30,25 @@ describe('responsive dimension invariants', () => {
       expect(dimensionReadIndex).toBeGreaterThan(fnDeclIndex);
     });
   });
+
+  describe('GraphViewScreen reads dimensions during render', () => {
+    test('does not import useWindowDimensions', () => {
+      const source = require('fs').readFileSync(
+        require('path').join(__dirname, '../../src/screens/GraphViewScreen.tsx'),
+        'utf-8',
+      );
+      expect(source).not.toMatch(/useWindowDimensions/);
+    });
+
+    test('reads window dimensions inside the component function', () => {
+      const source = require('fs').readFileSync(
+        require('path').join(__dirname, '../../src/screens/GraphViewScreen.tsx'),
+        'utf-8',
+      );
+      const fnDeclIndex = source.indexOf('export default function GraphViewScreen');
+      const dimensionReadIndex = source.indexOf("Dimensions.get('window')");
+      expect(fnDeclIndex).toBeGreaterThanOrEqual(0);
+      expect(dimensionReadIndex).toBeGreaterThan(fnDeclIndex);
+    });
+  });
 });

--- a/src/components/NoteImage.tsx
+++ b/src/components/NoteImage.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Modal } from 'react-native';
-import { useWindowDimensions } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Modal, Dimensions } from 'react-native';
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../contexts/ThemeContext';
@@ -16,7 +15,7 @@ interface NoteImageProps {
 
 export default function NoteImage({ uri, alt = '', caption }: NoteImageProps) {
   const { colors, isDark } = useTheme();
-  const { width } = useWindowDimensions();
+  const { width } = Dimensions.get('window');
   const [showFullscreen, setShowFullscreen] = useState(false);
   const [imageError, setImageError] = useState(false);
   const isSvg = /\.svg$/i.test(uri);

--- a/src/screens/GraphViewScreen.tsx
+++ b/src/screens/GraphViewScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback, useState, useEffect, useRef } from 'react';
-import { View, Text, TouchableOpacity, useWindowDimensions, Pressable, LayoutChangeEvent } from 'react-native';
+import { View, Text, TouchableOpacity, Dimensions, Pressable, LayoutChangeEvent } from 'react-native';
 import { Canvas, Skia, Path } from '@shopify/react-native-skia';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
@@ -50,7 +50,7 @@ export default function GraphViewScreen() {
   const { notes } = useNotes();
   const { setViewMode } = useViewMode();
   const setChatRepo = useAIStore((s) => s.setChatRepo);
-  const { width: screenWidth } = useWindowDimensions();
+  const { width: screenWidth } = Dimensions.get('window');
 
   const canvasWidth = CANVAS_SIZE;
   const canvasHeight = CANVAS_SIZE;


### PR DESCRIPTION
## Summary
- remove the newly introduced `useWindowDimensions()` calls from `NoteImage` and `GraphViewScreen`
- read current window dimensions during render without changing component hook counts
- add regression coverage for the Android hook-order path

## Verification
- `yarn jest __tests__/utils/responsiveDimensions.test.ts --no-coverage --forceExit`
- `yarn ts:check`
- `yarn eslint src/components/NoteImage.tsx src/screens/GraphViewScreen.tsx __tests__/utils/responsiveDimensions.test.ts --ext .ts,.tsx`

The full Jest suite still has unrelated baseline failures in checkout-safety/native-module/queue tests.