### PR TITLE
fix(explore): guard onLayout event.nativeEvent against null

### DIFF
--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -296,9 +296,11 @@ export default function ExploreScreen() {
       <View
         pointerEvents="box-none"
         style={{ position: 'absolute', top: 0, left: 0, right: 0 }}
-        onLayout={(event: LayoutChangeEvent) =>
-          setChromeTotalHeight((currentHeight) => Math.max(currentHeight, event.nativeEvent.layout.height))
-        }
+        onLayout={(event: LayoutChangeEvent) => {
+          if (event.nativeEvent?.layout) {
+            setChromeTotalHeight((currentHeight) => Math.max(currentHeight, event.nativeEvent.layout.height));
+          }
+        }}
       >
         <BlurView intensity={60} tint={isDark ? 'dark' : 'light'} style={{ overflow: 'hidden' }}>
             <View style={{ paddingTop: insets.top }}>


### PR DESCRIPTION
## Summary

Fixes a render crash in `ExploreScreen` when navigating to it via the floating git button.

**Root cause:** The `onLayout` handler in `ExploreScreen.tsx:300` reads `event.nativeEvent.layout.height` directly. React Native reuses synthetic events for performance — after the event is handled and pooled, `nativeEvent` becomes `null`. When navigation from the floating button remounts the component asynchronously, the pooled event is already released, causing:

```
TypeError: Cannot read property 'layout' of null
```

**Reproduction:** Hold and release the floating git button → `onReleaseSegment` fires with segment `stage` → `onQuickTap` navigates to `ExploreScreen` → crash.

**Fix:** Guard with optional chaining `event.nativeEvent?.layout` before reading `layout.height`.

## Checklist

- [x] ESLint passes (0 errors)
- [x] Conventional commit format