### PR TITLE
fix(explore): persist event and capture layout before reading in onLayout

### DIFF
--- a/src/screens/ExploreScreen.tsx
+++ b/src/screens/ExploreScreen.tsx
@@ -297,8 +297,10 @@ export default function ExploreScreen() {
         pointerEvents="box-none"
         style={{ position: 'absolute', top: 0, left: 0, right: 0 }}
         onLayout={(event: LayoutChangeEvent) => {
-          if (event.nativeEvent?.layout) {
-            setChromeTotalHeight((currentHeight) => Math.max(currentHeight, event.nativeEvent.layout.height));
+          event.persist();
+          const { layout } = event.nativeEvent;
+          if (layout) {
+            setChromeTotalHeight((currentHeight) => Math.max(currentHeight, layout.height));
           }
         }}
       >


### PR DESCRIPTION
Second fix for the ExploreScreen onLayout crash when navigating via the floating git button.

Root cause (refined): The first fix added optional chaining on layout, but the crash persists because event.nativeEvent itself can be null at read time due to React synthetic event pooling.

This fix:
1. event.persist() to remove event from the pool
2. Capture layout into a local const before the guard
3. Guard on the captured layout reference

This is the defensive pattern recommended for onLayout handlers that read from pooled events.