### PR TITLE
fix(explore): keep Git tab content below the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable fixes and feature changes to GitNotēs are documented here.
 
 ## 2026-09-12
 
+### fix(explore): keep Git tab content below the header
+
+**What:** Git sub-tabs could render list content and empty-state messages underneath the absolute workspace header, hiding their top content.
+
+**Fix:** Apply the measured Git header inset to loading, error, and not-cloned states across the affected Explore sections.
+
 ### fix(android): stabilize explore files section hooks
 
 **What:** Android could crash with `Rendered fewer hooks than expected` when `FilesSection` changed from loading to clone-error or not-cloned state.

--- a/__tests__/components/explore/FilesSection.test.tsx
+++ b/__tests__/components/explore/FilesSection.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { act, render, fireEvent, waitFor } from '@testing-library/react-native';
 import { Text } from 'react-native';
 
 jest.mock('expo-file-system', () => ({}));
@@ -178,5 +178,36 @@ describe('FilesSection row navigation', () => {
     );
 
     await findByText('Clone required');
+  });
+
+  it('keeps loading content below the Git header', async () => {
+    let resolveClone: (cloned: boolean) => void = () => undefined;
+    (GitFsService.isCloned as jest.Mock).mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolveClone = resolve;
+      }),
+    );
+
+    const { getByTestId } = render(
+      <FilesSection repo={mockRepo} active={true} onChanged={jest.fn()} chromeTopInset={128} status={null} />,
+    );
+
+    expect(getByTestId('explore.files.list').props.contentContainerStyle.paddingTop).toBe(128);
+    await act(async () => {
+      resolveClone(true);
+    });
+  });
+
+  it('keeps the not-cloned message below the Git header', async () => {
+    (GitFsService.isCloned as jest.Mock).mockResolvedValueOnce(false);
+
+    const { findByText, findByTestId } = render(
+      <FilesSection repo={mockRepo} active={true} onChanged={jest.fn()} chromeTopInset={128} status={null} />,
+    );
+
+    const message = await findByText('Clone required');
+    expect(message).toBeTruthy();
+    const state = await findByTestId('explore.files.not-cloned');
+    expect(state.props.style.paddingTop).toBe(128);
   });
 });

--- a/src/components/explore/ChangesSection.tsx
+++ b/src/components/explore/ChangesSection.tsx
@@ -177,7 +177,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0, on
 
   if (error) {
     return (
-      <View className="absolute inset-0 items-center justify-center px-8 py-10 z-50" style={{ backgroundColor: colors.background + 'ee' }}>
+      <View className="absolute inset-0 items-center justify-center px-8 py-10 z-50" style={{ backgroundColor: colors.background + 'ee', paddingTop: chromeTopInset }}>
         <Ionicons name="warning-outline" size={36} color={colors.error} />
         <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
         <Button variant="outline" size="sm" className="mt-3" onPress={() => void load()}>
@@ -189,7 +189,7 @@ export function ChangesSection({ repo, active, onChanged, chromeTopInset = 0, on
 
   if (notCloned) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset }}>
         <Ionicons name="folder-outline" size={36} color={colors.textSecondary} />
         <Text className="mt-2 text-center text-sm font-semibold" style={{ color: colors.text }}>Clone required</Text>
         <Text className="mt-1 text-center text-xs" style={{ color: colors.textSecondary }}>

--- a/src/components/explore/ConflictsSection.tsx
+++ b/src/components/explore/ConflictsSection.tsx
@@ -66,7 +66,7 @@ export function ConflictsSection({ repo, active, chromeTopInset = 0 }: SectionPr
 
   if (error) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset }}>
         <Ionicons name="warning-outline" size={36} color={colors.error} />
         <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
       </View>
@@ -75,7 +75,7 @@ export function ConflictsSection({ repo, active, chromeTopInset = 0 }: SectionPr
 
   if (notCloned) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset }}>
         <Ionicons name="folder-outline" size={36} color={colors.textSecondary} />
         <Text className="mt-2 text-center text-sm font-semibold" style={{ color: colors.text }}>Clone required</Text>
         <Text className="mt-1 text-center text-xs" style={{ color: colors.textSecondary }}>

