### PR TITLE
fix(explore): stabilize files section hook order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable fixes and feature changes to GitNotēs are documented here.
 >
 > **History**: prior fixes (pre-2026-08) lived in single-PR wiki pages. Those pages were retired in [#1047](https://github.com/gedwolmen/gitnotes/pull/1047); their full diagnostic content is preserved in git history via `git log -p -- docs/wiki/<file>.md`.
 
+## 2026-09-12
+
+### fix(android): stabilize explore files section hooks
+
+**What:** Android could crash with `Rendered fewer hooks than expected` when `FilesSection` changed from loading to clone-error or not-cloned state.
+
+**Fix:** Move the list container `useMemo` before conditional render returns and add a regression test for the not-cloned transition.
+
 ## 2026-09-11
 
 ### fix(android): avoid dimension hooks in affected render paths

--- a/__tests__/components/explore/FilesSection.test.tsx
+++ b/__tests__/components/explore/FilesSection.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Text } from 'react-native';
 
 jest.mock('expo-file-system', () => ({}));
 
@@ -48,15 +49,16 @@ jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn((cb: () => void) => cb()),
 }));
 
+const mockColors = {
+  background: '#ffffff', card: '#f0f0f0', border: '#cccccc',
+  text: '#000000', textSecondary: '#666666', accent: '#007AFF',
+  success: '#34C759', error: '#FF3B30', warning: '#FF9500',
+  surface: '#e5e5ea', surfaceSecondary: '#e5e5ea',
+};
+
 jest.mock('@/contexts/ThemeContext', () => ({
-  useTokens: () => ({
-    colors: {
-      background: '#ffffff', card: '#f0f0f0', border: '#cccccc',
-      text: '#000000', textSecondary: '#666666', accent: '#007AFF',
-      success: '#34C759', error: '#FF3B30', warning: '#FF9500',
-      surface: '#e5e5ea', surfaceSecondary: '#e5e5ea',
-    },
-  }),
+  useTheme: () => ({ colors: mockColors }),
+  useTokens: () => ({ colors: mockColors }),
 }));
 
 import { FilesSection } from '@/components/explore/FilesSection';
@@ -69,6 +71,22 @@ const mockRepo = {
   id: 'test-repo-id', path: 'owner/test-repo', name: 'test-repo',
   localPath: '/mock/repos/test-repo', branch: 'main',
 };
+
+class TestErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) return <Text>{this.state.error.message}</Text>;
+    return this.props.children;
+  }
+}
 
 describe('FilesSection row navigation', () => {
   beforeEach(() => {
@@ -148,5 +166,17 @@ describe('FilesSection row navigation', () => {
       await waitFor(() => expect(getByTestId('explore.file.readme.md')).toBeTruthy());
       expect(mockNavigate).not.toHaveBeenCalled();
     });
+  });
+
+  it('does not change hook count when loading changes to the not-cloned state', async () => {
+    (GitFsService.isCloned as jest.Mock).mockResolvedValueOnce(false);
+
+    const { findByText } = render(
+      <TestErrorBoundary>
+        <FilesSection repo={mockRepo} active={true} onChanged={jest.fn()} status={null} />,
+      </TestErrorBoundary>,
+    );
+
+    await findByText('Clone required');
   });
 });

--- a/src/components/explore/FilesSection.tsx
+++ b/src/components/explore/FilesSection.tsx
@@ -171,6 +171,15 @@ export function FilesSection({ repo, active, chromeTopInset = 0, branchInvalidat
     [data, navigation, repo.id, toggleDir],
   );
 
+  const listContentContainerStyle = useMemo(
+    () => ({
+      paddingTop: data ? chromeTopInset : 0,
+      paddingBottom: 96,
+      flexGrow: 1,
+    }),
+    [data, chromeTopInset],
+  );
+
   if (error) {
     return (
       <View className="items-center px-8 py-10">
@@ -194,15 +203,6 @@ export function FilesSection({ repo, active, chromeTopInset = 0, branchInvalidat
       </View>
     );
   }
-
-  const listContentContainerStyle = useMemo(
-    () => ({
-      paddingTop: data ? chromeTopInset : 0,
-      paddingBottom: 96,
-      flexGrow: 1,
-    }),
-    [data, chromeTopInset],
-  );
 
   return (
     <FlatList


### PR DESCRIPTION
## Summary
- move `FilesSection` hooks before conditional loading/error returns
- add regression coverage for loading to not-cloned transitions
- document the Android crash fix in the changelog

## Verification
- `yarn jest __tests__/components/explore/FilesSection.test.tsx --no-coverage --forceExit`
- `yarn ts:check`
- ESLint: 0 errors, 2 existing warnings

Resolves the Android `Rendered fewer hooks than expected` crash observed through `FilesSection`.