--- a/src/components/explore/FilesSection.tsx
+++ b/src/components/explore/FilesSection.tsx
@@ -173,16 +173,16 @@ export function FilesSection({ repo, active, chromeTopInset = 0, branchInvalidat
 
   const listContentContainerStyle = useMemo(
     () => ({
-      paddingTop: data ? chromeTopInset : 0,
+      paddingTop: chromeTopInset,
       paddingBottom: 96,
       flexGrow: 1,
     }),
-    [data, chromeTopInset],
+    [chromeTopInset],
   );
 
   if (error) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset }}>
         <Ionicons name="warning-outline" size={36} color={colors.error} />
         <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
         <Button variant="outline" size="sm" className="mt-3" onPress={() => void load()}>
@@ -194,7 +194,7 @@ export function FilesSection({ repo, active, chromeTopInset = 0, branchInvalidat
 
   if (notCloned) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset }} testID="explore.files.not-cloned">
         <Ionicons name="folder-outline" size={36} color={colors.textSecondary} />
         <Text className="mt-2 text-center text-sm font-semibold" style={{ color: colors.text }}>Clone required</Text>
         <Text className="mt-1 text-center text-xs" style={{ color: colors.textSecondary }}>

--- a/src/components/explore/RemotesSection.tsx
+++ b/src/components/explore/RemotesSection.tsx
@@ -184,7 +184,7 @@ export function RemotesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
 
   if (error) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset }}>
         <Ionicons name="warning-outline" size={36} color={colors.error} />
         <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
         <Button variant="outline" size="sm" className="mt-3" onPress={() => void load()}>
@@ -196,7 +196,7 @@ export function RemotesSection({ repo, active, onChanged, chromeTopInset = 0 }: 
 
   if (notCloned) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset }}>
         <Ionicons name="folder-outline" size={36} color={colors.textSecondary} />
         <Text className="mt-2 text-center text-sm font-semibold" style={{ color: colors.text }}>Clone required</Text>
         <Text className="mt-1 text-center text-xs" style={{ color: colors.textSecondary }}>

--- a/src/components/explore/RepoInfoSection.tsx
+++ b/src/components/explore/RepoInfoSection.tsx
@@ -162,7 +162,7 @@ export function RepoInfoSection({ repo, status, active, onChanged, chromeTopInse
 
   if (notCloned) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset }}>
         <Ionicons name="folder-outline" size={36} color={colors.textSecondary} />
         <Text className="mt-2 text-center text-sm font-semibold" style={{ color: colors.text }}>Clone required</Text>
         <Text className="mt-1 text-center text-xs" style={{ color: colors.textSecondary }}>

--- a/src/components/explore/StagingSection.tsx
+++ b/src/components/explore/StagingSection.tsx
@@ -198,7 +198,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0, on
 
   if (error) {
     return (
-      <View className="absolute inset-0 items-center justify-center px-8 py-10 z-50" style={{ backgroundColor: colors.background + 'ee' }}>
+      <View className="absolute inset-0 items-center justify-center px-8 py-10 z-50" style={{ backgroundColor: colors.background + 'ee', paddingTop: chromeTopInset }}>
         <Ionicons name="warning-outline" size={36} color={colors.error} />
         <Text className="mt-2 text-center text-sm" style={{ color: colors.error }}>{error}</Text>
         <Button variant="outline" size="sm" className="mt-3" onPress={() => void load()}>
@@ -210,7 +210,7 @@ export function StagingSection({ repo, active, onChanged, chromeTopInset = 0, on
 
   if (notCloned) {
     return (
-      <View className="items-center px-8 py-10">
+      <View className="items-center px-8 py-10" style={{ paddingTop: chromeTopInset }}>
         <Ionicons name="folder-outline" size={36} color={colors.textSecondary} />
         <Text className="mt-2 text-center text-sm font-semibold" style={{ color: colors.text }}>Clone required</Text>
         <Text className="mt-1 text-center text-xs" style={{ color: colors.textSecondary }}>


### PR DESCRIPTION
## Summary
- apply the measured Git header inset to loading, error, empty, and not-cloned states across Explore sections
- keep FilesSection loading content below the header from its first render
- add regression coverage and changelog entry

## Verification
- `yarn jest __tests__/components/explore/FilesSection.test.tsx __tests__/components/explore/CommitsSection.test.tsx --no-coverage --forceExit`
- `yarn ts:check`
- ESLint: 0 errors; 7 pre-existing hook-dependency warnings
- Prettier: passed
- iOS simulator smoke check: passed

Resolves Git-tab content being hidden beneath the absolute workspace header.